### PR TITLE
bench: fix false fails (unique keys/run) + add --bc to avoid multi-node nested-parallelism hang

### DIFF
--- a/src/dfkv_bench_main.cc
+++ b/src/dfkv_bench_main.cc
@@ -9,6 +9,8 @@
  * connection (cap by DFKV_RDMA_DEPTH); B=1 is the per-op path. Each op uses a
  * unique key ("dfkv-bench-<i>") so the write-once cache never collides. Reports
  * aggregate GB/s and per-call p50/p99/max latency for the PUT and GET phases. */
+#include <unistd.h>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -107,7 +109,13 @@ int main(int argc, char** argv) {
 
   std::string val(size, '\0');
   for (size_t i = 0; i < size; ++i) val[i] = static_cast<char>(i & 0xFF);
-  auto key = [](size_t i) { return "dfkv-bench-" + std::to_string(i); };
+  // Unique key namespace per run (pid + size): dfkv is write-once (idempotent
+  // Cache), so a fixed key set would make reruns at a different --size skip the
+  // PUT (measuring nothing) and miss the GET (stored size != requested size) =>
+  // false fails. pid+size guarantees fresh keys each invocation.
+  const std::string run_id =
+      "dfkv-bench-" + std::to_string(static_cast<long>(getpid())) + "-" + std::to_string(size) + "-";
+  auto key = [&run_id](size_t i) { return run_id + std::to_string(i); };
   const size_t units = (count + batch - 1) / batch;
 
   std::vector<double> lat;

--- a/src/dfkv_bench_main.cc
+++ b/src/dfkv_bench_main.cc
@@ -85,13 +85,14 @@ static void Report(const char* phase, size_t count, size_t size, size_t threads,
 
 int main(int argc, char** argv) {
   std::string members, op = "both";
-  size_t size = 2752512, count = 2000, threads = 8, batch = 1;
+  size_t size = 2752512, count = 2000, threads = 8, batch = 1, bc = 0;
   for (int i = 1; i + 1 < argc; i += 2) {
     if (!std::strcmp(argv[i], "--members")) members = argv[i + 1];
     else if (!std::strcmp(argv[i], "--size")) size = std::stoull(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--count")) count = std::stoull(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--threads")) threads = std::stoull(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--batch")) batch = std::stoull(argv[i + 1]);
+    else if (!std::strcmp(argv[i], "--bc")) bc = std::stoull(argv[i + 1]);  // KVClient internal batch_concurrency
     else if (!std::strcmp(argv[i], "--op")) op = argv[i + 1];
   }
   if (batch < 1) batch = 1;
@@ -106,6 +107,11 @@ int main(int argc, char** argv) {
   ValueHeader hdr = ValueHeader::Make(0x51, 64, 0x46384534u, ValueHeader::kFlagIsMla,
                                       8, 0, 78, 1, 576);
   KVClient c(mem, hdr);
+  // External --threads already provide concurrency; with multi-node members the
+  // client's per-call internal RunParallel(batch_concurrency) would nest under
+  // each external thread (threads x nodes x bc) and can exhaust threads/connections.
+  // --bc 1 disables internal nesting so external threads drive load cleanly.
+  if (bc) c.set_batch_concurrency(bc);
 
   std::string val(size, '\0');
   for (size_t i = 0; i < size; ++i) val[i] = static_cast<char>(i & 0xFF);


### PR DESCRIPTION
Two `dfkv_bench` correctness fixes found while benchmarking the 3-node ring on hd03 real hardware. Both touch only `src/dfkv_bench_main.cc`.

### 1. Unique key namespace per run (pid+size)
dfkv is write-once (idempotent `Cache`). The fixed `dfkv-bench-<i>` key set made reruns at a different `--size` silently **skip the PUT** (key already exists) and **miss the GET** (stored size != requested size) → false `fails` and meaningless PUT timings. Key now includes `pid+size` so every run writes fresh data.

### 2. Add `--bc` (batch_concurrency)
With multi-node `--members`, the client's per-call `RunParallel(batch_concurrency)` nests under each external `--threads` worker (threads × nodes × bc threads), exhausting threads/connections and **hanging** at higher concurrency. `--bc 1` disables internal nesting so external `--threads` drive multi-node load cleanly.

### Validation
Rebased on current `main` (incl. O_DIRECT + access-log). Builds clean; **107 ctest + 18 py tests pass**.