### PR TITLE
build: drop unused librdmacm dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build g++ git ca-certificates libibverbs-dev librdmacm-dev
+            cmake ninja-build g++ git ca-certificates libibverbs-dev
       - name: Configure + build with DFKV_WITH_RDMA=ON (no device at runtime)
         run: |
           cmake -S . -B build-rdma -G Ninja -DCMAKE_BUILD_TYPE=Release \
             -DDFKV_WITH_RDMA=ON -DDFKV_BUILD_TESTS=OFF
           cmake --build build-rdma -j
-      - name: Verify ibverbs/rdmacm linked
-        run: ldd build-rdma/dfkv_server | grep -E 'ibverbs|rdmacm'
+      - name: Verify ibverbs linked
+        run: ldd build-rdma/dfkv_server | grep ibverbs
 
   rdma-loopback:
     name: RDMA datapath (Soft-RoCE loopback + TSan)
@@ -92,7 +92,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++ git ca-certificates \
-            libibverbs-dev librdmacm-dev rdma-core iproute2
+            libibverbs-dev rdma-core iproute2
       - name: Set up Soft-RoCE (rdma_rxe) over loopback
         run: |
           # rxe over 'lo' keeps packets in-host, so RC self-loopback actually

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ add_compile_options(-Wall -Wextra)
 
 option(DFKV_BUILD_TESTS "Build dfkv tests" ON)
 option(DFKV_STATIC_LIBSTDCXX "Statically link libstdc++/libgcc for portable artifacts" OFF)
-option(DFKV_WITH_RDMA "Build the RDMA transport (needs libibverbs + librdmacm)" OFF)
+option(DFKV_WITH_RDMA "Build the RDMA transport (needs libibverbs)" OFF)
 if(DFKV_STATIC_LIBSTDCXX)
   add_link_options(-static-libstdc++ -static-libgcc)
 endif()
@@ -43,7 +43,7 @@ find_package(Threads REQUIRED)
 target_link_libraries(dfkv_core PUBLIC Threads::Threads)
 if(DFKV_WITH_RDMA)
   target_compile_definitions(dfkv_core PUBLIC DFKV_WITH_RDMA)
-  target_link_libraries(dfkv_core PUBLIC ibverbs rdmacm)
+  target_link_libraries(dfkv_core PUBLIC ibverbs)
 endif()
 
 # C ABI shared lib for the Python (ctypes) plugin
@@ -53,7 +53,7 @@ target_compile_definitions(dfkv PRIVATE _GNU_SOURCE)  # O_DIRECT/fallocate in kv
 target_link_libraries(dfkv PUBLIC Threads::Threads)
 if(DFKV_WITH_RDMA)
   target_compile_definitions(dfkv PUBLIC DFKV_WITH_RDMA)
-  target_link_libraries(dfkv PUBLIC ibverbs rdmacm)
+  target_link_libraries(dfkv PUBLIC ibverbs)
 endif()
 
 # standalone cache-node daemon + CLI tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build a portable dfkv image (TCP transport). For RDMA add libibverbs-dev
-# librdmacm-dev and -DDFKV_WITH_RDMA=ON.
+# and -DDFKV_WITH_RDMA=ON.
 FROM ubuntu:24.04 AS build
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake ninja-build g++ git ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -32,9 +32,10 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
 cmake --build build -j
 # 产物：build/dfkv_server  build/dfkv_mds  build/libdfkv.so
 #        build/dfkv_smoke  build/dfkvctl  build/dfkv_bench
-ldd build/dfkv_server | grep -E 'ibverbs|rdmacm'          # 确认链接了 RDMA 库
+ldd build/dfkv_server | grep ibverbs                      # 确认链接了 RDMA 库
 ```
-依赖：`libibverbs-dev librdmacm-dev`（构建期）+ 运行节点装 `rdma-core`。无 RDMA 也可去掉 `-DDFKV_WITH_RDMA` 构建纯 TCP 版。
+依赖：`libibverbs-dev`（构建期）+ 运行节点装 `rdma-core`。无 RDMA 也可去掉 `-DDFKV_WITH_RDMA` 构建纯 TCP 版。
+> QP 信息走 TCP bootstrap 交换（非 librdmacm），所以只依赖 libibverbs，不需要 librdmacm。
 
 ## 2. 每节点：分发 + 缓存目录
 


### PR DESCRIPTION
dfkv exchanges QP info over a plain TCP bootstrap socket (see `rdma_verbs.h`), never the librdmacm connection manager. No `rdma_cm` API is referenced anywhere in `src/`, so the linker already dropped librdmacm via `--as-needed` — `ldd` shows only `libibverbs`.

This removes `rdmacm` from the `DFKV_WITH_RDMA` link line so the declared deps match reality, and updates the Dockerfile / CI / DEPLOY.md package lists and `ldd` checks accordingly.

**No-op for artifacts:** an RDMA=ON node build produces a byte-identical `dfkv_server` (same md5) before and after this change. It just drops a dead build-time dependency (`libibverbs-dev` alone now suffices for RDMA builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)