### PR TITLE
docs: fix broken CI badge (point at dingodb/dfkv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dfkv — distributed KV cache for SGLang HiCache
 
-[![CI](https://github.com/ketor/dfkv/actions/workflows/ci.yml/badge.svg)](https://github.com/ketor/dfkv/actions/workflows/ci.yml)
+[![CI](https://github.com/dingodb/dfkv/actions/workflows/ci.yml/badge.svg)](https://github.com/dingodb/dfkv/actions/workflows/ci.yml)
 
 A small, **self-contained** distributed key-value cache that plugs into SGLang's
 HiCache as its L3 external KV store. Built to pool GPU-node NVMe SSDs into a


### PR DESCRIPTION
The README CI badge pointed at `github.com/ketor/dfkv` (a fork). Forks have GitHub Actions disabled by default, so the `badge.svg` endpoint returns no status and renders as a **broken image** on the dingodb/dfkv repo homepage.

Point both the badge image and its link at `dingodb/dfkv` so it reflects the canonical repo's CI status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)