### PR TITLE
test: fix tool_smoke flake (awk on missing file under set -e)

### DIFF
--- a/tests/tool_smoke.sh
+++ b/tests/tool_smoke.sh
@@ -3,11 +3,13 @@
 set -e
 BUILD="${1:?build dir}"
 D=$(mktemp -d)
-"$BUILD/dfkv_server" --dir "$D" --port 0 --cap 1073741824 >"$D/srv.out" 2>&1 &
+: > "$D/srv.out"   # pre-create so the awk below can't fail on a missing file under `set -e`
+"$BUILD/dfkv_server" --dir "$D" --port 0 --cap 1073741824 >>"$D/srv.out" 2>&1 &
 PID=$!
 trap 'kill $PID 2>/dev/null; rm -rf "$D"' EXIT
 P=""
-for i in $(seq 1 100); do P=$(awk '/PORT/{print $2}' "$D/srv.out" 2>/dev/null); [ -n "$P" ] && break; sleep 0.05; done
+# `|| true`: a transient awk read must never trip `set -e` before the server prints PORT.
+for i in $(seq 1 100); do P=$(awk '/PORT/{print $2}' "$D/srv.out" 2>/dev/null || true); [ -n "$P" ] && break; sleep 0.05; done
 [ -n "$P" ] || { echo "server did not report PORT"; cat "$D/srv.out"; exit 1; }
 "$BUILD/dfkv_smoke" --members "n=127.0.0.1:$P" --size 4096
 "$BUILD/dfkvctl" --members "n=127.0.0.1:$P" put k v12345


### PR DESCRIPTION
The port-wait loop ran `P=$(awk '/PORT/{...}' srv.out)` under `set -e`. Before the backgrounded server's redirect created `srv.out`, awk exited non-zero on the missing file → the command-substitution assignment failed → `set -e` killed the script in ~0.01s (the intermittent tool_smoke failure seen on a main CI run; the identical code passed on its PR run). Pre-create `srv.out` + `|| true` so a transient read can't trip set -e before the server prints PORT. Verified 3× locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)