### PR TITLE
harden: wire length clamp, C-ABI null guards, plugin packaging, stale docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,13 @@ install(TARGETS dfkv dfkv_server dfkv_mds dfkv_smoke dfkvctl dfkv_bench dfkv_dis
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfkv FILES_MATCHING PATTERN "*.h")
-install(FILES python/dfkv_hicache.py DESTINATION ${CMAKE_INSTALL_DATADIR}/dfkv/python)
+# dfkv_hicache.py imports dfkv_access_log and dfkv_metrics at module load, so all
+# three must ship together or an installed plugin fails with ImportError.
+install(FILES
+  python/dfkv_hicache.py
+  python/dfkv_access_log.py
+  python/dfkv_metrics.py
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/dfkv/python)
 
 # --- tests ---
 if(DFKV_BUILD_TESTS)

--- a/src/dfkv_c_api.cc
+++ b/src/dfkv_c_api.cc
@@ -45,17 +45,17 @@ dfkv_client_t dfkv_open(const char* members, uint64_t model_hash,
 }
 
 int dfkv_put(dfkv_client_t c, const char* key, const void* ptr, uint64_t n) {
-  if (!c) return -1;
+  if (!c || !key) return -1;  // key is wrapped in std::string -> must be non-null
   return static_cast<KVClient*>(c)->Put(key, ptr, static_cast<size_t>(n)) ? 0 : -1;
 }
 
 int dfkv_get(dfkv_client_t c, const char* key, void* ptr, uint64_t n) {
-  if (!c) return 0;
+  if (!c || !key) return 0;  // 0 == miss; null key can't construct std::string
   return static_cast<KVClient*>(c)->Get(key, ptr, static_cast<size_t>(n)) ? 1 : 0;
 }
 
 int dfkv_exist(dfkv_client_t c, const char* key) {
-  if (!c) return 0;
+  if (!c || !key) return 0;
   return static_cast<KVClient*>(c)->Exist(key) ? 1 : 0;
 }
 
@@ -66,34 +66,48 @@ int dfkv_register_memory(dfkv_client_t c, const void* base, uint64_t size) {
   return 0;
 }
 
+// The batch entrypoints take caller-owned C arrays. We validate the array
+// pointers up front (null with n>0 => bad call) and tolerate a null element:
+// a null keys[i] is substituted with an empty item so BatchPut/Get stays index-
+// aligned, and that slot is reported as failed (out[i]=0) instead of feeding a
+// null into std::string() (undefined behavior across the FFI boundary).
 int dfkv_batch_put(dfkv_client_t c, const char** keys, const void** ptrs,
                    const uint64_t* sizes, int n, int* out_ok) {
   if (!c || n < 0) return -1;
+  if (n > 0 && (!keys || !ptrs || !sizes || !out_ok)) return -1;
   std::vector<dfkv::KvPutItem> items(n);
-  for (int i = 0; i < n; ++i)
-    items[i] = {keys[i], ptrs[i], static_cast<size_t>(sizes[i])};
+  for (int i = 0; i < n; ++i) {
+    const char* k = keys[i];
+    items[i] = {k ? std::string(k) : std::string(), k ? ptrs[i] : nullptr,
+                k ? static_cast<size_t>(sizes[i]) : 0};
+  }
   auto r = static_cast<KVClient*>(c)->BatchPut(items);
-  for (int i = 0; i < n; ++i) out_ok[i] = r[i] ? 1 : 0;
+  for (int i = 0; i < n; ++i) out_ok[i] = (keys[i] && r[i]) ? 1 : 0;
   return 0;
 }
 
 int dfkv_batch_get(dfkv_client_t c, const char** keys, void** ptrs,
                    const uint64_t* sizes, int n, int* out_hit) {
   if (!c || n < 0) return -1;
+  if (n > 0 && (!keys || !ptrs || !sizes || !out_hit)) return -1;
   std::vector<dfkv::KvGetItem> items(n);
-  for (int i = 0; i < n; ++i)
-    items[i] = {keys[i], ptrs[i], static_cast<size_t>(sizes[i])};
+  for (int i = 0; i < n; ++i) {
+    const char* k = keys[i];
+    items[i] = {k ? std::string(k) : std::string(), k ? ptrs[i] : nullptr,
+                k ? static_cast<size_t>(sizes[i]) : 0};
+  }
   auto r = static_cast<KVClient*>(c)->BatchGet(items);
-  for (int i = 0; i < n; ++i) out_hit[i] = r[i] ? 1 : 0;
+  for (int i = 0; i < n; ++i) out_hit[i] = (keys[i] && r[i]) ? 1 : 0;
   return 0;
 }
 
 int dfkv_batch_exist(dfkv_client_t c, const char** keys, int n, int* out_exist) {
   if (!c || n < 0) return -1;
+  if (n > 0 && (!keys || !out_exist)) return -1;
   std::vector<std::string> ks(n);
-  for (int i = 0; i < n; ++i) ks[i] = keys[i];
+  for (int i = 0; i < n; ++i) ks[i] = keys[i] ? std::string(keys[i]) : std::string();
   auto r = static_cast<KVClient*>(c)->BatchExist(ks);
-  for (int i = 0; i < n; ++i) out_exist[i] = r[i] ? 1 : 0;
+  for (int i = 0; i < n; ++i) out_exist[i] = (keys[i] && r[i]) ? 1 : 0;
   return 0;
 }
 

--- a/src/kv_client.h
+++ b/src/kv_client.h
@@ -1,9 +1,12 @@
 /* KVClient — the standalone DingoFS KV cache client used by the SGLang HiCache
  * plugin. Routes keys via consistent hash, wraps values with a ValueHeader
- * (model/page/dtype/layer + CRC), and speaks to cache nodes via a Transport.
+ * (model/page/dtype/layer geometry), and speaks to cache nodes via a Transport.
  *  - Put  -> SyncCache (durable-visible write, header-wrapped)
- *  - Get  -> Range + header/CRC verify (mismatch or corruption => miss)
- *  - Exist-> local existence check on the owning node */
+ *  - Get  -> Range + header geometry verify (mismatch => miss)
+ *  - Exist-> local existence check on the owning node
+ * NOTE: the header carries geometry, not a payload checksum (CRC was dropped in
+ * v3). A geometry mismatch is caught, but silent payload bit-rot on the wire/disk
+ * is not detected here — we rely on the underlying transport/filesystem. */
 #ifndef DFKV_KV_CLIENT_H_
 #define DFKV_KV_CLIENT_H_
 

--- a/src/membership.h
+++ b/src/membership.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include "net_util.h"  // net::PutU32/PutU64/GetU32/GetU64 (little-endian)
+#include "net_util.h"  // net::PutU32/PutU64/GetU32/GetU64 (host-endian codec)
 
 namespace dfkv {
 
@@ -22,8 +22,9 @@ struct MemberInfo {
 
 // Wire format for a membership view. Register payload = 1 member; ListMembers
 // response = N members + the epoch (etcd revision) clients compare to skip
-// rebuilding an unchanged ring. Layout (little-endian via net::):
+// rebuilding an unchanged ring. Layout (host-endian via net::):
 //   epoch u64 | count u32 | repeat{ idlen u32, id, iplen u32, ip, port u32, weight u32 }
+// (host-endian via net::; correct between same-endianness peers — see net_util.h)
 inline std::string EncodeMembers(const std::vector<MemberInfo>& ms,
                                  uint64_t epoch) {
   std::string out;

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -1,6 +1,7 @@
-/* Minimal POSIX TCP + little-endian codec helpers for the portable test
- * transport. The real build uses brpc; this is only for the standalone,
- * GPU-free end-to-end harness. */
+/* Minimal POSIX TCP + integer codec helpers for the portable test transport.
+ * The codec is host-endian (raw memcpy, no byte-swap): it is correct only
+ * between same-endianness peers, which holds for all current x86_64 deploys.
+ * The real build uses brpc; this is only for the standalone, GPU-free harness. */
 #ifndef DFKV_NET_UTIL_H_
 #define DFKV_NET_UTIL_H_
 
@@ -49,6 +50,7 @@ inline bool ReadAll(int fd, void* buf, size_t n) {
   return true;
 }
 
+// host-endian (native byte order via memcpy); see file header for the caveat.
 inline void PutU64(char* p, uint64_t v) { std::memcpy(p, &v, 8); }
 inline void PutU32(char* p, uint32_t v) { std::memcpy(p, &v, 4); }
 inline uint64_t GetU64(const char* p) { uint64_t v; std::memcpy(&v, p, 8); return v; }

--- a/src/wire.h
+++ b/src/wire.h
@@ -11,7 +11,7 @@
 
 #include "kv_store.h"   // Status
 #include "kv_types.h"   // BlockKey
-#include "net_util.h"   // net::PutU32/PutU64/GetU32/GetU64 (little-endian)
+#include "net_util.h"   // net::PutU32/PutU64/GetU32/GetU64 (host-endian codec)
 
 namespace dfkv {
 
@@ -25,6 +25,14 @@ enum class WireOp : uint8_t {
 };
 
 constexpr uint8_t kProtoVersion = 1;
+
+// Hard ceiling on a single wire frame's variable payload. Decode rejects any
+// frame whose declared length exceeds this, so a garbage/hostile 64-bit length
+// (a version skew, corruption, or a hostile peer) can't drive a multi-exabyte
+// std::vector/std::string allocation -> bad_alloc/OOM that kills the process.
+// No real dfkv frame (one KV block value, or a stats/membership blob) comes
+// anywhere near 16 GiB; callers that know a tighter bound pass it explicitly.
+constexpr uint64_t kMaxFrameLen = 1ull << 34;  // 16 GiB
 
 // Request prefix: ver(1) op(1) id(8) index(4) size(4) offset(8) length(8) payload_len(8)
 constexpr size_t kReqPrefix = 1 + 1 + 8 + 4 + 4 + 8 + 8 + 8;  // = 42
@@ -53,8 +61,12 @@ struct ReqFields {
   uint64_t payload_len;
 };
 
-// Returns false on a protocol-version mismatch (caller drops the connection).
-inline bool DecodeReq(const char* p, ReqFields* o) {
+// Returns false on a protocol-version mismatch or an oversized declared payload
+// (> max_payload); the caller drops the connection in either case. max_payload
+// defaults to the global frame ceiling, so every caller is guarded even without
+// passing a tighter bound.
+inline bool DecodeReq(const char* p, ReqFields* o,
+                      uint64_t max_payload = kMaxFrameLen) {
   if (static_cast<uint8_t>(p[0]) != kProtoVersion) return false;
   o->op = static_cast<uint8_t>(p[1]);
   o->id = net::GetU64(p + 2);
@@ -63,6 +75,7 @@ inline bool DecodeReq(const char* p, ReqFields* o) {
   o->offset = net::GetU64(p + 18);
   o->length = net::GetU64(p + 26);
   o->payload_len = net::GetU64(p + 34);
+  if (o->payload_len > max_payload) return false;  // reject oversized frame
   return true;
 }
 
@@ -72,10 +85,12 @@ inline void EncodeResp(char* p, Status st, uint64_t data_len) {
   net::PutU64(p + 2, data_len);
 }
 
-inline bool DecodeResp(const char* p, Status* st, uint64_t* data_len) {
+inline bool DecodeResp(const char* p, Status* st, uint64_t* data_len,
+                       uint64_t max_data = kMaxFrameLen) {
   if (static_cast<uint8_t>(p[0]) != kProtoVersion) return false;
   *st = static_cast<Status>(static_cast<uint8_t>(p[1]));
   *data_len = net::GetU64(p + 2);
+  if (*data_len > max_data) return false;  // reject oversized frame
   return true;
 }
 

--- a/tests/c_api_test.cc
+++ b/tests/c_api_test.cc
@@ -1,0 +1,69 @@
+// C ABI guard tests: the FFI boundary must reject null handles/arrays and must
+// not feed a null pointer into std::string() (undefined behavior). These run
+// against a discovery-only client (empty member list => empty ring), so they
+// need no server: routing fails fast and every slot reports miss/failure.
+#include "dfkv_c_api.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+dfkv_client_t OpenEmpty() {
+  // members="" => discovery-only; ring stays empty until MDS discovery runs.
+  return dfkv_open("", /*model_hash=*/1, /*page_size=*/64, /*dtype_tag=*/0,
+                   /*flags=*/0, /*tp_size=*/1, /*tp_rank=*/0, /*layer_num=*/0,
+                   /*head_num=*/0, /*head_dim=*/0);
+}
+}  // namespace
+
+TEST(CApiGuard, RejectsNullClient) {
+  EXPECT_EQ(dfkv_batch_put(nullptr, nullptr, nullptr, nullptr, 0, nullptr), -1);
+  EXPECT_EQ(dfkv_batch_get(nullptr, nullptr, nullptr, nullptr, 0, nullptr), -1);
+  EXPECT_EQ(dfkv_batch_exist(nullptr, nullptr, 0, nullptr), -1);
+  EXPECT_EQ(dfkv_put(nullptr, "k", "v", 1), -1);
+  EXPECT_EQ(dfkv_get(nullptr, "k", nullptr, 0), 0);
+  EXPECT_EQ(dfkv_exist(nullptr, "k"), 0);
+}
+
+TEST(CApiGuard, RejectsNullArraysWithPositiveN) {
+  dfkv_client_t c = OpenEmpty();
+  ASSERT_NE(c, nullptr);
+  int out[2] = {9, 9};
+  EXPECT_EQ(dfkv_batch_put(c, nullptr, nullptr, nullptr, 2, out), -1);
+  EXPECT_EQ(dfkv_batch_get(c, nullptr, nullptr, nullptr, 2, out), -1);
+  EXPECT_EQ(dfkv_batch_exist(c, nullptr, 2, out), -1);
+  EXPECT_EQ(dfkv_put(c, nullptr, "v", 1), -1);
+  EXPECT_EQ(dfkv_get(c, nullptr, nullptr, 0), 0);
+  EXPECT_EQ(dfkv_exist(c, nullptr), 0);
+  dfkv_close(c);
+}
+
+TEST(CApiGuard, NullElementIsSkippedNotDereferenced) {
+  dfkv_client_t c = OpenEmpty();
+  ASSERT_NE(c, nullptr);
+  const char* keys[2] = {nullptr, "real-key"};
+  const void* ptrs[2] = {nullptr, "vv"};
+  uint64_t sizes[2] = {0, 2};
+  int ok[2] = {9, 9};
+  EXPECT_EQ(dfkv_batch_put(c, keys, ptrs, sizes, 2, ok), 0);  // no crash
+  EXPECT_EQ(ok[0], 0);  // null key reported as failure, not UB
+
+  void* outs[2] = {nullptr, nullptr};
+  int hit[2] = {9, 9};
+  EXPECT_EQ(dfkv_batch_get(c, keys, outs, sizes, 2, hit), 0);
+  EXPECT_EQ(hit[0], 0);
+
+  int ex[2] = {9, 9};
+  EXPECT_EQ(dfkv_batch_exist(c, keys, 2, ex), 0);
+  EXPECT_EQ(ex[0], 0);
+  dfkv_close(c);
+}
+
+TEST(CApiGuard, ZeroLengthBatchIsOk) {
+  dfkv_client_t c = OpenEmpty();
+  ASSERT_NE(c, nullptr);
+  // n==0 with null arrays must be accepted (nothing to do), not rejected.
+  EXPECT_EQ(dfkv_batch_put(c, nullptr, nullptr, nullptr, 0, nullptr), 0);
+  EXPECT_EQ(dfkv_batch_get(c, nullptr, nullptr, nullptr, 0, nullptr), 0);
+  EXPECT_EQ(dfkv_batch_exist(c, nullptr, 0, nullptr), 0);
+  dfkv_close(c);
+}

--- a/tests/wire_test.cc
+++ b/tests/wire_test.cc
@@ -1,0 +1,87 @@
+// Wire-framing encode/decode: round-trips plus the negative paths a hostile or
+// version-skewed peer can take (bad version byte, oversized declared length).
+#include "wire.h"
+
+#include <cstring>
+
+#include <gtest/gtest.h>
+
+using namespace dfkv;
+
+TEST(Wire, ReqRoundTrip) {
+  char buf[kReqPrefix];
+  BlockKey k{0x1122334455667788ull, 0xAABBCCDD, 0x12345678};
+  EncodeReq(buf, WireOp::kCache, k, 4096, 8192, 65536);
+  ReqFields rq;
+  ASSERT_TRUE(DecodeReq(buf, &rq));
+  EXPECT_EQ(rq.op, static_cast<uint8_t>(WireOp::kCache));
+  EXPECT_EQ(rq.id, k.id);
+  EXPECT_EQ(rq.index, k.index);
+  EXPECT_EQ(rq.size, k.size);
+  EXPECT_EQ(rq.offset, 4096u);
+  EXPECT_EQ(rq.length, 8192u);
+  EXPECT_EQ(rq.payload_len, 65536u);
+}
+
+TEST(Wire, RespRoundTrip) {
+  char buf[kRespPrefix];
+  EncodeResp(buf, Status::kOk, 1u << 20);
+  Status st = Status::kInvalid;
+  uint64_t dlen = 0;
+  ASSERT_TRUE(DecodeResp(buf, &st, &dlen));
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(dlen, 1u << 20);
+}
+
+TEST(Wire, ReqRejectsBadVersion) {
+  char buf[kReqPrefix];
+  EncodeReq(buf, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, 0);
+  buf[0] = static_cast<char>(kProtoVersion + 1);  // version skew
+  ReqFields rq;
+  EXPECT_FALSE(DecodeReq(buf, &rq));
+}
+
+TEST(Wire, RespRejectsBadVersion) {
+  char buf[kRespPrefix];
+  EncodeResp(buf, Status::kOk, 0);
+  buf[0] = static_cast<char>(kProtoVersion + 1);
+  Status st = Status::kInvalid;
+  uint64_t dlen = 0;
+  EXPECT_FALSE(DecodeResp(buf, &st, &dlen));
+}
+
+TEST(Wire, ReqRejectsOversizedPayload) {
+  char buf[kReqPrefix];
+  // A garbage/hostile 64-bit length must NOT decode (else it drives a huge alloc).
+  EncodeReq(buf, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, kMaxFrameLen + 1);
+  ReqFields rq;
+  EXPECT_FALSE(DecodeReq(buf, &rq));               // rejected by default ceiling
+  EXPECT_TRUE(DecodeReq(buf, &rq, kMaxFrameLen + 1));  // explicit higher bound accepts
+  EXPECT_EQ(rq.payload_len, kMaxFrameLen + 1);
+}
+
+TEST(Wire, ReqAcceptsPayloadAtCeiling) {
+  char buf[kReqPrefix];
+  EncodeReq(buf, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, kMaxFrameLen);
+  ReqFields rq;
+  EXPECT_TRUE(DecodeReq(buf, &rq));  // exactly at the ceiling is allowed
+  EXPECT_EQ(rq.payload_len, kMaxFrameLen);
+}
+
+TEST(Wire, ReqRejectsOverTighterBound) {
+  char buf[kReqPrefix];
+  EncodeReq(buf, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, 4097);
+  ReqFields rq;
+  EXPECT_FALSE(DecodeReq(buf, &rq, 4096));  // caller-supplied tighter cap enforced
+  EXPECT_TRUE(DecodeReq(buf, &rq, 4097));
+}
+
+TEST(Wire, RespRejectsOversizedData) {
+  char buf[kRespPrefix];
+  EncodeResp(buf, Status::kOk, kMaxFrameLen + 1);
+  Status st = Status::kInvalid;
+  uint64_t dlen = 0;
+  EXPECT_FALSE(DecodeResp(buf, &st, &dlen));
+  EXPECT_TRUE(DecodeResp(buf, &st, &dlen, kMaxFrameLen + 1));
+  EXPECT_EQ(dlen, kMaxFrameLen + 1);
+}


### PR DESCRIPTION
Hardening batch from the v1.0.0 code review. Four cheap, high-value robustness fixes; no behavior change on the happy path.

## #1 — Wire frame length clamp (DoS hardening)
`DecodeReq`/`DecodeResp` now take an optional `max_len` (default `kMaxFrameLen` = 16 GiB) and return false when the declared payload/data length exceeds it. A garbage or hostile 64-bit length (version skew, corruption, a hostile peer) previously flowed straight into `std::vector<char>(n)` / `std::string(n)` at three sites (`kv_node_server`, `mds_server`, `tcp_transport`), risking a multi-exabyte allocation → `bad_alloc`/OOM kill. The fix is centralized in `wire.h`, so all three call sites are covered with no call-site churn (they already drop the connection when decode returns false).

## #2 — C ABI null guards
`dfkv_batch_{put,get,exist}` validate array pointers (null with `n>0` ⇒ `-1`) and tolerate a null `keys[i]` by substituting an empty item (reported as failure) instead of constructing `std::string(nullptr)` (UB across the FFI boundary). Single-item `dfkv_put/get/exist` reject a null key.

## #9 — Plugin packaging
`dfkv_hicache.py` imports `dfkv_access_log` and `dfkv_metrics` at module load; the install rule shipped only the main file, so an installed plugin failed with `ImportError`. All three now install together.

## #10 — Stale comments
- CRC was dropped in v3: `kv_client.h` now documents that the ValueHeader carries geometry only (no payload checksum).
- The `net::` codec is host-endian (raw memcpy), not little-endian: corrected in `net_util.h`, `wire.h`, `membership.h`.

## Tests
- New `tests/wire_test.cc`: round-trip + negative paths (bad version byte, oversized payload/data, caller-supplied tighter bound, at-ceiling boundary).
- New `tests/c_api_test.cc`: null client, null arrays, null element (no UB), zero-length batch.
- Full suite: **126/126 ctest pass** locally under `-DDFKV_WITH_RDMA=ON` with rxe0 Soft-RoCE, incl. `python_plugin` and `tool_smoke`.