### PR TITLE
rdma-server: reclaim idle connections + reap finished Serve threads (#3)

### DIFF
--- a/src/rdma_server.cc
+++ b/src/rdma_server.cc
@@ -59,13 +59,33 @@ void RdmaServer::Stop() {
   if (listen_fd_ >= 0) { ::close(listen_fd_); listen_fd_ = -1; }
   // Wake every in-flight Serve thread out of WaitComp, then join them all so no
   // handler call can race the owner's destruction after Stop() returns.
-  std::vector<std::thread> threads;
+  std::vector<Conn> conns;
   {
     std::lock_guard<std::mutex> lk(conn_mu_);
     for (rdma::RcEndpoint* ep : live_eps_) ep->Wake();
-    threads.swap(conn_threads_);
+    conns.swap(conns_);
   }
-  for (auto& t : threads) if (t.joinable()) t.join();
+  for (auto& c : conns) if (c.th.joinable()) c.th.join();
+}
+
+// Join and drop any Serve threads that have already finished. Called from
+// AcceptLoop under conn_mu_; only threads whose `done` is set are touched, and a
+// thread sets `done` only after its final conn_mu_ release, so join() never
+// blocks here. This keeps conns_ bounded by the live (not lifetime) conn count.
+void RdmaServer::ReapDoneLocked() {
+  for (auto it = conns_.begin(); it != conns_.end();) {
+    if (it->done->load(std::memory_order_acquire)) {
+      if (it->th.joinable()) it->th.join();
+      it = conns_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+size_t RdmaServer::live_conn_count() {
+  std::lock_guard<std::mutex> lk(conn_mu_);
+  return conns_.size();
 }
 
 void RdmaServer::AcceptLoop() {
@@ -78,7 +98,13 @@ void RdmaServer::AcceptLoop() {
     ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));  // can't hang Stop()
     std::lock_guard<std::mutex> lk(conn_mu_);
     if (!running_) { ::close(fd); break; }
-    conn_threads_.emplace_back([this, fd] { Serve(fd); });
+    ReapDoneLocked();  // reap connections that finished since the last accept
+    auto done = std::make_shared<std::atomic<bool>>(false);
+    conns_.push_back({std::thread([this, fd, done] {
+                        Serve(fd);
+                        done->store(true, std::memory_order_release);  // last act
+                      }),
+                      done});
   }
 }
 
@@ -90,6 +116,26 @@ size_t ServerDepth() {
   const char* e = std::getenv("DFKV_RDMA_DEPTH");
   if (e && *e) { long v = std::strtol(e, nullptr, 10); if (v >= 1 && v <= 256) return (size_t)v; }
   return 1;
+}
+
+int ServerIdleMs() {
+  // Per-connection idle timeout. A connection with no completions for this long
+  // is reclaimed: its Serve thread returns (freeing the QP, pinned buffers, and
+  // the thread itself, which ReapDoneLocked then joins). Without this, a Serve
+  // thread blocks in WaitComp forever after a silent client disconnect (a torn-
+  // down RC peer yields no completion), so a long-running server accumulates one
+  // live thread per lifetime connection. Reclaiming idle connections is safe:
+  // the client re-dials a stale pooled connection via RdmaTransport's 2-attempt
+  // retry. Default 10 min keeps active/recently-used pooled conns alive; set
+  // DFKV_RDMA_IDLE_MS=0 to disable (block forever, the legacy behavior).
+  const char* e = std::getenv("DFKV_RDMA_IDLE_MS");
+  if (e && *e) {
+    long v = std::strtol(e, nullptr, 10);
+    if (v <= 0) return -1;               // disabled => block forever
+    if (v > 86400000) v = 86400000;      // clamp to 24h
+    return static_cast<int>(v);
+  }
+  return 600000;  // 10 minutes
 }
 
 }  // namespace
@@ -200,9 +246,10 @@ void RdmaServer::Serve(int boot_fd) {
   // it broke zero-copy correctness for marginal gain; GET scales via connections.)
   std::vector<ibv_wc> wcs(K);
   bool fail = false;
+  const int idle_ms = ServerIdleMs();
   while (running_ && !fail) {
-    int g = ep.WaitComp(wcs.data(), static_cast<int>(K));
-    if (g <= 0) break;
+    int g = ep.WaitComp(wcs.data(), static_cast<int>(K), idle_ms);
+    if (g <= 0) break;  // <0: error / Stop()'s Wake().  0: idle_ms elapsed -> reclaim.
     for (int w = 0; w < g && !fail; ++w) {
       const ibv_wc& wc = wcs[w];
       if (wc.status != IBV_WC_SUCCESS) { fail = true; break; }

--- a/src/rdma_server.h
+++ b/src/rdma_server.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -50,9 +51,24 @@ class RdmaServer {
   void Stop();
   int port() const { return port_; }
 
+  // Observability (used by tests): number of Serve threads not yet reaped.
+  // Bounded under churn now that finished connections are joined as new ones
+  // arrive — previously this grew without bound until Stop().
+  size_t live_conn_count();
+
  private:
   void AcceptLoop();
   void Serve(int boot_fd);
+  void ReapDoneLocked();  // join+erase finished Serve threads; conn_mu_ held
+
+  // A live connection: its Serve thread plus a flag the thread sets (last thing
+  // it does) so AcceptLoop can tell it has finished and join it without blocking.
+  // The flag is a shared_ptr because conns_ reallocates on push_back — the thread
+  // captures its own copy, so the atomic outlives any vector move/erase.
+  struct Conn {
+    std::thread th;
+    std::shared_ptr<std::atomic<bool>> done;
+  };
 
   Handler handler_;
   RangeHandler range_handler_;
@@ -63,9 +79,10 @@ class RdmaServer {
   std::atomic<bool> running_{false};
   std::thread accept_thread_;
   // Track per-connection Serve threads + their endpoints so Stop() can wake them
-  // out of WaitComp and join them before the handler's owner is destroyed.
+  // out of WaitComp and join them before the handler's owner is destroyed, and
+  // so finished threads are reaped incrementally (see ReapDoneLocked).
   std::mutex conn_mu_;
-  std::vector<std::thread> conn_threads_;
+  std::vector<Conn> conns_;
   std::unordered_set<rdma::RcEndpoint*> live_eps_;
 };
 

--- a/src/rdma_verbs.cc
+++ b/src/rdma_verbs.cc
@@ -365,7 +365,7 @@ bool RcEndpoint::PostRecvScatter(size_t slot, void* payload, size_t payload_len,
   return ibv_post_recv(qp_, &wr, &bad) == 0;
 }
 
-int RcEndpoint::WaitComp(ibv_wc* out, int max) {
+int RcEndpoint::WaitComp(ibv_wc* out, int max, int timeout_ms) {
   for (;;) {
     int got = ibv_poll_cq(cq_, max, out);
     if (got != 0) return got;  // >0 completions, or <0 error
@@ -376,8 +376,10 @@ int RcEndpoint::WaitComp(ibv_wc* out, int max) {
     got = ibv_poll_cq(cq_, max, out);
     if (got != 0) return got;
     pollfd pfds[2] = {{chan_->fd, POLLIN, 0}, {wake_rfd_, POLLIN, 0}};
-    int pr = ::poll(pfds, 2, -1);
+    int pr = ::poll(pfds, 2, timeout_ms);
     if (pr < 0) { if (errno == EINTR) continue; return -1; }
+    if (pr == 0)  // timed out (finite timeout_ms): one last poll, else 0 = idle.
+      return ibv_poll_cq(cq_, max, out);
     if (pfds[1].revents & POLLIN) return -1;  // woken for shutdown
     if (pfds[0].revents & POLLIN) {
       ibv_cq* ev_cq = nullptr; void* ev_ctx = nullptr;

--- a/src/rdma_verbs.h
+++ b/src/rdma_verbs.h
@@ -109,7 +109,10 @@ class RcEndpoint {
   // Block until at least one completion, drain up to `max` into out[]; returns
   // the count (>0), or <0 on error / when Wake() is called. wr_id of each wc =
   // the slot. Used for single round-trips (max=1) and pipelined batches.
-  int WaitComp(ibv_wc* out, int max);
+  // timeout_ms < 0 blocks forever (the default, used by the client). A finite
+  // timeout returns 0 if no completion arrives in that window — the server uses
+  // it to reclaim an idle/abandoned connection instead of blocking indefinitely.
+  int WaitComp(ibv_wc* out, int max, int timeout_ms = -1);
   // Unblock a thread sitting in WaitComp (so the server can join its Serve
   // threads at shutdown). Thread-safe vs the waiter.
   void Wake();

--- a/tests/rdma_loopback_test.cc
+++ b/tests/rdma_loopback_test.cc
@@ -13,11 +13,13 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -42,7 +44,7 @@ struct RdmaNode {
   std::unique_ptr<RdmaServer> rsrv;
   std::string addr;  // bootstrap "ip:port" for the client member list
 
-  explicit RdmaNode(const std::string& tag) {
+  explicit RdmaNode(const std::string& tag, size_t max_msg = kMaxMsg) {
     dir = fs::temp_directory_path() / ("dfkv_rdma_" + tag);
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -53,7 +55,7 @@ struct RdmaNode {
                uint64_t len, const char* pl, uint64_t pll, std::string* out) {
           return srv->ProcessRequest(op, id, idx, ks, off, len, pl, pll, out);
         },
-        kMaxMsg);
+        max_msg);
     rsrv->set_range_handler(
         [this](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
                char* io_buf, size_t cap, const char** out_data, size_t* out_len) {
@@ -273,4 +275,50 @@ TEST(RdmaLoopback, PipelinedPoolDepth) {
 
   ::unsetenv("DFKV_RDMA_DEPTH");
   ::unsetenv("DFKV_RDMA_WORKERS");
+}
+
+// Regression for the conn-thread leak (#3). A server Serve thread blocks in
+// WaitComp forever after a silent client disconnect (a torn-down RC peer yields
+// no completion), so without an idle timeout a long-running server accumulates
+// one live thread per lifetime connection — Stop() is the only reaper. The fix:
+// an idle timeout reclaims the connection (the thread returns), and ReapDoneLocked
+// joins the finished thread on the next accept. This test sets a short idle window
+// and verifies the live count drains back to the baseline; without the fix it
+// would stay pinned near N and time out.
+TEST(RdmaLoopback, ReclaimsAndReapsIdleConnThreads) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ::setenv("DFKV_RDMA_IDLE_MS", "120", 1);  // reclaim idle conns fast (test only)
+  constexpr size_t kSmallMsg = 16 * 1024;   // stay well under an 8 MiB memlock
+  RdmaNode node("reap", kSmallMsg);          // server buffers must be small too
+  // One long-lived client endpoint holds the shared per-device ibv_context open
+  // (its server side may be reclaimed when idle and is transparently re-dialed).
+  RdmaTransport keep(kSmallMsg);
+  KVClient ckeep({{"n", node.addr}}, SelfHdr(), &keep);
+  std::string kk(64, 'k');
+  ASSERT_TRUE(ckeep.Put("keep", kk.data(), kk.size()));
+
+  const int N = 30;
+  for (int i = 0; i < N; ++i) {
+    RdmaTransport rt(kSmallMsg);
+    KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+    std::string v(512, static_cast<char>(i & 0xFF));
+    ASSERT_TRUE(c.Put("k" + std::to_string(i), v.data(), v.size())) << "i=" << i;
+    // rt + c leave scope here -> transient client gone -> server conn goes idle.
+  }
+
+  // Each round: wait past the idle window so every prior connection's Serve thread
+  // has exited, then make ONE connection whose accept runs ReapDoneLocked to join
+  // all the finished threads. Only that single in-flight drain thread should then
+  // remain. Without reclaim+reap the N transient threads stay in conns_ and the
+  // count never falls (the loop exhausts its rounds and the assert fails).
+  size_t live = 0;
+  for (int round = 0; round < 6; ++round) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));  // > idle (120 ms)
+    { RdmaTransport rt(kSmallMsg); KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+      std::string v(16, 'x'); c.Put("drain", v.data(), v.size()); }
+    live = node.rsrv->live_conn_count();
+    if (live <= 2) break;
+  }
+  EXPECT_LE(live, 2u) << "idle conn threads were not reclaimed + reaped (leak)";
+  ::unsetenv("DFKV_RDMA_IDLE_MS");
 }


### PR DESCRIPTION
Fixes the unbounded `conn_threads_` growth flagged in the v1.0.0 review.

## What the investigation found
The review framed this as "completed Serve threads are only joined at `Stop()`." Tracing the actual behavior (added a diagnostic over Soft-RoCE loopback) showed the real cause is worse: **a `Serve` thread blocks in `WaitComp` forever after a client disconnects** — a silently torn-down RC peer produces no completion — so threads essentially never finish on their own. A long-running server therefore accumulates one *live* (blocked) thread + QP + pinned buffer set per lifetime connection. Reaping finished threads alone would be a near no-op.

## Fix (two coordinated parts)
1. **Idle timeout.** `RcEndpoint::WaitComp` gains an optional `timeout_ms` (default `-1` = block forever, so all four client call sites are unchanged). `RdmaServer`'s serve loop passes `DFKV_RDMA_IDLE_MS` (default **10 min**, `0` disables): a connection idle that long is reclaimed — the `Serve` thread returns and frees its QP/buffers/thread. Safe because a client transparently re-dials a stale pooled connection via `RdmaTransport`'s existing 2-attempt retry (same as TCP). The pre-existing `if (g <= 0) break;` already treats the new `0` (idle) return as "reclaim".
2. **Reaping.** `conn_threads_` becomes `conns_` (each = thread + a `shared_ptr<atomic<bool>>` done-flag the thread sets as its last act). `AcceptLoop` calls `ReapDoneLocked()` to join + drop finished threads as new connections arrive, bounding `conns_` to the *live* (not lifetime) connection count. `Stop()` still wakes and joins all remaining.

## Why it's safe
- Client call sites pass no timeout → `-1` → identical blocking behavior.
- A reclaimed idle connection is re-established on next use by the client's retry path (verified in `rdma_transport.cc` RoundTrip).
- `ReapDoneLocked` only joins threads whose `done` flag is set, and a thread sets `done` only after its final `conn_mu_` release, so the join under `conn_mu_` never blocks.

## Tests
- New `RdmaLoopback.ReclaimsAndReapsIdleConnThreads`: short idle window, churn 30 connections, verify the live count drains back to baseline (without the fix it stays pinned near 30).
- Full suite **127/127** locally under `-DDFKV_WITH_RDMA=ON` (rxe0); `rdma_loopback_test` **clean under ThreadSanitizer**.