### PR TITLE
perf(store): persistent CLOCK hand + bounded eviction work (#4)

### DIFF
--- a/src/kv_store.cc
+++ b/src/kv_store.cc
@@ -210,32 +210,52 @@ void KVStore::RebuildIndex() {  // constructor-time, single-threaded: no locks
     uint64_t sz = static_cast<uint64_t>(fs::file_size(it->path(), ec));
     Shard& sh = ShardFor(fname);
     sh.ring.push_front(fname);
-    sh.index.try_emplace(fname, it->path().string(), sz, sh.ring.begin());
+    sh.index.try_emplace(fname, it->path().string(), sz);
     sh.used_bytes += sz;
   }
 }
 
+// Advance the CLOCK hand one step toward the front (newer). Past the front,
+// return end() so the next iteration wraps back to the tail (oldest).
+static std::list<std::string>::iterator HandNext(
+    std::list<std::string>& ring, std::list<std::string>::iterator it) {
+  return (it == ring.begin()) ? ring.end() : std::prev(it);
+}
+
 // CLOCK second-chance eviction within one shard (exclusive lock held). A newly
-// inserted entry starts unreferenced; an access (read lock) sets its bit. The
-// hand sweeps from the ring tail: a referenced entry is cleared and given a
-// second chance (spliced to the front), an unreferenced one is evicted. Each
-// full sweep clears every bit, so the loop always terminates.
+// inserted entry starts unreferenced; an access (read lock) sets its bit. A
+// PERSISTENT hand (sh.hand) sweeps tail->front across calls: a referenced entry
+// is cleared and given a second chance (hand advances, no list reorder), an
+// unreferenced one is evicted. Carrying the hand across Cache() calls amortizes
+// the scan so a hot, over-capacity shard does not re-clear the whole ring on
+// every write (the previous splice-to-front did). The per-call work is also
+// bounded (`limit`): after sweeping ~two full cycles without freeing enough, the
+// current victim is evicted regardless of its bit, guaranteeing forward progress
+// and termination even under ring/index drift.
 void KVStore::EvictLocked(Shard& sh) {
   // size() > 1 (not !empty()): never evict a shard's last entry, so a value larger
   // than the per-shard capacity still stays cached (it just keeps the shard over).
+  size_t spins = 0;
   while (sh.used_bytes > sh.capacity && sh.ring.size() > 1) {
-    auto it = sh.index.find(sh.ring.back());
-    if (it == sh.index.end()) { sh.ring.pop_back(); continue; }  // ring/index drift (shouldn't happen)
-    if (it->second.referenced.load(std::memory_order_relaxed)) {
-      it->second.referenced.store(false, std::memory_order_relaxed);  // second chance
-      sh.ring.splice(sh.ring.begin(), sh.ring, std::prev(sh.ring.end()));
-      it->second.ring_it = sh.ring.begin();
+    const size_t limit = 2 * sh.ring.size();  // recomputed: ring shrinks as we evict
+    if (sh.hand == sh.ring.end()) sh.hand = std::prev(sh.ring.end());  // (re)start at tail
+    auto cur = sh.hand;
+    auto it = sh.index.find(*cur);
+    if (it == sh.index.end()) {  // ring/index drift (shouldn't happen): drop the node
+      sh.hand = HandNext(sh.ring, cur);
+      sh.ring.erase(cur);
       continue;
     }
+    if (it->second.referenced.load(std::memory_order_relaxed) && ++spins <= limit) {
+      it->second.referenced.store(false, std::memory_order_relaxed);  // second chance
+      sh.hand = HandNext(sh.ring, cur);
+      continue;
+    }
+    sh.hand = HandNext(sh.ring, cur);  // move off the victim before erasing it
     std::error_code ec;
     fs::remove(it->second.path, ec);
     sh.used_bytes -= it->second.size;
-    sh.ring.erase(it->second.ring_it);
+    sh.ring.erase(cur);
     sh.index.erase(it);
   }
 }
@@ -265,7 +285,7 @@ Status KVStore::Cache(const BlockKey& key, const void* data, size_t len) {
   fs::rename(tmp, full, ec);  // atomic publish
   if (ec) { fs::remove(tmp, ec); return Status::kIOError; }
   sh.ring.push_front(fname);
-  sh.index.try_emplace(fname, full.string(), len, sh.ring.begin());
+  sh.index.try_emplace(fname, full.string(), len);
   sh.used_bytes += len;
   EvictLocked(sh);
   return Status::kOk;

--- a/src/kv_store.h
+++ b/src/kv_store.h
@@ -70,10 +70,8 @@ class KVStore {
   struct Entry {
     std::string path;
     uint64_t size = 0;
-    std::list<std::string>::iterator ring_it;  // position in the shard's CLOCK ring
-    std::atomic<bool> referenced{false};        // CLOCK bit: set on access (read lock)
-    Entry(std::string p, uint64_t s, std::list<std::string>::iterator it)
-        : path(std::move(p)), size(s), ring_it(it) {}
+    std::atomic<bool> referenced{false};  // CLOCK bit: set on access (read lock)
+    Entry(std::string p, uint64_t s) : path(std::move(p)), size(s) {}
   };
   struct Shard {
     mutable std::shared_mutex mu;
@@ -81,6 +79,12 @@ class KVStore {
     std::list<std::string> ring;                    // CLOCK ring, front = newest
     uint64_t used_bytes = 0;
     uint64_t capacity = 0;
+    // Persistent CLOCK hand: the next eviction candidate, swept tail->front and
+    // wrapped. Carrying it across Cache() calls amortizes the second-chance scan
+    // so a hot, over-capacity shard does not re-clear the whole ring on every
+    // write. end() means "(re)start at the tail (oldest)".
+    std::list<std::string>::iterator hand;
+    Shard() : hand(ring.end()) {}
   };
 
   Shard& ShardFor(const std::string& fname) const;

--- a/tests/kv_store_test.cc
+++ b/tests/kv_store_test.cc
@@ -143,6 +143,30 @@ TEST_F(KVStoreTest, LruEvictsLeastRecentlyUsedWhenOverCapacity) {
   EXPECT_LE(s.UsedBytes(), 2200u);
 }
 
+// All-hot eviction: every resident entry is marked referenced right before each
+// new insert. The persistent CLOCK hand must still make progress — clear a cycle
+// of reference bits, then evict — and keep usage bounded. A naive guard could
+// loop forever (always finds a referenced entry) or let the shard grow without
+// bound; this pins that it does neither.
+TEST_F(KVStoreTest, EvictsUnderAllReferencedPressure) {
+  const uint64_t obj = 1000, cap = 5500;  // ~5 objects fit in one shard
+  KVStore s(Opts(cap, /*shards=*/1));
+  auto put = [&](uint64_t id) {
+    std::string v(obj, char('a' + (id % 20)));
+    return s.Cache(BlockKey{id, 0, 1}, v.data(), v.size());
+  };
+  auto touch = [&](uint64_t id) {
+    std::string out;
+    s.Range(BlockKey{id, 0, 1}, 0, 8, &out);  // sets the CLOCK bit if resident
+  };
+  for (uint64_t id = 1; id <= 40; ++id) {
+    for (uint64_t j = (id > 8 ? id - 8 : 1); j < id; ++j) touch(j);  // make all hot
+    ASSERT_EQ(put(id), Status::kOk) << "id=" << id;
+    EXPECT_LE(s.UsedBytes(), cap) << "id=" << id;  // eviction kept usage bounded
+  }
+  EXPECT_TRUE(s.IsCached(BlockKey{40, 0, 1}));  // the newest insert survives
+}
+
 TEST_F(KVStoreTest, ReloadFromDiskRebuildsIndex) {
   BlockKey k{55, 0, 1};
   std::string v = "persisted";


### PR DESCRIPTION
Addresses the O(ring-size)-per-write eviction scan flagged in the v1.0.0 review.

## Problem
`EvictLocked` restarted its scan at the ring tail on every call, and on a second chance it spliced the referenced entry to the front. On a hot, chronically over-capacity shard that re-clears much of the ring on every write — O(ring size) per `Cache()`.

## Fix
A **persistent CLOCK hand** (`sh.hand`) sweeps tail→front and is carried **across** `Cache()` calls:
- A referenced entry is cleared **in place** (no list reorder) and the hand advances.
- The next eviction resumes where the last left off, so the second-chance scan **amortizes** instead of repeating from scratch.
- Per-call work is **bounded**: after ~two full cycles without freeing enough (which can't normally happen under the exclusive eviction lock, but guards against ring/index drift), the current victim is evicted regardless of its bit — the loop always terminates and makes forward progress.

Also drops the now-unused `Entry::ring_it` (std::list iterators are stable, and eviction now erases via the hand).

## Safety / behavior
- Normal workloads unchanged: `LruEvictsLeastRecentlyUsedWhenOverCapacity` still passes (traced the new hand against it — same victim).
- Eviction holds the exclusive shard lock; readers set the CLOCK bit under the shared lock. `ConcurrentShardedReadWrite` passes and `kv_store_test` is **clean under ThreadSanitizer**.

## Tests
- New `EvictsUnderAllReferencedPressure`: every resident entry marked referenced before each insert; verifies eviction still progresses and usage stays bounded (a naive guard would loop forever or grow unbounded).
- Full suite **128/128** locally under `-DDFKV_WITH_RDMA=ON` (rxe0).