### PR TITLE
mds: epoch = membership content hash, not etcd revision (#7)

### DIFF
--- a/src/mds_server.cc
+++ b/src/mds_server.cc
@@ -100,7 +100,11 @@ Status MdsServer::ListMembers(const std::string& group, std::string* out) {
     if (DecodeMembers(kv.second.data(), kv.second.size(), &one, &e) && one.size() == 1)
       members.push_back(one[0]);
   }
-  *out = EncodeMembers(members, static_cast<uint64_t>(r->revision));
+  // Epoch = content hash of the member set, NOT etcd's global revision: the
+  // revision bumps on every cluster write (including unrelated groups), which
+  // would make clients rebuild their ring needlessly. The hash changes iff THIS
+  // group's membership content changes.
+  *out = EncodeMembers(members, MembersEpoch(members));
   return Status::kOk;
 }
 

--- a/src/membership.h
+++ b/src/membership.h
@@ -1,6 +1,7 @@
 #ifndef DFKV_MEMBERSHIP_H_
 #define DFKV_MEMBERSHIP_H_
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -68,6 +69,32 @@ inline bool DecodeMembers(const char* p, size_t n,
     out->push_back(std::move(m));
   }
   return true;
+}
+
+// Content epoch for a membership view: an order-independent 64-bit hash of the
+// member SET. Clients compare it to decide whether to rebuild their ring. The
+// MDS uses this instead of etcd's global revision, which bumps on ANY cluster
+// write (other groups too) and would trigger needless full-ring rebuilds. Sorting
+// by id makes the hash canonical regardless of etcd's return order; hashing every
+// field means a content-only change (e.g. an ip/weight edit) still bumps the epoch.
+inline uint64_t MembersEpoch(std::vector<MemberInfo> ms) {
+  std::sort(ms.begin(), ms.end(), [](const MemberInfo& a, const MemberInfo& b) {
+    return a.id < b.id;
+  });
+  uint64_t h = 1469598103934665603ull;  // FNV-1a 64-bit offset basis
+  auto mix = [&h](const void* p, size_t n) {
+    const unsigned char* b = static_cast<const unsigned char*>(p);
+    for (size_t i = 0; i < n; ++i) { h ^= b[i]; h *= 1099511628211ull; }
+  };
+  for (const auto& m : ms) {
+    uint32_t idn = static_cast<uint32_t>(m.id.size());
+    uint32_t ipn = static_cast<uint32_t>(m.ip.size());
+    mix(&idn, 4); mix(m.id.data(), m.id.size());  // length-prefixed: no field-boundary ambiguity
+    mix(&ipn, 4); mix(m.ip.data(), m.ip.size());
+    mix(&m.port, sizeof(m.port));
+    mix(&m.weight, sizeof(m.weight));
+  }
+  return h;
 }
 
 }  // namespace dfkv

--- a/tests/membership_test.cc
+++ b/tests/membership_test.cc
@@ -33,3 +33,39 @@ TEST(MembershipCodec, RejectsTruncated) {
     EXPECT_FALSE(DecodeMembers(buf.data(), cut, &got, &epoch)) << "cut=" << cut;
   EXPECT_TRUE(DecodeMembers(buf.data(), buf.size(), &got, &epoch));  // full = ok
 }
+
+TEST(MembersEpoch, OrderIndependentAndContentSensitive) {
+  std::vector<MemberInfo> a = {
+      {"n1", "10.0.0.1", 28000, 1},
+      {"n2", "10.0.0.2", 28000, 3},
+      {"n3", "10.0.0.3", 28000, 1},
+  };
+  std::vector<MemberInfo> reordered = {a[2], a[0], a[1]};
+  EXPECT_EQ(MembersEpoch(a), MembersEpoch(reordered)) << "order must not matter";
+
+  // Removing a member changes the epoch.
+  std::vector<MemberInfo> fewer = {a[0], a[1]};
+  EXPECT_NE(MembersEpoch(a), MembersEpoch(fewer));
+
+  // A content-only change (same ids) changes the epoch.
+  std::vector<MemberInfo> b = a;
+  b[1].weight = 7;  // was 3
+  EXPECT_NE(MembersEpoch(a), MembersEpoch(b));
+  std::vector<MemberInfo> c = a;
+  c[0].ip = "10.0.0.9";
+  EXPECT_NE(MembersEpoch(a), MembersEpoch(c));
+  std::vector<MemberInfo> d = a;
+  d[2].port = 28001;
+  EXPECT_NE(MembersEpoch(a), MembersEpoch(d));
+
+  // Stable across calls; empty set is deterministic.
+  EXPECT_EQ(MembersEpoch(a), MembersEpoch(a));
+  EXPECT_EQ(MembersEpoch({}), MembersEpoch({}));
+}
+
+TEST(MembersEpoch, NoFieldBoundaryCollision) {
+  // Length-prefixing must prevent "ab"+"c" hashing the same as "a"+"bc".
+  std::vector<MemberInfo> x = {{"ab", "c", 0, 0}};
+  std::vector<MemberInfo> y = {{"a", "bc", 0, 0}};
+  EXPECT_NE(MembersEpoch(x), MembersEpoch(y));
+}


### PR DESCRIPTION
From the v1.0.0 review.

`MdsServer::ListMembers` returned etcd's **global revision** as the membership epoch. Clients rebuild their consistent-hash ring whenever the epoch changes — but the global revision bumps on **every cluster write**, including writes to *unrelated groups*, so clients rebuilt their ring on churn that didn't change their membership.

Fix: `MembersEpoch()` — an order-independent FNV-1a hash over the **sorted member set** (`id`/`ip`/`port`/`weight`, length-prefixed so field boundaries can't alias). `ListMembers` returns that. The epoch now changes **iff this group's membership content changes**; content-only edits (ip/weight/port) are still detected. The poller only compares epochs for inequality, so a non-monotonic hash is fine.

**Tests:** new `MembersEpoch` cases — order-independence, add/remove + content-change sensitivity, no field-boundary collision, determinism. Full suite **130/130** locally (`-DDFKV_WITH_RDMA=ON`, rxe0). MDS↔etcd integration tests are gated on a real etcd (skipped locally and in CI), as before.