### PR TITLE
mds: move etcd I/O out of lease_mu_ in Upsert (#8)

### DIFF
--- a/src/mds_server.cc
+++ b/src/mds_server.cc
@@ -79,13 +79,30 @@ void MdsServer::AcceptLoop() {
 Status MdsServer::Upsert(const std::string& group, const MemberInfo& m) {
   std::string key = MemberKey(group, m.id);
   std::string val = EncodeMembers({m}, 0);
-  std::lock_guard<std::mutex> lk(lease_mu_);
-  auto it = leases_.find(key);
-  if (it != leases_.end() && etcd_.LeaseKeepAlive(it->second)) return Status::kOk;
+  // Look up this member's known lease under the lock, then do the BLOCKING etcd
+  // calls OUTSIDE it. Previously lease_mu_ was held across LeaseKeepAlive/Grant/Put,
+  // so every member's heartbeat serialized on one mutex held across network I/O —
+  // a slow etcd stalled all members' liveness. Now heartbeats for distinct members
+  // run in parallel; the lock only guards the in-memory {key->leaseID} map.
+  int64_t existing = 0;
+  bool have = false;
+  {
+    std::lock_guard<std::mutex> lk(lease_mu_);
+    auto it = leases_.find(key);
+    if (it != leases_.end()) { existing = it->second; have = true; }
+  }
+  if (have && etcd_.LeaseKeepAlive(existing)) return Status::kOk;  // fast path: refresh
+  // Slow path: (re)grant a lease and (re)write the member key. A same-key race
+  // here (two heartbeats both missing the lease) can briefly orphan one lease,
+  // which expires on its own via the TTL; same-key heartbeats are serial in
+  // practice (one node, one connection), so this is rare and harmless.
   auto lid = etcd_.LeaseGrant(kTtlSeconds);
   if (!lid) return Status::kIOError;
   if (!etcd_.Put(key, val, *lid)) return Status::kIOError;
-  leases_[key] = *lid;
+  {
+    std::lock_guard<std::mutex> lk(lease_mu_);
+    leases_[key] = *lid;
+  }
   return Status::kOk;
 }
 


### PR DESCRIPTION
From the v1.0.0 review (last of the medium items).

`MdsServer::Upsert` held `lease_mu_` across the **blocking** etcd calls (`LeaseKeepAlive` / `LeaseGrant` / `Put`). Every member's heartbeat therefore serialized on one mutex held across network I/O, so a slow etcd stalled the liveness refresh of **all** members (the lock can be held for a full etcd round-trip).

Fix: the lock now guards only the in-memory `{key -> leaseID}` map. Look up the lease under the lock, **release it**, do the etcd round-trip, then re-acquire briefly to store the new lease id. Heartbeats for distinct members run in parallel.

Edge case: a same-key re-grant race (two heartbeats both missing the lease) can briefly orphan one lease, which expires via its TTL. Same-key heartbeats are serial in practice (one node, one connection), so this is rare and harmless — documented in the code.

## Validation (against a real etcd)
Downloaded etcd 3.5 locally and ran the otherwise-skipped integration suite with `DFKV_TEST_ETCD=127.0.0.1:2379`:
- **All 25** MDS/etcd/registrar tests pass, incl. `MdsServer.RegisterThenListRoundTripsThroughEtcd`, `MdsRegistrar.BackgroundLoopRegistersAndKeepsAlive`, `MdsMemberPoller.PollFiresOnChangeAndDedupsByEpoch`.
- `mds_server_test` + `mds_registrar_test` (concurrent heartbeats) are **clean under ThreadSanitizer** against the real etcd — no race on `leases_`.

Full unit suite **130/130** locally (`-DDFKV_WITH_RDMA=ON`, rxe0).