### PR TITLE
rdma: NUMA-aware rail selection in client; deprecate plugin rail_affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ docs/lmcache/  LMCache connector docs (DESIGN · IMPLEMENTATION · DEPLOY)
   buffer; the client scatters the payload directly into the caller's buffer (e.g.
   a SGLang HiCache registered host page) — no intermediate copies.
 - **Optional pipelining** (`DFKV_RDMA_DEPTH=K`): K requests in flight per connection.
+- **NUMA-aware rail selection** (`DFKV_RDMA_NUMA=1`): pins buffers/serve-threads to
+  the rail's NUMA node AND, with a multi-rail `DFKV_RDMA_DEV`, picks a NUMA-local
+  rail per connection (falls back to round-robin over all rails when no local rail
+  exists). Off by default; vendor-neutral (sysfs + `sched_getcpu`, no libnuma/CUDA).
 - **HiCache v2** (PoolTransfer) for multi-pool models (Mamba/SWA/DeepSeek-V4).
 - **Packaging**: CPack (deb/rpm/tgz) + Dockerfile; **graceful shutdown**; leveled logging.
 

--- a/python/dfkv_hicache.py
+++ b/python/dfkv_hicache.py
@@ -118,28 +118,19 @@ class DfkvHiCache(HiCacheStorage):
             # its own env -- client depth must be <= server depth.
             if cfg.get("rdma_depth"):
                 os.environ["DFKV_RDMA_DEPTH"] = str(int(cfg["rdma_depth"]))
-            # Per-TP-rank RDMA rail affinity. SGLang's ranks all inherit one
-            # DFKV_RDMA_DEV; with rail_affinity each rank narrows to a single rail
-            # so the readers (every rank reads in MLA) spread deterministically
-            # across the available rails with NUMA locality, instead of each rank
-            # round-robining all rails. Writes are MLA rank0-only so unaffected;
-            # this lifts READ aggregate bandwidth. Also pins the client's buffers/
-            # serve-threads to that rail's NUMA node.
-            #
-            # NUMA-grouped BLOCK mapping (not modulo): contiguous blocks of ranks
-            # share a rail, so with a NUMA-ordered rail list (NUMA0 rails first)
-            # each rank lands on a rail on its own socket. Correct for both
-            # rails==ranks (e.g. 8x400G: block=1 -> rank i -> rail i, rails 0-3
-            # = NUMA0 / GPU0-3, rails 4-7 = NUMA1 / GPU4-7) and rails<ranks (e.g.
-            # 2x400G: block=4 -> ranks 0-3 -> rail0, ranks 4-7 -> rail1). Modulo
-            # would scatter a socket's ranks across both NUMA rails when rails<ranks.
+            # rail_affinity (per-tp_rank narrowing) is DEPRECATED and now a no-op:
+            # it keyed off tp_rank, which is always 0 under DP-attention (every rank
+            # is its own attention TP group of size 1), so it collapsed all ranks to
+            # one rail. NUMA-aware rail selection now lives in the C++ client: keep
+            # the full multi-rail DFKV_RDMA_DEV and set DFKV_RDMA_NUMA=1, and the
+            # client picks a NUMA-local rail per connection (works for TP and DP).
             if cfg.get("rail_affinity"):
-                rails = [d for d in os.environ.get("DFKV_RDMA_DEV", "").split(",") if d]
-                if rails:
-                    block = max(1, self.tp_size // len(rails))
-                    idx = min(self.tp_rank // block, len(rails) - 1)
-                    os.environ["DFKV_RDMA_DEV"] = rails[idx]
-                    os.environ.setdefault("DFKV_RDMA_NUMA", "1")
+                import sys as _sys
+                print("[dfkv] WARNING: 'rail_affinity' is deprecated and ignored; "
+                      "set DFKV_RDMA_NUMA=1 + multi-rail DFKV_RDMA_DEV for NUMA-aware "
+                      "rail selection in the client.", file=_sys.stderr, flush=True)
+            if cfg.get("rdma_numa"):
+                os.environ.setdefault("DFKV_RDMA_NUMA", "1")
             self._lib = _load_lib(cfg.get("lib_path"))
             flags = _FLAG_IS_MLA if self.is_mla else 0
             model_hash = int(cfg.get("model_hash", 0)) & 0xFFFFFFFFFFFFFFFF

--- a/src/numa_util.h
+++ b/src/numa_util.h
@@ -6,8 +6,10 @@
  * thread — to the NUMA node of its RDMA device, so each rail stays local.
  *
  * Opt-in via env DFKV_RDMA_NUMA (off by default; only meaningful on multi-socket
- * hosts). All ops are best-effort: unknown node / sysfs absent => no-op. Uses raw
- * syscalls + sysfs so there is no libnuma build dependency. */
+ * hosts). When on it ALSO drives NUMA-aware rail selection: the client prefers a
+ * rail on the calling thread's NUMA node (see rail_select.h / PickRail). All ops
+ * are best-effort: unknown node / sysfs absent => no-op / round-robin all rails.
+ * Uses raw syscalls + sysfs so there is no libnuma build dependency. */
 #ifndef DFKV_NUMA_UTIL_H_
 #define DFKV_NUMA_UTIL_H_
 

--- a/src/numa_util.h
+++ b/src/numa_util.h
@@ -83,6 +83,47 @@ inline void PinThreadToNode(int node) {
   if (CPU_COUNT(&set) > 0) ::sched_setaffinity(0, sizeof(set), &set);
 }
 
+// True if cpu id is present in a sysfs cpulist like "0-3,8-11" or "5".
+inline bool CpuInList(const char* list, int cpu) {
+  if (!list) return false;
+  const char* p = list;
+  while (*p) {
+    int lo = -1, hi = -1, consumed = 0;
+    if (std::sscanf(p, "%d-%d%n", &lo, &hi, &consumed) >= 2) {
+      if (cpu >= lo && cpu <= hi) return true;
+    } else if (std::sscanf(p, "%d%n", &lo, &consumed) >= 1) {
+      if (cpu == lo) return true;
+    } else {
+      break;
+    }
+    p += consumed;
+    while (*p == ',' || *p == ' ' || *p == '\n') ++p;
+  }
+  return false;
+}
+
+// NUMA node of the calling thread's current CPU (sysfs), or -1 if unknown/single.
+inline int CurrentNode() {
+  int cpu = ::sched_getcpu();
+  if (cpu < 0) return -1;
+  for (int node = 0; node < 256; ++node) {
+    char path[256];
+    std::snprintf(path, sizeof(path),
+                  "/sys/devices/system/node/node%d/cpulist", node);
+    FILE* f = std::fopen(path, "r");
+    if (!f) continue;
+    char buf[8192] = {0};
+    size_t n = std::fread(buf, 1, sizeof(buf) - 1, f);
+    std::fclose(f);
+    // If the list filled the buffer it was likely truncated mid-token; skip
+    // this node rather than risk parsing a severed range (degrades to -1 ->
+    // round-robin all rails, never a wrong NUMA classification).
+    if (n == sizeof(buf) - 1) continue;
+    if (n && CpuInList(buf, cpu)) return node;
+  }
+  return -1;
+}
+
 }  // namespace numa
 }  // namespace dfkv
 

--- a/src/rail_select.h
+++ b/src/rail_select.h
@@ -1,0 +1,31 @@
+/* Rail (RDMA device) selection for the multi-rail client. Pure + header-only so
+ * it is unit-testable without RDMA hardware or sysfs. */
+#ifndef DFKV_RAIL_SELECT_H_
+#define DFKV_RAIL_SELECT_H_
+
+#include <cstddef>
+#include <vector>
+
+namespace dfkv {
+namespace rdma {
+
+// Choose a device index into `dev_node` (NUMA node per device; -1 = unknown).
+// NUMA-aware: when numa_on && caller_node>=0 && some device sits on caller_node,
+// round-robin among THOSE devices (by rr_tick); otherwise round-robin across all.
+// Returns 0 if dev_node is empty (a sentinel — caller must not index an empty set).
+inline size_t PickRail(const std::vector<int>& dev_node, int caller_node,
+                       bool numa_on, size_t rr_tick) {
+  const size_t n = dev_node.size();
+  if (n == 0) return 0;
+  if (!numa_on || n == 1 || caller_node < 0) return rr_tick % n;
+  std::vector<size_t> local;
+  for (size_t i = 0; i < n; ++i)
+    if (dev_node[i] == caller_node) local.push_back(i);
+  if (local.empty()) return rr_tick % n;        // no NUMA-local rail -> all
+  return local[rr_tick % local.size()];
+}
+
+}  // namespace rdma
+}  // namespace dfkv
+
+#endif  // DFKV_RAIL_SELECT_H_

--- a/src/rdma_transport.cc
+++ b/src/rdma_transport.cc
@@ -8,6 +8,8 @@
 
 #include "net_util.h"     // Dial / WriteAll / ReadAll / Put*/Get*
 #include "rdma_verbs.h"   // RcEndpoint, QpInfo
+#include "numa_util.h"     // numa::DeviceNode / CurrentNode / Enabled
+#include "rail_select.h"   // rdma::PickRail
 
 namespace dfkv {
 
@@ -68,6 +70,8 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
     i = c + 1;
   }
   if (devs_.empty()) devs_.push_back("");  // first available device
+  for (const auto& d : devs_)
+    dev_node_.push_back(numa::DeviceNode(d.empty() ? nullptr : d.c_str()));
   const char* d = std::getenv("DFKV_RDMA_DEPTH");  // pipeline depth (must be <= server's)
   if (d && *d) { long v = std::strtol(d, nullptr, 10); if (v >= 1 && v <= 256) depth_ = (size_t)v; }
   connect_ms_ = EnvInt("DFKV_RDMA_CONNECT_MS", 3000);
@@ -106,8 +110,11 @@ RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, bool* from_
   int fd = net::Dial(node, connect_ms_, io_ms_);
   if (fd < 0) return nullptr;
 
-  // Round-robin a device for this connection (multi-rail spreads load over ports).
-  const std::string& dev = devs_[rr_.fetch_add(1, std::memory_order_relaxed) % devs_.size()];
+  // Pick a device for this connection: NUMA-aware when DFKV_RDMA_NUMA is on
+  // (prefer a rail on the calling thread's NUMA node), else round-robin all.
+  size_t tick = rr_.fetch_add(1, std::memory_order_relaxed);
+  const std::string& dev =
+      devs_[rdma::PickRail(dev_node_, numa::CurrentNode(), numa::Enabled(), tick)];
 
   auto* c = new Conn();
   if (!c->ep.Open(dev.empty() ? nullptr : dev.c_str(), max_msg_, depth_)) {

--- a/src/rdma_transport.h
+++ b/src/rdma_transport.h
@@ -77,6 +77,7 @@ class RdmaTransport : public Transport {
   int io_ms_ = 10000;                 // bootstrap TCP IO timeout (DFKV_RDMA_IO_MS)
   size_t pool_max_ = 256;             // idle conns kept per node (DFKV_RDMA_POOL_MAX)
   std::vector<std::string> devs_;     // RDMA devices (multi-rail); "" = first
+  std::vector<int> dev_node_;         // NUMA node per devs_ entry (-1 unknown)
   std::atomic<size_t> rr_{0};         // round-robin selector across devs_
 };
 

--- a/tests/numa_util_test.cc
+++ b/tests/numa_util_test.cc
@@ -1,0 +1,32 @@
+#include "numa_util.h"
+
+#include <gtest/gtest.h>
+
+using dfkv::numa::CpuInList;
+using dfkv::numa::CurrentNode;
+
+TEST(CpuInList, Ranges) {
+  EXPECT_TRUE(CpuInList("0-3,8-11", 2));
+  EXPECT_TRUE(CpuInList("0-3,8-11", 0));
+  EXPECT_TRUE(CpuInList("0-3,8-11", 3));
+  EXPECT_TRUE(CpuInList("0-3,8-11", 8));
+  EXPECT_TRUE(CpuInList("0-3,8-11", 11));
+  EXPECT_TRUE(CpuInList("0-3,8-11", 9));
+  EXPECT_FALSE(CpuInList("0-3,8-11", 5));
+  EXPECT_FALSE(CpuInList("0-3,8-11", 12));
+}
+
+TEST(CpuInList, SingletonsAndEdges) {
+  EXPECT_TRUE(CpuInList("5", 5));
+  EXPECT_FALSE(CpuInList("5", 6));
+  EXPECT_TRUE(CpuInList("48-95,144-191", 144));
+  EXPECT_FALSE(CpuInList("48-95,144-191", 96));
+  EXPECT_FALSE(CpuInList("", 0));
+  EXPECT_FALSE(CpuInList(nullptr, 0));
+}
+
+TEST(CurrentNode, BestEffortStableAndValid) {
+  int a = CurrentNode();
+  EXPECT_GE(a, -1);          // -1 (unknown/single) or a real node id
+  EXPECT_EQ(a, CurrentNode());  // stable across calls on a pinned/idle thread
+}

--- a/tests/python/test_dfkv_hicache.py
+++ b/tests/python/test_dfkv_hicache.py
@@ -180,23 +180,36 @@ class DingoFSHiCacheTest(unittest.TestCase):
             else:
                 os.environ["DFKV_RDMA_DEV"] = saved
 
-    def test_rail_affinity_8rails_rank_i_to_rail_i(self):
-        # 8 rails == 8 ranks: block=1 -> rank i pins to ib7s400p{i} (NUMA-aligned).
+    def test_rail_affinity_deprecated_is_noop_8rails(self):
+        # rail_affinity is DEPRECATED: it must NOT narrow DFKV_RDMA_DEV anymore.
+        # The full multi-rail list is preserved (the C++ client now selects a
+        # NUMA-local rail per connection). It also no longer forces DFKV_RDMA_NUMA.
         members, _, _ = self._node("rail8")
         rails = "ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7"
         dev, numa = self._rail_for(members, rails, tp_rank=3, tp_size=8)
-        self.assertEqual(dev, "ib7s400p3")
-        self.assertEqual(numa, "1")
+        self.assertEqual(dev, rails)   # unchanged: no per-rank narrowing
+        self.assertIsNone(numa)        # rail_affinity no longer sets DFKV_RDMA_NUMA
 
-    def test_rail_affinity_2rails_numa_block(self):
-        # 2 rails, 8 ranks: block=4 -> ranks 0-3 -> rail0(NUMA0),
-        # ranks 4-7 -> rail1(NUMA1). Modulo would put rank5 on rail1 too but rank2
-        # on rail0; block keeps each socket's ranks on one rail.
+    def test_rail_affinity_deprecated_is_noop_2rails(self):
+        # Regardless of tp_rank, the full rail list survives (no DP-attention collapse).
         members, _, _ = self._node("rail2")
-        rails = "ibA,ibB"  # ibA=NUMA0 first, ibB=NUMA1
-        self.assertEqual(self._rail_for(members, rails, tp_rank=2, tp_size=8)[0], "ibA")
-        self.assertEqual(self._rail_for(members, rails, tp_rank=5, tp_size=8)[0], "ibB")
-        self.assertEqual(self._rail_for(members, rails, tp_rank=7, tp_size=8)[0], "ibB")
+        rails = "ibA,ibB"
+        self.assertEqual(self._rail_for(members, rails, tp_rank=2, tp_size=8)[0], rails)
+        self.assertEqual(self._rail_for(members, rails, tp_rank=5, tp_size=8)[0], rails)
+        self.assertEqual(self._rail_for(members, rails, tp_rank=7, tp_size=8)[0], rails)
+
+    def test_rdma_numa_extra_config_sets_env(self):
+        # The new rdma_numa knob opts into client-side NUMA-aware rail selection
+        # by setting DFKV_RDMA_NUMA=1 (replaces rail_affinity's old side effect).
+        members, _, _ = self._node("rnuma")
+        os.environ.pop("DFKV_RDMA_NUMA", None)
+        try:
+            cfg = self._cfg(members)
+            cfg.extra_config["rdma_numa"] = True
+            dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+            self.assertEqual(os.environ.get("DFKV_RDMA_NUMA"), "1")
+        finally:
+            os.environ.pop("DFKV_RDMA_NUMA", None)
 
     def test_generic_get_roundtrip(self):
         # Generic (non zero-copy) set/get round-trips a page through dfkv.

--- a/tests/rail_select_test.cc
+++ b/tests/rail_select_test.cc
@@ -1,0 +1,57 @@
+#include "rail_select.h"
+
+#include <gtest/gtest.h>
+
+using dfkv::rdma::PickRail;
+
+TEST(PickRail, NumaOffRoundRobinsAll) {
+  std::vector<int> dn{0, 0, 1, 1};
+  for (size_t t = 0; t < 6; ++t)
+    EXPECT_EQ(PickRail(dn, /*caller=*/1, /*numa_on=*/false, t), t % 4);
+}
+
+TEST(PickRail, CallerUnknownRoundRobinsAll) {
+  std::vector<int> dn{0, 1};
+  EXPECT_EQ(PickRail(dn, -1, true, 0), 0u);
+  EXPECT_EQ(PickRail(dn, -1, true, 1), 1u);
+  EXPECT_EQ(PickRail(dn, -1, true, 2), 0u);
+}
+
+TEST(PickRail, SingleRailAlwaysZero) {
+  std::vector<int> dn{-1};
+  EXPECT_EQ(PickRail(dn, 0, true, 0), 0u);
+  EXPECT_EQ(PickRail(dn, 0, true, 7), 0u);
+}
+
+TEST(PickRail, PicksLocalSubsetNode1) {  // dev 2,3 are on NUMA1
+  std::vector<int> dn{0, 0, 1, 1};
+  EXPECT_EQ(PickRail(dn, 1, true, 0), 2u);
+  EXPECT_EQ(PickRail(dn, 1, true, 1), 3u);
+  EXPECT_EQ(PickRail(dn, 1, true, 2), 2u);
+}
+
+TEST(PickRail, PicksLocalSubsetNode0) {  // dev 0,1 are on NUMA0
+  std::vector<int> dn{0, 0, 1, 1};
+  EXPECT_EQ(PickRail(dn, 0, true, 0), 0u);
+  EXPECT_EQ(PickRail(dn, 0, true, 1), 1u);
+  EXPECT_EQ(PickRail(dn, 0, true, 2), 0u);
+}
+
+TEST(PickRail, NoLocalRailFallsBackToAll) {  // caller NUMA1 but both devs NUMA0
+  std::vector<int> dn{0, 0};
+  EXPECT_EQ(PickRail(dn, 1, true, 0), 0u);
+  EXPECT_EQ(PickRail(dn, 1, true, 1), 1u);
+  EXPECT_EQ(PickRail(dn, 1, true, 2), 0u);
+}
+
+TEST(PickRail, AllUnknownFallsBackToAll) {  // single-NUMA box: all -1
+  std::vector<int> dn{-1, -1};
+  EXPECT_EQ(PickRail(dn, 0, true, 0), 0u);
+  EXPECT_EQ(PickRail(dn, 0, true, 1), 1u);
+}
+
+TEST(PickRail, EmptyDeviceListReturnsZero) {
+  std::vector<int> dn{};
+  EXPECT_EQ(PickRail(dn, 0, true, 5), 0u);
+  EXPECT_EQ(PickRail(dn, -1, false, 0), 0u);
+}


### PR DESCRIPTION
## What

NUMA-aware IB rail selection in the C++ client. At connection setup the client now prefers a rail (RDMA device) on the **calling thread's NUMA node**; when no local rail exists it falls back to round-robin over all rails — identical to today's behavior. Selection lives below the C ABI, so **both** the SGLang HiCache plugin and the vLLM/LMCache connector benefit with no per-client code.

The SGLang plugin's old per-`tp_rank` `rail_affinity` is **deprecated to a no-op** (with a stderr warning). It keyed off `tp_rank`, which is always 0 under DP-attention (each rank is its own attention TP group of size 1), so it collapsed every rank onto a single rail. A new `rdma_numa` plugin knob sets `DFKV_RDMA_NUMA=1`.

## How

- `src/rail_select.h` (new): pure, header-only `PickRail(dev_node, caller_node, numa_on, rr_tick)` — unit-testable without RDMA/sysfs.
- `src/numa_util.h`: `CpuInList` (sysfs cpulist parse) + `CurrentNode` (calling-thread NUMA via `sched_getcpu` + `/sys`), vendor-neutral, best-effort (never errors; unknown ⇒ round-robin all).
- `src/rdma_transport.cc`: precompute per-rail NUMA in ctor; `Acquire` picks via `PickRail`. Selection only on new-connection setup (pooled connections unaffected); no new shared mutable state (`dev_node_` ctor-write/read-only, `rr_` already atomic).
- `DFKV_RDMA_NUMA=1` now drives both buffer/thread pinning (existing) and rail selection (new). Off by default.

## Tested

- New unit tests: `PickRail` (8 cases incl. empty/single/unknown/no-local-fallback) + `CpuInList`/`CurrentNode`.
- Full suite **146/146 green**; `rdma_loopback` clean under **TSan** (no data race).
- Plugin tests updated to assert the new no-op contract + `rdma_numa` env knob.

Server side unchanged (already `PinThreadToNode` per client-chosen rail). Variable-length get (`dfkv_get_auto`) is orthogonal — selection is below the C ABI, covering all ops.