### PR TITLE
feat(access-log): size-rotate the plugin access log to bound disk

### DIFF
--- a/docs/access_log.md
+++ b/docs/access_log.md
@@ -25,17 +25,30 @@
 
 ## 配置项
 
-三个开关。**优先级：`extra_config` 键 > 环境变量 > 默认值**（按每个开关独立解析）。
+**优先级：`extra_config` 键 > 环境变量 > 默认值**（按每个开关独立解析）。
 
 | 作用 | `extra_config` 键 | 环境变量 | 默认 |
 |---|---|---|---|
 | 开 / 关 | `access_log` | `DFKV_ACCESS_LOG_ENABLED` | 关 |
 | 日志路径 | `access_log_path` | `DFKV_ACCESS_LOG_PATH` | 空 → 写 stderr |
 | 慢操作阈值（微秒） | `access_log_threshold_us` | `DFKV_ACCESS_LOG_THRESHOLD_US` | `0`（全记） |
+| 单文件滚动大小（字节） | `access_log_max_bytes` | `DFKV_ACCESS_LOG_MAX_BYTES` | `134217728`（128MiB） |
+| 保留的滚动备份份数 | `access_log_backup_count` | `DFKV_ACCESS_LOG_BACKUP_COUNT` | `5` |
 
 - 开关取值接受 `1/true/yes/on`（大小写不敏感）或 JSON 里的 `1`/布尔。
 - `access_log_threshold_us` 设成比如 `1000`，则只记录耗时 ≥ 1ms 的操作，排查长尾很方便。
 - 配置在插件 `__init__` 里**运行时解析一次**（每进程首个实例生效，幂等）；不像 dingofs 在 import 时读 env。
+
+## 日志滚动与清理（自动，无需 logrotate）
+
+写文件时走 `RotatingFileHandler`，**按大小自动滚动并清理旧日志**，开着不管也不会撑爆盘：
+
+- 单文件写到 `access_log_max_bytes` 就滚动：`access.log` → `access.log.1` → `access.log.2` …，
+  超过 `access_log_backup_count` 份后**覆盖最旧的**。
+- 每个 TP rank 的磁盘占用上限 = `max_bytes × (backup_count + 1)`。默认 `128MiB × 6 ≈ 768MiB/rank`，到顶即循环覆盖。
+- 每个 rank 各写各的文件、各滚各的，**无跨进程滚动竞争**。
+- **逃生口**：`access_log_max_bytes=0` 关闭滚动，退化成单个无界文件（旧行为，需自己接 logrotate 清理）。
+- 滚动落盘动作在后台 `QueueListener` 线程里做，**不在热路径**。
 
 ## 使用方式
 
@@ -54,7 +67,8 @@ sglang serve ... \
     "layer_num":78, "head_num":1, "head_dim":576,
     "access_log":1,
     "access_log_path":"/var/log/dfkv/access.log",
-    "access_log_threshold_us":0 }'
+    "access_log_threshold_us":0,
+    "access_log_max_bytes":134217728, "access_log_backup_count":5 }'
 ```
 
 ### 方式 B — 环境变量（不想改启动 JSON 时，运维临时开启）
@@ -63,6 +77,8 @@ sglang serve ... \
 DFKV_ACCESS_LOG_ENABLED=1 \
 DFKV_ACCESS_LOG_PATH=/var/log/dfkv/access.log \
 DFKV_ACCESS_LOG_THRESHOLD_US=0 \
+DFKV_ACCESS_LOG_MAX_BYTES=134217728 \
+DFKV_ACCESS_LOG_BACKUP_COUNT=5 \
 sglang serve ...
 ```
 
@@ -109,11 +125,13 @@ SGLang 每个 TP rank 一个进程，会**同时写同一路径**。为避免互
 无需 GPU/torch，单测会拉起真实 `dfkv_server` 节点驱动插件：
 
 ```bash
-DFKV_BUILD=$(pwd)/build python3 tests/python/test_dfkv_hicache.py   # 含 8 个 access-log 用例
+DFKV_BUILD=$(pwd)/build python3 tests/python/test_dfkv_hicache.py   # 含 access-log + 滚动用例
+# 滚动用例不依赖 node/so，可单独快速跑：
+python3 -m unittest test_dfkv_hicache.DfkvAccessLogRotationTest -v
 ```
 
 ## 实现位置
 
 - [python/dfkv_access_log.py](../python/dfkv_access_log.py) — `configure()` / `access_log()` 上下文管理器、noop 单例、异步队列、格式化辅助。
 - [python/dfkv_hicache.py](../python/dfkv_hicache.py) — `__init__` 里调 `configure()`，并用 `with access_log(...)` 包住各继承接口。
-- [tests/python/test_dfkv_hicache.py](../tests/python/test_dfkv_hicache.py) — `DfkvAccessLogTest` 测试类。
+- [tests/python/test_dfkv_hicache.py](../tests/python/test_dfkv_hicache.py) — `DfkvAccessLogTest`（接口逐 op 日志）+ `DfkvAccessLogRotationTest`（滚动/清理）测试类。

--- a/python/dfkv_access_log.py
+++ b/python/dfkv_access_log.py
@@ -23,10 +23,20 @@ default:
     access_log (bool)         DFKV_ACCESS_LOG_ENABLED         off
     access_log_path (str)     DFKV_ACCESS_LOG_PATH            "" -> stderr
     access_log_threshold_us   DFKV_ACCESS_LOG_THRESHOLD_US    0 (log every call)
+    access_log_max_bytes      DFKV_ACCESS_LOG_MAX_BYTES       128*1024*1024 (128MiB)
+    access_log_backup_count   DFKV_ACCESS_LOG_BACKUP_COUNT    5
 
 ``access_log_path`` supports ``{rank}``/``{model}`` placeholders; if neither is
 present the path is auto-suffixed ``.r{rank}`` so the one-process-per-TP-rank
 SGLang layout never has two ranks corrupting a shared file.
+
+When a path is set the file is **size-rotated** via a ``RotatingFileHandler``:
+at ``max_bytes`` it rolls ``acc.log`` -> ``acc.log.1`` -> ... up to
+``backup_count`` backups, then overwrites the oldest. Disk per rank is therefore
+bounded by ``max_bytes * (backup_count + 1)`` (default ~768MiB), so an access log
+left on forever can never fill the disk. Set ``max_bytes=0`` to disable rotation
+and keep one unbounded file (the legacy behavior). Each TP rank owns its own file
+(and its own rotation), so there is no cross-process rollover race.
 
 Performance:
   - Disabled: ~tens of ns/call. A frozen _NoopLog singleton is returned, so the
@@ -121,9 +131,31 @@ def configure(cfg: Optional[dict], tp_rank: int = 0, model: str = "") -> None:
         _ENABLED = True
         return
 
+    # Size-based rotation so an enabled access log can never grow a single file
+    # unbounded. max_bytes=0 disables rotation (legacy single-file behavior, an
+    # escape hatch). Disk per rank is bounded by max_bytes * (backup_count + 1).
+    try:
+        max_bytes = int(_resolve(cfg, "access_log_max_bytes",
+                                 "DFKV_ACCESS_LOG_MAX_BYTES", 128 * 1024 * 1024))
+    except (TypeError, ValueError):
+        max_bytes = 128 * 1024 * 1024
+    try:
+        backup_count = int(_resolve(cfg, "access_log_backup_count",
+                                    "DFKV_ACCESS_LOG_BACKUP_COUNT", 5))
+    except (TypeError, ValueError):
+        backup_count = 5
+    if max_bytes < 0:
+        max_bytes = 0
+    if backup_count < 0:
+        backup_count = 0
+
     if path:
         try:
-            sink: logging.Handler = logging.FileHandler(path, mode="a")
+            if max_bytes > 0:
+                sink: logging.Handler = logging.handlers.RotatingFileHandler(
+                    path, mode="a", maxBytes=max_bytes, backupCount=backup_count)
+            else:
+                sink = logging.FileHandler(path, mode="a")  # rotation disabled
         except OSError as exc:
             sys.stderr.write(
                 f"[dfkv.access] cannot open {path!r}: {exc}; "

--- a/tests/python/test_dfkv_hicache.py
+++ b/tests/python/test_dfkv_hicache.py
@@ -547,5 +547,76 @@ class DfkvAccessLogTest(unittest.TestCase):
         self.assertIn("FAIL RuntimeError: boom", txt)
 
 
+class DfkvAccessLogRotationTest(unittest.TestCase):
+    """Size-based rotation of the access-log file (RotatingFileHandler).
+
+    Pure module-level: drives dfkv_access_log.configure + the logger directly, so
+    it needs no cache node / libdfkv.so (unlike DfkvAccessLogTest). Codifies that
+    an enabled access log no longer grows a single file unbounded."""
+
+    def setUp(self):
+        _reset_access_log()
+        self.tmp = tempfile.mkdtemp(prefix="dfkv_alog_rot_")
+
+    def tearDown(self):
+        _reset_access_log()
+
+    def _flush(self):
+        # stop() drains the queue (writing + rolling over remaining records) and
+        # joins the listener thread before we inspect the files.
+        if alog._listener is not None:
+            alog._listener.stop()
+            alog._listener = None
+
+    def _emit(self, n, nbytes=200):
+        line = "x" * nbytes
+        for _ in range(n):
+            alog._logger.info("%s", line)
+
+    def test_rotates_by_size_and_caps_backup_count(self):
+        path = os.path.join(self.tmp, "acc.{rank}.log")
+        alog.configure({"access_log": 1, "access_log_path": path,
+                        "access_log_max_bytes": 4096,
+                        "access_log_backup_count": 2}, tp_rank=0)
+        self.assertTrue(alog.is_enabled())
+        base = os.path.join(self.tmp, "acc.0.log")
+        self._emit(400)  # ~400 * ~225B = ~90KB >> 4KiB*3 cap -> many rollovers
+        self._flush()
+        # base + .1 + .2 only; .3 must never appear (backup_count=2 caps it)
+        self.assertTrue(os.path.exists(base))
+        self.assertTrue(os.path.exists(base + ".1"))
+        self.assertTrue(os.path.exists(base + ".2"))
+        self.assertFalse(os.path.exists(base + ".3"))
+        # disk is bounded: each retained file <= maxBytes (+ one line of slack)
+        for suffix in ("", ".1", ".2"):
+            self.assertLessEqual(os.path.getsize(base + suffix), 4096 + 512)
+
+    def test_max_bytes_zero_keeps_single_unbounded_file(self):
+        # Escape hatch: max_bytes=0 restores the legacy plain-FileHandler behavior
+        # (one file, no rotation) for anyone who wants it.
+        path = os.path.join(self.tmp, "acc.{rank}.log")
+        alog.configure({"access_log": 1, "access_log_path": path,
+                        "access_log_max_bytes": 0}, tp_rank=0)
+        base = os.path.join(self.tmp, "acc.0.log")
+        self._emit(200)
+        self._flush()
+        self.assertFalse(os.path.exists(base + ".1"))   # rotation disabled
+        self.assertGreater(os.path.getsize(base), 4096)  # grew past a rotation size
+
+    def test_defaults_enable_rotation(self):
+        # No explicit knobs -> rotation ON by default so disk is always bounded.
+        # The 128MiB default isn't reached here, so only the base file exists.
+        path = os.path.join(self.tmp, "acc.{rank}.log")
+        alog.configure({"access_log": 1, "access_log_path": path}, tp_rank=0)
+        import logging.handlers as _h
+        sink = alog._listener.handlers[0]  # capture before _flush() nulls listener
+        base = os.path.join(self.tmp, "acc.0.log")
+        self._emit(50)
+        self._flush()
+        self.assertIsInstance(sink, _h.RotatingFileHandler)
+        self.assertTrue(os.path.exists(base))
+        self.assertFalse(os.path.exists(base + ".1"))  # 128MiB default not reached
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

The SGLang dfkv plugin access log (`python/dfkv_access_log.py`) used a plain
`logging.FileHandler` in append mode: **one file per TP rank that grows unbounded
with no rotation or cleanup**. An access log left enabled for debugging would
eventually fill the disk; the only mitigation today is an external logrotate.

## Change

Swap the file sink to a `RotatingFileHandler` (size-based) with two new knobs,
resolved via the existing `extra_config` > env > default precedence:

| extra_config key | env fallback | default |
|---|---|---|
| `access_log_max_bytes` | `DFKV_ACCESS_LOG_MAX_BYTES` | 128MiB |
| `access_log_backup_count` | `DFKV_ACCESS_LOG_BACKUP_COUNT` | 5 |

- Disk per rank is now **bounded by `max_bytes * (backup_count + 1)`** (~768MiB
  default); at the cap the oldest backup is overwritten — no external logrotate
  needed.
- **Escape hatch:** `max_bytes=0` keeps the legacy single unbounded file.
- Each TP rank owns its own file and its own rotation → no cross-process rollover
  race. Rotation runs in the background `QueueListener` thread, off the hot path.
- **Plugin call sites untouched** — this is a sink swap inside `configure()` only.

## Tests

- New module-level `DfkvAccessLogRotationTest` (needs no cache node / `libdfkv.so`):
  rotation + backup-count cap, the `max_bytes=0` escape hatch, and
  rotation-on-by-default.
- Full `python_plugin` suite **26/26 green** after rebuild (no regression).

```
python3 -m unittest test_dfkv_hicache.DfkvAccessLogRotationTest -v   # fast, no deps
DFKV_BUILD=$(pwd)/build python3 -m unittest test_dfkv_hicache        # full suite
```

## Docs

`docs/access_log.md` updated: two new knobs in the config table + a "日志滚动与清理"
section documenting the per-rank disk bound and the escape hatch.