### PR TITLE
feat(metrics): embedded Prometheus /metrics endpoint (P0, no datapath impact)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ endif()
 
 add_library(dfkv_core STATIC ${DFKV_SRCS})
 target_include_directories(dfkv_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_compile_definitions(dfkv_core PRIVATE _GNU_SOURCE)  # O_DIRECT/fallocate in kv_store.cc
+target_compile_definitions(dfkv_core PRIVATE _GNU_SOURCE  # O_DIRECT/fallocate in kv_store.cc
+  DFKV_VERSION="${PROJECT_VERSION}")
 find_package(Threads REQUIRED)
 target_link_libraries(dfkv_core PUBLIC Threads::Threads)
 if(DFKV_WITH_RDMA)
@@ -49,7 +50,8 @@ endif()
 # C ABI shared lib for the Python (ctypes) plugin
 add_library(dfkv SHARED ${DFKV_SRCS})
 target_include_directories(dfkv PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_compile_definitions(dfkv PRIVATE _GNU_SOURCE)  # O_DIRECT/fallocate in kv_store.cc
+target_compile_definitions(dfkv PRIVATE _GNU_SOURCE  # O_DIRECT/fallocate in kv_store.cc
+  DFKV_VERSION="${PROJECT_VERSION}")
 target_link_libraries(dfkv PUBLIC Threads::Threads)
 if(DFKV_WITH_RDMA)
   target_compile_definitions(dfkv PUBLIC DFKV_WITH_RDMA)

--- a/docs/superpowers/plans/2026-06-17-dfkv-observability.md
+++ b/docs/superpowers/plans/2026-06-17-dfkv-observability.md
@@ -1,0 +1,190 @@
+# dfkv Observability (P0/P1/P2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans (inline, autonomous to v1.4.0 release). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make dfkv cluster/ring/node/IO/RPC observable (Prometheus-scrapeable server+MDS, cluster/ring CLI, client + RDMA metrics, plugin histograms) without touching datapath performance.
+
+**Architecture:** Relaxed-atomic counters on the hot path (existing pattern); 1/64-sampled latency via vDSO clock into a lock-free histogram; a tiny self-contained HTTP/1.0 `/metrics` responder on a dedicated thread/port (opt-in); client metrics surfaced through a new C ABI snapshot consumed by a sleeping plugin poller thread.
+
+**Tech Stack:** C++17 (atomics, std::thread, libibverbs), CMake/ctest/gtest, Python (prometheus_client, ctypes), GitHub PRs to dingodb/dfkv.
+
+**Design:** `docs/superpowers/specs/2026-06-17-dfkv-observability-design.md`
+
+**Delivery:** 5 PRs (A→E) each TDD'd, CI-green, squash-merged when `mergeStateStatus=CLEAN`; then bump v1.4.0 + GitHub release. Branch from clean main per PR, `feat/obs-*` naming (avoid `perf` prefix). Each PR: RED→GREEN→commit→push origin→`gh pr create --repo dingodb/dfkv`→wait CLEAN→`gh pr merge --squash --delete-branch`→sync main.
+
+---
+
+## PR-A — Embedded HTTP /metrics + MetricsText upgrade (branch: feat/obs-metrics-http)
+
+**Files:**
+- Create: `src/metrics_http.h`, `src/metrics_http.cc`
+- Create: `tests/metrics_http_test.cc`
+- Modify: `src/kv_node_server.h`, `src/kv_node_server.cc` (HELP/TYPE, labels, identity, uptime, build_info)
+- Modify: `src/dfkv_server_main.cc` (`--metrics-port`, identity wiring)
+- Modify: `CMakeLists.txt` (metrics_http in lib, new test)
+
+### Task A1: MetricsHttpServer
+- [ ] Test `tests/metrics_http_test.cc`: start `MetricsHttpServer([]{return "dfkv_x 1\n";})` on port 0; HTTP GET `/metrics` over a socket returns `200` + body contains `dfkv_x 1`; GET `/healthz` returns `200 ok`; GET `/bad` returns `404`.
+- [ ] Run → FAIL (no class).
+- [ ] Implement `metrics_http.{h,cc}`: ctor takes `std::function<std::string()> render`; `Start(int port)` binds INADDR_ANY, accept thread; per-conn read request line (until `\r\n`), parse method+path; route /metrics→200 text/plain + body, /healthz→200 "ok", else 404; `Stop()` shuts down + joins (mirror KvNodeServer Stop drain). `port()` accessor.
+- [ ] Run → PASS. Commit.
+
+### Task A2: MetricsText Prometheus upgrade + identity
+- [ ] Test in `tests/metrics_test.cc` (extend): a KvNodeServer with `set_identity("n1","g1")` → MetricsText contains `# TYPE dfkv_cache_hit_total counter`, `dfkv_cache_hit_total{node="n1",group="g1"} 0`, `dfkv_build_info{`, `dfkv_uptime_seconds`.
+- [ ] Run → FAIL.
+- [ ] Implement: add `set_identity(id,group)`, `start_time_` (set in ctor); rewrite `MetricsText()` to emit HELP/TYPE, label suffix helper `lbl()` (empty id → no braces), gauges (used_bytes/objects/disks/open_connections) vs counters (`_total`), `dfkv_build_info{version="<VER>",transport="rdma|tcp"} 1`, `dfkv_uptime_seconds`. Version from a `DFKV_VERSION` compile def (add in CMake `target_compile_definitions`).
+- [ ] Run → PASS. Commit.
+
+### Task A3: Wire --metrics-port into dfkv_server
+- [ ] Modify `dfkv_server_main.cc`: parse `--metrics-port`; if >0, construct `MetricsHttpServer([&srv]{return srv.MetricsText();})`, Start, log. Pass `--id`/`--group` to `srv.set_identity`. Stop on shutdown.
+- [ ] Manual smoke (in plan exec): start server with `--metrics-port`, `curl :PORT/metrics`. Add a line to `tests/tool_smoke.sh` if feasible (curl optional → guard).
+- [ ] Build all, run full ctest → green. Commit. Open PR-A (include the already-committed design doc commit on this branch).
+
+---
+
+## PR-B — Cluster/ring CLI + MDS metrics (branch: feat/obs-cluster-cli)
+
+**Files:**
+- Modify: `src/mds_server.h`, `src/mds_server.cc` (counters + MetricsText)
+- Create: `tests/mds_metrics_test.cc`
+- Modify: `src/dfkv_mds_main.cc` (`--metrics-port`)
+- Modify: `src/dfkvctl_main.cc` (`ring`, `stat --all`)
+- Modify: `src/tcp_transport.{h,cc}` if a ListMembers helper is needed for ctl
+- Modify: `CMakeLists.txt`
+
+### Task B1: MDS counters + MetricsText
+- [ ] Test `mds_metrics_test.cc`: drive `MdsServer` against a fake/real etcd path is heavy — instead unit-test a `MdsMetrics` struct (atomics + `Render()`), assert counters increment and `Render()` emits `dfkv_mds_list_requests_total`. Keep MdsServer wiring covered by existing mds_server_test (extend to assert MetricsText nonempty after a ListMembers).
+- [ ] Run → FAIL.
+- [ ] Implement: add atomics to MdsServer (`list_requests_`, `register_requests_`, `keepalives_`, `lease_grants_`, `etcd_errors_`, `members_gauge_` per group is hard → expose total members last-listed); increment at Upsert (register vs keepalive by op), ListMembers, etcd error returns. Add `MetricsText()`.
+- [ ] Run → PASS. Commit.
+
+### Task B2: dfkv_mds --metrics-port
+- [ ] Modify `dfkv_mds_main.cc`: `--metrics-port`; if >0 start MetricsHttpServer over `mds.MetricsText()`.
+- [ ] Build, smoke. Commit.
+
+### Task B3: dfkvctl ring
+- [ ] Test: extend `tests/tool_smoke.sh` — bring up MDS + 2 nodes registering, run `dfkvctl ring --mds <ep> --group default`, assert output has both node ids and a `vnodes` column. (If smoke infra too heavy for ring, add a focused unit on the ring-render function.)
+- [ ] Implement `ring` subcommand: query MDS ListMembers (reuse `MdsMemberPoller` one-shot or a direct `kListMembers` round-trip via TcpTransport), build `ConHash` with weights, print table: id, addr, weight; then per-node vnode count + share% from the ring.
+- [ ] Run → PASS. Commit.
+
+### Task B4: dfkvctl stat --all
+- [ ] Implement `stat --all --mds <eps> --group <g>`: discover members, for each `TcpTransport::Stats(addr)`, parse `dfkv_used_bytes`/`dfkv_objects`/`dfkv_cache_hit_total`/`dfkv_cache_miss_total`/etc, print per-node rows + aggregate totals + cluster hit-rate.
+- [ ] Smoke assert aggregate line present. Commit. Open PR-B.
+
+---
+
+## PR-C — Server-side depth metrics (branch: feat/obs-server-depth)
+
+**Files:**
+- Modify: `src/kv_store.h`, `src/kv_store.cc` (eviction/cache_full counters, per-disk surfaced via group)
+- Modify: `src/disk_cache_group.h`, `src/disk_cache_group.cc` (per-disk used/objects accessors, evict counters passthrough)
+- Create: `src/latency_hist.h` (lock-free sampled histogram)
+- Create: `tests/latency_hist_test.cc`
+- Modify: `src/kv_node_server.{h,cc}` (errors{op,status}, open_connections, latency sampling, per-disk in MetricsText, evict counters in MetricsText)
+- Modify: `tests/kv_store_test.cc` (eviction counter assertions)
+- Modify: `CMakeLists.txt`
+
+### Task C1: LatencyHist (lock-free, sampled record API)
+- [ ] Test `latency_hist_test.cc`: `LatencyHist h;` record 100 values across buckets via `h.Observe(seconds)`; assert `h.Count()==100`, `h.Sum()≈`, and `h.Render("dfkv_op_latency_seconds", "{op=\"get\"}")` emits `_bucket{le="..."}`, `_sum`, `_count` lines monotonic. Separately test the sampler: `Sampler s(64)` → `s.ShouldSample()` true exactly every 64th call.
+- [ ] Run → FAIL.
+- [ ] Implement `latency_hist.h`: fixed `static constexpr double kBounds[] = {50e-6,100e-6,250e-6,500e-6,1e-3,2.5e-3,5e-3,10e-3,25e-3,50e-3,100e-3}`; `std::atomic<uint64_t> buckets_[N+1]`, `_sum_us`, `_count`. `Observe(sec)`: linear/branch scan to bucket, relaxed inc. `Render(name,labels)`. `Sampler{atomic<uint64_t> seq; mask}` `ShouldSample(){return (seq.fetch_add(1,relaxed)&mask)==0;}`.
+- [ ] Run → PASS. Commit.
+
+### Task C2: KVStore eviction counters
+- [ ] Test `kv_store_test.cc`: tiny-capacity store, write enough to evict; assert `store.Evictions()>0` and `store.EvictedBytes()>0`; on a write that can't fit assert `store.CacheFull()` increments (if applicable to CLOCK path).
+- [ ] Run → FAIL.
+- [ ] Implement: atomics in KVStore incremented inside `EvictLocked` (count + bytes per evicted entry); expose `Evictions()/EvictedBytes()/CacheFull()`. DiskCacheGroup aggregates across stores; expose `Evictions()` etc + per-disk `DiskUsedBytes(i)`/`DiskObjects(i)`/`DiskPath(i)`.
+- [ ] Run → PASS. Commit.
+
+### Task C3: KvNodeServer depth wiring
+- [ ] Test (metrics_test extend): after a forced IO error path is hard; assert presence of new series in MetricsText: `dfkv_open_connections`, `dfkv_evictions_total`, `dfkv_op_latency_seconds_count`, `dfkv_disk_used_bytes{disk="..."}`. Assert open_connections increments under a live TCP conn (use existing client) then returns to 0 after close.
+- [ ] Run → FAIL.
+- [ ] Implement: `open_connections_` atomic (++ in AcceptLoop before handler, -- at handler end); `errors_` map keyed by (op,status) for kIOError/kInvalid (fixed small set → individual atomics: `put_io_err_`, `get_io_err_`, `invalid_`); latency: a `Sampler` + two `LatencyHist` (get/put), bracket in ProcessRequest/RangeInto/RangeDirect only when `sampler.ShouldSample()`; extend MetricsText to emit eviction, open_conns, latency, per-disk, errors.
+- [ ] Run → PASS, full ctest green. Commit. Open PR-C.
+
+---
+
+## PR-D — Client metrics + C ABI snapshot + plugin poller (branch: feat/obs-client-metrics)
+
+**Files:**
+- Create: `src/client_metrics.h`
+- Create: `tests/client_metrics_test.cc`
+- Modify: `src/peer_health.h` (mark_bad/mark_good counters)
+- Modify: `src/kv_client.{h,cc}` (hold ClientMetrics, increment per op/peer, Snapshot render)
+- Modify: `src/dfkv_c_api.{h,cc}` (`dfkv_stats_snapshot`)
+- Modify: `tests/c_api_test.cc` (snapshot smoke)
+- Modify: `python/dfkv_metrics.py` (client-snapshot poller: parse + delta + Counters), `python/dfkv_hicache.py` (start/stop poller thread)
+- Modify: `tests/python/test_dfkv_hicache.py` (poller parses snapshot, increments)
+- Modify: `CMakeLists.txt`
+
+### Task D1: ClientMetrics + PeerHealth counters
+- [ ] Test `client_metrics_test.cc`: `ClientMetrics m; m.OnGet(true); m.OnGet(false); m.OnError(Status::kIOError,"1.2.3.4:1"); m.OnRoute("1.2.3.4:1");` → `m.Render()` text contains `dfkv_client_get_hit_total 1`, `dfkv_client_get_miss_total 1`, `dfkv_client_errors_total{status="io"} 1`, `dfkv_client_peer_routed_total{peer="1.2.3.4:1"} 1`. PeerHealth: MarkBad/MarkGood increment `bad_total/good_total`.
+- [ ] Run → FAIL.
+- [ ] Implement `client_metrics.h`: atomics for put/get/exist calls, get_hit/get_miss, errors by status (fixed enum), and a peer map (mutex only on first-seen insert; value is struct of atomics) for routed/error per peer; `Render()`. Add counters to PeerHealth.
+- [ ] Run → PASS. Commit.
+
+### Task D2: Wire into KVClient
+- [ ] Test (kv_client_test extend): do a Put then Get(hit) then Get(miss) against a live node; `client.MetricsSnapshot()` contains get_hit_total ≥1 and peer_routed_total for the node addr.
+- [ ] Run → FAIL.
+- [ ] Implement: KVClient holds `ClientMetrics metrics_`; increment in Put/Get/GetAuto/Exist/Batch* (per-op + per-route + per-error); expose `std::string MetricsSnapshot() const`.
+- [ ] Run → PASS. Commit.
+
+### Task D3: C ABI dfkv_stats_snapshot
+- [ ] Test `c_api_test.cc`: open client, do ops, `int n = dfkv_stats_snapshot(c, buf, sizeof buf); assert n>0 && strstr(buf,"dfkv_client_get")`. cap=0 returns required length.
+- [ ] Run → FAIL.
+- [ ] Implement `dfkv_stats_snapshot` in c_api: render snapshot to string, copy into buf (≤cap), return full length. Declare in header.
+- [ ] Run → PASS. Commit.
+
+### Task D4: Plugin poller
+- [ ] Test (test_dfkv_hicache extend, module-level, no node needed where possible): feed `dfkv_metrics.ClientStatsPoller` a fake snapshot-provider returning two successive texts; assert it computes deltas and increments prometheus Counters / snapshot() reflects totals. Then an integration assert: DfkvHiCache with `client_stats_poll_s=0` starts no thread; >0 starts a daemon thread that stops on __del__.
+- [ ] Run → FAIL.
+- [ ] Implement: `dfkv_metrics.ClientStatsPoller(get_text_fn, interval_s)` thread: parse Prometheus lines → dict; diff vs last; `.inc(delta)` on mirrored Counters; `start()/stop()`. In DfkvHiCache.__init__ read `client_stats_poll_s` (extra_config/env, default 10), if >0 build poller with `lambda: _read_snapshot(self._lib,self._h)` and start; stop in __del__.
+- [ ] Run → PASS, full python suite + ctest green. Commit. Open PR-D.
+
+---
+
+## PR-E — RDMA counters + plugin histograms (branch: feat/obs-rdma-metrics)
+
+**Files:**
+- Modify: `src/rdma_server.{h,cc}` (completions/errors/active_conns/idle_reclaims atomics + accessors)
+- Modify: `src/rdma_transport.{h,cc}` (mr_registrations, per-rail rail_ops)
+- Modify: `src/kv_node_server.{h,cc}` + `dfkv_server_main.cc` (fold RDMA server counters into MetricsText via a getter callback)
+- Modify: `src/client_metrics.h` / kv_client to include transport rail/mr counters in snapshot
+- Modify: `python/dfkv_metrics.py` (Histogram set/get seconds, errors{op})
+- Modify: `python/dfkv_hicache.py` (observe duration into histogram in batch_set_v1/get_v1; count errors)
+- Modify: tests: `tests/rdma_loopback_test.cc` (counter asserts), `tests/python/test_dfkv_hicache.py` (histogram observed)
+- Modify: `CMakeLists.txt`
+
+### Task E1: RDMA server counters
+- [ ] Test `rdma_loopback_test.cc` (RDMA build only): after a loopback GET, `rserver.Completions()>0`, `rserver.ActiveConns()` tracked. Guard under DFKV_WITH_RDMA.
+- [ ] Run → FAIL.
+- [ ] Implement: atomics in RdmaServer incremented in Serve completion loop (`completions_`, on `wc.status!=SUCCESS` `completion_errors_`, active_conns ++/-- on Serve thread start/exit, `idle_reclaims_` on idle timeout path); accessors.
+- [ ] Run → PASS. Commit.
+
+### Task E2: RDMA client transport counters + fold into outputs
+- [ ] Test: rdma_transport: after RegisterMemory + an op, `mr_registrations_>0`; rail_ops indexed by dev. (loopback test).
+- [ ] Implement: counters in RdmaTransport (`mr_registrations_`, `rail_ops_[dev]`); expose via accessor; KVClient folds into snapshot; dfkv_server folds RdmaServer counters into MetricsText (pass a `std::function` getter to KvNodeServer or render in main and append).
+- [ ] Run → PASS. Commit.
+
+### Task E3: Plugin histograms + error counters
+- [ ] Test (test_dfkv_hicache): after batch_set_v1/get_v1, `_Metrics` snapshot exposes histogram counts; an induced FAIL increments `errors`.
+- [ ] Run → FAIL.
+- [ ] Implement: dfkv_metrics add `Histogram` (multiproc-safe) for set/get seconds + `errors` counter{op}; DfkvHiCache passes the measured duration (perf_counter, reuse access-log timing where on) into `on_set/on_get`; count errors on FAIL.
+- [ ] Run → PASS, full suite green. Commit. Open PR-E.
+
+---
+
+## M6 — Release v1.4.0
+
+- [ ] After A–E all merged + main synced: branch `release-1.4.0`, bump `VERSION` + CMake `project()` to 1.4.0, commit, PR, wait CLEAN, merge.
+- [ ] Annotated tag `v1.4.0` on merge commit, push upstream.
+- [ ] Wait for main CI run → download `dfkv-linux-x86_64` artifact (`dfkv-1.4.0-linux-x86_64.tar.gz`), sha256.
+- [ ] `gh release create v1.4.0 --repo dingodb/dfkv` with notes (P0/P1/P2 highlights, compatibility = no wire change / opt-in, validation incl. real-machine A/B bench) + artifact.
+- [ ] Optional real-machine A/B bench on hd03/hd04 (metrics-port on vs off) to confirm no datapath regression; record in release notes.
+
+## Perf-safety checklist (verify before E merge)
+- [ ] All hot-path counters are relaxed atomics (grep for any mutex on Range/Cache/Process/Serve path).
+- [ ] Latency only sampled (Sampler mask), only sampled ops call clock_gettime.
+- [ ] No per-byte counters; RDMA counters in completion loop only.
+- [ ] HTTP server on its own thread/port; render reads relaxed only.
+- [ ] Plugin poller is a sleeping daemon, interval-gated, off batch path.

--- a/docs/superpowers/specs/2026-06-17-dfkv-observability-design.md
+++ b/docs/superpowers/specs/2026-06-17-dfkv-observability-design.md
@@ -1,0 +1,122 @@
+# dfkv 可观测性增强设计（P0/P1/P2）
+
+> 2026-06-17 ｜ 目标版本 v1.4.0 ｜ 状态：已确认，待实现
+
+## 1. 背景与目标
+
+当前 dfkv 可观测性现状（v1.3.0）：
+
+- **服务端**：`KvNodeServer::MetricsText()` 11 个计数，只能经私有 `kStats` wire op 取（`dfkvctl stat <ip:port>` 单点），**Prometheus 无法抓取**。
+- **客户端**（`KVClient`）：**零指标**，仅 `PeerHealth` 内存表。
+- **MDS**：零指标。
+- **RDMA 层**：零导出计数。
+- **集群/环**：**完全无视角**——无法看整个集群、整个环、聚合健康；MDS 里有权威成员表但无读工具。
+- **插件**（Python）：已有 access log（逐 op + 耗时）+ 每 rank Prometheus 计数（set/get calls/pages/bytes/hits）——这层较完整。
+
+目标：补齐"看整个集群 / 整个环 / 具体 server 节点健康 / I/O / 接口调用统计"四个视角，**硬约束：不影响性能**（不碰 RDMA 数据面热路径吞吐/延迟）。
+
+## 2. 性能安全原则（最高约束）
+
+整个设计的每一项都必须满足：
+
+1. **热路径定义**：RDMA 数据面（`batch_get_v1`/`batch_set_v1` → C 客户端 → RDMA WRITE/READ）、TCP handler、`KVStore::Range/Cache`、`RdmaServer` 完成环。
+2. **计数器**：热路径上一律 `std::atomic<uint64_t>` 的 relaxed `fetch_add`——与现有 `kv_node_server.cc` 完全同模式。零锁、零分配、零 syscall。
+3. **延迟测量**：1/64 采样。一个 relaxed 原子序号计数器，`(seq & 63) == 0` 时才取 `clock_gettime(CLOCK_MONOTONIC)`（Linux vDSO，约 20ns，无 syscall），落无锁固定桶直方图。分支高度可预测，64 次只测 1 次 → 摊销近零。
+4. **HTTP `/metrics`**：独立端口 + 独立 accept 线程；仅在 Prometheus scrape 时把原子读成文本。与数据面线程零交互（除 relaxed load）。
+5. **文本序列化**：只读 relaxed load，发生在 scrape 线程，不在热路径。
+6. **插件客户端指标**：后台轮询线程（睡眠态，每 ~10s 醒一次读 C ABI 快照），不在 per-batch/per-page 路径上。
+7. **验证**：每个 PR 跑 RDMA Soft-RoCE loopback + ThreadSanitizer（CI 已有）；P2 完成后在 hd03/hd04 真机做 A/B 裸 bench（开/关 metrics-port），确认吞吐/延迟无回归。
+
+## 3. 分层设计
+
+### P0 — 集群/环可见性 + 服务端可抓取
+
+**3.0.1 内嵌 HTTP `/metrics`**（新文件 `src/metrics_http.{h,cc}`）
+- 极小 HTTP/1.0 响应器，复用 `net_util.h` 的 `ReadAll/WriteAll`。
+- 单 accept 线程；读请求行，路由：`GET /metrics` → 200 + Prometheus 文本；`GET /healthz` → 200 `ok`；其余 → 404。
+- 接口：`MetricsHttpServer(std::function<std::string()> render)`；`Start(int port)`；`Stop()`。`render` 回调由 `dfkv_server`/`dfkv_mds` 提供（分别返回各自的 MetricsText）。
+- `dfkv_server` 加 `--metrics-port <p>`（0/缺省 = 关，opt-in，默认不开端口保证零行为变化）。
+- `dfkv_mds` 同样加 `--metrics-port`。
+- 无第三方依赖（不引入 brpc/civetweb），自包含 ~80 行。
+
+**3.0.2 MetricsText 升级**（`kv_node_server.cc`）
+- 加 `# HELP`/`# TYPE`（counter/gauge 正确标注）。
+- 加节点身份 label：`{node="<id>",group="<g>"}`（id/group 经 `set_identity()` 由 main 传入；缺省空 label 省略）。
+- 新增：`dfkv_build_info{version,transport}` gauge(=1)、`dfkv_uptime_seconds`、`dfkv_start_time_seconds`。
+
+**3.0.3 集群/环读工具**（`dfkvctl_main.cc` 扩展）
+- `dfkvctl ring --mds <eps> --group <g>`：经 `MdsMemberPoller`/一次性 ListMembers 查成员表，打印 id / addr / weight / epoch；用 `ConHash` 重建环，打印每节点 vnode 数与占比（路由倾斜可见）。
+- `dfkvctl stat --all --mds <eps> --group <g>`：从 MDS 发现成员 → 逐节点 `Stats()`（TCP `kStats`）→ 解析关键字段 → 打印 per-node 表 + 集群聚合（总 used/cap、objects、命中率、bytes r/w）。
+- 兼容旧用法：`dfkvctl stat <ip:port>` 保持不变。
+
+**3.0.4 MDS 指标**（新增 MDS 侧 MetricsText）
+- `dfkv_mds_members{group}` gauge、`dfkv_mds_lease_grants_total`、`dfkv_mds_keepalives_total`、`dfkv_mds_etcd_errors_total`、`dfkv_mds_list_requests_total`、`dfkv_mds_register_requests_total`。
+- 全 relaxed atomic，在 `Upsert`/`ListMembers`/etcd 调用点自增。
+
+### P1 — 单节点深度 + 客户端指标
+
+**3.1.1 服务端深度**（`kv_node_server.{h,cc}` + `kv_store.{h,cc}`）
+- 淘汰计数（`KVStore` 暴露）：`dfkv_evictions_total`、`dfkv_evicted_bytes_total`、`dfkv_cache_full_total`（在 `EvictLocked` / 容量拒绝处自增）。
+- 错误分型：`dfkv_errors_total{op,status}`——对 `kIOError`/`kInvalid` 计数（`kNotFound` 已是 miss，不重复）。
+- 采样延迟直方图：`dfkv_op_latency_seconds{op="get|put"}`，桶边界（秒）：`50µs,100µs,250µs,500µs,1ms,2.5ms,5ms,10ms,25ms,50ms,100ms,+Inf`（12 桶）。固定 `std::atomic<uint64_t>` 数组 + `_sum`/`_count`。1/64 采样。
+- 连接 gauge：`dfkv_open_connections`（accept 处 +1，Handle 退出 -1，atomic）。
+- per-disk：`dfkv_disk_used_bytes{disk}`、`dfkv_disk_objects{disk}`——`DiskCacheGroup` 暴露 per-disk 视图，仅 scrape 时读。
+
+**3.1.2 客户端指标**（新 `src/client_metrics.h`，`KVClient` 持有）
+- 全 relaxed atomic：`put/get/exist` calls；`get_hit/get_miss`；`errors{status}`；per-peer `routed_total{peer}`、`error_total{peer}`（小 map，路由时自增——注意：per-peer 用 `mutex` 保护的 map 仅在**首次见到新 peer**时加锁建项，热路径命中已存在项走原子，避免热路径锁；或固定从 ring 成员预建项）。peer 熔断切换在 `PeerHealth::MarkBad/MarkGood` 计数。
+- C ABI：`int dfkv_stats_snapshot(dfkv_client_t c, char* buf, uint64_t cap)` → 写 Prometheus 文本（client-labeled），返回字节数（>cap 时返回所需长度，不写）。
+- **插件侧**（`dfkv_hicache.py` + `dfkv_metrics.py`）：`DfkvHiCache` 启一个 daemon 后台线程，每 `client_stats_poll_s`（默认 10s，0=关）调 `dfkv_stats_snapshot`，解析、对上次快照 diff、`.inc(delta)` 到 prometheus Counter（兼容 multiproc）。线程睡眠态，进程退出时优雅停。
+
+### P2 — RDMA 计数 + 插件直方图
+
+**3.2.1 RDMA 计数**（`rdma_server.cc` / `rdma_verbs.cc` / `rdma_transport.cc`）
+- Server（完成环里，非 per-byte）：`dfkv_rdma_completions_total`、`dfkv_rdma_completion_errors_total`、`dfkv_rdma_active_conns` gauge、`dfkv_rdma_idle_reclaims_total`。
+- Client transport：`dfkv_rdma_mr_registrations_total`、per-rail `dfkv_rdma_rail_ops_total{dev}`（在 `PickRail`/rr 选轨处自增）。
+- Server 计数并入 `dfkv_server` /metrics；client 计数并入 `dfkv_stats_snapshot`。
+
+**3.2.2 插件直方图 + 错误 label**（`dfkv_metrics.py`）
+- prometheus `Histogram`：`dfkv_client_set_seconds`/`dfkv_client_get_seconds{tp_rank}`——**复用 access log 已经用 `perf_counter` 算出的耗时**（per-batch 调用一次，非 per-page），`observe()` 零额外测量成本；access log 关闭时单独测一次 per-batch（可忽略）。
+- `dfkv_client_errors_total{op,tp_rank}`：从各接口 FAIL 结果自增。
+
+## 4. 交付方式与里程碑
+
+按 dfkv 既有节奏：**独立 PR / 维护者合 CLEAN / TDD**。
+
+| 阶段 | PR | 内容 | 主要测试 |
+|---|---|---|---|
+| M1 | PR-A | P0：HTTP `/metrics` + MetricsText 升级（server+mds） | `metrics_http_test`、`metrics_test` 扩展 |
+| M2 | PR-B | P0：`dfkvctl ring`/`stat --all` + MDS 指标 | `dfkvctl` smoke、mds metrics 单测 |
+| M3 | PR-C | P1：服务端深度（淘汰/错误/采样延迟/连接/per-disk） | `kv_store_test`、`kv_node_server` 指标单测 |
+| M4 | PR-D | P1：客户端指标 + C ABI 快照 + 插件轮询 | `client_metrics_test`、`c_api_test`、python 插件单测 |
+| M5 | PR-E | P2：RDMA 计数 + 插件直方图 | `rdma_loopback_test` 扩展、`dfkv_metrics` 单测 |
+| M6 | — | bump v1.4.0 + GitHub release（挂 portable artifact） | 全 ctest + 真机 A/B 裸 bench |
+
+每个 PR：从干净 main 开分支（`feat/obs-*`，避开 `perf` 前缀）→ TDD（先 RED 后 GREEN）→ push origin → PR 到 dingodb/dfkv → 等 `mergeStateStatus=CLEAN` → squash 合并 → 同步 main。全部合完后 M6 发版。
+
+PR 顺序有依赖：A→B（B 用 A 的 MetricsText/HTTP），C 独立，D 依赖（无强依赖，可在 C 后），E 依赖 server/client metrics 基座（A、D）。实际按 A,B,C,D,E 串行，简单稳妥。
+
+## 5. 兼容性
+
+- 全部**新增**，无 wire 协议变更——v1.3.0 server/client 完全兼容。
+- `--metrics-port` opt-in 默认关 → 不开端口时行为与 v1.3.0 完全一致。
+- 客户端快照 C ABI 为新增符号，旧插件不调用即无影响。
+- 插件轮询线程 `client_stats_poll_s=0` 可关。
+
+## 6. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 采样延迟仍碰热路径 | 1/64 + vDSO clock；P2 后真机 A/B 裸 bench 实测无回归方可发版 |
+| per-peer map 热路径加锁 | 命中已存在项走纯原子；仅新 peer 首见时加锁建项（ring 成员有限、稳态零加锁） |
+| HTTP 端点被滥用/暴露 | opt-in；仅 GET /metrics、/healthz；按部署网络隔离（同 cache 端口口径，见 DEPLOY.md） |
+| 插件 multiproc 下 Histogram | 复用 prometheus_client multiproc 支持的 Histogram 类型（文件聚合），不用自定义 collector |
+| TSan 报数据竞争 | 全 relaxed atomic；CI 每 PR 跑 TSan |
+
+## 7. 验收标准
+
+- Prometheus 能直接抓 `dfkv_server`/`dfkv_mds` 的 `/metrics`。
+- `dfkvctl ring` 一条命令看到整个环 + vnode 分布；`dfkvctl stat --all` 看到集群聚合。
+- 单节点可见：淘汰、错误分型、采样延迟 p50/p99、连接数、per-disk、RDMA 完成/错误/per-rail。
+- 客户端可见：per-op/per-peer 调用、命中、错误、熔断切换（经插件 /metrics）。
+- 真机 A/B 裸 bench：开 metrics-port vs 关，吞吐/延迟差异在噪声内（fails=0）。
+- 全 ctest + python 插件 + TSan + RDMA loopback 绿。

--- a/src/dfkv_server_main.cc
+++ b/src/dfkv_server_main.cc
@@ -15,6 +15,7 @@
 #include "kv_node_server.h"
 #include "log.h"
 #include "mds_registrar.h"
+#include "metrics_http.h"
 #ifdef DFKV_WITH_RDMA
 #include "rdma_server.h"
 #endif
@@ -29,7 +30,7 @@ int main(int argc, char** argv) {
   std::string dir = "/tmp/dfkv_node";
   std::string rdma_dev, mds, group = "default", node_id, advertise;
   int weight = 1;
-  int port = 0, rdma_port = -1;
+  int port = 0, rdma_port = -1, metrics_port = -1;
   unsigned long long cap = 1ull << 30;
   for (int i = 1; i + 1 < argc; i += 2) {
     if (!std::strcmp(argv[i], "--dir")) dir = argv[i + 1];
@@ -42,6 +43,7 @@ int main(int argc, char** argv) {
     else if (!std::strcmp(argv[i], "--id")) node_id = argv[i + 1];
     else if (!std::strcmp(argv[i], "--advertise")) advertise = argv[i + 1];
     else if (!std::strcmp(argv[i], "--weight")) weight = std::atoi(argv[i + 1]);
+    else if (!std::strcmp(argv[i], "--metrics-port")) metrics_port = std::atoi(argv[i + 1]);
   }
   (void)rdma_port;
   std::signal(SIGINT, OnSig);
@@ -57,12 +59,25 @@ int main(int argc, char** argv) {
   if (dirs.empty()) dirs.push_back(dir);
 
   KvNodeServer srv(dirs, cap);
+  // Identity for Prometheus labels: reuse the MDS --id/--group when present.
+  if (!node_id.empty() || group != "default") srv.set_identity(node_id, group);
   if (srv.Start(port) != Status::kOk) {
     std::fprintf(stderr, "failed to start on port %d\n", port);
     return 1;
   }
   std::printf("PORT %d\n", srv.port());
   std::fflush(stdout);
+
+  // Optional Prometheus /metrics endpoint on a dedicated port/thread (off the
+  // datapath). Absent --metrics-port => no listener, behavior unchanged.
+  std::unique_ptr<dfkv::MetricsHttpServer> mhttp;
+  if (metrics_port >= 0) {
+    mhttp = std::make_unique<dfkv::MetricsHttpServer>([&srv] { return srv.MetricsText(); });
+    if (mhttp->Start(metrics_port) == Status::kOk)
+      DFKV_LOG_INFO("dfkv_server /metrics on port " + std::to_string(mhttp->port()));
+    else
+      DFKV_LOG_WARN("dfkv_server /metrics failed to start on port " + std::to_string(metrics_port));
+  }
   DFKV_LOG_INFO("dfkv_server listening on port " + std::to_string(srv.port()) + ", dir=" + dir);
 
   // Announce the transport build mode loudly so a TCP-only binary (built without
@@ -125,6 +140,7 @@ int main(int argc, char** argv) {
 
   while (!g_stop) { struct timespec ts{0, 50 * 1000 * 1000}; nanosleep(&ts, nullptr); }
   DFKV_LOG_INFO("dfkv_server shutting down");
+  if (mhttp) mhttp->Stop();
   if (registrar) registrar->Stop();
 #ifdef DFKV_WITH_RDMA
   if (rsrv) rsrv->Stop();

--- a/src/kv_node_server.cc
+++ b/src/kv_node_server.cc
@@ -64,22 +64,54 @@ void KvNodeServer::Stop() {
   for (auto& t : threads) if (t.joinable()) t.join();
 }
 
+#ifndef DFKV_VERSION
+#define DFKV_VERSION "dev"
+#endif
+#ifdef DFKV_WITH_RDMA
+#define DFKV_BUILD_TRANSPORT "rdma"
+#else
+#define DFKV_BUILD_TRANSPORT "tcp"
+#endif
+
 std::string KvNodeServer::MetricsText() const {
-  auto line = [](const char* k, size_t v) {
-    return std::string(k) + " " + std::to_string(v) + "\n";
-  };
+  // Label suffix from node identity; empty (unlabeled) when identity is unset so
+  // a single-node scrape and older tooling keep the bare `metric N` form.
+  std::string lbl;
+  if (!node_id_.empty() || !node_group_.empty())
+    lbl = "{node=\"" + node_id_ + "\",group=\"" + node_group_ + "\"}";
   std::string s;
-  s += line("dfkv_cache_put_total", m_cache_put());
-  s += line("dfkv_cache_hit_total", m_cache_hit());
-  s += line("dfkv_cache_miss_total", m_cache_miss());
-  s += line("dfkv_exist_hit_total", m_exist_hit());
-  s += line("dfkv_exist_miss_total", m_exist_miss());
-  s += line("dfkv_bytes_written_total", bytes_written_.load(std::memory_order_relaxed));
-  s += line("dfkv_bytes_read_total", bytes_read_.load(std::memory_order_relaxed));
-  s += line("dfkv_accepts_total", AcceptCount());
-  s += line("dfkv_objects", group_.Count());
-  s += line("dfkv_used_bytes", group_.UsedBytes());
-  s += line("dfkv_disks", group_.DiskCount());
+  auto metric = [&](const char* name, const char* type, const char* help,
+                    uint64_t v) {
+    s += "# HELP "; s += name; s += " "; s += help; s += "\n";
+    s += "# TYPE "; s += name; s += " "; s += type; s += "\n";
+    s += name; s += lbl; s += " "; s += std::to_string(v); s += "\n";
+  };
+  // build/version + uptime
+  s += "# HELP dfkv_build_info Build and version info (constant 1)\n";
+  s += "# TYPE dfkv_build_info gauge\n";
+  s += std::string("dfkv_build_info{version=\"") + DFKV_VERSION +
+       "\",transport=\"" DFKV_BUILD_TRANSPORT "\"";
+  if (!node_id_.empty() || !node_group_.empty())
+    s += ",node=\"" + node_id_ + "\",group=\"" + node_group_ + "\"";
+  s += "} 1\n";
+  uint64_t up = std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::steady_clock::now() - start_time_).count();
+  metric("dfkv_uptime_seconds", "gauge", "Seconds since node start", up);
+  // counters
+  metric("dfkv_cache_put_total", "counter", "Cache (PUT) ops accepted", m_cache_put());
+  metric("dfkv_cache_hit_total", "counter", "Range (GET) ops that hit", m_cache_hit());
+  metric("dfkv_cache_miss_total", "counter", "Range (GET) ops that missed", m_cache_miss());
+  metric("dfkv_exist_hit_total", "counter", "Exist checks that hit", m_exist_hit());
+  metric("dfkv_exist_miss_total", "counter", "Exist checks that missed", m_exist_miss());
+  metric("dfkv_bytes_written_total", "counter", "Payload bytes written",
+         bytes_written_.load(std::memory_order_relaxed));
+  metric("dfkv_bytes_read_total", "counter", "Payload bytes read",
+         bytes_read_.load(std::memory_order_relaxed));
+  metric("dfkv_accepts_total", "counter", "TCP connections accepted", AcceptCount());
+  // gauges
+  metric("dfkv_objects", "gauge", "Cached objects on this node", group_.Count());
+  metric("dfkv_used_bytes", "gauge", "Bytes used on disk", group_.UsedBytes());
+  metric("dfkv_disks", "gauge", "Backing NVMe disks", group_.DiskCount());
   return s;
 }
 

--- a/src/kv_node_server.h
+++ b/src/kv_node_server.h
@@ -6,6 +6,7 @@
 #define DFKV_KV_NODE_SERVER_H_
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -32,6 +33,11 @@ class KvNodeServer {
   // Cluster member list this node advertises for discovery (kMembers wire op):
   // "name=ip:port,name=ip:port,...". Clients query any node to learn the cluster.
   void set_members(const std::string& members) { members_ = members; }
+  // Node identity for Prometheus labels. When unset, series are emitted unlabeled
+  // (back-compat with single-node scrapes / older tooling).
+  void set_identity(const std::string& id, const std::string& group) {
+    node_id_ = id; node_group_ = group;
+  }
   int port() const { return port_; }
   size_t Count() const { return group_.Count(); }
   uint64_t UsedBytes() const { return group_.UsedBytes(); }
@@ -72,6 +78,8 @@ class KvNodeServer {
   std::atomic<size_t> exist_hit_{0}, exist_miss_{0};
   std::atomic<size_t> bytes_written_{0}, bytes_read_{0};
   std::string members_;  // advertised cluster membership (kMembers)
+  std::string node_id_, node_group_;       // identity for Prometheus labels (optional)
+  std::chrono::steady_clock::time_point start_time_ = std::chrono::steady_clock::now();
 
   DiskCacheGroup group_;
   int listen_fd_ = -1;

--- a/src/metrics_http.cc
+++ b/src/metrics_http.cc
@@ -1,0 +1,109 @@
+#include "metrics_http.h"
+
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "net_util.h"
+
+namespace dfkv {
+
+MetricsHttpServer::~MetricsHttpServer() { Stop(); }
+
+Status MetricsHttpServer::Start(int port) {
+  listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (listen_fd_ < 0) return Status::kIOError;
+  int one = 1;
+  ::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+  sockaddr_in sa{};
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_ANY);
+  sa.sin_port = htons(static_cast<uint16_t>(port));
+  if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)) != 0) {
+    ::close(listen_fd_); listen_fd_ = -1; return Status::kIOError;
+  }
+  if (::listen(listen_fd_, 16) != 0) {
+    ::close(listen_fd_); listen_fd_ = -1; return Status::kIOError;
+  }
+  socklen_t sl = sizeof(sa);
+  ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&sa), &sl);
+  port_ = ntohs(sa.sin_port);
+  running_ = true;
+  accept_thread_ = std::thread([this] { AcceptLoop(); });
+  return Status::kOk;
+}
+
+void MetricsHttpServer::Stop() {
+  if (!running_.exchange(false)) return;  // idempotent
+  if (listen_fd_ >= 0) ::shutdown(listen_fd_, SHUT_RDWR);
+  if (accept_thread_.joinable()) accept_thread_.join();
+  if (listen_fd_ >= 0) { ::close(listen_fd_); listen_fd_ = -1; }
+  std::vector<int> fds;
+  std::vector<std::thread> threads;
+  {
+    std::lock_guard<std::mutex> lk(conn_mu_);
+    fds.assign(conn_fds_.begin(), conn_fds_.end());
+    threads.swap(conn_threads_);
+  }
+  for (int fd : fds) ::shutdown(fd, SHUT_RDWR);
+  for (auto& t : threads) if (t.joinable()) t.join();
+}
+
+void MetricsHttpServer::AcceptLoop() {
+  while (running_) {
+    int fd = ::accept(listen_fd_, nullptr, nullptr);
+    if (fd < 0) { if (!running_) break; continue; }
+    std::lock_guard<std::mutex> lk(conn_mu_);
+    conn_fds_.insert(fd);
+    conn_threads_.emplace_back([this, fd] {
+      Handle(fd);
+      { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
+      ::close(fd);
+    });
+  }
+}
+
+namespace {
+// Build an HTTP/1.0 response (Connection: close — we recv to EOF on the client).
+std::string Resp(const char* status_line, const char* ctype, const std::string& body) {
+  return std::string("HTTP/1.0 ") + status_line + "\r\n" +
+         "Content-Type: " + ctype + "\r\n" +
+         "Content-Length: " + std::to_string(body.size()) + "\r\n" +
+         "Connection: close\r\n\r\n" + body;
+}
+}  // namespace
+
+void MetricsHttpServer::Handle(int fd) {
+  // Read just the request line (up to CRLF). Headers/body are ignored — we only
+  // need method + path. Bound the read so a silent peer can't pin the thread.
+  std::string line;
+  char c;
+  size_t guard = 0;
+  while (guard++ < 8192) {
+    ssize_t r = ::recv(fd, &c, 1, 0);
+    if (r <= 0) return;  // peer closed / error
+    if (c == '\n') break;
+    if (c != '\r') line.push_back(c);
+  }
+  // line == "GET /path HTTP/1.x"
+  std::string path;
+  {
+    size_t s = line.find(' ');
+    size_t e = (s == std::string::npos) ? std::string::npos : line.find(' ', s + 1);
+    if (s != std::string::npos && e != std::string::npos) path = line.substr(s + 1, e - s - 1);
+  }
+  std::string out;
+  if (path == "/metrics") {
+    out = Resp("200 OK", "text/plain; version=0.0.4", render_ ? render_() : "");
+  } else if (path == "/healthz") {
+    out = Resp("200 OK", "text/plain", "ok\n");
+  } else {
+    out = Resp("404 Not Found", "text/plain", "not found\n");
+  }
+  net::WriteAll(fd, out.data(), out.size());
+}
+
+}  // namespace dfkv

--- a/src/metrics_http.h
+++ b/src/metrics_http.h
@@ -1,0 +1,50 @@
+/* MetricsHttpServer — a tiny, self-contained HTTP/1.0 responder that exposes a
+ * single render callback at GET /metrics (plus GET /healthz). No third-party HTTP
+ * dependency: it accepts on its own port and thread and is OFF the datapath, so a
+ * Prometheus scrape never touches the cache/RDMA hot path. Only the render
+ * callback's relaxed-atomic reads run per scrape. Opt-in (a daemon enables it via
+ * --metrics-port); when no port is given no listener exists and behavior is
+ * unchanged. */
+#ifndef DFKV_METRICS_HTTP_H_
+#define DFKV_METRICS_HTTP_H_
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "kv_store.h"  // Status
+
+namespace dfkv {
+
+class MetricsHttpServer {
+ public:
+  // render() returns the Prometheus exposition text served at /metrics. It is
+  // called once per scrape on the HTTP thread (never on the datapath).
+  explicit MetricsHttpServer(std::function<std::string()> render)
+      : render_(std::move(render)) {}
+  ~MetricsHttpServer();
+
+  Status Start(int port);  // port 0 => ephemeral; query with port()
+  void Stop();             // idempotent
+  int port() const { return port_; }
+
+ private:
+  void AcceptLoop();
+  void Handle(int fd);
+
+  std::function<std::string()> render_;
+  int listen_fd_ = -1;
+  int port_ = 0;
+  std::atomic<bool> running_{false};
+  std::thread accept_thread_;
+  std::mutex conn_mu_;
+  std::set<int> conn_fds_;
+  std::vector<std::thread> conn_threads_;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_METRICS_HTTP_H_

--- a/tests/metrics_http_test.cc
+++ b/tests/metrics_http_test.cc
@@ -1,0 +1,64 @@
+// TDD — tiny embedded HTTP /metrics responder.
+#include "metrics_http.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+
+#include "net_util.h"
+
+using namespace dfkv;  // NOLINT
+
+namespace {
+// Minimal HTTP/1.0 client: send one request, read the whole response (server
+// closes the connection after the body, so recv to EOF).
+std::string HttpGet(int port, const std::string& path) {
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 1000, 2000);
+  if (fd < 0) return "";
+  std::string req = "GET " + path + " HTTP/1.0\r\n\r\n";
+  if (!net::WriteAll(fd, req.data(), req.size())) { ::close(fd); return ""; }
+  std::string resp;
+  char buf[4096];
+  for (;;) {
+    ssize_t r = ::recv(fd, buf, sizeof(buf), 0);
+    if (r <= 0) break;
+    resp.append(buf, static_cast<size_t>(r));
+  }
+  ::close(fd);
+  return resp;
+}
+}  // namespace
+
+TEST(MetricsHttp, ServesMetricsHealthzAnd404) {
+  std::atomic<int> renders{0};
+  MetricsHttpServer srv([&renders] {
+    renders.fetch_add(1);
+    return std::string("dfkv_x 1\n");
+  });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int port = srv.port();
+  ASSERT_GT(port, 0);
+
+  std::string m = HttpGet(port, "/metrics");
+  EXPECT_NE(m.find("200"), std::string::npos) << m;
+  EXPECT_NE(m.find("dfkv_x 1"), std::string::npos) << m;
+  EXPECT_NE(m.find("text/plain"), std::string::npos) << m;
+  EXPECT_GE(renders.load(), 1);
+
+  std::string h = HttpGet(port, "/healthz");
+  EXPECT_NE(h.find("200"), std::string::npos) << h;
+  EXPECT_NE(h.find("ok"), std::string::npos) << h;
+
+  std::string nf = HttpGet(port, "/nope");
+  EXPECT_NE(nf.find("404"), std::string::npos) << nf;
+
+  srv.Stop();
+}
+
+TEST(MetricsHttp, StopIsIdempotent) {
+  MetricsHttpServer srv([] { return std::string("x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  srv.Stop();
+  srv.Stop();  // must not crash / hang
+}

--- a/tests/metrics_test.cc
+++ b/tests/metrics_test.cc
@@ -50,6 +50,34 @@ TEST(Metrics, CountersTrackOps) {
   s->Stop();
 }
 
+TEST(Metrics, PrometheusFormatAndIdentity) {
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_metrics_c";
+  auto s = Start(dir, &addr);
+  s->set_identity("n1", "g1");
+  std::string text = s->MetricsText();
+  // HELP/TYPE metadata present
+  EXPECT_NE(text.find("# TYPE dfkv_cache_hit_total counter"), std::string::npos) << text;
+  EXPECT_NE(text.find("# TYPE dfkv_used_bytes gauge"), std::string::npos) << text;
+  // identity labels applied to series
+  EXPECT_NE(text.find("dfkv_cache_hit_total{node=\"n1\",group=\"g1\"} 0"), std::string::npos) << text;
+  // build_info + uptime present
+  EXPECT_NE(text.find("dfkv_build_info{"), std::string::npos) << text;
+  EXPECT_NE(text.find("version=\""), std::string::npos) << text;
+  EXPECT_NE(text.find("dfkv_uptime_seconds"), std::string::npos) << text;
+  s->Stop();
+}
+
+TEST(Metrics, NoIdentityKeepsUnlabeledSeries) {
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_metrics_d";
+  auto s = Start(dir, &addr);  // no set_identity
+  std::string text = s->MetricsText();
+  // back-compat: bare metric line, no label braces
+  EXPECT_NE(text.find("dfkv_cache_hit_total 0"), std::string::npos) << text;
+  s->Stop();
+}
+
 TEST(Metrics, RemoteStatsOp) {
   std::string addr;
   auto dir = fs::temp_directory_path() / "dfkv_metrics_b";


### PR DESCRIPTION
First of 5 PRs implementing the observability design
(`docs/superpowers/specs/2026-06-17-dfkv-observability-design.md`) toward v1.4.0.

## What
- **Tiny embedded HTTP/1.0 `/metrics` responder** (`src/metrics_http.{h,cc}`): self-contained (no brpc/civetweb), own port + accept thread, serves `GET /metrics` and `GET /healthz`. **Off the datapath** — only the render callback's relaxed-atomic reads run per scrape.
- **`dfkv_server --metrics-port <p>`** (opt-in; absent ⇒ no listener, behavior unchanged). Identity (`--id`/`--group`) flows into Prometheus labels.
- **MetricsText upgraded to proper Prometheus exposition**: `# HELP`/`# TYPE`, counter vs gauge, optional `{node,group}` labels, plus `dfkv_build_info{version,transport}` and `dfkv_uptime_seconds`. **No identity set ⇒ bare unlabeled series** (back-compat preserved + tested).

## Perf
Zero hot-path impact: HTTP server is a separate thread/port; metric reads are relaxed atomics (existing pattern); nothing added to Cache/Range/Process.

## Tests
- `metrics_http_test`: serves /metrics + body, /healthz, 404; idempotent Stop.
- `metrics_test`: new Prometheus-format + identity-label test, and a back-compat test asserting unlabeled series when no identity.
- Full ctest **141/141** green; live `curl :PORT/metrics` verified.

## Compatibility
Pure addition, no wire-protocol change. Includes the design + implementation-plan docs for the whole P0/P1/P2 effort.