### PR TITLE
feat(obs): cluster/ring CLI + MDS metrics (P0)

### DIFF
--- a/src/con_hash.cc
+++ b/src/con_hash.cc
@@ -28,6 +28,12 @@ void ConHash::Build() {
   }
 }
 
+std::map<std::string, size_t> ConHash::NodePointCounts() const {
+  std::map<std::string, size_t> counts;
+  for (const auto& [point, name] : ring_) counts[name]++;
+  return counts;
+}
+
 bool ConHash::Lookup(const std::string& key, std::string* node) const {
   if (ring_.empty()) return false;
   uint32_t h = Md5_32(key);

--- a/src/con_hash.h
+++ b/src/con_hash.h
@@ -18,6 +18,10 @@ class ConHash {
   // Returns false when the ring is empty.
   bool Lookup(const std::string& key, std::string* node) const;
   size_t NodeCount() const { return nodes_.size(); }
+  size_t RingSize() const { return ring_.size(); }
+  // Ring points owned per node (the realized vnode distribution after hash
+  // collisions). Used by `dfkvctl ring` to show routing share. Off the datapath.
+  std::map<std::string, size_t> NodePointCounts() const;
 
  private:
   std::vector<std::pair<std::string, int>> nodes_;  // (name, weight)

--- a/src/dfkv_mds_main.cc
+++ b/src/dfkv_mds_main.cc
@@ -3,9 +3,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <memory>
 #include <string>
 
 #include "mds_server.h"
+#include "metrics_http.h"
 
 namespace {
 volatile sig_atomic_t g_stop = 0;
@@ -14,10 +16,11 @@ void OnSig(int) { g_stop = 1; }  // async-signal-safe: just set a flag
 
 int main(int argc, char** argv) {
   std::string etcd = "127.0.0.1:2379";
-  int port = 0;
+  int port = 0, metrics_port = -1;
   for (int i = 1; i + 1 < argc; i += 2) {
     if (!std::strcmp(argv[i], "--etcd")) etcd = argv[i + 1];
     else if (!std::strcmp(argv[i], "--listen")) port = std::atoi(argv[i + 1]);
+    else if (!std::strcmp(argv[i], "--metrics-port")) metrics_port = std::atoi(argv[i + 1]);
   }
   dfkv::MdsServer srv(etcd);
   std::signal(SIGINT, OnSig);
@@ -28,8 +31,17 @@ int main(int argc, char** argv) {
   }
   std::printf("dfkv_mds listening on %d, etcd=%s\n", srv.port(), etcd.c_str());
   std::fflush(stdout);
+  // Optional Prometheus /metrics on a dedicated port/thread. Absent => no listener.
+  std::unique_ptr<dfkv::MetricsHttpServer> mhttp;
+  if (metrics_port >= 0) {
+    mhttp = std::make_unique<dfkv::MetricsHttpServer>([&srv] { return srv.MetricsText(); });
+    if (mhttp->Start(metrics_port) == dfkv::Status::kOk)
+      std::printf("dfkv_mds /metrics on port %d\n", mhttp->port());
+    std::fflush(stdout);
+  }
   // poll flag from normal context (matches dfkv_server_main.cc)
   while (!g_stop) { struct timespec ts{0, 50 * 1000 * 1000}; nanosleep(&ts, nullptr); }
+  if (mhttp) mhttp->Stop();
   srv.Stop();  // called from the main thread, not the signal handler
   return 0;
 }

--- a/src/dfkvctl_main.cc
+++ b/src/dfkvctl_main.cc
@@ -3,18 +3,102 @@
  *   dfkvctl --members "n=ip:port,..." get   <key>
  *   dfkvctl --members "n=ip:port,..." exist <key>
  *   dfkvctl stat <node-ip:port>           # fetch a node's Prometheus metrics
+ *   dfkvctl ring --mds <ep,...> --group <g>          # show the cluster ring + vnode share
+ *   dfkvctl stat --all --mds <ep,...> --group <g>    # per-node metrics + cluster aggregate
  * Geometry flags (must match the writer for get to hit): --model_hash --page_size
  *   --dtype_tag --layer_num --head_num --head_dim --mla 0|1 --tp_size --tp_rank */
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
 
+#include "con_hash.h"
 #include "kv_client.h"
+#include "mds_member_poller.h"
+#include "membership.h"
+#include "prom_parse.h"
 #include "tcp_transport.h"
 #include "value_header.h"
 
 using namespace dfkv;  // NOLINT
+
+static std::vector<std::string> SplitCsv(const std::string& s) {
+  std::vector<std::string> out;
+  for (size_t i = 0, j; i <= s.size(); i = j + 1) {
+    j = s.find(',', i);
+    if (j == std::string::npos) j = s.size();
+    if (j > i) out.push_back(s.substr(i, j - i));
+  }
+  return out;
+}
+
+// One-shot MDS member query via the poller (PollOnce fires the callback on the
+// first epoch). Returns true if the MDS answered.
+static bool QueryMembers(const std::string& mds, const std::string& group,
+                         std::vector<MemberInfo>* out) {
+  auto eps = SplitCsv(mds);
+  if (eps.empty()) return false;
+  bool got = false;
+  MdsMemberPoller poller(eps, group,
+                         [&](const std::vector<MemberInfo>& ms) { *out = ms; got = true; },
+                         1000, 2000);
+  poller.PollOnce();
+  return got;
+}
+
+static int CmdRing(const std::string& mds, const std::string& group) {
+  if (mds.empty()) { std::fprintf(stderr, "ring needs --mds ip:port[,...]\n"); return 2; }
+  std::vector<MemberInfo> ms;
+  if (!QueryMembers(mds, group, &ms)) { std::fprintf(stderr, "ring: MDS query failed\n"); return 1; }
+  ConHash ring;
+  for (const auto& m : ms) ring.AddNode(m.id, m.weight);
+  ring.Build();
+  auto pc = ring.NodePointCounts();
+  size_t total = ring.RingSize();
+  std::printf("group=%s members=%zu ring_points=%zu\n", group.c_str(), ms.size(), total);
+  std::printf("%-16s %-22s %6s %8s %7s\n", "ID", "ADDR", "WEIGHT", "VNODES", "SHARE");
+  for (const auto& m : ms) {
+    std::string addr = m.ip + ":" + std::to_string(m.port);
+    size_t v = pc.count(m.id) ? pc[m.id] : 0;
+    double share = total ? 100.0 * static_cast<double>(v) / static_cast<double>(total) : 0.0;
+    std::printf("%-16s %-22s %6u %8zu %6.1f%%\n", m.id.c_str(), addr.c_str(), m.weight, v, share);
+  }
+  return 0;
+}
+
+static int CmdStatAll(const std::string& mds, const std::string& group) {
+  if (mds.empty()) { std::fprintf(stderr, "stat --all needs --mds ip:port[,...]\n"); return 2; }
+  std::vector<MemberInfo> ms;
+  if (!QueryMembers(mds, group, &ms)) { std::fprintf(stderr, "stat --all: MDS query failed\n"); return 1; }
+  TcpTransport t; t.set_timeouts(2000, 3000);
+  uint64_t T_used = 0, T_obj = 0, T_hit = 0, T_miss = 0, T_w = 0, T_r = 0;
+  std::printf("%-14s %-20s %10s %9s %9s %9s %6s\n",
+              "ID", "ADDR", "USED_MB", "OBJECTS", "HITS", "MISSES", "HIT%");
+  for (const auto& m : ms) {
+    std::string addr = m.ip + ":" + std::to_string(m.port), text;
+    if (t.Stats(addr, &text) != Status::kOk) {
+      std::printf("%-14s %-20s   (unreachable)\n", m.id.c_str(), addr.c_str());
+      continue;
+    }
+    uint64_t used = PromMetricValue(text, "dfkv_used_bytes");
+    uint64_t obj = PromMetricValue(text, "dfkv_objects");
+    uint64_t hit = PromMetricValue(text, "dfkv_cache_hit_total");
+    uint64_t miss = PromMetricValue(text, "dfkv_cache_miss_total");
+    uint64_t w = PromMetricValue(text, "dfkv_bytes_written_total");
+    uint64_t r = PromMetricValue(text, "dfkv_bytes_read_total");
+    double hr = (hit + miss) ? 100.0 * static_cast<double>(hit) / static_cast<double>(hit + miss) : 0.0;
+    std::printf("%-14s %-20s %10.1f %9llu %9llu %9llu %5.1f%%\n", m.id.c_str(), addr.c_str(),
+                used / 1048576.0, (unsigned long long)obj, (unsigned long long)hit,
+                (unsigned long long)miss, hr);
+    T_used += used; T_obj += obj; T_hit += hit; T_miss += miss; T_w += w; T_r += r;
+  }
+  double thr = (T_hit + T_miss) ? 100.0 * static_cast<double>(T_hit) / static_cast<double>(T_hit + T_miss) : 0.0;
+  std::printf("TOTAL used=%.1fMB objects=%llu hits=%llu misses=%llu hit%%=%.1f bytes_w=%llu bytes_r=%llu\n",
+              T_used / 1048576.0, (unsigned long long)T_obj, (unsigned long long)T_hit,
+              (unsigned long long)T_miss, thr, (unsigned long long)T_w, (unsigned long long)T_r);
+  return 0;
+}
 
 static std::vector<std::pair<std::string, std::string>> ParseMembers(const std::string& s) {
   std::vector<std::pair<std::string, std::string>> out;
@@ -35,12 +119,17 @@ int main(int argc, char** argv) {
   std::string members;
   uint64_t model_hash = 0x51;
   uint32_t page = 64, dtype = 0x46384534u, layer = 78, head = 1, hd = 576, tps = 8, tpr = 0, mla = 1;
+  std::string mds, group = "default";
+  bool all = false;
   std::vector<std::string> pos;
   for (int i = 1; i < argc; ++i) {
     std::string a = argv[i];
     auto nv = [&](uint64_t* d) { if (i + 1 < argc) *d = std::stoull(argv[++i]); };
     auto nv32 = [&](uint32_t* d) { if (i + 1 < argc) *d = (uint32_t)std::stoul(argv[++i]); };
     if (a == "--members" && i + 1 < argc) members = argv[++i];
+    else if (a == "--mds" && i + 1 < argc) mds = argv[++i];
+    else if (a == "--group" && i + 1 < argc) group = argv[++i];
+    else if (a == "--all") all = true;
     else if (a == "--model_hash") nv(&model_hash);
     else if (a == "--page_size") nv32(&page);
     else if (a == "--dtype_tag") nv32(&dtype);
@@ -52,11 +141,14 @@ int main(int argc, char** argv) {
     else if (a == "--mla") nv32(&mla);
     else pos.push_back(a);
   }
-  if (pos.empty()) { std::fprintf(stderr, "usage: dfkvctl [--members ...] put|get|exist|stat ...\n"); return 2; }
+  if (pos.empty()) { std::fprintf(stderr, "usage: dfkvctl [--members ...] put|get|exist|stat|ring ...\n"); return 2; }
   const std::string& cmd = pos[0];
 
+  if (cmd == "ring") return CmdRing(mds, group);
+
   if (cmd == "stat") {
-    if (pos.size() < 2) { std::fprintf(stderr, "stat <node-ip:port>\n"); return 2; }
+    if (all) return CmdStatAll(mds, group);
+    if (pos.size() < 2) { std::fprintf(stderr, "stat <node-ip:port>  |  stat --all --mds ...\n"); return 2; }
     TcpTransport t; std::string text;
     if (t.Stats(pos[1], &text) != Status::kOk) { std::fprintf(stderr, "stat failed\n"); return 1; }
     std::fputs(text.c_str(), stdout);

--- a/src/mds_metrics.h
+++ b/src/mds_metrics.h
@@ -1,0 +1,44 @@
+/* MdsMetrics — relaxed-atomic counters for the MDS, rendered as Prometheus text.
+ * Held by MdsServer and incremented at the register/heartbeat/list/etcd call
+ * sites. Kept in its own header so the counting + exposition format is unit-
+ * testable without standing up etcd. */
+#ifndef DFKV_MDS_METRICS_H_
+#define DFKV_MDS_METRICS_H_
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+
+namespace dfkv {
+
+struct MdsMetrics {
+  std::atomic<uint64_t> register_requests{0};
+  std::atomic<uint64_t> keepalives{0};
+  std::atomic<uint64_t> list_requests{0};
+  std::atomic<uint64_t> lease_grants{0};
+  std::atomic<uint64_t> etcd_errors{0};
+  std::atomic<uint64_t> members_last_list{0};  // members returned by the last ListMembers
+
+  std::string Render() const {
+    std::string s;
+    auto m = [&](const char* name, const char* type, const char* help, uint64_t v) {
+      s += "# HELP "; s += name; s += " "; s += help; s += "\n";
+      s += "# TYPE "; s += name; s += " "; s += type; s += "\n";
+      s += name; s += " "; s += std::to_string(v); s += "\n";
+    };
+    auto ld = [](const std::atomic<uint64_t>& a) {
+      return a.load(std::memory_order_relaxed);
+    };
+    m("dfkv_mds_register_requests_total", "counter", "Register ops received", ld(register_requests));
+    m("dfkv_mds_keepalives_total", "counter", "Heartbeat ops received", ld(keepalives));
+    m("dfkv_mds_list_requests_total", "counter", "ListMembers ops served", ld(list_requests));
+    m("dfkv_mds_lease_grants_total", "counter", "etcd lease grants issued", ld(lease_grants));
+    m("dfkv_mds_etcd_errors_total", "counter", "etcd I/O failures", ld(etcd_errors));
+    m("dfkv_mds_members", "gauge", "Members returned by the last ListMembers", ld(members_last_list));
+    return s;
+  }
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_MDS_METRICS_H_

--- a/src/mds_server.cc
+++ b/src/mds_server.cc
@@ -97,8 +97,9 @@ Status MdsServer::Upsert(const std::string& group, const MemberInfo& m) {
   // which expires on its own via the TTL; same-key heartbeats are serial in
   // practice (one node, one connection), so this is rare and harmless.
   auto lid = etcd_.LeaseGrant(kTtlSeconds);
-  if (!lid) return Status::kIOError;
-  if (!etcd_.Put(key, val, *lid)) return Status::kIOError;
+  if (!lid) { metrics_.etcd_errors.fetch_add(1, std::memory_order_relaxed); return Status::kIOError; }
+  metrics_.lease_grants.fetch_add(1, std::memory_order_relaxed);
+  if (!etcd_.Put(key, val, *lid)) { metrics_.etcd_errors.fetch_add(1, std::memory_order_relaxed); return Status::kIOError; }
   {
     std::lock_guard<std::mutex> lk(lease_mu_);
     leases_[key] = *lid;
@@ -107,9 +108,10 @@ Status MdsServer::Upsert(const std::string& group, const MemberInfo& m) {
 }
 
 Status MdsServer::ListMembers(const std::string& group, std::string* out) {
+  metrics_.list_requests.fetch_add(1, std::memory_order_relaxed);
   std::string prefix = "/dfkv/v1/groups/" + group + "/members/";
   auto r = etcd_.RangePrefix(prefix);
-  if (!r) return Status::kIOError;
+  if (!r) { metrics_.etcd_errors.fetch_add(1, std::memory_order_relaxed); return Status::kIOError; }
   std::vector<MemberInfo> members;
   for (const auto& kv : r->kvs) {
     std::vector<MemberInfo> one;
@@ -121,6 +123,7 @@ Status MdsServer::ListMembers(const std::string& group, std::string* out) {
   // revision bumps on every cluster write (including unrelated groups), which
   // would make clients rebuild their ring needlessly. The hash changes iff THIS
   // group's membership content changes.
+  metrics_.members_last_list.store(members.size(), std::memory_order_relaxed);
   *out = EncodeMembers(members, MembersEpoch(members));
   return Status::kOk;
 }
@@ -138,6 +141,10 @@ void MdsServer::Handle(int fd) {
     Status st = Status::kInvalid;
     WireOp op = static_cast<WireOp>(rq.op);
     if (op == WireOp::kRegister || op == WireOp::kHeartbeat) {
+      if (op == WireOp::kRegister)
+        metrics_.register_requests.fetch_add(1, std::memory_order_relaxed);
+      else
+        metrics_.keepalives.fetch_add(1, std::memory_order_relaxed);
       std::string group;
       MemberInfo m;
       if (DecodeMemberReq(payload.data(), rq.payload_len, &group, &m))

--- a/src/mds_server.h
+++ b/src/mds_server.h
@@ -11,6 +11,7 @@
 #include "etcd_client.h"
 #include "http_client.h"
 #include "kv_store.h"
+#include "mds_metrics.h"
 #include "membership.h"
 
 namespace dfkv {
@@ -28,6 +29,7 @@ class MdsServer {
   Status Start(int port);
   void Stop();
   int port() const { return port_; }
+  std::string MetricsText() const { return metrics_.Render(); }
 
   static constexpr int kTtlSeconds = 30;
 
@@ -49,6 +51,7 @@ class MdsServer {
   std::vector<std::thread> conn_threads_;
   std::mutex lease_mu_;
   std::map<std::string, int64_t> leases_;
+  MdsMetrics metrics_;
 };
 
 }  // namespace dfkv

--- a/src/prom_parse.h
+++ b/src/prom_parse.h
@@ -1,0 +1,39 @@
+/* Minimal Prometheus exposition value extractor for client tooling (dfkvctl
+ * stat --all). Finds the sample line for an exact metric name — with or without
+ * a {label} set — and returns its trailing uint64 value. Skips # HELP/# TYPE.
+ * Not on any datapath. */
+#ifndef DFKV_PROM_PARSE_H_
+#define DFKV_PROM_PARSE_H_
+
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+
+namespace dfkv {
+
+// Returns the value of the first sample line whose metric name == `name`
+// (followed by ' ' or '{'); 0 if not present.
+inline uint64_t PromMetricValue(const std::string& text, const std::string& name) {
+  size_t pos = 0;
+  while (pos < text.size()) {
+    size_t eol = text.find('\n', pos);
+    size_t len = (eol == std::string::npos) ? text.size() - pos : eol - pos;
+    if (len > name.size() && text.compare(pos, name.size(), name) == 0) {
+      char after = text[pos + name.size()];
+      if ((after == ' ' || after == '{') && text[pos] != '#') {
+        // value is the token after the last space on the line
+        size_t line_end = pos + len;
+        size_t sp = text.rfind(' ', line_end - 1);
+        if (sp != std::string::npos && sp + 1 < line_end)
+          return std::strtoull(text.c_str() + sp + 1, nullptr, 10);
+      }
+    }
+    if (eol == std::string::npos) break;
+    pos = eol + 1;
+  }
+  return 0;
+}
+
+}  // namespace dfkv
+
+#endif  // DFKV_PROM_PARSE_H_

--- a/tests/con_hash_test.cc
+++ b/tests/con_hash_test.cc
@@ -69,6 +69,18 @@ TEST(ConHash, AddingNodeRemapsOnlyAFraction) {
   EXPECT_GT(frac, 0.05);
 }
 
+TEST(ConHash, NodePointCountsReflectWeightAndSumToRing) {
+  ConHash ring;
+  ring.AddNode("light", 1);
+  ring.AddNode("heavy", 3);
+  ring.Build();
+  auto pc = ring.NodePointCounts();
+  ASSERT_EQ(pc.size(), 2u);
+  // points sum to the realized ring size; heavy (weight 3) owns more vnodes
+  EXPECT_EQ(pc["light"] + pc["heavy"], ring.RingSize());
+  EXPECT_GT(pc["heavy"], pc["light"] * 2);
+}
+
 TEST(ConHash, WeightShiftsShareProportionally) {
   ConHash ring;
   ring.AddNode("light", 1);

--- a/tests/mds_metrics_test.cc
+++ b/tests/mds_metrics_test.cc
@@ -1,0 +1,27 @@
+// TDD — MDS metrics counters + Prometheus exposition (no etcd needed).
+#include "mds_metrics.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace dfkv;  // NOLINT
+
+TEST(MdsMetrics, CountsAndRenders) {
+  MdsMetrics m;
+  m.register_requests.fetch_add(2);
+  m.keepalives.fetch_add(5);
+  m.list_requests.fetch_add(3);
+  m.lease_grants.fetch_add(1);
+  m.etcd_errors.fetch_add(0);
+  m.members_last_list.store(4);
+
+  std::string t = m.Render();
+  EXPECT_NE(t.find("# TYPE dfkv_mds_list_requests_total counter"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_mds_register_requests_total 2"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_mds_keepalives_total 5"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_mds_list_requests_total 3"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_mds_lease_grants_total 1"), std::string::npos) << t;
+  EXPECT_NE(t.find("# TYPE dfkv_mds_members gauge"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_mds_members 4"), std::string::npos) << t;
+}

--- a/tests/prom_parse_test.cc
+++ b/tests/prom_parse_test.cc
@@ -1,0 +1,30 @@
+// TDD — Prometheus value extractor used by `dfkvctl stat --all`.
+#include "prom_parse.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfkv;  // NOLINT
+
+TEST(PromParse, BareAndLabeledAndMissing) {
+  std::string text =
+      "# HELP dfkv_used_bytes Bytes used on disk\n"
+      "# TYPE dfkv_used_bytes gauge\n"
+      "dfkv_used_bytes 4096\n"
+      "# TYPE dfkv_cache_hit_total counter\n"
+      "dfkv_cache_hit_total{node=\"n1\",group=\"g\"} 17\n"
+      "dfkv_objects{node=\"n1\"} 3\n";
+  EXPECT_EQ(PromMetricValue(text, "dfkv_used_bytes"), 4096u);
+  EXPECT_EQ(PromMetricValue(text, "dfkv_cache_hit_total"), 17u);
+  EXPECT_EQ(PromMetricValue(text, "dfkv_objects"), 3u);
+  EXPECT_EQ(PromMetricValue(text, "dfkv_missing_metric"), 0u);
+}
+
+TEST(PromParse, DoesNotMatchPrefixOrHelpLine) {
+  std::string text =
+      "# HELP dfkv_cache_hit_total help\n"
+      "dfkv_cache_hit_total 5\n"
+      "dfkv_cache_hit_total_extra 999\n";
+  // exact-name match only: must not pick up _extra, must not read the HELP line
+  EXPECT_EQ(PromMetricValue(text, "dfkv_cache_hit_total"), 5u);
+  EXPECT_EQ(PromMetricValue(text, "dfkv_cache_hit_total_extra"), 999u);
+}


### PR DESCRIPTION
PR 2/5 of the observability effort (toward v1.4.0). Adds the "see the whole
cluster / whole ring" views and makes the MDS scrapeable.

## What
- **MDS metrics** (`src/mds_metrics.h`): relaxed-atomic counters (`dfkv_mds_register_requests_total`, `keepalives_total`, `list_requests_total`, `lease_grants_total`, `etcd_errors_total`, `dfkv_mds_members` gauge), wired into `MdsServer`. `MdsServer::MetricsText()`.
- **`dfkv_mds --metrics-port`**: reuses the embedded HTTP responder from PR #29.
- **`dfkvctl ring --mds <eps> --group <g>`**: queries MDS membership, prints the consistent-hash ring — id / addr / weight / **vnode count + routing share %**.
- **`dfkvctl stat --all --mds <eps> --group <g>`**: discovers members, scrapes each node, prints per-node table + **cluster aggregate**.
- Supporting: `ConHash::NodePointCounts()`/`RingSize()`; `src/prom_parse.h` `PromMetricValue()`.

## Perf
MDS counters are relaxed atomics off any datapath; ring/stat-all are client-side CLI only.

## Tests
- `mds_metrics_test`, `prom_parse_test`, `con_hash_test` (NodePointCounts) added.
- Full ctest **145/145**; ring/stat-all failure paths smoke-verified. Live exercised on real MDS+etcd at deploy time.

## Compatibility
Pure addition, no wire-protocol change.