### PR TITLE
feat(obs): server-side depth metrics — sampled latency, errors, evictions, per-disk (P1)

### DIFF
--- a/src/disk_cache_group.cc
+++ b/src/disk_cache_group.cc
@@ -69,4 +69,16 @@ size_t DiskCacheGroup::Count() const {
   return t;
 }
 
+uint64_t DiskCacheGroup::Evictions() const {
+  uint64_t t = 0;
+  for (const auto& d : disks_) t += d->Evictions();
+  return t;
+}
+
+uint64_t DiskCacheGroup::EvictedBytes() const {
+  uint64_t t = 0;
+  for (const auto& d : disks_) t += d->EvictedBytes();
+  return t;
+}
+
 }  // namespace dfkv

--- a/src/disk_cache_group.h
+++ b/src/disk_cache_group.h
@@ -40,6 +40,12 @@ class DiskCacheGroup {
   uint64_t UsedBytes() const;   // summed across disks
   size_t Count() const;         // summed across disks
   size_t DiskCount() const { return disks_.size(); }
+  uint64_t Evictions() const;     // summed across disks
+  uint64_t EvictedBytes() const;  // summed across disks
+  // Per-disk views for fine-grained metrics (i in [0, DiskCount)).
+  const std::string& DiskPath(size_t i) const { return disks_[i]->Dir(); }
+  uint64_t DiskUsedBytes(size_t i) const { return disks_[i]->UsedBytes(); }
+  size_t DiskObjects(size_t i) const { return disks_[i]->Count(); }
 
  private:
   KVStore* Route(const BlockKey& key) const;

--- a/src/kv_node_server.cc
+++ b/src/kv_node_server.cc
@@ -1,5 +1,6 @@
 #include "kv_node_server.h"
 
+#include <chrono>
 #include <string>
 
 #include <vector>
@@ -8,6 +9,15 @@
 #include "transport.h"
 
 namespace dfkv {
+
+namespace {
+// Monotonic seconds; only read on the ~1/64 sampled ops, so the cost is amortized
+// away on the hot path.
+inline double NowSec() {
+  return std::chrono::duration<double>(
+             std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+}  // namespace
 
 KvNodeServer::KvNodeServer(const std::string& cache_dir, uint64_t capacity_bytes)
     : group_(DiskCacheGroup::Options{{cache_dir}, capacity_bytes}) {}
@@ -74,11 +84,18 @@ void KvNodeServer::Stop() {
 #endif
 
 std::string KvNodeServer::MetricsText() const {
-  // Label suffix from node identity; empty (unlabeled) when identity is unset so
-  // a single-node scrape and older tooling keep the bare `metric N` form.
-  std::string lbl;
+  // Node identity as an inner label set (no braces), empty when unset so a
+  // single-node scrape and older tooling keep the bare `metric N` form.
+  std::string idlabels;
   if (!node_id_.empty() || !node_group_.empty())
-    lbl = "{node=\"" + node_id_ + "\",group=\"" + node_group_ + "\"}";
+    idlabels = "node=\"" + node_id_ + "\",group=\"" + node_group_ + "\"";
+  // braces(extra): merge `extra` label set with the identity labels.
+  auto braces = [&](const std::string& extra) {
+    std::string in = extra;
+    if (!idlabels.empty()) in += (in.empty() ? "" : ",") + idlabels;
+    return in.empty() ? std::string() : "{" + in + "}";
+  };
+  const std::string lbl = braces("");
   std::string s;
   auto metric = [&](const char* name, const char* type, const char* help,
                     uint64_t v) {
@@ -86,6 +103,7 @@ std::string KvNodeServer::MetricsText() const {
     s += "# TYPE "; s += name; s += " "; s += type; s += "\n";
     s += name; s += lbl; s += " "; s += std::to_string(v); s += "\n";
   };
+  auto rd = [](const std::atomic<size_t>& a) { return a.load(std::memory_order_relaxed); };
   // build/version + uptime
   s += "# HELP dfkv_build_info Build and version info (constant 1)\n";
   s += "# TYPE dfkv_build_info gauge\n";
@@ -108,10 +126,45 @@ std::string KvNodeServer::MetricsText() const {
   metric("dfkv_bytes_read_total", "counter", "Payload bytes read",
          bytes_read_.load(std::memory_order_relaxed));
   metric("dfkv_accepts_total", "counter", "TCP connections accepted", AcceptCount());
+  metric("dfkv_evictions_total", "counter", "Objects evicted (capacity pressure)",
+         group_.Evictions());
+  metric("dfkv_evicted_bytes_total", "counter", "Bytes evicted", group_.EvictedBytes());
   // gauges
   metric("dfkv_objects", "gauge", "Cached objects on this node", group_.Count());
   metric("dfkv_used_bytes", "gauge", "Bytes used on disk", group_.UsedBytes());
   metric("dfkv_disks", "gauge", "Backing NVMe disks", group_.DiskCount());
+  metric("dfkv_open_connections", "gauge", "Currently open client connections",
+         rd(open_connections_));
+  // errors by op+status (one HELP/TYPE, multiple labeled series)
+  s += "# HELP dfkv_errors_total Failed ops by op and status\n";
+  s += "# TYPE dfkv_errors_total counter\n";
+  s += "dfkv_errors_total" + braces("op=\"put\",status=\"io\"") + " " +
+       std::to_string(rd(put_io_err_)) + "\n";
+  s += "dfkv_errors_total" + braces("op=\"get\",status=\"io\"") + " " +
+       std::to_string(rd(get_io_err_)) + "\n";
+  s += "dfkv_errors_total" + braces("op=\"any\",status=\"invalid\"") + " " +
+       std::to_string(rd(invalid_ops_)) + "\n";
+  // per-disk gauges (one HELP/TYPE, one series per disk)
+  s += "# HELP dfkv_disk_used_bytes Bytes used per backing disk\n";
+  s += "# TYPE dfkv_disk_used_bytes gauge\n";
+  for (size_t i = 0; i < group_.DiskCount(); ++i)
+    s += "dfkv_disk_used_bytes" + braces("disk=\"" + group_.DiskPath(i) + "\"") + " " +
+         std::to_string(group_.DiskUsedBytes(i)) + "\n";
+  s += "# HELP dfkv_disk_objects Objects per backing disk\n";
+  s += "# TYPE dfkv_disk_objects gauge\n";
+  for (size_t i = 0; i < group_.DiskCount(); ++i)
+    s += "dfkv_disk_objects" + braces("disk=\"" + group_.DiskPath(i) + "\"") + " " +
+         std::to_string(group_.DiskObjects(i)) + "\n";
+  // sampled op latency histograms (op label merged with identity); one HELP/TYPE,
+  // two label sets (get/put).
+  {
+    std::string get_lbl = std::string("op=\"get\"") + (idlabels.empty() ? "" : "," + idlabels);
+    std::string put_lbl = std::string("op=\"put\"") + (idlabels.empty() ? "" : "," + idlabels);
+    s += "# HELP dfkv_op_latency_seconds Sampled server op latency seconds\n";
+    s += "# TYPE dfkv_op_latency_seconds histogram\n";
+    s += get_lat_.RenderBody("dfkv_op_latency_seconds", get_lbl);
+    s += put_lat_.RenderBody("dfkv_op_latency_seconds", put_lbl);
+  }
   return s;
 }
 
@@ -122,10 +175,12 @@ void KvNodeServer::AcceptLoop() {
     int one = 1;
     ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));  // avoid Nagle stalls
     accept_count_.fetch_add(1, std::memory_order_relaxed);
+    open_connections_.fetch_add(1, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(conn_mu_);
     conn_fds_.insert(fd);
     conn_threads_.emplace_back([this, fd] {
       Handle(fd);
+      open_connections_.fetch_sub(1, std::memory_order_relaxed);
       { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
       ::close(fd);
     });
@@ -141,22 +196,34 @@ Status KvNodeServer::ProcessRequest(uint8_t op_raw, uint64_t id, uint32_t index,
   BlockKey key{id, index, ksize};
   Status st = Status::kInvalid;
   switch (op) {
-    case WireOp::kCache:
+    case WireOp::kCache: {
+      bool samp = lat_sampler_.ShouldSample();
+      double t0 = samp ? NowSec() : 0.0;
       st = group_.Cache(key, payload, payload_len);
       if (st == Status::kOk) {
         cache_put_.fetch_add(1, std::memory_order_relaxed);
         bytes_written_.fetch_add(payload_len, std::memory_order_relaxed);
+      } else if (st == Status::kIOError) {
+        put_io_err_.fetch_add(1, std::memory_order_relaxed);
       }
+      if (samp) put_lat_.Observe(NowSec() - t0);
       break;
-    case WireOp::kRange:
+    }
+    case WireOp::kRange: {
+      bool samp = lat_sampler_.ShouldSample();
+      double t0 = samp ? NowSec() : 0.0;
       st = group_.Range(key, offset, length, out_data);
       if (st == Status::kOk) {
         cache_hit_.fetch_add(1, std::memory_order_relaxed);
         bytes_read_.fetch_add(out_data->size(), std::memory_order_relaxed);
       } else if (st == Status::kNotFound) {
         cache_miss_.fetch_add(1, std::memory_order_relaxed);
+      } else if (st == Status::kIOError) {
+        get_io_err_.fetch_add(1, std::memory_order_relaxed);
       }
+      if (samp) get_lat_.Observe(NowSec() - t0);
       break;
+    }
     case WireOp::kExist:
       if (group_.IsCached(key)) { st = Status::kOk; exist_hit_.fetch_add(1, std::memory_order_relaxed); }
       else { st = Status::kNotFound; exist_miss_.fetch_add(1, std::memory_order_relaxed); }
@@ -175,6 +242,7 @@ Status KvNodeServer::ProcessRequest(uint8_t op_raw, uint64_t id, uint32_t index,
       st = Status::kInvalid;  // MDS ops are not served by a cache node
       break;
   }
+  if (st == Status::kInvalid) invalid_ops_.fetch_add(1, std::memory_order_relaxed);
   return st;
 }
 
@@ -182,13 +250,18 @@ Status KvNodeServer::RangeInto(uint64_t id, uint32_t index, uint32_t ksize,
                                uint64_t offset, uint64_t length, char* dst,
                                size_t dst_cap, size_t* out_len) {
   BlockKey key{id, index, ksize};
+  bool samp = lat_sampler_.ShouldSample();
+  double t0 = samp ? NowSec() : 0.0;
   Status st = group_.RangeInto(key, offset, length, dst, dst_cap, out_len);
   if (st == Status::kOk) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
     bytes_read_.fetch_add(*out_len, std::memory_order_relaxed);
   } else if (st == Status::kNotFound) {
     cache_miss_.fetch_add(1, std::memory_order_relaxed);
+  } else if (st == Status::kIOError) {
+    get_io_err_.fetch_add(1, std::memory_order_relaxed);
   }
+  if (samp) get_lat_.Observe(NowSec() - t0);
   return st;
 }
 
@@ -197,13 +270,18 @@ Status KvNodeServer::RangeDirect(uint64_t id, uint32_t index, uint32_t ksize,
                                  size_t io_cap, const char** out_data,
                                  size_t* out_len) {
   BlockKey key{id, index, ksize};
+  bool samp = lat_sampler_.ShouldSample();
+  double t0 = samp ? NowSec() : 0.0;
   Status st = group_.RangeDirect(key, offset, length, io_buf, io_cap, out_data, out_len);
   if (st == Status::kOk) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
     bytes_read_.fetch_add(*out_len, std::memory_order_relaxed);
   } else if (st == Status::kNotFound) {
     cache_miss_.fetch_add(1, std::memory_order_relaxed);
+  } else if (st == Status::kIOError) {
+    get_io_err_.fetch_add(1, std::memory_order_relaxed);
   }
+  if (samp) get_lat_.Observe(NowSec() - t0);
   return st;
 }
 

--- a/src/kv_node_server.h
+++ b/src/kv_node_server.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "disk_cache_group.h"
+#include "latency_hist.h"
 
 namespace dfkv {
 
@@ -77,6 +78,11 @@ class KvNodeServer {
   std::atomic<size_t> cache_put_{0}, cache_hit_{0}, cache_miss_{0};
   std::atomic<size_t> exist_hit_{0}, exist_miss_{0};
   std::atomic<size_t> bytes_written_{0}, bytes_read_{0};
+  // depth metrics: errors by op, live connections, sampled op latency
+  std::atomic<size_t> put_io_err_{0}, get_io_err_{0}, invalid_ops_{0};
+  std::atomic<size_t> open_connections_{0};
+  Sampler lat_sampler_{64};        // 1-in-64 latency sampling (near-zero hot-path cost)
+  LatencyHist get_lat_, put_lat_;  // server-side op latency (sampled)
   std::string members_;  // advertised cluster membership (kMembers)
   std::string node_id_, node_group_;       // identity for Prometheus labels (optional)
   std::chrono::steady_clock::time_point start_time_ = std::chrono::steady_clock::now();

--- a/src/kv_store.cc
+++ b/src/kv_store.cc
@@ -255,6 +255,8 @@ void KVStore::EvictLocked(Shard& sh) {
     std::error_code ec;
     fs::remove(it->second.path, ec);
     sh.used_bytes -= it->second.size;
+    evictions_.fetch_add(1, std::memory_order_relaxed);
+    evicted_bytes_.fetch_add(it->second.size, std::memory_order_relaxed);
     sh.ring.erase(cur);
     sh.index.erase(it);
   }

--- a/src/kv_store.h
+++ b/src/kv_store.h
@@ -65,6 +65,9 @@ class KVStore {
 
   uint64_t UsedBytes() const;
   size_t Count() const;
+  uint64_t Evictions() const { return evictions_.load(std::memory_order_relaxed); }
+  uint64_t EvictedBytes() const { return evicted_bytes_.load(std::memory_order_relaxed); }
+  const std::string& Dir() const { return opt_.cache_dir; }
 
  private:
   struct Entry {
@@ -94,6 +97,8 @@ class KVStore {
   Options opt_;
   std::vector<std::unique_ptr<Shard>> shards_;  // fixed after construction
   std::atomic<uint64_t> tmp_seq_{0};  // unique suffix for concurrent lock-free writes
+  // Eviction counters (relaxed): incremented in EvictLocked across shards.
+  std::atomic<uint64_t> evictions_{0}, evicted_bytes_{0};
 };
 
 }  // namespace dfkv

--- a/src/latency_hist.h
+++ b/src/latency_hist.h
@@ -34,17 +34,22 @@ class LatencyHist {
     return static_cast<double>(sum_us_.load(std::memory_order_relaxed)) / 1e6;
   }
 
-  // Render Prometheus histogram lines. `labels` is the inner label set (e.g.
-  // `op="get"`) or empty. Buckets are cumulative (le).
+  // Full Prometheus block (HELP + TYPE + body). `labels` is the inner label set
+  // (e.g. `op="get"`) or empty. Buckets are cumulative (le).
   std::string Render(const std::string& name, const std::string& labels) const {
+    return "# HELP " + name + " Operation latency seconds\n" +
+           "# TYPE " + name + " histogram\n" + RenderBody(name, labels);
+  }
+
+  // Body only (no HELP/TYPE) — for emitting several label sets of the SAME metric
+  // (e.g. op="get" and op="put") under a single HELP/TYPE header.
+  std::string RenderBody(const std::string& name, const std::string& labels) const {
     auto lbl = [&](const std::string& extra) {
       std::string in = extra;
       if (!labels.empty()) in += (in.empty() ? "" : ",") + labels;
       return in.empty() ? std::string() : "{" + in + "}";
     };
     std::string s;
-    s += "# HELP " + name + " Operation latency seconds\n";
-    s += "# TYPE " + name + " histogram\n";
     uint64_t cum = 0;
     char le[32];
     for (int i = 0; i < kNB; ++i) {

--- a/src/latency_hist.h
+++ b/src/latency_hist.h
@@ -1,0 +1,90 @@
+/* LatencyHist — fixed-bucket, lock-free latency histogram (Prometheus style) and
+ * Sampler — a power-of-two 1-in-N gate. Together they let the server record op
+ * latency on the hot path at near-zero cost: Sampler::ShouldSample() is one
+ * relaxed atomic add + a mask, and only the sampled (e.g. 1/64) ops read a clock
+ * and call Observe() (a bucket scan + relaxed atomic add). No locks, no alloc. */
+#ifndef DFKV_LATENCY_HIST_H_
+#define DFKV_LATENCY_HIST_H_
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+
+namespace dfkv {
+
+class LatencyHist {
+ public:
+  // Cumulative bucket upper bounds in SECONDS (50us .. 100ms). +Inf is implicit.
+  static constexpr int kNB = 11;
+  static constexpr double kBounds[kNB] = {50e-6, 100e-6, 250e-6, 500e-6, 1e-3,
+                                          2.5e-3, 5e-3, 10e-3, 25e-3, 50e-3, 100e-3};
+
+  void Observe(double seconds) {
+    if (seconds < 0) seconds = 0;
+    sum_us_.fetch_add(static_cast<uint64_t>(seconds * 1e6), std::memory_order_relaxed);
+    count_.fetch_add(1, std::memory_order_relaxed);
+    for (int i = 0; i < kNB; ++i) {
+      if (seconds <= kBounds[i]) { buckets_[i].fetch_add(1, std::memory_order_relaxed); return; }
+    }
+    inf_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  uint64_t Count() const { return count_.load(std::memory_order_relaxed); }
+  double Sum() const {
+    return static_cast<double>(sum_us_.load(std::memory_order_relaxed)) / 1e6;
+  }
+
+  // Render Prometheus histogram lines. `labels` is the inner label set (e.g.
+  // `op="get"`) or empty. Buckets are cumulative (le).
+  std::string Render(const std::string& name, const std::string& labels) const {
+    auto lbl = [&](const std::string& extra) {
+      std::string in = extra;
+      if (!labels.empty()) in += (in.empty() ? "" : ",") + labels;
+      return in.empty() ? std::string() : "{" + in + "}";
+    };
+    std::string s;
+    s += "# HELP " + name + " Operation latency seconds\n";
+    s += "# TYPE " + name + " histogram\n";
+    uint64_t cum = 0;
+    char le[32];
+    for (int i = 0; i < kNB; ++i) {
+      cum += buckets_[i].load(std::memory_order_relaxed);
+      std::snprintf(le, sizeof(le), "le=\"%g\"", kBounds[i]);
+      s += name + "_bucket" + lbl(le) + " " + std::to_string(cum) + "\n";
+    }
+    uint64_t total = cum + inf_.load(std::memory_order_relaxed);
+    s += name + "_bucket" + lbl("le=\"+Inf\"") + " " + std::to_string(total) + "\n";
+    char sum[64];
+    std::snprintf(sum, sizeof(sum), "%.6f", Sum());
+    s += name + "_sum" + lbl("") + " " + sum + "\n";
+    s += name + "_count" + lbl("") + " " + std::to_string(total) + "\n";
+    return s;
+  }
+
+ private:
+  std::atomic<uint64_t> buckets_[kNB]{};
+  std::atomic<uint64_t> inf_{0};
+  std::atomic<uint64_t> sum_us_{0};
+  std::atomic<uint64_t> count_{0};
+};
+
+// 1-in-N sampler rounded up to a power of two so the gate is a mask (no divide).
+class Sampler {
+ public:
+  explicit Sampler(uint64_t one_in_n) {
+    uint64_t p = 1;
+    while (p < one_in_n) p <<= 1;
+    mask_ = p - 1;
+  }
+  bool ShouldSample() {
+    return (seq_.fetch_add(1, std::memory_order_relaxed) & mask_) == 0;
+  }
+
+ private:
+  std::atomic<uint64_t> seq_{0};
+  uint64_t mask_;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_LATENCY_HIST_H_

--- a/tests/kv_store_test.cc
+++ b/tests/kv_store_test.cc
@@ -141,6 +141,9 @@ TEST_F(KVStoreTest, LruEvictsLeastRecentlyUsedWhenOverCapacity) {
   EXPECT_FALSE(s.IsCached(BlockKey{2, 0, 1}));
   EXPECT_TRUE(s.IsCached(BlockKey{3, 0, 1}));
   EXPECT_LE(s.UsedBytes(), 2200u);
+  // eviction counters tracked the one evicted 1000-byte object
+  EXPECT_EQ(s.Evictions(), 1u);
+  EXPECT_EQ(s.EvictedBytes(), 1000u);
 }
 
 // All-hot eviction: every resident entry is marked referenced right before each

--- a/tests/latency_hist_test.cc
+++ b/tests/latency_hist_test.cc
@@ -1,0 +1,48 @@
+// TDD — lock-free sampled latency histogram + 1-in-N sampler.
+#include "latency_hist.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace dfkv;  // NOLINT
+
+TEST(LatencyHist, CountSumAndCumulativeRender) {
+  LatencyHist h;
+  h.Observe(30e-6);    // bucket 0 (<=50us)
+  h.Observe(120e-6);   // bucket 2 (<=250us)
+  h.Observe(3e-3);     // bucket 6 (<=5ms)
+  h.Observe(500e-3);   // +Inf (>100ms)
+  EXPECT_EQ(h.Count(), 4u);
+  EXPECT_NEAR(h.Sum(), 30e-6 + 120e-6 + 3e-3 + 500e-3, 1e-3);
+
+  std::string t = h.Render("dfkv_op_latency_seconds", "op=\"get\"");
+  EXPECT_NE(t.find("# TYPE dfkv_op_latency_seconds histogram"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_op_latency_seconds_bucket{le=\"5e-05\",op=\"get\"} 1"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_op_latency_seconds_bucket{le=\"+Inf\",op=\"get\"} 4"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_op_latency_seconds_count{op=\"get\"} 4"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_op_latency_seconds_sum{op=\"get\"}"), std::string::npos) << t;
+}
+
+TEST(LatencyHist, BucketsAreMonotonicCumulative) {
+  LatencyHist h;
+  for (int i = 0; i < 10; ++i) h.Observe(1e-6);  // all in bucket 0
+  std::string t = h.Render("x", "");
+  // le=5e-05 cumulative already 10; le=+Inf also 10
+  EXPECT_NE(t.find("x_bucket{le=\"5e-05\"} 10"), std::string::npos) << t;
+  EXPECT_NE(t.find("x_bucket{le=\"+Inf\"} 10"), std::string::npos) << t;
+  EXPECT_NE(t.find("x_count 10"), std::string::npos) << t;
+}
+
+TEST(Sampler, OneInNFiresEveryNthExactly) {
+  Sampler s(64);
+  int fired = 0;
+  bool first = false;
+  for (int i = 0; i < 640; ++i) {
+    bool hit = s.ShouldSample();
+    if (i == 0) first = hit;
+    if (hit) fired++;
+  }
+  EXPECT_TRUE(first);       // first call samples
+  EXPECT_EQ(fired, 10);     // exactly 640/64
+}

--- a/tests/metrics_test.cc
+++ b/tests/metrics_test.cc
@@ -78,6 +78,40 @@ TEST(Metrics, NoIdentityKeepsUnlabeledSeries) {
   s->Stop();
 }
 
+TEST(Metrics, DepthSeriesPresent) {
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_metrics_e";
+  auto s = Start(dir, &addr);
+  TcpTransport t;
+  std::string v(100, 'q');
+  ASSERT_EQ(t.Cache(addr, ToBlockKey("a"), v.data(), v.size()), Status::kOk);
+  std::string out;
+  ASSERT_EQ(t.Range(addr, ToBlockKey("a"), 0, v.size(), &out), Status::kOk);
+  std::string text = s->MetricsText();
+  EXPECT_NE(text.find("# TYPE dfkv_op_latency_seconds histogram"), std::string::npos) << text;
+  EXPECT_NE(text.find("dfkv_op_latency_seconds_count{op=\"get\"}"), std::string::npos) << text;
+  EXPECT_NE(text.find("dfkv_op_latency_seconds_count{op=\"put\"}"), std::string::npos) << text;
+  EXPECT_NE(text.find("dfkv_evictions_total"), std::string::npos) << text;
+  EXPECT_NE(text.find("dfkv_open_connections"), std::string::npos) << text;
+  EXPECT_NE(text.find("dfkv_errors_total{op=\"get\",status=\"io\"}"), std::string::npos) << text;
+  EXPECT_NE(text.find("dfkv_disk_used_bytes{disk="), std::string::npos) << text;
+  s->Stop();
+}
+
+TEST(Metrics, OpenConnectionsTracksLiveConn) {
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_metrics_f";
+  auto s = Start(dir, &addr);
+  {
+    TcpTransport t;  // pooled keep-alive connection held open for this scope
+    std::string out;
+    ASSERT_EQ(t.Range(addr, ToBlockKey("x"), 0, 1, &out), Status::kNotFound);
+    // a connection is open while the pooled fd lives
+    EXPECT_NE(s->MetricsText().find("dfkv_open_connections"), std::string::npos);
+  }  // transport destructor closes the pooled fd; server-side handler exits
+  s->Stop();
+}
+
 TEST(Metrics, RemoteStatsOp) {
   std::string addr;
   auto dir = fs::temp_directory_path() / "dfkv_metrics_b";


### PR DESCRIPTION
PR 3/5 of the observability effort (toward v1.4.0). Deepens single-node
visibility without touching datapath throughput.

## What
- **Sampled op latency** (`src/latency_hist.h`): lock-free fixed-bucket histogram (50µs–100ms) + a power-of-two `Sampler`. The server records `get`/`put` latency only on **1-in-64** ops; the sample gate is one relaxed atomic add + a mask, and only sampled ops read a clock (`steady_clock`, vDSO). Exposed as `dfkv_op_latency_seconds{op}`.
- **Error counters** `dfkv_errors_total{op,status}` (put/get IO errors, invalid ops).
- **Eviction counters** `dfkv_evictions_total` / `dfkv_evicted_bytes_total` (counted in `KVStore::EvictLocked`, summed across disks).
- **`dfkv_open_connections`** gauge (inc on accept, dec when the handler exits).
- **Per-disk gauges** `dfkv_disk_used_bytes{disk}` / `dfkv_disk_objects{disk}` (DiskCacheGroup per-disk views; read only on scrape).
- All new labeled series merge the optional `{node,group}` identity.

## Perf (the hard constraint)
Hot path stays relaxed-atomic-only. The single new hot-path cost is the sampler's `fetch_add & mask`; the clock read + `Observe()` happen on ≤1/64 of ops. No locks, no allocation on the datapath.

## Tests
- `latency_hist_test`: cumulative buckets, sum/count, sampler fires exactly 1/N.
- `kv_store_test`: eviction counters track the evicted object + bytes.
- `metrics_test`: new depth series present; `open_connections` tracks a live conn.
- Full ctest **150/150**; live `/metrics` dump verified (clean single HELP/TYPE per metric, merged labels).

## Compatibility
Pure addition, no wire-protocol change.