### PR TITLE
feat(obs): client-side metrics + snapshot C ABI + plugin poller (P1)

### DIFF
--- a/python/dfkv_hicache.py
+++ b/python/dfkv_hicache.py
@@ -19,7 +19,7 @@ from sglang.srt.mem_cache.hicache_storage import HiCacheStorage, HiCacheStorageC
 from dfkv_access_log import (access_log, configure as _configure_access_log,
                             fmt_bytes as _fmt_bytes, fmt_pools as _fmt_pools,
                             fmt_pool_results as _fmt_pool_results)
-from dfkv_metrics import Metrics as _Metrics
+from dfkv_metrics import Metrics as _Metrics, ClientStatsPoller as _ClientStatsPoller
 
 _FLAG_IS_MLA = 0x1
 
@@ -58,9 +58,21 @@ def _load_lib(path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_refresh_members.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
     lib.dfkv_start_mds_discovery.restype = ctypes.c_int
     lib.dfkv_start_mds_discovery.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
+    lib.dfkv_stats_snapshot.restype = ctypes.c_uint64
+    lib.dfkv_stats_snapshot.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint64]
     lib.dfkv_close.restype = None
     lib.dfkv_close.argtypes = [ctypes.c_void_p]
     return lib
+
+
+def _read_snapshot(lib, h) -> str:
+    """Read the C client's Prometheus metrics snapshot (size query, then fetch)."""
+    need = int(lib.dfkv_stats_snapshot(h, None, 0))
+    if need <= 0:
+        return ""
+    buf = ctypes.create_string_buffer(need + 1)
+    lib.dfkv_stats_snapshot(h, buf, need + 1)
+    return buf.value.decode("utf-8", "replace")
 
 
 def _arrays(subkeys, ptrs, sizes):
@@ -151,7 +163,29 @@ class DfkvHiCache(HiCacheStorage):
             self.mem_pool_host = None
             r.result = "ok mds-discovery" if mds else "ok static"
 
+        # Background mirror of the C client's metrics snapshot onto Prometheus
+        # (sleeping daemon thread; off the request path). client_stats_poll_s<=0
+        # disables it. extra_config wins, then env, then 10s default.
+        self._poller = None
+        try:
+            poll_s = cfg.get("client_stats_poll_s")
+            if poll_s is None:
+                poll_s = os.environ.get("DFKV_CLIENT_STATS_POLL_S", 10)
+            poll_s = float(poll_s)
+        except (TypeError, ValueError):
+            poll_s = 10.0
+        if poll_s > 0:
+            self._poller = _ClientStatsPoller(
+                lambda: _read_snapshot(self._lib, self._h), self.tp_rank, poll_s)
+            self._poller.start()
+
     def __del__(self):
+        try:
+            if getattr(self, "_poller", None):
+                self._poller.stop()
+                self._poller = None
+        except Exception:
+            pass
         try:
             if getattr(self, "_h", None):
                 self._lib.dfkv_close(self._h)

--- a/python/dfkv_metrics.py
+++ b/python/dfkv_metrics.py
@@ -79,3 +79,101 @@ class Metrics:
     def snapshot(self):
         with self._lock:
             return dict(self._c)
+
+
+# --- client-side snapshot mirroring (from the C client via dfkv_stats_snapshot) ---
+#
+# The C++ KVClient accumulates client-observed counters (ops served, IO errors,
+# peer-health transitions) that the Python layer can't see. A sleeping daemon
+# thread polls the snapshot text and mirrors the aggregate counters onto
+# Prometheus Counters by delta, so they aggregate across the per-TP-rank
+# processes in SGLang's multiprocess metrics mode. Off the request hot path.
+
+_CLIENT_NAMES = [
+    "dfkv_client_ops_served_total",
+    "dfkv_client_io_errors_total",
+    "dfkv_client_unhealthy_skips_total",
+    "dfkv_client_peer_marked_bad_total",
+    "dfkv_client_peer_recovered_total",
+]
+
+_CLIENT_PROM = {}
+if _HAVE_PROM:
+    for _n in _CLIENT_NAMES:
+        try:
+            _CLIENT_PROM[_n] = _PromCounter(_n, _n, ["tp_rank"])
+        except Exception:
+            _CLIENT_PROM = {}
+            break
+
+
+class ClientStatsPoller:
+    """Polls a Prometheus-text snapshot provider and mirrors the aggregate client
+    counters onto Prometheus Counters by delta. One sleeping daemon thread."""
+
+    def __init__(self, get_text, tp_rank, interval_s=10.0):
+        self._get_text = get_text
+        self._rank = str(int(tp_rank))
+        self._interval = float(interval_s)
+        self._last = {n: 0 for n in _CLIENT_NAMES}
+        self._totals = {n: 0 for n in _CLIENT_NAMES}  # in-process mirror (tests/debug)
+        self._stop = threading.Event()
+        self._thread = None
+
+    @staticmethod
+    def _parse(text):
+        out = {}
+        for line in text.splitlines():
+            if not line or line[0] == "#":
+                continue
+            sp = line.rfind(" ")
+            if sp <= 0:
+                continue
+            name = line[:sp]
+            brace = name.find("{")
+            if brace != -1:
+                name = name[:brace]
+            if name in _CLIENT_NAMES:
+                try:
+                    out[name] = out.get(name, 0) + int(line[sp + 1:])
+                except ValueError:
+                    pass
+        return out
+
+    def poll_once(self):
+        vals = self._parse(self._get_text() or "")
+        for n in _CLIENT_NAMES:
+            v = vals.get(n, 0)
+            d = v - self._last[n]
+            if d > 0:
+                self._last[n] = v
+                self._totals[n] += d
+                if _HAVE_PROM and n in _CLIENT_PROM:
+                    _CLIENT_PROM[n].labels(self._rank).inc(d)
+
+    def totals(self):
+        return dict(self._totals)
+
+    def _loop(self):
+        while not self._stop.wait(self._interval):
+            try:
+                self.poll_once()
+            except Exception:
+                pass  # never let a transient snapshot error kill the thread
+
+    def start(self):
+        if self._interval <= 0:
+            return  # disabled
+        try:
+            self.poll_once()  # immediate first read
+        except Exception:
+            pass
+        self._thread = threading.Thread(target=self._loop, name="dfkv-client-stats",
+                                        daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None

--- a/src/dfkv_c_api.cc
+++ b/src/dfkv_c_api.cc
@@ -1,5 +1,6 @@
 #include "dfkv_c_api.h"
 
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
@@ -167,6 +168,18 @@ int dfkv_start_mds_discovery(dfkv_client_t c, const char* mds_endpoints,
   static_cast<KVClient*>(c)->StartMdsDiscovery(std::move(eps), group,
                                                poll_ms > 0 ? poll_ms : 3000);
   return 0;
+}
+
+uint64_t dfkv_stats_snapshot(dfkv_client_t c, char* buf, uint64_t cap) {
+  if (!c) return 0;
+  std::string text = static_cast<KVClient*>(c)->MetricsSnapshot();
+  uint64_t full = static_cast<uint64_t>(text.size());
+  if (buf && cap > 0) {
+    uint64_t n = full < cap ? full : cap - 1;  // leave room for NUL
+    std::memcpy(buf, text.data(), static_cast<size_t>(n));
+    buf[n] = '\0';
+  }
+  return full;
 }
 
 void dfkv_close(dfkv_client_t c) { delete static_cast<KVClient*>(c); }

--- a/src/dfkv_c_api.h
+++ b/src/dfkv_c_api.h
@@ -61,6 +61,13 @@ int dfkv_batch_get_auto(dfkv_client_t c, const char** keys, void** ptrs,
                         uint64_t* out_len);
 int dfkv_batch_exist(dfkv_client_t c, const char** keys, int n, int* out_exist);
 
+// Client-side Prometheus metrics snapshot (ops served, IO errors, peer health
+// transitions, per-peer errors). Writes up to `cap` bytes (NUL-terminated when
+// it fits) into buf and returns the FULL text length (excluding NUL). Pass cap=0
+// (buf may be NULL) to size the buffer first. The plugin polls this and mirrors
+// the deltas onto its Prometheus counters.
+uint64_t dfkv_stats_snapshot(dfkv_client_t c, char* buf, uint64_t cap);
+
 void dfkv_close(dfkv_client_t c);
 
 #ifdef __cplusplus

--- a/src/kv_client.h
+++ b/src/kv_client.h
@@ -91,6 +91,10 @@ class KVClient {
   // MDS — point at any live node. Returns true if a non-empty list was applied.
   bool RefreshMembers(const std::string& seed_addr);
 
+  // Client-side Prometheus metrics text (ops served, IO errors, peer health
+  // transitions, per-peer errors). Surfaced to the plugin via the C ABI.
+  std::string MetricsSnapshot() const { return health_.Render(); }
+
  private:
   std::string Route(const std::string& key) const;
   uint64_t NowMs() const;

--- a/src/peer_health.h
+++ b/src/peer_health.h
@@ -1,7 +1,9 @@
 #ifndef DFKV_PEER_HEALTH_H_
 #define DFKV_PEER_HEALTH_H_
 
+#include <atomic>
 #include <cstdint>
+#include <map>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -12,28 +14,84 @@ namespace dfkv {
 // is marked unhealthy for cooldown_ms; while unhealthy the client short-circuits
 // requests to it (miss) WITHOUT touching the ring. A served response (hit or
 // logical miss) clears it. Thread-safe: BatchGet/Put route from many threads.
+//
+// It is also the client's uniform metrics chokepoint: every op calls Healthy()
+// then exactly one of MarkBad()/MarkGood(), so the client-observed counters live
+// here at no extra hot-path cost (the mutex is already taken on these calls).
 class PeerHealth {
  public:
   explicit PeerHealth(uint64_t cooldown_ms = 2000) : cooldown_ms_(cooldown_ms) {}
 
   bool Healthy(const std::string& peer, uint64_t now_ms) const {
     std::lock_guard<std::mutex> lk(mu_);
+    checks_.fetch_add(1, std::memory_order_relaxed);
     auto it = until_.find(peer);
-    return it == until_.end() || it->second <= now_ms;
+    bool ok = it == until_.end() || it->second <= now_ms;
+    if (!ok) unhealthy_skips_.fetch_add(1, std::memory_order_relaxed);
+    return ok;
   }
   void MarkBad(const std::string& peer, uint64_t now_ms) {
     std::lock_guard<std::mutex> lk(mu_);
+    auto it = until_.find(peer);
+    bool was_ok = it == until_.end() || it->second <= now_ms;
     until_[peer] = now_ms + cooldown_ms_;
+    errors_.fetch_add(1, std::memory_order_relaxed);
+    if (was_ok) marked_bad_.fetch_add(1, std::memory_order_relaxed);  // healthy->bad edge
+    peer_errors_[peer]++;
   }
   void MarkGood(const std::string& peer) {
     std::lock_guard<std::mutex> lk(mu_);
-    until_.erase(peer);
+    served_.fetch_add(1, std::memory_order_relaxed);
+    if (until_.erase(peer)) recovered_.fetch_add(1, std::memory_order_relaxed);  // bad->good edge
   }
+
+  // Prometheus client-side metrics text. Aggregates + per-peer error counts.
+  std::string Render() const {
+    auto m = [](std::string& s, const char* name, const char* type, const char* help,
+                uint64_t v) {
+      s += "# HELP "; s += name; s += " "; s += help; s += "\n";
+      s += "# TYPE "; s += name; s += " "; s += type; s += "\n";
+      s += name; s += " "; s += std::to_string(v); s += "\n";
+    };
+    std::string s;
+    m(s, "dfkv_client_ops_served_total", "counter", "Ops with a served response",
+      served_.load(std::memory_order_relaxed));
+    m(s, "dfkv_client_io_errors_total", "counter", "Transport IO failures (client-observed)",
+      errors_.load(std::memory_order_relaxed));
+    m(s, "dfkv_client_health_checks_total", "counter", "Peer health checks performed",
+      checks_.load(std::memory_order_relaxed));
+    m(s, "dfkv_client_unhealthy_skips_total", "counter", "Ops short-circuited (peer in cooldown)",
+      unhealthy_skips_.load(std::memory_order_relaxed));
+    m(s, "dfkv_client_peer_marked_bad_total", "counter", "Healthy->bad peer transitions",
+      marked_bad_.load(std::memory_order_relaxed));
+    m(s, "dfkv_client_peer_recovered_total", "counter", "Bad->good peer transitions",
+      recovered_.load(std::memory_order_relaxed));
+    // per-peer errors (one HELP/TYPE, one series per peer seen)
+    std::map<std::string, uint64_t> snap;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      snap.insert(peer_errors_.begin(), peer_errors_.end());
+    }
+    s += "# HELP dfkv_client_peer_errors_total IO failures per peer\n";
+    s += "# TYPE dfkv_client_peer_errors_total counter\n";
+    for (const auto& [peer, n] : snap)
+      s += "dfkv_client_peer_errors_total{peer=\"" + peer + "\"} " + std::to_string(n) + "\n";
+    return s;
+  }
+
+  // test accessors
+  uint64_t served() const { return served_.load(std::memory_order_relaxed); }
+  uint64_t errors() const { return errors_.load(std::memory_order_relaxed); }
+  uint64_t marked_bad() const { return marked_bad_.load(std::memory_order_relaxed); }
+  uint64_t recovered() const { return recovered_.load(std::memory_order_relaxed); }
 
  private:
   mutable std::mutex mu_;
   uint64_t cooldown_ms_;
-  std::unordered_map<std::string, uint64_t> until_;  // peer -> unhealthy-until (ms)
+  std::unordered_map<std::string, uint64_t> until_;        // peer -> unhealthy-until (ms)
+  std::unordered_map<std::string, uint64_t> peer_errors_;  // peer -> cumulative IO errors
+  mutable std::atomic<uint64_t> checks_{0}, unhealthy_skips_{0}, errors_{0},
+      marked_bad_{0}, served_{0}, recovered_{0};
 };
 
 }  // namespace dfkv

--- a/tests/c_api_test.cc
+++ b/tests/c_api_test.cc
@@ -6,6 +6,10 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <string>
+#include <vector>
+
 namespace {
 dfkv_client_t OpenEmpty() {
   // members="" => discovery-only; ring stays empty until MDS discovery runs.
@@ -34,6 +38,25 @@ TEST(CApiGuard, RejectsNullArraysWithPositiveN) {
   EXPECT_EQ(dfkv_put(c, nullptr, "v", 1), -1);
   EXPECT_EQ(dfkv_get(c, nullptr, nullptr, 0), 0);
   EXPECT_EQ(dfkv_exist(c, nullptr), 0);
+  dfkv_close(c);
+}
+
+TEST(CApiStats, SnapshotSizingAndContent) {
+  dfkv_client_t c = OpenEmpty();
+  ASSERT_NE(c, nullptr);
+  // a few ops against the empty ring exercise the health/metrics chokepoint
+  EXPECT_EQ(dfkv_get(c, "k", nullptr, 0), 0);
+  // size query: cap=0 returns the full length without writing
+  uint64_t need = dfkv_stats_snapshot(c, nullptr, 0);
+  EXPECT_GT(need, 0u);
+  // full read: NUL-terminated, contains the client metric family
+  std::vector<char> buf(need + 1, 'X');
+  uint64_t n = dfkv_stats_snapshot(c, buf.data(), buf.size());
+  EXPECT_EQ(n, need);
+  EXPECT_EQ(buf[need], '\0');
+  EXPECT_NE(std::string(buf.data()).find("dfkv_client_ops_served_total"), std::string::npos);
+  // null-client snapshot is 0, no crash
+  EXPECT_EQ(dfkv_stats_snapshot(nullptr, buf.data(), buf.size()), 0u);
   dfkv_close(c);
 }
 

--- a/tests/client_metrics_test.cc
+++ b/tests/client_metrics_test.cc
@@ -1,0 +1,34 @@
+// TDD — client-side metrics live in PeerHealth (the uniform per-op chokepoint).
+#include "peer_health.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace dfkv;  // NOLINT
+
+TEST(ClientMetrics, CountsServedErrorsTransitionsAndRenders) {
+  PeerHealth h(/*cooldown_ms=*/1000);
+  const std::string p = "10.0.0.1:12000";
+  // a healthy check, then a served response
+  EXPECT_TRUE(h.Healthy(p, 1000));
+  h.MarkGood(p);
+  // an IO error marks it bad (healthy->bad edge), then a skip while in cooldown
+  h.MarkBad(p, 1000);
+  EXPECT_FALSE(h.Healthy(p, 1500));   // still in cooldown -> skip
+  // recovery: a later served response clears it (bad->good edge)
+  h.MarkGood(p);
+
+  EXPECT_EQ(h.served(), 2u);
+  EXPECT_EQ(h.errors(), 1u);
+  EXPECT_EQ(h.marked_bad(), 1u);
+  EXPECT_EQ(h.recovered(), 1u);
+
+  std::string t = h.Render();
+  EXPECT_NE(t.find("dfkv_client_ops_served_total 2"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_client_io_errors_total 1"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_client_unhealthy_skips_total 1"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_client_peer_marked_bad_total 1"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_client_peer_recovered_total 1"), std::string::npos) << t;
+  EXPECT_NE(t.find("dfkv_client_peer_errors_total{peer=\"10.0.0.1:12000\"} 1"), std::string::npos) << t;
+}

--- a/tests/python/test_dfkv_hicache.py
+++ b/tests/python/test_dfkv_hicache.py
@@ -618,5 +618,60 @@ class DfkvAccessLogRotationTest(unittest.TestCase):
         self.assertFalse(os.path.exists(base + ".1"))  # 128MiB default not reached
 
 
+class ClientStatsPollerTest(unittest.TestCase):
+    """Mirrors the C client's Prometheus snapshot onto delta counters. Pure
+    module-level: feeds a fake snapshot provider, no node / libdfkv.so."""
+
+    def _poller(self, texts):
+        from dfkv_metrics import ClientStatsPoller
+        # get_text returns successive snapshots from `texts`, repeating the last
+        seq = {"i": 0}
+
+        def get_text():
+            i = min(seq["i"], len(texts) - 1)
+            seq["i"] += 1
+            return texts[i]
+
+        return ClientStatsPoller(get_text, tp_rank=0, interval_s=0.01)
+
+    def test_parse_handles_bare_and_labeled(self):
+        from dfkv_metrics import ClientStatsPoller
+        text = ("# TYPE dfkv_client_ops_served_total counter\n"
+                "dfkv_client_ops_served_total 7\n"
+                "dfkv_client_peer_errors_total{peer=\"1.2.3.4:1\"} 3\n")
+        vals = ClientStatsPoller._parse(text)
+        self.assertEqual(vals.get("dfkv_client_ops_served_total"), 7)
+        # per-peer series is not in the mirrored aggregate set
+        self.assertNotIn("dfkv_client_peer_errors_total", vals)
+
+    def test_poll_once_accumulates_deltas(self):
+        p = self._poller([
+            "dfkv_client_ops_served_total 5\ndfkv_client_io_errors_total 1\n",
+            "dfkv_client_ops_served_total 8\ndfkv_client_io_errors_total 1\n",
+        ])
+        p.poll_once()  # first read: delta 5 (from 0)
+        t1 = p.totals()
+        self.assertEqual(t1["dfkv_client_ops_served_total"], 5)
+        self.assertEqual(t1["dfkv_client_io_errors_total"], 1)
+        p.poll_once()  # cumulative 8 -> delta +3
+        t2 = p.totals()
+        self.assertEqual(t2["dfkv_client_ops_served_total"], 8)
+        self.assertEqual(t2["dfkv_client_io_errors_total"], 1)  # unchanged
+
+    def test_disabled_interval_starts_no_thread(self):
+        from dfkv_metrics import ClientStatsPoller
+        p = ClientStatsPoller(lambda: "", tp_rank=0, interval_s=0)
+        p.start()
+        self.assertIsNone(p._thread)
+        p.stop()  # must not crash
+
+    def test_start_stop_lifecycle(self):
+        p = self._poller(["dfkv_client_ops_served_total 1\n"])
+        p.start()
+        self.assertIsNotNone(p._thread)
+        p.stop()
+        self.assertIsNone(p._thread)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
PR 4/5 of the observability effort (toward v1.4.0). Surfaces the client's view
(transport errors, peer-health transitions) that neither the server nor the
plugin can see.

## What
- **Client counters folded into `PeerHealth`** — the uniform per-op chokepoint (every op calls `Healthy()` + one of `MarkBad()/MarkGood()`, already under its mutex). Zero edits to the op methods, **no new hot-path locks**. Exposes `dfkv_client_ops_served_total`, `io_errors_total`, `unhealthy_skips_total`, `peer_marked_bad_total`, `peer_recovered_total`, and per-peer `peer_errors_total{peer}` via `PeerHealth::Render()`.
- **`KVClient::MetricsSnapshot()`** → the rendered text.
- **C ABI `dfkv_stats_snapshot(c, buf, cap)`**: size-query (cap=0) then fetch, NUL-terminated.
- **Plugin poller** (`dfkv_metrics.ClientStatsPoller`): a sleeping daemon thread (default 10s, `client_stats_poll_s`/`DFKV_CLIENT_STATS_POLL_S`, 0=off) reads the snapshot, mirrors aggregate counters onto Prometheus Counters by delta (multiproc-safe). Started in `DfkvHiCache.__init__`, stopped in `__del__`.

## Perf
The counters ride mutex sections that already existed on the client path; no new locks, no per-op map lookups (per-peer counts only on the rare error path). The plugin poller sleeps off the request path.

## Tests
- `client_metrics_test`: served/errors/transitions counting + render incl. per-peer.
- `c_api_test`: snapshot sizing (cap=0), NUL-termination, content, null-client safety.
- `test_dfkv_hicache.ClientStatsPollerTest`: parse (bare/labeled), delta accumulation, disabled-interval no-thread, start/stop lifecycle.
- Full ctest **152/152** + python plugin **30/30** (poller runs in `__init__` and stops cleanly).

## Compatibility
New C ABI symbol + pure additions; no wire-protocol change.