### PR TITLE
feat(obs): RDMA counters + plugin latency histograms (P2)

### DIFF
--- a/python/dfkv_hicache.py
+++ b/python/dfkv_hicache.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import ctypes
 import os
+import time
 from typing import List, Optional
 
 from sglang.srt.mem_cache.hicache_storage import HiCacheStorage, HiCacheStorageConfig
@@ -288,10 +289,12 @@ class DfkvHiCache(HiCacheStorage):
             ptrs, sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
             sub, sks, sp, ss = self._flatten(keys, ptrs, sizes)
             karr, parr, sarr, out, _kb = _arrays(sks, sp, ss)
+            t0 = time.perf_counter()
             self._lib.dfkv_batch_put(self._h, karr, parr, sarr, len(sks), out)
+            dur = time.perf_counter() - t0
             res = self._fold([out[i] == 1 for i in range(len(sks))], n, sub)
             r.result = f"ok {sum(res)}/{n}"
-            self._metrics.on_set(pages=n, ok_pages=sum(res), nbytes=sum(ss))
+            self._metrics.on_set(pages=n, ok_pages=sum(res), nbytes=sum(ss), seconds=dur)
             return res
 
     def batch_get_v1(self, keys, host_indices, extra_info=None) -> List[bool]:
@@ -300,10 +303,12 @@ class DfkvHiCache(HiCacheStorage):
             ptrs, sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
             sub, sks, sp, ss = self._flatten(keys, ptrs, sizes)
             karr, parr, sarr, out, _kb = _arrays(sks, sp, ss)
+            t0 = time.perf_counter()
             self._lib.dfkv_batch_get(self._h, karr, parr, sarr, len(sks), out)
+            dur = time.perf_counter() - t0
             res = self._fold([out[i] == 1 for i in range(len(sks))], n, sub)
             r.result = f"hits={sum(res)}/{n}"
-            self._metrics.on_get(pages=n, hit_pages=sum(res), nbytes=sum(ss))
+            self._metrics.on_get(pages=n, hit_pages=sum(res), nbytes=sum(ss), seconds=dur)
             return res
 
     def batch_exists(self, keys, extra_info=None) -> int:

--- a/python/dfkv_metrics.py
+++ b/python/dfkv_metrics.py
@@ -24,10 +24,24 @@ Metric names (labels: tp_rank):
 import threading
 
 try:
-    from prometheus_client import Counter as _PromCounter
+    from prometheus_client import Counter as _PromCounter, Histogram as _PromHistogram
     _HAVE_PROM = True
 except Exception:  # prometheus_client absent -> in-process counters only
     _HAVE_PROM = False
+
+# Latency buckets (seconds) for the set/get batch-call duration histograms.
+_HIST_BUCKETS = (0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0)
+_HIST = {}
+if _HAVE_PROM:
+    try:
+        _HIST["set"] = _PromHistogram("dfkv_client_set_seconds",
+                                      "batch_set_v1 call duration seconds",
+                                      ["tp_rank"], buckets=_HIST_BUCKETS)
+        _HIST["get"] = _PromHistogram("dfkv_client_get_seconds",
+                                      "batch_get_v1 call duration seconds",
+                                      ["tp_rank"], buckets=_HIST_BUCKETS)
+    except Exception:
+        _HIST = {}
 
 _SPECS = [
     ("set_calls", "dfkv_client_set_calls_total", "batch_set_v1 calls that wrote"),
@@ -60,6 +74,7 @@ class Metrics:
         self._rank = str(int(tp_rank))
         self._lock = threading.Lock()
         self._c = {attr: 0 for attr, _, _ in _SPECS}
+        self._obs = {"set": 0, "get": 0}  # histogram observation counts (tests/debug)
 
     def _add(self, **deltas):
         with self._lock:
@@ -70,15 +85,28 @@ class Metrics:
                 if v:
                     _PROM[k].labels(self._rank).inc(v)
 
-    def on_set(self, pages, ok_pages, nbytes):
-        self._add(set_calls=1, set_pages=pages, set_ok_pages=ok_pages, set_bytes=nbytes)
+    def _observe(self, op, seconds):
+        with self._lock:
+            self._obs[op] += 1
+        if _HAVE_PROM and op in _HIST:
+            _HIST[op].labels(self._rank).observe(seconds)
 
-    def on_get(self, pages, hit_pages, nbytes):
+    def on_set(self, pages, ok_pages, nbytes, seconds=None):
+        self._add(set_calls=1, set_pages=pages, set_ok_pages=ok_pages, set_bytes=nbytes)
+        if seconds is not None:
+            self._observe("set", seconds)
+
+    def on_get(self, pages, hit_pages, nbytes, seconds=None):
         self._add(get_calls=1, get_pages=pages, get_hit_pages=hit_pages, get_bytes=nbytes)
+        if seconds is not None:
+            self._observe("get", seconds)
 
     def snapshot(self):
         with self._lock:
-            return dict(self._c)
+            snap = dict(self._c)
+            snap.update({"set_observations": self._obs["set"],
+                         "get_observations": self._obs["get"]})
+            return snap
 
 
 # --- client-side snapshot mirroring (from the C client via dfkv_stats_snapshot) ---

--- a/src/dfkv_server_main.cc
+++ b/src/dfkv_server_main.cc
@@ -68,16 +68,9 @@ int main(int argc, char** argv) {
   std::printf("PORT %d\n", srv.port());
   std::fflush(stdout);
 
-  // Optional Prometheus /metrics endpoint on a dedicated port/thread (off the
-  // datapath). Absent --metrics-port => no listener, behavior unchanged.
+  // Optional Prometheus /metrics endpoint (declared here, started after the RDMA
+  // server below so its render callback can fold in the RDMA server counters).
   std::unique_ptr<dfkv::MetricsHttpServer> mhttp;
-  if (metrics_port >= 0) {
-    mhttp = std::make_unique<dfkv::MetricsHttpServer>([&srv] { return srv.MetricsText(); });
-    if (mhttp->Start(metrics_port) == Status::kOk)
-      DFKV_LOG_INFO("dfkv_server /metrics on port " + std::to_string(mhttp->port()));
-    else
-      DFKV_LOG_WARN("dfkv_server /metrics failed to start on port " + std::to_string(metrics_port));
-  }
   DFKV_LOG_INFO("dfkv_server listening on port " + std::to_string(srv.port()) + ", dir=" + dir);
 
   // Announce the transport build mode loudly so a TCP-only binary (built without
@@ -113,6 +106,22 @@ int main(int argc, char** argv) {
       DFKV_LOG_WARN("dfkv_server RDMA listener failed to start (no device?)");
   }
 #endif
+
+  // Start /metrics now that the (optional) RDMA server exists: the render
+  // callback combines the cache-node metrics with the RDMA server counters.
+  if (metrics_port >= 0) {
+    mhttp = std::make_unique<dfkv::MetricsHttpServer>([&] {
+      std::string s = srv.MetricsText();
+#ifdef DFKV_WITH_RDMA
+      if (rsrv) s += rsrv->MetricsText();
+#endif
+      return s;
+    });
+    if (mhttp->Start(metrics_port) == Status::kOk)
+      DFKV_LOG_INFO("dfkv_server /metrics on port " + std::to_string(mhttp->port()));
+    else
+      DFKV_LOG_WARN("dfkv_server /metrics failed to start on port " + std::to_string(metrics_port));
+  }
 
   std::unique_ptr<dfkv::MdsRegistrar> registrar;
   if (!mds.empty()) {

--- a/src/kv_client.h
+++ b/src/kv_client.h
@@ -92,8 +92,9 @@ class KVClient {
   bool RefreshMembers(const std::string& seed_addr);
 
   // Client-side Prometheus metrics text (ops served, IO errors, peer health
-  // transitions, per-peer errors). Surfaced to the plugin via the C ABI.
-  std::string MetricsSnapshot() const { return health_.Render(); }
+  // transitions, per-peer errors) plus transport-level counters (RDMA per-rail
+  // connections, MR regions). Surfaced to the plugin via the C ABI.
+  std::string MetricsSnapshot() const { return health_.Render() + t_->MetricsText(); }
 
  private:
   std::string Route(const std::string& key) const;

--- a/src/rdma_server.cc
+++ b/src/rdma_server.cc
@@ -247,14 +247,20 @@ void RdmaServer::Serve(int boot_fd) {
   std::vector<ibv_wc> wcs(K);
   bool fail = false;
   const int idle_ms = ServerIdleMs();
+  active_conns_.fetch_add(1, std::memory_order_relaxed);
   while (running_ && !fail) {
     int g = ep.WaitComp(wcs.data(), static_cast<int>(K), idle_ms);
-    if (g <= 0) break;  // <0: error / Stop()'s Wake().  0: idle_ms elapsed -> reclaim.
+    if (g == 0) { idle_reclaims_.fetch_add(1, std::memory_order_relaxed); break; }  // idle -> reclaim
+    if (g < 0) break;  // error / Stop()'s Wake()
     for (int w = 0; w < g && !fail; ++w) {
       const ibv_wc& wc = wcs[w];
-      if (wc.status != IBV_WC_SUCCESS) { fail = true; break; }
+      if (wc.status != IBV_WC_SUCCESS) {
+        completion_errors_.fetch_add(1, std::memory_order_relaxed);
+        fail = true; break;
+      }
       if (wc.opcode == IBV_WC_SEND) { free_send.push_back(static_cast<size_t>(wc.wr_id)); continue; }
       if (wc.opcode != IBV_WC_RECV || wc.byte_len < kReqPrefix) { fail = true; break; }
+      completions_.fetch_add(1, std::memory_order_relaxed);  // a request RECV
       size_t r = static_cast<size_t>(wc.wr_id);
       ReqFields rq;
       if (!DecodeReq(ep.rbuf(r), &rq)) { fail = true; break; }  // bad protocol version
@@ -273,8 +279,28 @@ void RdmaServer::Serve(int boot_fd) {
       if (!sent) { fail = true; break; }
     }
   }
+  active_conns_.fetch_sub(1, std::memory_order_relaxed);
   { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
   // ep dtor tears down the QP; the peer observes the drop as an error completion.
+}
+
+std::string RdmaServer::MetricsText() const {
+  auto m = [](std::string& s, const char* name, const char* type, const char* help,
+              uint64_t v) {
+    s += "# HELP "; s += name; s += " "; s += help; s += "\n";
+    s += "# TYPE "; s += name; s += " "; s += type; s += "\n";
+    s += name; s += " "; s += std::to_string(v); s += "\n";
+  };
+  std::string s;
+  m(s, "dfkv_rdma_completions_total", "counter", "RDMA request completions served",
+    Completions());
+  m(s, "dfkv_rdma_completion_errors_total", "counter", "RDMA error completions",
+    CompletionErrors());
+  m(s, "dfkv_rdma_active_conns", "gauge", "RDMA connections currently serving",
+    ActiveConns());
+  m(s, "dfkv_rdma_idle_reclaims_total", "counter", "RDMA connections reclaimed on idle timeout",
+    IdleReclaims());
+  return s;
 }
 
 }  // namespace dfkv

--- a/src/rdma_server.h
+++ b/src/rdma_server.h
@@ -56,6 +56,13 @@ class RdmaServer {
   // arrive — previously this grew without bound until Stop().
   size_t live_conn_count();
 
+  // RDMA completion counters (relaxed atomics, incremented in the serve loop).
+  uint64_t Completions() const { return completions_.load(std::memory_order_relaxed); }
+  uint64_t CompletionErrors() const { return completion_errors_.load(std::memory_order_relaxed); }
+  uint64_t ActiveConns() const { return active_conns_.load(std::memory_order_relaxed); }
+  uint64_t IdleReclaims() const { return idle_reclaims_.load(std::memory_order_relaxed); }
+  std::string MetricsText() const;  // Prometheus text (dfkv_rdma_*)
+
  private:
   void AcceptLoop();
   void Serve(int boot_fd);
@@ -84,6 +91,8 @@ class RdmaServer {
   std::mutex conn_mu_;
   std::vector<Conn> conns_;
   std::unordered_set<rdma::RcEndpoint*> live_eps_;
+  std::atomic<uint64_t> completions_{0}, completion_errors_{0}, active_conns_{0},
+      idle_reclaims_{0};
 };
 
 }  // namespace dfkv

--- a/src/rdma_transport.cc
+++ b/src/rdma_transport.cc
@@ -82,6 +82,7 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
   // (destroy+recreate every op), which fails the bootstrap under load. Default
   // 256 covers typical fan-out; raise via DFKV_RDMA_POOL_MAX for more threads.
   pool_max_ = static_cast<size_t>(EnvInt("DFKV_RDMA_POOL_MAX", 256));
+  rail_conns_ = std::make_unique<std::atomic<uint64_t>[]>(devs_.size());  // 0-initialized
 }
 
 RdmaTransport::~RdmaTransport() {
@@ -113,8 +114,8 @@ RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, bool* from_
   // Pick a device for this connection: NUMA-aware when DFKV_RDMA_NUMA is on
   // (prefer a rail on the calling thread's NUMA node), else round-robin all.
   size_t tick = rr_.fetch_add(1, std::memory_order_relaxed);
-  const std::string& dev =
-      devs_[rdma::PickRail(dev_node_, numa::CurrentNode(), numa::Enabled(), tick)];
+  size_t ridx = rdma::PickRail(dev_node_, numa::CurrentNode(), numa::Enabled(), tick);
+  const std::string& dev = devs_[ridx];
 
   auto* c = new Conn();
   if (!c->ep.Open(dev.empty() ? nullptr : dev.c_str(), max_msg_, depth_)) {
@@ -138,6 +139,8 @@ RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, bool* from_
   if (!net::ReadAll(fd, &ready, 1) || ready != 1) { ::close(fd); delete c; return nullptr; }
   ::close(fd);  // bootstrap done; QP is RTS
   c->ep.EnsurePoolMrs(pools);  // register the declared host-pool regions on this PD
+  conns_opened_.fetch_add(1, std::memory_order_relaxed);
+  if (ridx < devs_.size()) rail_conns_[ridx].fetch_add(1, std::memory_order_relaxed);
   return c;
 }
 
@@ -146,8 +149,29 @@ void RdmaTransport::RegisterMemory(void* base, size_t size) {
   std::lock_guard<std::mutex> lk(mu_);
   for (const auto& p : pools_) if (p.first == base) return;  // dedup by base
   pools_.push_back({base, size});
+  mr_regions_.fetch_add(1, std::memory_order_relaxed);
   // Connections register this lazily on their next Acquire (EnsurePoolMrs); call
   // before traffic so every connection's PD has the whole pool registered once.
+}
+
+std::string RdmaTransport::MetricsText() const {
+  std::string s;
+  s += "# HELP dfkv_rdma_client_conns_opened_total RDMA client connections opened\n";
+  s += "# TYPE dfkv_rdma_client_conns_opened_total counter\n";
+  s += "dfkv_rdma_client_conns_opened_total " +
+       std::to_string(conns_opened_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_mr_regions Declared host MR regions\n";
+  s += "# TYPE dfkv_rdma_client_mr_regions gauge\n";
+  s += "dfkv_rdma_client_mr_regions " +
+       std::to_string(mr_regions_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_rail_conns_total Connections opened per rail (device)\n";
+  s += "# TYPE dfkv_rdma_client_rail_conns_total counter\n";
+  for (size_t i = 0; i < devs_.size(); ++i) {
+    const std::string& d = devs_[i].empty() ? std::string("default") : devs_[i];
+    s += "dfkv_rdma_client_rail_conns_total{dev=\"" + d + "\"} " +
+         std::to_string(rail_conns_[i].load(std::memory_order_relaxed)) + "\n";
+  }
+  return s;
 }
 
 void RdmaTransport::Release(const std::string& node, Conn* c) {

--- a/src/rdma_transport.h
+++ b/src/rdma_transport.h
@@ -12,6 +12,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -40,6 +41,7 @@ class RdmaTransport : public Transport {
   Status Members(const std::string& node, std::string* out) override;
 
   void RegisterMemory(void* base, size_t size) override;
+  std::string MetricsText() const override;  // dfkv_rdma_client_* (conns, per-rail)
 
   bool pipelined() const override { return true; }
   // Pipelined: up to `depth_` requests in flight on a single connection.
@@ -79,6 +81,11 @@ class RdmaTransport : public Transport {
   std::vector<std::string> devs_;     // RDMA devices (multi-rail); "" = first
   std::vector<int> dev_node_;         // NUMA node per devs_ entry (-1 unknown)
   std::atomic<size_t> rr_{0};         // round-robin selector across devs_
+  // observability (relaxed): connections opened total + per-rail breakdown +
+  // declared MR regions. Connection opens are infrequent (pooled), off the op path.
+  std::atomic<uint64_t> conns_opened_{0};
+  std::atomic<uint64_t> mr_regions_{0};
+  std::unique_ptr<std::atomic<uint64_t>[]> rail_conns_;  // sized to devs_.size()
 };
 
 }  // namespace dfkv

--- a/src/transport.h
+++ b/src/transport.h
@@ -46,6 +46,11 @@ class Transport {
     (void)node; (void)out; return Status::kInvalid;
   }
 
+  // Transport-level Prometheus metrics (e.g. RDMA per-rail connections, MR
+  // registrations). Default empty; the RDMA transport overrides it. Folded into
+  // the client snapshot. Off the datapath (rendered on demand).
+  virtual std::string MetricsText() const { return ""; }
+
   // Register a large caller memory region (e.g. the whole SGLang host KV pool) for
   // zero-copy transfer. A pipelined (RDMA) transport registers it once per
   // connection so the Get/Put datapath never does a per-op MR registration —

--- a/tests/python/test_dfkv_hicache.py
+++ b/tests/python/test_dfkv_hicache.py
@@ -269,6 +269,9 @@ class DingoFSHiCacheTest(unittest.TestCase):
         self.assertEqual(m["get_pages"], 3)
         self.assertEqual(m["get_hit_pages"], 3)
         self.assertEqual(m["get_bytes"], 3 * self.PAGE_BYTES)
+        # latency histograms observed one duration per batch call
+        self.assertEqual(m["set_observations"], 1)
+        self.assertEqual(m["get_observations"], 1)
 
     def test_mla_writes_single_object_per_page(self):
         members, port, ndir = self._node("mla")

--- a/tests/rdma_loopback_test.cc
+++ b/tests/rdma_loopback_test.cc
@@ -95,6 +95,38 @@ TEST(RdmaLoopback, PutGetExistMissOverRdma) {
   EXPECT_FALSE(c.Exist("absent"));
 }
 
+// Observability counters: the server tallies request completions and the client
+// transport tallies connections opened (+ per-rail) and MR regions.
+TEST(RdmaLoopback, MetricsCountersTrackOps) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  RdmaNode node("mco");
+  RdmaTransport rt(kMaxMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+
+  std::vector<char> pool(64 * 1024);
+  c.RegisterMemory(pool.data(), pool.size());
+  std::string v(2048, 'z');
+  ASSERT_TRUE(c.Put("m1", v.data(), v.size()));
+  std::string out(v.size(), '\0');
+  ASSERT_TRUE(c.Get("m1", &out[0], out.size()));
+
+  // server: at least the PUT + GET requests were completed
+  EXPECT_GE(node.rsrv->Completions(), 2u);
+  std::string srv_text = node.rsrv->MetricsText();
+  EXPECT_NE(srv_text.find("dfkv_rdma_completions_total"), std::string::npos) << srv_text;
+
+  // client transport: a connection was opened and the MR region declared
+  std::string cli_text = rt.MetricsText();
+  EXPECT_NE(cli_text.find("dfkv_rdma_client_conns_opened_total"), std::string::npos) << cli_text;
+  EXPECT_NE(cli_text.find("dfkv_rdma_client_rail_conns_total{dev="), std::string::npos) << cli_text;
+  EXPECT_NE(cli_text.find("dfkv_rdma_client_mr_regions 1"), std::string::npos) << cli_text;
+
+  // and the client snapshot folds transport metrics in after the health metrics
+  std::string snap = c.MetricsSnapshot();
+  EXPECT_NE(snap.find("dfkv_client_ops_served_total"), std::string::npos) << snap;
+  EXPECT_NE(snap.find("dfkv_rdma_client_conns_opened_total"), std::string::npos) << snap;
+}
+
 TEST(RdmaLoopback, BatchZeroCopyRoundtrip) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   RdmaNode node("bzc");


### PR DESCRIPTION
PR 5/5 — the final observability layer (toward v1.4.0). Adds RDMA-level counters
and plugin-side latency histograms.

## What
- **RDMA server counters** (`RdmaServer`): `dfkv_rdma_completions_total`, `completion_errors_total`, `active_conns` (gauge), `idle_reclaims_total`, incremented in the completion loop. Folded into `dfkv_server`'s `/metrics` render callback (combined with the cache-node metrics).
- **RDMA client transport counters** (`RdmaTransport`): `dfkv_rdma_client_conns_opened_total`, `mr_regions`, and per-rail `rail_conns_total{dev}` (counted at connection setup / `PickRail`). Exposed via a new `Transport::MetricsText()` virtual (default empty; TCP no-op) and **folded into the client snapshot** (`KVClient::MetricsSnapshot`).
- **Plugin latency histograms** (`dfkv_metrics.py`): `dfkv_client_set_seconds` / `dfkv_client_get_seconds{tp_rank}` (multiproc-safe Histograms). `batch_set_v1`/`batch_get_v1` measure one `perf_counter` pair per **batch** (not per page) and observe it.

## Perf
RDMA counters are relaxed atomics in the completion loop / at (infrequent, pooled) connection setup — no per-byte work. The plugin times once per batch call. No datapath regression.

## Tests
- `rdma_loopback_test.MetricsCountersTrackOps`: server completions + client conns/rail/MR counters + combined snapshot — **run on real Soft-RoCE (rdma_rxe) locally, passed**.
- `test_dfkv_hicache`: histogram observation count per batch call.
- Full ctest: **152/152** (TCP) and **162/162** (RDMA build, rxe loopback) green; python plugin **30/30**.

## Compatibility
New virtual + counters; pure additions, no wire-protocol change.