### PR TITLE
feat(cli): --version / -V flag on all binaries

### DIFF
--- a/src/dfkv_bench_main.cc
+++ b/src/dfkv_bench_main.cc
@@ -25,6 +25,7 @@
 #include "kv_client.h"
 #include "transport_factory.h"
 #include "value_header.h"
+#include "version.h"
 
 using namespace dfkv;  // NOLINT
 using Clock = std::chrono::steady_clock;
@@ -84,6 +85,7 @@ static void Report(const char* phase, size_t count, size_t size, size_t threads,
 }
 
 int main(int argc, char** argv) {
+  if (dfkv::WantsVersion(argc, argv)) { std::printf("dfkv_bench %s\n", dfkv::Version()); return 0; }
   std::string members, op = "both";
   size_t size = 2752512, count = 2000, threads = 8, batch = 1, bc = 0;
   for (int i = 1; i + 1 < argc; i += 2) {

--- a/src/dfkv_discover_smoke_main.cc
+++ b/src/dfkv_discover_smoke_main.cc
@@ -22,6 +22,7 @@
 
 #include "kv_client.h"
 #include "value_header.h"
+#include "version.h"
 
 using dfkv::KVClient;
 using dfkv::ValueHeader;
@@ -37,6 +38,7 @@ static std::vector<std::string> SplitComma(const std::string& s) {
 }
 
 int main(int argc, char** argv) {
+  if (dfkv::WantsVersion(argc, argv)) { std::printf("dfkv_discover_smoke %s\n", dfkv::Version()); return 0; }
   std::string mds_arg;
   std::string group   = "default";
   int         count   = 200;

--- a/src/dfkv_mds_main.cc
+++ b/src/dfkv_mds_main.cc
@@ -8,6 +8,7 @@
 
 #include "mds_server.h"
 #include "metrics_http.h"
+#include "version.h"
 
 namespace {
 volatile sig_atomic_t g_stop = 0;
@@ -15,6 +16,7 @@ void OnSig(int) { g_stop = 1; }  // async-signal-safe: just set a flag
 }  // namespace
 
 int main(int argc, char** argv) {
+  if (dfkv::WantsVersion(argc, argv)) { std::printf("dfkv_mds %s\n", dfkv::Version()); return 0; }
   std::string etcd = "127.0.0.1:2379";
   int port = 0, metrics_port = -1;
   for (int i = 1; i + 1 < argc; i += 2) {

--- a/src/dfkv_server_main.cc
+++ b/src/dfkv_server_main.cc
@@ -16,6 +16,7 @@
 #include "log.h"
 #include "mds_registrar.h"
 #include "metrics_http.h"
+#include "version.h"
 #ifdef DFKV_WITH_RDMA
 #include "rdma_server.h"
 #endif
@@ -27,6 +28,7 @@ static volatile sig_atomic_t g_stop = 0;
 static void OnSig(int) { g_stop = 1; }
 
 int main(int argc, char** argv) {
+  if (dfkv::WantsVersion(argc, argv)) { std::printf("dfkv_server %s\n", dfkv::Version()); return 0; }
   std::string dir = "/tmp/dfkv_node";
   std::string rdma_dev, mds, group = "default", node_id, advertise;
   int weight = 1;

--- a/src/dfkv_smoke_main.cc
+++ b/src/dfkv_smoke_main.cc
@@ -8,6 +8,7 @@
 
 #include "kv_client.h"
 #include "value_header.h"
+#include "version.h"
 
 using namespace dfkv;  // NOLINT
 
@@ -27,6 +28,7 @@ static std::vector<std::pair<std::string, std::string>> ParseMembers(const std::
 }
 
 int main(int argc, char** argv) {
+  if (WantsVersion(argc, argv)) { std::printf("dfkv_smoke %s\n", Version()); return 0; }
   std::string members;
   size_t size = 4096;
   for (int i = 1; i + 1 < argc; i += 2) {

--- a/src/dfkvctl_main.cc
+++ b/src/dfkvctl_main.cc
@@ -20,6 +20,7 @@
 #include "prom_parse.h"
 #include "tcp_transport.h"
 #include "value_header.h"
+#include "version.h"
 
 using namespace dfkv;  // NOLINT
 
@@ -116,6 +117,7 @@ static std::vector<std::pair<std::string, std::string>> ParseMembers(const std::
 }
 
 int main(int argc, char** argv) {
+  if (WantsVersion(argc, argv)) { std::printf("dfkvctl %s\n", Version()); return 0; }
   std::string members;
   uint64_t model_hash = 0x51;
   uint32_t page = 64, dtype = 0x46384534u, layer = 78, head = 1, hd = 576, tps = 8, tpr = 0, mla = 1;

--- a/src/version.cc
+++ b/src/version.cc
@@ -1,0 +1,20 @@
+#include "version.h"
+
+#include <cstring>
+
+#ifndef DFKV_VERSION
+#define DFKV_VERSION "dev"
+#endif
+
+namespace dfkv {
+
+const char* Version() { return DFKV_VERSION; }
+
+bool WantsVersion(int argc, char** argv) {
+  for (int i = 1; i < argc; ++i)
+    if (!std::strcmp(argv[i], "--version") || !std::strcmp(argv[i], "-V"))
+      return true;
+  return false;
+}
+
+}  // namespace dfkv

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,20 @@
+/* dfkv version string, baked in at build time (DFKV_VERSION from CMake
+ * PROJECT_VERSION). Defined in version.cc which is compiled into dfkv_core — the
+ * only target that carries the DFKV_VERSION compile definition — so every binary
+ * that links the core gets the same value. */
+#ifndef DFKV_VERSION_H_
+#define DFKV_VERSION_H_
+
+namespace dfkv {
+
+// e.g. "1.4.0" (or "dev" for an un-stamped build).
+const char* Version();
+
+// True if argv contains "--version" or "-V". Helper so each *_main can early-exit
+// before its (flag-pair) argument parser, which would otherwise ignore a lone
+// --version and fall through to running the daemon.
+bool WantsVersion(int argc, char** argv);
+
+}  // namespace dfkv
+
+#endif  // DFKV_VERSION_H_

--- a/tests/tool_smoke.sh
+++ b/tests/tool_smoke.sh
@@ -2,6 +2,15 @@
 # Integration smoke for dfkv_server + dfkv_smoke + dfkvctl. arg1 = build dir.
 set -e
 BUILD="${1:?build dir}"
+
+# --version: each binary prints its name + a version string and exits 0 (must NOT
+# fall through to running the daemon).
+for b in dfkv_server dfkv_mds dfkvctl dfkv_bench dfkv_smoke; do
+  out=$("$BUILD/$b" --version)
+  echo "$out" | grep -qE "^$b [0-9]+\.[0-9]+" || { echo "$b --version bad: '$out'"; exit 1; }
+done
+echo "version smoke OK"
+
 D=$(mktemp -d)
 : > "$D/srv.out"   # pre-create so the awk below can't fail on a missing file under `set -e`
 "$BUILD/dfkv_server" --dir "$D" --port 0 --cap 1073741824 >>"$D/srv.out" 2>&1 &

--- a/tests/version_test.cc
+++ b/tests/version_test.cc
@@ -1,0 +1,31 @@
+// TDD — version string + --version arg detection.
+#include "version.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+using namespace dfkv;  // NOLINT
+
+TEST(Version, NonEmptyAndSemverish) {
+  std::string v = Version();
+  ASSERT_FALSE(v.empty());
+  // CI/release builds stamp DFKV_VERSION (e.g. "1.4.1"); has a digit and a dot.
+  EXPECT_NE(v.find('.'), std::string::npos) << v;
+  EXPECT_NE(v.find_first_of("0123456789"), std::string::npos) << v;
+}
+
+TEST(Version, WantsVersionDetectsFlag) {
+  char a0[] = "dfkv_server";
+  char vlong[] = "--version";
+  char vshort[] = "-V";
+  char other[] = "--listen";
+  char* with_long[] = {a0, vlong};
+  char* with_short[] = {a0, vshort};
+  char* without[] = {a0, other};
+  EXPECT_TRUE(WantsVersion(2, with_long));
+  EXPECT_TRUE(WantsVersion(2, with_short));
+  EXPECT_FALSE(WantsVersion(2, without));
+  EXPECT_FALSE(WantsVersion(1, with_long));  // argv[0] only
+}


### PR DESCRIPTION
Adds `--version`/`-V` to every binary (`dfkv_server`, `dfkv_mds`, `dfkvctl`, `dfkv_bench`, `dfkv_smoke`, `dfkv_discover_smoke`): prints `<name> <version>` and exits 0.

## Why
dfkv had **no version flag**, and the pair-wise (`i+=2`) arg parsers silently ignored a lone `--version` and fell through to **running the daemon** — e.g. `dfkv_mds --version` would start a stray second MDS. This is the clean way to verify a deployed/upgraded binary's version (complements `dfkv_build_info{version}` on `/metrics`).

## How
Version baked from CMake `PROJECT_VERSION` via `DFKV_VERSION`, centralized in `src/version.{h,cc}` (compiled into `dfkv_core`, the only target carrying the define). Each main early-exits via `dfkv::WantsVersion(argc, argv)` before its parser.

## Tests
- `version_test`: `Version()` non-empty/semver-ish; `WantsVersion` detects `--version`/`-V`.
- `tool_smoke.sh`: every binary's `--version` prints `^<name> <ver>` and exits 0.
- Full ctest **154/154**.