### PR TITLE
fix(server): reap finished connection-handler threads (no unbounded growth)

### DIFF
--- a/src/kv_node_server.cc
+++ b/src/kv_node_server.cc
@@ -64,14 +64,30 @@ void KvNodeServer::Stop() {
   // accept loop is done; drain in-flight connections: unblock their recv(), then
   // join handler threads so group_ outlives them.
   std::vector<int> fds;
-  std::vector<std::thread> threads;
+  std::vector<Conn> conns;
   {
     std::lock_guard<std::mutex> lk(conn_mu_);
     fds.assign(conn_fds_.begin(), conn_fds_.end());
-    threads.swap(conn_threads_);
+    conns.swap(conns_);
   }
   for (int fd : fds) ::shutdown(fd, SHUT_RDWR);
-  for (auto& t : threads) if (t.joinable()) t.join();
+  for (auto& c : conns) if (c.th.joinable()) c.th.join();
+}
+
+void KvNodeServer::ReapDoneLocked() {
+  for (auto it = conns_.begin(); it != conns_.end();) {
+    if (it->done->load(std::memory_order_acquire)) {
+      if (it->th.joinable()) it->th.join();
+      it = conns_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+size_t KvNodeServer::live_conn_count() {
+  std::lock_guard<std::mutex> lk(conn_mu_);
+  return conns_.size();
 }
 
 #ifndef DFKV_VERSION
@@ -177,13 +193,18 @@ void KvNodeServer::AcceptLoop() {
     accept_count_.fetch_add(1, std::memory_order_relaxed);
     open_connections_.fetch_add(1, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(conn_mu_);
+    if (!running_) { open_connections_.fetch_sub(1, std::memory_order_relaxed); ::close(fd); break; }
+    ReapDoneLocked();  // join handlers that finished since the last accept
     conn_fds_.insert(fd);
-    conn_threads_.emplace_back([this, fd] {
-      Handle(fd);
-      open_connections_.fetch_sub(1, std::memory_order_relaxed);
-      { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
-      ::close(fd);
-    });
+    auto done = std::make_shared<std::atomic<bool>>(false);
+    conns_.push_back({std::thread([this, fd, done] {
+                        Handle(fd);
+                        open_connections_.fetch_sub(1, std::memory_order_relaxed);
+                        { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
+                        ::close(fd);
+                        done->store(true, std::memory_order_release);  // last act
+                      }),
+                      done});
   }
 }
 

--- a/src/kv_node_server.h
+++ b/src/kv_node_server.h
@@ -44,6 +44,7 @@ class KvNodeServer {
   uint64_t UsedBytes() const { return group_.UsedBytes(); }
   size_t DiskCount() const { return group_.DiskCount(); }
   size_t AcceptCount() const { return accept_count_.load(std::memory_order_relaxed); }
+  size_t live_conn_count();  // handler threads not yet reaped (test/diagnostic)
 
   // metrics (relaxed atomics)
   size_t m_cache_put() const { return cache_put_.load(std::memory_order_relaxed); }
@@ -81,6 +82,7 @@ class KvNodeServer {
  private:
   void AcceptLoop();
   void Handle(int fd);
+  void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
   std::atomic<size_t> cache_put_{0}, cache_hit_{0}, cache_miss_{0};
   std::atomic<size_t> exist_hit_{0}, exist_miss_{0};
   std::atomic<size_t> bytes_written_{0}, bytes_read_{0};
@@ -100,10 +102,16 @@ class KvNodeServer {
   std::atomic<size_t> accept_count_{0};
   std::thread accept_thread_;
   // connection drain: track per-connection handler threads + their fds so Stop()
-  // can unblock (shutdown) and join them before group_ is destroyed.
+  // can unblock (shutdown) and join them before group_ is destroyed. Finished
+  // handlers are reaped incrementally at accept time (done flag), so a long-lived
+  // node with churning clients doesn't accumulate dead thread handles.
+  struct Conn {
+    std::thread th;
+    std::shared_ptr<std::atomic<bool>> done;
+  };
   std::mutex conn_mu_;
   std::set<int> conn_fds_;
-  std::vector<std::thread> conn_threads_;
+  std::vector<Conn> conns_;
 };
 
 }  // namespace dfkv

--- a/src/mds_server.cc
+++ b/src/mds_server.cc
@@ -46,14 +46,30 @@ void MdsServer::Stop() {
   if (accept_thread_.joinable()) accept_thread_.join();
   if (listen_fd_ >= 0) { ::close(listen_fd_); listen_fd_ = -1; }
   std::vector<int> fds;
-  std::vector<std::thread> threads;
+  std::vector<Conn> conns;
   {
     std::lock_guard<std::mutex> lk(conn_mu_);
     fds.assign(conn_fds_.begin(), conn_fds_.end());
-    threads.swap(conn_threads_);
+    conns.swap(conns_);
   }
   for (int fd : fds) ::shutdown(fd, SHUT_RDWR);
-  for (auto& t : threads) if (t.joinable()) t.join();
+  for (auto& c : conns) if (c.th.joinable()) c.th.join();
+}
+
+void MdsServer::ReapDoneLocked() {
+  for (auto it = conns_.begin(); it != conns_.end();) {
+    if (it->done->load(std::memory_order_acquire)) {
+      if (it->th.joinable()) it->th.join();
+      it = conns_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+size_t MdsServer::live_conn_count() {
+  std::lock_guard<std::mutex> lk(conn_mu_);
+  return conns_.size();
 }
 
 void MdsServer::AcceptLoop() {
@@ -63,16 +79,21 @@ void MdsServer::AcceptLoop() {
     int one = 1;
     ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     std::lock_guard<std::mutex> lk(conn_mu_);
+    if (!running_) { ::close(fd); break; }
+    ReapDoneLocked();  // join handlers that finished since the last accept
     conn_fds_.push_back(fd);
-    conn_threads_.emplace_back([this, fd] {
-      Handle(fd);
-      {
-        std::lock_guard<std::mutex> lk(conn_mu_);
-        for (auto it = conn_fds_.begin(); it != conn_fds_.end(); ++it)
-          if (*it == fd) { conn_fds_.erase(it); break; }
-      }
-      ::close(fd);
-    });
+    auto done = std::make_shared<std::atomic<bool>>(false);
+    conns_.push_back({std::thread([this, fd, done] {
+                        Handle(fd);
+                        {
+                          std::lock_guard<std::mutex> lk(conn_mu_);
+                          for (auto it = conn_fds_.begin(); it != conn_fds_.end(); ++it)
+                            if (*it == fd) { conn_fds_.erase(it); break; }
+                        }
+                        ::close(fd);
+                        done->store(true, std::memory_order_release);  // last act
+                      }),
+                      done});
   }
 }
 

--- a/src/mds_server.h
+++ b/src/mds_server.h
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -30,12 +31,14 @@ class MdsServer {
   void Stop();
   int port() const { return port_; }
   std::string MetricsText() const { return metrics_.Render(); }
+  size_t live_conn_count();  // handler threads not yet reaped (test/diagnostic)
 
   static constexpr int kTtlSeconds = 30;
 
  private:
   void AcceptLoop();
   void Handle(int fd);
+  void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
   Status Upsert(const std::string& group, const MemberInfo& m);
   Status ListMembers(const std::string& group, std::string* out);
   static std::string MemberKey(const std::string& group, const std::string& id);
@@ -46,9 +49,13 @@ class MdsServer {
   int listen_fd_ = -1;
   int port_ = 0;
   std::thread accept_thread_;
+  struct Conn {
+    std::thread th;
+    std::shared_ptr<std::atomic<bool>> done;
+  };
   std::mutex conn_mu_;
   std::vector<int> conn_fds_;
-  std::vector<std::thread> conn_threads_;
+  std::vector<Conn> conns_;
   std::mutex lease_mu_;
   std::map<std::string, int64_t> leases_;
   MdsMetrics metrics_;

--- a/src/metrics_http.cc
+++ b/src/metrics_http.cc
@@ -42,14 +42,30 @@ void MetricsHttpServer::Stop() {
   if (accept_thread_.joinable()) accept_thread_.join();
   if (listen_fd_ >= 0) { ::close(listen_fd_); listen_fd_ = -1; }
   std::vector<int> fds;
-  std::vector<std::thread> threads;
+  std::vector<Conn> conns;
   {
     std::lock_guard<std::mutex> lk(conn_mu_);
     fds.assign(conn_fds_.begin(), conn_fds_.end());
-    threads.swap(conn_threads_);
+    conns.swap(conns_);
   }
   for (int fd : fds) ::shutdown(fd, SHUT_RDWR);
-  for (auto& t : threads) if (t.joinable()) t.join();
+  for (auto& c : conns) if (c.th.joinable()) c.th.join();
+}
+
+void MetricsHttpServer::ReapDoneLocked() {
+  for (auto it = conns_.begin(); it != conns_.end();) {
+    if (it->done->load(std::memory_order_acquire)) {
+      if (it->th.joinable()) it->th.join();
+      it = conns_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+size_t MetricsHttpServer::live_conn_count() {
+  std::lock_guard<std::mutex> lk(conn_mu_);
+  return conns_.size();
 }
 
 void MetricsHttpServer::AcceptLoop() {
@@ -57,12 +73,17 @@ void MetricsHttpServer::AcceptLoop() {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
     if (fd < 0) { if (!running_) break; continue; }
     std::lock_guard<std::mutex> lk(conn_mu_);
+    if (!running_) { ::close(fd); break; }
+    ReapDoneLocked();  // join finished scrape handlers (Connection: close => one per scrape)
     conn_fds_.insert(fd);
-    conn_threads_.emplace_back([this, fd] {
-      Handle(fd);
-      { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
-      ::close(fd);
-    });
+    auto done = std::make_shared<std::atomic<bool>>(false);
+    conns_.push_back({std::thread([this, fd, done] {
+                        Handle(fd);
+                        { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
+                        ::close(fd);
+                        done->store(true, std::memory_order_release);  // last act
+                      }),
+                      done});
   }
 }
 

--- a/src/metrics_http.h
+++ b/src/metrics_http.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <set>
 #include <thread>
@@ -30,10 +31,23 @@ class MetricsHttpServer {
   Status Start(int port);  // port 0 => ephemeral; query with port()
   void Stop();             // idempotent
   int port() const { return port_; }
+  // Handler threads not yet reaped (test/diagnostic). Bounded under scrape churn
+  // now that finished connections are joined as new ones arrive — Prometheus
+  // scrapes are Connection: close, so without reaping this grew per scrape.
+  size_t live_conn_count();
 
  private:
   void AcceptLoop();
   void Handle(int fd);
+  void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
+
+  // A live connection: its handler thread + a flag the thread sets last, so
+  // AcceptLoop can join it without blocking. shared_ptr because conns_ may
+  // reallocate; the thread captures its own copy.
+  struct Conn {
+    std::thread th;
+    std::shared_ptr<std::atomic<bool>> done;
+  };
 
   std::function<std::string()> render_;
   int listen_fd_ = -1;
@@ -42,7 +56,7 @@ class MetricsHttpServer {
   std::thread accept_thread_;
   std::mutex conn_mu_;
   std::set<int> conn_fds_;
-  std::vector<std::thread> conn_threads_;
+  std::vector<Conn> conns_;
 };
 
 }  // namespace dfkv

--- a/tests/metrics_http_test.cc
+++ b/tests/metrics_http_test.cc
@@ -56,6 +56,22 @@ TEST(MetricsHttp, ServesMetricsHealthzAnd404) {
   srv.Stop();
 }
 
+TEST(MetricsHttp, ReapsHandlerThreadsAcrossScrapes) {
+  // Prometheus scrapes are Connection: close — one connection per scrape. Without
+  // reaping, the handler-thread list grew unbounded. After many sequential
+  // scrapes the live (unreaped) count must stay small, not ~N.
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int port = srv.port();
+  for (int i = 0; i < 60; ++i) {
+    std::string m = HttpGet(port, "/metrics");
+    EXPECT_NE(m.find("dfkv_x 1"), std::string::npos);
+  }
+  // accept-time reaping joins finished handlers; allow a tiny in-flight slack.
+  EXPECT_LE(srv.live_conn_count(), 3u) << "handler threads not reaped";
+  srv.Stop();
+}
+
 TEST(MetricsHttp, StopIsIdempotent) {
   MetricsHttpServer srv([] { return std::string("x 1\n"); });
   ASSERT_EQ(srv.Start(0), Status::kOk);

--- a/tests/metrics_test.cc
+++ b/tests/metrics_test.cc
@@ -1,9 +1,14 @@
 // TDD R11 — server metrics counters + Prometheus text + remote Stats op.
 #include "kv_node_server.h"
 #include "key_map.h"
+#include "net_util.h"
 #include "tcp_transport.h"
 
 #include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+#include <unistd.h>
 
 #include <filesystem>
 #include <memory>
@@ -109,6 +114,31 @@ TEST(Metrics, OpenConnectionsTracksLiveConn) {
     // a connection is open while the pooled fd lives
     EXPECT_NE(s->MetricsText().find("dfkv_open_connections"), std::string::npos);
   }  // transport destructor closes the pooled fd; server-side handler exits
+  s->Stop();
+}
+
+TEST(Metrics, ReapsConnHandlerThreads) {
+  // Short-lived client connections (connect + immediate close) each spawn a
+  // handler thread that exits on peer-close. Reaping at accept time must keep the
+  // unreaped handler-thread list bounded, not growing ~1 per connection.
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_metrics_reap";
+  auto s = Start(dir, &addr);
+  for (int i = 0; i < 80; ++i) {
+    int fd = net::Dial(addr, 1000, 1000);
+    ASSERT_GE(fd, 0);
+    ::close(fd);  // peer close -> handler's ReadAll fails -> handler exits
+  }
+  // Reaping fires on accept; nudge a few more + poll until it drains.
+  size_t live = 999;
+  for (int r = 0; r < 40; ++r) {
+    int fd = net::Dial(addr, 1000, 1000);
+    if (fd >= 0) ::close(fd);
+    live = s->live_conn_count();
+    if (live <= 5) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  EXPECT_LE(live, 5u) << "conn handler threads not reaped";
   s->Stop();
 }
 


### PR DESCRIPTION
From a v1.5.1 code review (finding #1, HIGH). `metrics_http`, `kv_node_server`, and `mds_server` use a thread-per-connection model and only joined handler threads at `Stop()` — so finished handlers' `std::thread` objects accumulated for the daemon's whole lifetime.

**Acute for `metrics_http`:** Prometheus scrapes are `Connection: close`, so **every scrape leaked one thread object** (~thousands/day per node once `/metrics` is enabled — which it now is across the hd04 fleet). `kv_node_server`/`mds_server` share the pattern (less acute: keep-alive connections).

## Fix
Mirror the existing, proven `rdma_server` reaping: each handler sets a shared `done` flag as its **last** act; `AcceptLoop` calls `ReapDoneLocked()` (join+erase finished handlers) before accepting the next connection. Added `live_conn_count()` test accessor. No change to the hot path; `Stop()` still drains in-flight connections.

The `done`-set-last invariant (after all `conn_mu_` use in the handler) means the reaper only ever joins threads that are about to exit → never blocks (same as `rdma_server`).

## Tests
- `MetricsHttp.ReapsHandlerThreadsAcrossScrapes`: 60 sequential scrapes → live unreaped ≤ 3.
- `Metrics.ReapsConnHandlerThreads`: 80 short-lived connections → live ≤ 5.
- Full ctest **158/158**.