### PR TITLE
fix(metrics): escape label values; ns latency sum; per-peer cap; --metrics-bind

### DIFF
--- a/src/dfkv_mds_main.cc
+++ b/src/dfkv_mds_main.cc
@@ -17,12 +17,13 @@ void OnSig(int) { g_stop = 1; }  // async-signal-safe: just set a flag
 
 int main(int argc, char** argv) {
   if (dfkv::WantsVersion(argc, argv)) { std::printf("dfkv_mds %s\n", dfkv::Version()); return 0; }
-  std::string etcd = "127.0.0.1:2379";
+  std::string etcd = "127.0.0.1:2379", metrics_bind;
   int port = 0, metrics_port = -1;
   for (int i = 1; i + 1 < argc; i += 2) {
     if (!std::strcmp(argv[i], "--etcd")) etcd = argv[i + 1];
     else if (!std::strcmp(argv[i], "--listen")) port = std::atoi(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--metrics-port")) metrics_port = std::atoi(argv[i + 1]);
+    else if (!std::strcmp(argv[i], "--metrics-bind")) metrics_bind = argv[i + 1];
   }
   dfkv::MdsServer srv(etcd);
   std::signal(SIGINT, OnSig);
@@ -37,7 +38,7 @@ int main(int argc, char** argv) {
   std::unique_ptr<dfkv::MetricsHttpServer> mhttp;
   if (metrics_port >= 0) {
     mhttp = std::make_unique<dfkv::MetricsHttpServer>([&srv] { return srv.MetricsText(); });
-    if (mhttp->Start(metrics_port) == dfkv::Status::kOk)
+    if (mhttp->Start(metrics_port, metrics_bind) == dfkv::Status::kOk)
       std::printf("dfkv_mds /metrics on port %d\n", mhttp->port());
     std::fflush(stdout);
   }

--- a/src/dfkv_server_main.cc
+++ b/src/dfkv_server_main.cc
@@ -30,7 +30,7 @@ static void OnSig(int) { g_stop = 1; }
 int main(int argc, char** argv) {
   if (dfkv::WantsVersion(argc, argv)) { std::printf("dfkv_server %s\n", dfkv::Version()); return 0; }
   std::string dir = "/tmp/dfkv_node";
-  std::string rdma_dev, mds, group = "default", node_id, advertise;
+  std::string rdma_dev, mds, group = "default", node_id, advertise, metrics_bind;
   int weight = 1;
   int port = 0, rdma_port = -1, metrics_port = -1;
   unsigned long long cap = 1ull << 30;
@@ -46,6 +46,7 @@ int main(int argc, char** argv) {
     else if (!std::strcmp(argv[i], "--advertise")) advertise = argv[i + 1];
     else if (!std::strcmp(argv[i], "--weight")) weight = std::atoi(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--metrics-port")) metrics_port = std::atoi(argv[i + 1]);
+    else if (!std::strcmp(argv[i], "--metrics-bind")) metrics_bind = argv[i + 1];
   }
   (void)rdma_port;
   std::signal(SIGINT, OnSig);
@@ -124,7 +125,7 @@ int main(int argc, char** argv) {
 #endif
       return s;
     });
-    if (mhttp->Start(metrics_port) == Status::kOk)
+    if (mhttp->Start(metrics_port, metrics_bind) == Status::kOk)
       DFKV_LOG_INFO("dfkv_server /metrics on port " + std::to_string(mhttp->port()));
     else
       DFKV_LOG_WARN("dfkv_server /metrics failed to start on port " + std::to_string(metrics_port));

--- a/src/kv_node_server.cc
+++ b/src/kv_node_server.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "net_util.h"
+#include "prom_escape.h"
 #include "transport.h"
 
 namespace dfkv {
@@ -104,7 +105,8 @@ std::string KvNodeServer::MetricsText() const {
   // single-node scrape and older tooling keep the bare `metric N` form.
   std::string idlabels;
   if (!node_id_.empty() || !node_group_.empty())
-    idlabels = "node=\"" + node_id_ + "\",group=\"" + node_group_ + "\"";
+    idlabels = "node=\"" + PromLabelEscape(node_id_) + "\",group=\"" +
+               PromLabelEscape(node_group_) + "\"";
   // braces(extra): merge `extra` label set with the identity labels.
   auto braces = [&](const std::string& extra) {
     std::string in = extra;
@@ -126,7 +128,8 @@ std::string KvNodeServer::MetricsText() const {
   s += std::string("dfkv_build_info{version=\"") + DFKV_VERSION +
        "\",transport=\"" DFKV_BUILD_TRANSPORT "\"";
   if (!node_id_.empty() || !node_group_.empty())
-    s += ",node=\"" + node_id_ + "\",group=\"" + node_group_ + "\"";
+    s += ",node=\"" + PromLabelEscape(node_id_) + "\",group=\"" +
+         PromLabelEscape(node_group_) + "\"";
   s += "} 1\n";
   uint64_t up = std::chrono::duration_cast<std::chrono::seconds>(
                     std::chrono::steady_clock::now() - start_time_).count();
@@ -164,12 +167,12 @@ std::string KvNodeServer::MetricsText() const {
   s += "# HELP dfkv_disk_used_bytes Bytes used per backing disk\n";
   s += "# TYPE dfkv_disk_used_bytes gauge\n";
   for (size_t i = 0; i < group_.DiskCount(); ++i)
-    s += "dfkv_disk_used_bytes" + braces("disk=\"" + group_.DiskPath(i) + "\"") + " " +
+    s += "dfkv_disk_used_bytes" + braces("disk=\"" + PromLabelEscape(group_.DiskPath(i)) + "\"") + " " +
          std::to_string(group_.DiskUsedBytes(i)) + "\n";
   s += "# HELP dfkv_disk_objects Objects per backing disk\n";
   s += "# TYPE dfkv_disk_objects gauge\n";
   for (size_t i = 0; i < group_.DiskCount(); ++i)
-    s += "dfkv_disk_objects" + braces("disk=\"" + group_.DiskPath(i) + "\"") + " " +
+    s += "dfkv_disk_objects" + braces("disk=\"" + PromLabelEscape(group_.DiskPath(i)) + "\"") + " " +
          std::to_string(group_.DiskObjects(i)) + "\n";
   // sampled op latency histograms (op label merged with identity); one HELP/TYPE,
   // two label sets (get/put).

--- a/src/latency_hist.h
+++ b/src/latency_hist.h
@@ -21,7 +21,9 @@ class LatencyHist {
 
   void Observe(double seconds) {
     if (seconds < 0) seconds = 0;
-    sum_us_.fetch_add(static_cast<uint64_t>(seconds * 1e6), std::memory_order_relaxed);
+    // Accumulate nanoseconds (not µs) so sub-µs/fractional-µs cache-hit latencies
+    // aren't floored to 0 — at µs granularity _sum was biased low for fast ops.
+    sum_ns_.fetch_add(static_cast<uint64_t>(seconds * 1e9), std::memory_order_relaxed);
     count_.fetch_add(1, std::memory_order_relaxed);
     for (int i = 0; i < kNB; ++i) {
       if (seconds <= kBounds[i]) { buckets_[i].fetch_add(1, std::memory_order_relaxed); return; }
@@ -31,7 +33,7 @@ class LatencyHist {
 
   uint64_t Count() const { return count_.load(std::memory_order_relaxed); }
   double Sum() const {
-    return static_cast<double>(sum_us_.load(std::memory_order_relaxed)) / 1e6;
+    return static_cast<double>(sum_ns_.load(std::memory_order_relaxed)) / 1e9;
   }
 
   // Full Prometheus block (HELP + TYPE + body). `labels` is the inner label set
@@ -69,7 +71,7 @@ class LatencyHist {
  private:
   std::atomic<uint64_t> buckets_[kNB]{};
   std::atomic<uint64_t> inf_{0};
-  std::atomic<uint64_t> sum_us_{0};
+  std::atomic<uint64_t> sum_ns_{0};
   std::atomic<uint64_t> count_{0};
 };
 

--- a/src/metrics_http.cc
+++ b/src/metrics_http.cc
@@ -13,7 +13,7 @@ namespace dfkv {
 
 MetricsHttpServer::~MetricsHttpServer() { Stop(); }
 
-Status MetricsHttpServer::Start(int port) {
+Status MetricsHttpServer::Start(int port, const std::string& bind_addr) {
   listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
   if (listen_fd_ < 0) return Status::kIOError;
   int one = 1;
@@ -21,6 +21,10 @@ Status MetricsHttpServer::Start(int port) {
   sockaddr_in sa{};
   sa.sin_family = AF_INET;
   sa.sin_addr.s_addr = htonl(INADDR_ANY);
+  if (!bind_addr.empty() &&
+      ::inet_pton(AF_INET, bind_addr.c_str(), &sa.sin_addr) != 1) {
+    ::close(listen_fd_); listen_fd_ = -1; return Status::kInvalid;  // bad bind addr
+  }
   sa.sin_port = htons(static_cast<uint16_t>(port));
   if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)) != 0) {
     ::close(listen_fd_); listen_fd_ = -1; return Status::kIOError;

--- a/src/metrics_http.h
+++ b/src/metrics_http.h
@@ -28,7 +28,9 @@ class MetricsHttpServer {
       : render_(std::move(render)) {}
   ~MetricsHttpServer();
 
-  Status Start(int port);  // port 0 => ephemeral; query with port()
+  // port 0 => ephemeral (query with port()). bind_addr empty => all interfaces
+  // (back-compat); pass e.g. "127.0.0.1" to restrict /metrics to loopback.
+  Status Start(int port, const std::string& bind_addr = "");
   void Stop();             // idempotent
   int port() const { return port_; }
   // Handler threads not yet reaped (test/diagnostic). Bounded under scrape churn

--- a/src/peer_health.h
+++ b/src/peer_health.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "prom_escape.h"
+
 namespace dfkv {
 
 // Layer-1 fast avoidance: a peer (keyed by "ip:port") that fails a transport IO
@@ -37,7 +39,10 @@ class PeerHealth {
     until_[peer] = now_ms + cooldown_ms_;
     errors_.fetch_add(1, std::memory_order_relaxed);
     if (was_ok) marked_bad_.fetch_add(1, std::memory_order_relaxed);  // healthy->bad edge
-    peer_errors_[peer]++;
+    // Bound per-peer cardinality: only track a new peer while under the cap, so a
+    // long-lived client churning through many distinct addresses can't grow the
+    // map (and its scrape series) without bound. Aggregate errors_ still counts.
+    if (peer_errors_.size() < kMaxPeers || peer_errors_.count(peer)) peer_errors_[peer]++;
   }
   void MarkGood(const std::string& peer) {
     std::lock_guard<std::mutex> lk(mu_);
@@ -75,7 +80,8 @@ class PeerHealth {
     s += "# HELP dfkv_client_peer_errors_total IO failures per peer\n";
     s += "# TYPE dfkv_client_peer_errors_total counter\n";
     for (const auto& [peer, n] : snap)
-      s += "dfkv_client_peer_errors_total{peer=\"" + peer + "\"} " + std::to_string(n) + "\n";
+      s += "dfkv_client_peer_errors_total{peer=\"" + PromLabelEscape(peer) + "\"} " +
+           std::to_string(n) + "\n";
     return s;
   }
 
@@ -86,6 +92,7 @@ class PeerHealth {
   uint64_t recovered() const { return recovered_.load(std::memory_order_relaxed); }
 
  private:
+  static constexpr size_t kMaxPeers = 4096;  // per-peer error-map cardinality cap
   mutable std::mutex mu_;
   uint64_t cooldown_ms_;
   std::unordered_map<std::string, uint64_t> until_;        // peer -> unhealthy-until (ms)

--- a/src/prom_escape.h
+++ b/src/prom_escape.h
@@ -1,0 +1,29 @@
+/* Prometheus label-value escaping. The exposition format requires `\`, `"`, and
+ * newline in a label value to be escaped, else the whole scrape target is
+ * rejected. dfkv puts operator/config-controlled strings in labels (node/group
+ * identity, and especially disk paths from --dir, which may legally contain a
+ * quote or backslash on Linux), so escape them. Off the datapath. */
+#ifndef DFKV_PROM_ESCAPE_H_
+#define DFKV_PROM_ESCAPE_H_
+
+#include <string>
+
+namespace dfkv {
+
+inline std::string PromLabelEscape(const std::string& v) {
+  std::string out;
+  out.reserve(v.size());
+  for (char c : v) {
+    switch (c) {
+      case '\\': out += "\\\\"; break;
+      case '"': out += "\\\""; break;
+      case '\n': out += "\\n"; break;
+      default: out += c;
+    }
+  }
+  return out;
+}
+
+}  // namespace dfkv
+
+#endif  // DFKV_PROM_ESCAPE_H_

--- a/tests/client_metrics_test.cc
+++ b/tests/client_metrics_test.cc
@@ -32,3 +32,16 @@ TEST(ClientMetrics, CountsServedErrorsTransitionsAndRenders) {
   EXPECT_NE(t.find("dfkv_client_peer_recovered_total 1"), std::string::npos) << t;
   EXPECT_NE(t.find("dfkv_client_peer_errors_total{peer=\"10.0.0.1:12000\"} 1"), std::string::npos) << t;
 }
+
+TEST(ClientMetrics, PerPeerMapIsCardinalityBounded) {
+  // A client that churns through many distinct peer addresses must not grow the
+  // per-peer error map (and its scrape cardinality) without bound.
+  PeerHealth h(1000);
+  for (int i = 0; i < 6000; ++i) h.MarkBad("10.0.0." + std::to_string(i) + ":1", 1000);
+  std::string t = h.Render();
+  size_t n = 0, pos = 0;
+  const std::string needle = "dfkv_client_peer_errors_total{peer=";
+  while ((pos = t.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+  EXPECT_LE(n, 4096u) << "per-peer series cardinality not bounded: " << n;
+  EXPECT_EQ(h.errors(), 6000u);  // aggregate still counts every error
+}

--- a/tests/metrics_http_test.cc
+++ b/tests/metrics_http_test.cc
@@ -72,6 +72,18 @@ TEST(MetricsHttp, ReapsHandlerThreadsAcrossScrapes) {
   srv.Stop();
 }
 
+TEST(MetricsHttp, BindAddrRestrictsAndRejectsBad) {
+  // loopback bind still serves a loopback client
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0, "127.0.0.1"), Status::kOk);
+  std::string m = HttpGet(srv.port(), "/metrics");
+  EXPECT_NE(m.find("dfkv_x 1"), std::string::npos) << m;
+  srv.Stop();
+  // a malformed bind address fails cleanly (no listener)
+  MetricsHttpServer bad([] { return std::string(""); });
+  EXPECT_EQ(bad.Start(0, "not.an.ip"), Status::kInvalid);
+}
+
 TEST(MetricsHttp, StopIsIdempotent) {
   MetricsHttpServer srv([] { return std::string("x 1\n"); });
   ASSERT_EQ(srv.Start(0), Status::kOk);

--- a/tests/metrics_test.cc
+++ b/tests/metrics_test.cc
@@ -73,6 +73,18 @@ TEST(Metrics, PrometheusFormatAndIdentity) {
   s->Stop();
 }
 
+TEST(Metrics, LabelValuesAreEscaped) {
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_metrics_esc";
+  auto s = Start(dir, &addr);
+  s->set_identity("n\"1", "g\\x");  // identity with a quote + backslash
+  std::string text = s->MetricsText();
+  // raw `n"1` would break the scrape; must appear escaped
+  EXPECT_NE(text.find("node=\"n\\\"1\",group=\"g\\\\x\""), std::string::npos) << text;
+  EXPECT_EQ(text.find("node=\"n\"1\""), std::string::npos) << "unescaped quote leaked";
+  s->Stop();
+}
+
 TEST(Metrics, NoIdentityKeepsUnlabeledSeries) {
   std::string addr;
   auto dir = fs::temp_directory_path() / "dfkv_metrics_d";

--- a/tests/prom_escape_test.cc
+++ b/tests/prom_escape_test.cc
@@ -1,0 +1,16 @@
+// TDD — Prometheus label-value escaping.
+#include "prom_escape.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfkv;  // NOLINT
+
+TEST(PromEscape, EscapesBackslashQuoteNewline) {
+  EXPECT_EQ(PromLabelEscape("plain"), "plain");
+  EXPECT_EQ(PromLabelEscape("a\"b"), "a\\\"b");          // double-quote escaped
+  EXPECT_EQ(PromLabelEscape("a\\b"), "a\\\\b");          // backslash escaped
+  EXPECT_EQ(PromLabelEscape("a\nb"), "a\\nb");           // newline escaped
+  EXPECT_EQ(PromLabelEscape("/mnt/d\"k/p"), "/mnt/d\\\"k/p");  // disk path with a quote
+  // backslash escaped before quote: \" stays one backslash + escaped quote
+  EXPECT_EQ(PromLabelEscape("\\\""), "\\\\\\\"");
+}


### PR DESCRIPTION
From the v1.5.1 code review — findings #2 (MEDIUM) and the metrics-side of #4 (LOW).

- **#2 Label-value escaping.** `node`/`group` identity, **disk paths from `--dir`**, and `peer="ip:port"` were interpolated raw into `{...}`. A `"`/`\`/newline in a value (legal in a Linux path) yields a malformed exposition line → Prometheus rejects the **whole scrape target**. New `src/prom_escape.h` `PromLabelEscape()` (\\ → \\\\, " → \\", nl → \\n), applied at all label-value sites.
- **#4 Latency `_sum` precision.** `LatencyHist` now accumulates **nanoseconds** (was µs), so sub-µs / fractional-µs cache-hit latencies aren't floored to 0 in `_sum`.
- **#4 Per-peer map cap.** `PeerHealth` per-peer error map bounded to 4096 entries so a client churning through many distinct addresses can't grow the map (and scrape cardinality) without bound; aggregate counters still count every error.
- **#4 `--metrics-bind <addr>`.** Optional bind address for `dfkv_server`/`dfkv_mds` `/metrics` (default = all interfaces, back-compat) to restrict exposure to e.g. loopback.

## Tests
`prom_escape_test`, `Metrics.LabelValuesAreEscaped`, `MetricsHttp.BindAddrRestrictsAndRejectsBad`, `ClientMetrics.PerPeerMapIsCardinalityBounded`. Full ctest **162/162**, no warnings.