### PR TITLE
fix(rdma/client): MR cache cap >= depth; clamp max_msg; atomic batch_concurrency

### DIFF
--- a/src/kv_client.cc
+++ b/src/kv_client.cc
@@ -270,7 +270,7 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
   const size_t N = items.size();
   std::vector<char> ok(N, 0);  // char (not vector<bool>) for thread-safe writes
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
-    RunParallel(N, batch_concurrency_, [&](size_t i) {
+    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
       ok[i] = Put(items[i].key, items[i].value, items[i].n) ? 1 : 0;
     });
     return std::vector<bool>(ok.begin(), ok.end());
@@ -289,7 +289,7 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
     by_node[node].push_back(i);
   }
   std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
-  RunParallel(groups.size(), batch_concurrency_, [&](size_t g) {
+  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -312,7 +312,7 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
   const size_t N = items.size();
   std::vector<char> hit(N, 0);
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
-    RunParallel(N, batch_concurrency_, [&](size_t i) {
+    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
       hit[i] = Get(items[i].key, items[i].out, items[i].n) ? 1 : 0;
     });
     return std::vector<bool>(hit.begin(), hit.end());
@@ -325,7 +325,7 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
     by[{node, items[i].n}].push_back(i);
   }
   std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
-  RunParallel(groups.size(), batch_concurrency_, [&](size_t g) {
+  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -364,7 +364,7 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
   std::vector<char> hit(N, 0);
   std::vector<size_t> lens(N, 0);  // distinct indices => thread-safe writes
   if (!t_->pipelined()) {  // TCP: parallelize per item with our own threads.
-    RunParallel(N, batch_concurrency_, [&](size_t i) {
+    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
       size_t got = 0;
       if (GetAuto(items[i].key, items[i].out, items[i].n, &got)) { hit[i] = 1; lens[i] = got; }
     });
@@ -381,7 +381,7 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
     by[{node, items[i].n}].push_back(i);
   }
   std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
-  RunParallel(groups.size(), batch_concurrency_, [&](size_t g) {
+  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -418,7 +418,7 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
   const size_t N = keys.size();
   std::vector<char> e(N, 0);
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
-    RunParallel(N, batch_concurrency_, [&](size_t i) {
+    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
       e[i] = Exist(keys[i]) ? 1 : 0;
     });
     return std::vector<bool>(e.begin(), e.end());
@@ -433,7 +433,7 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
     by_node[node].push_back(i);
   }
   std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
-  RunParallel(groups.size(), batch_concurrency_, [&](size_t g) {
+  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;

--- a/src/kv_client.h
+++ b/src/kv_client.h
@@ -10,6 +10,7 @@
 #ifndef DFKV_KV_CLIENT_H_
 #define DFKV_KV_CLIENT_H_
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -64,7 +65,9 @@ class KVClient {
                                  std::vector<size_t>* out_lens);
   std::vector<bool> BatchExist(const std::vector<std::string>& keys);
 
-  void set_batch_concurrency(size_t n) { batch_concurrency_ = n ? n : 1; }
+  void set_batch_concurrency(size_t n) {
+    batch_concurrency_.store(n ? n : 1, std::memory_order_relaxed);
+  }
 
   // Register a large caller memory region (e.g. the whole SGLang host KV pool) for
   // zero-copy transfer, so Put/Get never do a per-op RDMA MR registration — every
@@ -108,7 +111,8 @@ class KVClient {
   std::unique_ptr<Transport> owned_;
   Transport* t_;
   std::string transport_reason_ = "unknown";
-  size_t batch_concurrency_ = 8;
+  // Atomic: configurable via the C ABI; reads on the batch path are relaxed.
+  std::atomic<size_t> batch_concurrency_{8};
   std::unique_ptr<MdsMemberPoller> poller_;
   PeerHealth health_;
 };

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -56,7 +56,10 @@ inline void PutU32(char* p, uint32_t v) { std::memcpy(p, &v, 4); }
 inline uint64_t GetU64(const char* p) { uint64_t v; std::memcpy(&v, p, 8); return v; }
 inline uint32_t GetU32(const char* p) { uint32_t v; std::memcpy(&v, p, 4); return v; }
 
-// "ip:port" -> connected fd, or -1.
+// "ip:port" -> connected fd, or -1. IPv4 only (inet_pton AF_INET): an IPv6
+// literal or hostname returns -1 (caller treats as a clean connect failure /
+// marks the endpoint down). All current deploys are IPv4 (192.168.x); switch to
+// getaddrinfo here if an IPv6/dual-stack fabric is ever introduced.
 inline int Dial(const std::string& addr, int connect_ms = 0, int io_ms = 0) {
   auto pos = addr.rfind(':');
   if (pos == std::string::npos) return -1;

--- a/src/rdma_server.cc
+++ b/src/rdma_server.cc
@@ -42,6 +42,12 @@ size_t ResolveMaxPayload(size_t configured) {
   size_t n = configured ? configured : (64u << 20);
   n = EnvBytes("DFKV_RDMA_MAX_PAYLOAD_BYTES", n);
   n = EnvBytes("DFKV_RDMA_MAX_MSG_BYTES", n);
+  // Clamp the constructor-supplied value too (EnvBytes only clamps the env paths):
+  // dbuf/SGE length is uint32, so payload must stay under uint32 - header - 2*align
+  // or the registered length silently overflows/truncates -> corruption.
+  constexpr size_t kMaxSge = static_cast<size_t>(
+      std::numeric_limits<uint32_t>::max() - ValueHeader::kSize - 2 * rdma::kDirectIoAlign);
+  if (n > kMaxSge) n = kMaxSge;
   return n;
 }
 

--- a/src/rdma_transport.cc
+++ b/src/rdma_transport.cc
@@ -42,6 +42,12 @@ size_t ResolveMaxPayload(size_t configured) {
   size_t n = configured ? configured : (64u << 20);
   n = EnvBytes("DFKV_RDMA_MAX_PAYLOAD_BYTES", n);
   n = EnvBytes("DFKV_RDMA_MAX_MSG_BYTES", n);  // compatibility alias
+  // Clamp the constructor-supplied value too (EnvBytes only clamps the env paths):
+  // dbuf/SGE length is uint32, so payload must stay under uint32 - header - 2*align
+  // or the registered length silently overflows/truncates -> corruption.
+  constexpr size_t kMaxSge = static_cast<size_t>(
+      std::numeric_limits<uint32_t>::max() - ValueHeader::kSize - 2 * rdma::kDirectIoAlign);
+  if (n > kMaxSge) n = kMaxSge;
   return n;
 }
 

--- a/src/rdma_verbs.cc
+++ b/src/rdma_verbs.cc
@@ -4,6 +4,7 @@
 #include <poll.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
@@ -122,6 +123,7 @@ void RcEndpoint::Close() {
 bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib_port,
                       bool direct_io_buffers, size_t direct_io_cap) {
   cap_ = cap; depth_ = depth; ib_port_ = ib_port;
+  user_mr_cap_ = std::max(kMinUserMr, depth_);  // >= depth: no in-window MR eviction
 
   int wp[2];
   if (::pipe(wp) != 0) return false;  // self-pipe to interrupt WaitComp
@@ -331,7 +333,7 @@ ibv_mr* RcEndpoint::RegisterUser(void* addr, size_t len) {
     user_lru_.erase(it->second.second);
     user_mr_.erase(it);
   }
-  while (user_mr_.size() >= kMaxUserMr && !user_lru_.empty()) {  // evict LRU
+  while (user_mr_.size() >= user_mr_cap_ && !user_lru_.empty()) {  // evict LRU
     uintptr_t victim = user_lru_.back();
     auto vit = user_mr_.find(victim);
     if (vit != user_mr_.end()) { ibv_dereg_mr(vit->second.first); user_mr_.erase(vit); }

--- a/src/rdma_verbs.h
+++ b/src/rdma_verbs.h
@@ -70,6 +70,7 @@ class RcEndpoint {
   bool Connect(const QpInfo& remote);                  // INIT -> RTR -> RTS
 
   size_t depth() const { return depth_; }
+  size_t user_mr_cap() const { return user_mr_cap_; }  // >= depth (test/diagnostic)
   size_t cap() const { return cap_; }
   int numa_node() const { return numa_node_; }  // device's NUMA node, or -1
   char* sbuf(size_t slot) { return sbuf_[slot]; }
@@ -143,8 +144,13 @@ class RcEndpoint {
   std::vector<PoolMr> pool_mr_;
   // LRU-capped cache of caller-buffer MRs (addr -> {mr, lru-iterator}); front of
   // user_lru_ is MRU. Bounded so a workload with many distinct buffers can't leak
-  // registrations (a stable HiCache pool stays fully cached and always hits).
-  static constexpr size_t kMaxUserMr = 64;
+  // registrations (a stable HiCache pool stays fully cached and always hits). The
+  // cap MUST be >= pipeline depth: one window registers up to `depth` distinct
+  // out-of-pool buffers before posting their WRs, so a smaller cap could evict
+  // (ibv_dereg_mr) an MR still referenced by an in-flight WR in the same window
+  // (use-after-dereg). Set to max(kMinUserMr, depth) in Open().
+  static constexpr size_t kMinUserMr = 64;
+  size_t user_mr_cap_ = kMinUserMr;
   std::list<uintptr_t> user_lru_;
   std::unordered_map<uintptr_t, std::pair<ibv_mr*, std::list<uintptr_t>::iterator>> user_mr_;
   QpInfo local_;

--- a/tests/rdma_loopback_test.cc
+++ b/tests/rdma_loopback_test.cc
@@ -292,6 +292,20 @@ TEST(RdmaLoopback, ManyEndpointsShareDeviceContext) {
   ASSERT_TRUE(again.Open(nullptr, 64 * 1024, 1));
 }
 
+// The user-MR LRU cap must be >= pipeline depth, else a single windowed batch
+// (which registers up to `depth` distinct out-of-pool buffers before posting
+// their WRs) could evict an MR still referenced by an in-flight WR.
+TEST(RdmaLoopback, UserMrCapTracksDepth) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  rdma::RcEndpoint shallow;
+  ASSERT_TRUE(shallow.Open(nullptr, 16 * 1024, 1));
+  EXPECT_GE(shallow.user_mr_cap(), 64u);            // floor
+  EXPECT_GE(shallow.user_mr_cap(), shallow.depth());
+  rdma::RcEndpoint deep;
+  ASSERT_TRUE(deep.Open(nullptr, 16 * 1024, 100));  // depth > default cap of 64
+  EXPECT_GE(deep.user_mr_cap(), 100u) << "cap below depth -> in-window MR eviction risk";
+}
+
 TEST(RdmaLoopback, PoolMrSharedAcrossBuffers) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   rdma::RcEndpoint ep;


### PR DESCRIPTION
From the v1.5.1 code review — finding #3 (MEDIUM) + the remaining #4 (LOW) items.

- **#3 MR-cache vs pipeline depth (use-after-dereg).** The user-MR LRU cap was a fixed 64, but `DFKV_RDMA_DEPTH` can be up to 256. A single windowed batch registers up to `depth` distinct out-of-pool buffers **before posting their WRs**, so a cap < depth could `ibv_dereg_mr` an MR still referenced by an in-flight WR → freed lkey on a posted WR (connection drop / possible corruption). Cap is now `max(64, depth)`, set per-endpoint in `Open()`. *Latent in production (SGLang/LMCache register the whole pool → bypass the LRU; default depth=8), but a real bug before raising depth past 64 with out-of-pool buffers.*
- **#4 `max_msg` constructor clamp.** `ResolveMaxPayload` clamped only the env paths; a huge value passed directly to the constructor could overflow the uint32 SGE/MR length → silent truncation. Now clamped uniformly.
- **#4 `batch_concurrency_` atomicity.** Was a plain `size_t` mutated by the `dfkv_set_batch_concurrency` C ABI while batch ops read it; now `std::atomic` (relaxed).
- **#4 `Dial()` documented IPv4-only** (an IPv6 literal/hostname returns -1 = clean connect failure; all deploys are IPv4).

## Tests
`RdmaLoopback.UserMrCapTracksDepth` (Soft-RoCE). Full ctest **162/162**; RDMA loopback suite **13/13** green under rxe.