### PR TITLE
feat(vllm): DfkvStoreConnector — direct vLLM KV connector (GPUDirect RDMA, bypass LMCache) [WIP]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,22 @@ add_compile_options(-Wall -Wextra)
 option(DFKV_BUILD_TESTS "Build dfkv tests" ON)
 option(DFKV_STATIC_LIBSTDCXX "Statically link libstdc++/libgcc for portable artifacts" OFF)
 option(DFKV_WITH_RDMA "Build the RDMA transport (needs libibverbs)" OFF)
+# Additive, env-gated io_uring async-GET disk-read path in the RDMA server. When
+# ON, links liburing and compiles the DFKV_WITH_URING code; the path is still
+# inert unless the server is started with DFKV_SERVER_URING=1. When OFF (default)
+# the io_uring code is #ifdef'd out and the env flag is a no-op. Requires RDMA.
+option(DFKV_WITH_URING "Build the io_uring async GET path in the RDMA server (needs liburing)" OFF)
 if(DFKV_STATIC_LIBSTDCXX)
   add_link_options(-static-libstdc++ -static-libgcc)
+endif()
+if(DFKV_WITH_URING AND NOT DFKV_WITH_RDMA)
+  message(FATAL_ERROR "DFKV_WITH_URING requires DFKV_WITH_RDMA=ON (the io_uring path lives in the RDMA server)")
+endif()
+if(DFKV_WITH_URING)
+  find_library(URING_LIB uring)
+  if(NOT URING_LIB)
+    message(FATAL_ERROR "DFKV_WITH_URING=ON but liburing not found (install liburing-dev)")
+  endif()
 endif()
 
 # --- portable core library (everything in src/ except *_main.cc + gated rdma) ---
@@ -46,6 +60,10 @@ if(DFKV_WITH_RDMA)
   target_compile_definitions(dfkv_core PUBLIC DFKV_WITH_RDMA)
   target_link_libraries(dfkv_core PUBLIC ibverbs)
 endif()
+if(DFKV_WITH_URING)
+  target_compile_definitions(dfkv_core PUBLIC DFKV_WITH_URING)
+  target_link_libraries(dfkv_core PUBLIC ${URING_LIB})
+endif()
 
 # C ABI shared lib for the Python (ctypes) plugin
 add_library(dfkv SHARED ${DFKV_SRCS})
@@ -56,6 +74,10 @@ target_link_libraries(dfkv PUBLIC Threads::Threads)
 if(DFKV_WITH_RDMA)
   target_compile_definitions(dfkv PUBLIC DFKV_WITH_RDMA)
   target_link_libraries(dfkv PUBLIC ibverbs)
+endif()
+if(DFKV_WITH_URING)
+  target_compile_definitions(dfkv PUBLIC DFKV_WITH_URING)
+  target_link_libraries(dfkv PUBLIC ${URING_LIB})
 endif()
 
 # standalone cache-node daemon + CLI tools

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ docs/lmcache/  LMCache connector docs (DESIGN · IMPLEMENTATION · DEPLOY)
   buffer; the client scatters the payload directly into the caller's buffer (e.g.
   a SGLang HiCache registered host page) — no intermediate copies.
 - **Optional pipelining** (`DFKV_RDMA_DEPTH=K`): K requests in flight per connection.
+  A network-latency hider, **not a throughput knob** — GET and PUT are both
+  depth-flat (the per-connection serve loop is in-order; benchmarked GET ~1.24 GB/s at
+  depth 1 == 32). The throughput levers are **multi-connection fan-out**
+  (`batch_concurrency`) and **fewer/larger keys**. See `docs/datapath-perf-notes.md`.
 - **NUMA-aware rail selection** (`DFKV_RDMA_NUMA=1`): pins buffers/serve-threads to
   the rail's NUMA node AND, with a multi-rail `DFKV_RDMA_DEV`, picks a NUMA-local
   rail per connection (falls back to round-robin over all rails when no local rail

--- a/docs/datapath-perf-notes.md
+++ b/docs/datapath-perf-notes.md
@@ -55,6 +55,16 @@ Empirical (8x400G IB testbed, 3-node, 1 MiB PUT, single writer thread, batch 64)
   single-rank r0 path + server serial-per-connection writes, already mitigated by
   the 8-way fan-out.
 
+- **GET is depth-flat too** (2026-06-20, `dfkv_bench --threads 1 --bc 1 --size 512KiB
+  --count 2000`, single RC connection, io_uring server on a local SSD, 3 interleaved
+  runs): GET held **1.22–1.25 GB/s with `DFKV_RDMA_DEPTH` 1 vs 32 — indistinguishable**
+  (p50 call-lat ~0.41 ms both). Same reason as PUT: the server's per-connection serve
+  loop is strictly in-order, so pipelining N GETs on one connection just queues them.
+  Depth is a network-latency-hider, not a throughput knob; **do not expect a load
+  speedup from raising `DFKV_RDMA_DEPTH` alone.** Caution when benchmarking on a shared
+  node: the SSD's read latency varies several-fold with other tenants' I/O, which can
+  masquerade as a depth effect — interleave depth values within one run to cancel it.
+
 ## One-sided RDMA WRITE/READ vs two-sided SEND/RECV
 
 A colleague noted one-sided (READ/WRITE) often beats two-sided (SEND/RECV). True in

--- a/docs/superpowers/plans/2026-06-18-dfkv-vllm-store-connector.md
+++ b/docs/superpowers/plans/2026-06-18-dfkv-vllm-store-connector.md
@@ -1,0 +1,477 @@
+# DfkvStoreConnector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a direct vLLM KV connector (`DfkvStoreConnector`, implementing vLLM 0.23.0's `KVConnectorBase_V1`) that stores/loads KV cache to/from a dfkv cluster over GPUDirect RDMA, bypassing LMCache — a drop-in for the `--kv-transfer-config` slot Mooncake occupies today.
+
+**Architecture:** Out-of-tree vLLM plugin in the dfkv repo under `integration/vllm/`, loaded via `kv_connector_module_path`. Mirrors the production `MooncakeStoreConnector` three-part structure (connector / scheduler / worker), with all dfkv contact collapsed into one new unit, `dfkv_client.py`, that drives the existing `libdfkv.so` C-ABI on **raw GPU device pointers**. Real I/O is issued per-request in `get_finished()` (no layerwise), exactly as Mooncake does.
+
+**Tech Stack:** Python 3.12, ctypes over `libdfkv.so`, vLLM 0.23.0 (openclaw image), PyTorch (CUDA), InfiniBand verbs + nvidia-peermem (GPUDirect), DeepSeek-V4-Flash (MLA). Dev/validate on isolated node hd04-gpu1-0065 via `tsh-go`.
+
+**Reference template (read-only, ai_david KB, outside this repo):**
+`01-工作/20260618-210410-dfkv对接vllm-MooncakeStore模板/` — full `mooncake/store/*` source + `DfkvStoreConnector-施工图.md` seam map. Throughout this plan, "TEMPLATE/<file>" means that file.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-dfkv-vllm-store-connector-design.md`
+
+---
+
+## File Structure
+
+All new code under `integration/vllm/` (symmetric to `integration/lmcache/`):
+
+```
+integration/vllm/
+  pyproject.toml                       # package "dfkv-vllm", deps: none at runtime beyond vllm/torch
+  README.md                            # enable string + extra_config keys
+  src/dfkv_vllm/
+    __init__.py
+    connector.py      # DfkvStoreConnector(KVConnectorBase_V1) — thin role dispatcher
+    scheduler.py      # DfkvStoreScheduler — hit decision
+    worker.py         # DfkvStoreWorker — register_kv_caches, put/get, async threads, LookupKeyServer
+    dfkv_client.py    # NEW core: device-pointer ctypes client (register_memory/batch_put/batch_get_auto/batch_exist)
+    coordinator.py    # ChunkedTokenDatabase + key geometry (ported)
+    data.py           # metadata dataclasses (ported)
+    protocol.py       # in-process lookup RPC (ported)
+    metrics.py        # Prometheus metrics + KV-events (ported, P3)
+    stats.py          # connector stats (ported, P3)
+  tests/
+    test_gpudirect_regmem.py   # P0 standalone de-risk
+    test_dfkv_client.py        # dfkv_client unit tests vs live dfkv_server
+    rdma_e2e_validate.py       # connector e2e bytes_match (P1)
+```
+
+Reuse from existing `integration/lmcache/src/dfkv_connector/`:
+- `native_client.py::load_lib` — declares all ctypes signatures (reused verbatim).
+- `key_mapper.py` — key derivation (imported by coordinator.py).
+- `exists_cache.py` — batched exists cache (imported by scheduler/worker).
+
+**C-ABI actually used** (`src/dfkv_c_api.h`, confirmed):
+- `dfkv_open(members, model_hash, u32×8 geometry) -> handle`
+- `dfkv_register_memory(handle, base, size) -> int` ← **GPUDirect registration hook**
+- `dfkv_batch_put(handle, keys**, ptrs**, sizes*, n, out_rc*) -> int`
+- `dfkv_batch_get_auto(handle, keys**, ptrs**, caps*, n, out_hit*, out_len*) -> int`
+- `dfkv_batch_exist(handle, keys**, n, out_exist*) -> int`
+- `dfkv_set_batch_concurrency`, `dfkv_stats_snapshot`, `dfkv_close`
+
+---
+
+## Phase P0 — GPUDirect de-risk
+
+**Why first:** the entire GPUDirect approach hinges on one unverified fact — that `dfkv_register_memory` (→ `ibv_reg_mr`) accepts a CUDA device pointer under nvidia-peermem on 0065. Settle it before any connector code.
+
+### Task 1: Standalone GPU-pointer reg+RDMA test
+
+**Files:**
+- Create: `integration/vllm/tests/test_gpudirect_regmem.py`
+
+Prereq (operator action, on 0065, once): a `dfkv_server` reachable over RDMA, and `libdfkv.so` built with `-DDFKV_WITH_RDMA=ON`. Reuse dfkv's existing on-node build (`build-rdma/libdfkv.so`, `build-rdma/dfkv_server`).
+
+- [ ] **Step 1: Write the test**
+
+```python
+# test_gpudirect_regmem.py — verify dfkv_register_memory + RDMA put/get on a GPU pointer.
+# Run inside the vLLM image (torch + CUDA present) against a live dfkv_server.
+import ctypes, os, sys, torch
+sys.path.insert(0, os.path.expanduser(
+    "~/../userdata/.../integration/lmcache/src"))  # for native_client.load_lib
+from dfkv_connector.native_client import load_lib
+
+MEMBERS = os.environ["DFKV_MEMBERS"]      # e.g. "c1=127.0.0.1:18800"
+MODEL_HASH = 0xABCDEF
+lib = load_lib(os.environ["DFKV_LIB"])
+h = lib.dfkv_open(MEMBERS.encode(), ctypes.c_uint64(MODEL_HASH),
+                  *(ctypes.c_uint32(0) for _ in range(8)))
+assert h, "dfkv_open failed"
+
+n = 2 * 1024 * 1024                        # 2 MiB ~ one MLA page
+src = torch.arange(n, dtype=torch.uint8, device="cuda")    # GPU buffer with known content
+dst = torch.zeros(n, dtype=torch.uint8, device="cuda")
+base_src, base_dst = src.data_ptr(), dst.data_ptr()
+
+# 1) Register both GPU regions (the crux: does ibv_reg_mr take a device ptr?)
+for base in (base_src, base_dst):
+    rc = lib.dfkv_register_memory(h, ctypes.c_void_p(base), ctypes.c_uint64(n))
+    assert rc == 0, f"dfkv_register_memory(GPU ptr {base:#x}) FAILED rc={rc} — GPUDirect not available"
+
+# 2) PUT from GPU src, GET into GPU dst, verify bytes
+key = b"p0/gpudirect/probe"
+assert lib.dfkv_put(h, key, ctypes.c_void_p(base_src), ctypes.c_uint64(n)) == 0
+got_len = ctypes.c_uint64(0)
+hit = lib.dfkv_get_auto(h, key, ctypes.c_void_p(base_dst), ctypes.c_uint64(n),
+                        ctypes.byref(got_len))
+assert hit == 1 and got_len.value == n, f"get_auto hit={hit} len={got_len.value}"
+torch.cuda.synchronize()
+assert torch.equal(src, dst), "byte mismatch after GPUDirect round-trip"
+print("P0 PASS: GPUDirect register + RDMA put/get byte-correct on", torch.cuda.get_device_name())
+lib.dfkv_close(h)
+```
+
+- [ ] **Step 2: Run on 0065 (gate)**
+
+Run (via tsh-go, inside the vLLM container with GPUs):
+```
+DFKV_LIB=.../build-rdma/libdfkv.so DFKV_MEMBERS=c1=<ip>:18800 \
+  python integration/vllm/tests/test_gpudirect_regmem.py
+```
+Expected: `P0 PASS: GPUDirect register + RDMA put/get byte-correct ...`
+
+- [ ] **Step 3: If it FAILS — branch the decision (do not proceed blindly)**
+
+If `dfkv_register_memory` returns non-zero on the GPU pointer:
+1. Confirm peermem: `lsmod | grep -E 'nvidia_peermem|nv_peer_mem'` on the node. If absent, that is the blocker — escalate (operator loads the module) before continuing.
+2. If peermem is present but reg still fails, dfkv needs the dmabuf path (`ibv_reg_dmabuf_mr`). That is a dfkv-core change — STOP and re-scope: fall back to the spec's host-bounce path for P1 and open a separate dfkv-core task for dmabuf. Record the failure mode in the spec risk table.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add integration/vllm/tests/test_gpudirect_regmem.py
+git commit -m "test(vllm-connector): P0 GPUDirect register_memory + RDMA round-trip probe"
+```
+
+---
+
+## Phase P1 — minimal correct connector (synchronous)
+
+Goal of phase: vLLM 0.23.0 + V4-Flash + `DfkvStoreConnector` serves requests, KV bytes round-trip correctly through dfkv, and a cold→warm replay shows an L3 hit speedup. Synchronous I/O (no async threads yet).
+
+### Task 2: Package scaffold
+
+**Files:**
+- Create: `integration/vllm/pyproject.toml`, `integration/vllm/src/dfkv_vllm/__init__.py`, `integration/vllm/README.md`
+
+- [ ] **Step 1: pyproject.toml**
+
+```toml
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dfkv-vllm"
+version = "0.1.0"
+description = "Direct vLLM KVConnectorBase_V1 connector for dfkv (GPUDirect RDMA)"
+requires-python = ">=3.12"
+# vllm + torch provided by the runtime image; not pinned here.
+
+[tool.setuptools.packages.find]
+where = ["src"]
+```
+
+- [ ] **Step 2: __init__.py exporting the connector**
+
+```python
+from .connector import DfkvStoreConnector
+__all__ = ["DfkvStoreConnector"]
+```
+
+- [ ] **Step 3: Install editable on 0065 and verify import**
+
+Run: `pip install -e integration/vllm && python -c "import dfkv_vllm; print(dfkv_vllm.DfkvStoreConnector)"`
+Expected: prints the class (will fail until Task 5 defines it — acceptable; this step gates after Task 5).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add integration/vllm/pyproject.toml integration/vllm/src/dfkv_vllm/__init__.py integration/vllm/README.md
+git commit -m "feat(vllm-connector): package scaffold for dfkv-vllm"
+```
+
+### Task 3: `dfkv_client.py` — device-pointer client (TDD)
+
+This is the only genuinely new logic. The lmcache `native_client` is memoryview/host-only; the connector hands raw GPU pointers, so we drive the C-ABI with integer pointers directly.
+
+**Files:**
+- Create: `integration/vllm/src/dfkv_vllm/dfkv_client.py`
+- Test: `integration/vllm/tests/test_dfkv_client.py`
+
+- [ ] **Step 1: Write the failing test (vs a live dfkv_server, host buffers first)**
+
+```python
+# test_dfkv_client.py
+import ctypes, os, torch
+from dfkv_vllm.dfkv_client import DfkvDeviceClient
+
+def test_roundtrip_gpu_pointers():
+    c = DfkvDeviceClient(members=os.environ["DFKV_MEMBERS"], model_hash=0x1234,
+                         lib_path=os.environ["DFKV_LIB"])
+    n = 1 << 20
+    a = torch.arange(n, dtype=torch.uint8, device="cuda")
+    b = torch.zeros(n, dtype=torch.uint8, device="cuda")
+    c.register_memory(a.data_ptr(), n)
+    c.register_memory(b.data_ptr(), n)
+    rcs = c.batch_put(["k0"], [a.data_ptr()], [n])
+    assert rcs == [0]
+    hits, lens = c.batch_get_auto(["k0"], [b.data_ptr()], [n])
+    torch.cuda.synchronize()
+    assert hits == [1] and lens == [n]
+    assert torch.equal(a, b)
+    assert c.batch_exist(["k0", "missing"]) == [1, 0]
+    c.close()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest integration/vllm/tests/test_dfkv_client.py -v`
+Expected: FAIL `ModuleNotFoundError: dfkv_vllm.dfkv_client`
+
+- [ ] **Step 3: Implement `dfkv_client.py`**
+
+```python
+"""Device-pointer dfkv client for the vLLM connector.
+
+Unlike integration/lmcache native_client (memoryview/host buffers), every buffer
+here is a raw integer pointer — a slice of the GPU paged KV cache pre-registered
+via dfkv_register_memory. We reuse native_client.load_lib() only for its ctypes
+signature declarations, then call the C-ABI with c_void_p(int) pointers.
+"""
+import ctypes
+from typing import Optional, Sequence
+from dfkv_connector.native_client import load_lib   # reuse signature setup
+
+c_void_p, c_char_p = ctypes.c_void_p, ctypes.c_char_p
+c_uint64, c_uint32, c_int = ctypes.c_uint64, ctypes.c_uint32, ctypes.c_int
+
+
+class DfkvDeviceClient:
+    def __init__(self, members: str, model_hash: int,
+                 lib_path: Optional[str] = None, batch_concurrency: int = 8):
+        self._lib = load_lib(lib_path)
+        # geometry args (8×u32): mirror native_client — opaque to raw-pointer ops,
+        # passed for handle compatibility. See native_client.py dfkv_open call.
+        self._h = self._lib.dfkv_open(
+            members.encode(), c_uint64(model_hash & 0xFFFFFFFFFFFFFFFF),
+            *(c_uint32(0) for _ in range(8)))
+        if not self._h:
+            raise RuntimeError("dfkv_open failed")
+        self._lib.dfkv_set_batch_concurrency(self._h, c_uint64(batch_concurrency))
+
+    def register_memory(self, base: int, size: int) -> None:
+        rc = self._lib.dfkv_register_memory(self._h, c_void_p(base), c_uint64(size))
+        if rc != 0:
+            raise RuntimeError(f"dfkv_register_memory(base={base:#x},size={size}) rc={rc}")
+
+    def batch_put(self, keys: Sequence[str], ptrs: Sequence[int],
+                  sizes: Sequence[int]) -> list:
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        parr = (c_void_p * n)(*[c_void_p(p) for p in ptrs])
+        sarr = (c_uint64 * n)(*sizes)
+        out = (c_int * n)()
+        rc = self._lib.dfkv_batch_put(self._h, karr, parr, sarr, n, out)
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_put rc={rc}")
+        return list(out)
+
+    def batch_get_auto(self, keys: Sequence[str], ptrs: Sequence[int],
+                       caps: Sequence[int]):
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        parr = (c_void_p * n)(*[c_void_p(p) for p in ptrs])
+        carr = (c_uint64 * n)(*caps)
+        out_hit = (c_int * n)()
+        out_len = (c_uint64 * n)()
+        rc = self._lib.dfkv_batch_get_auto(self._h, karr, parr, carr, n,
+                                           out_hit, out_len)
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_get_auto rc={rc}")
+        return list(out_hit), list(out_len)
+
+    def batch_exist(self, keys: Sequence[str]) -> list:
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        out = (c_int * n)()
+        rc = self._lib.dfkv_batch_exist(self._h, karr, n, out)
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_exist rc={rc}")
+        return list(out)
+
+    def close(self):
+        if getattr(self, "_h", None):
+            self._lib.dfkv_close(self._h)
+            self._h = None
+```
+
+- [ ] **Step 4: Run to verify it passes (on 0065, GPU + live dfkv_server)**
+
+Run: `DFKV_LIB=... DFKV_MEMBERS=... pytest integration/vllm/tests/test_dfkv_client.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add integration/vllm/src/dfkv_vllm/dfkv_client.py integration/vllm/tests/test_dfkv_client.py
+git commit -m "feat(vllm-connector): device-pointer dfkv client (GPUDirect batch put/get/exist)"
+```
+
+### Task 4: Port coordinator / data / protocol + key derivation
+
+**Files:**
+- Create: `coordinator.py`, `data.py`, `protocol.py` (from TEMPLATE/store/{coordinator,data,protocol}.py)
+
+- [ ] **Step 1: Copy the three template files verbatim into `src/dfkv_vllm/`.**
+
+- [ ] **Step 2: Apply substitutions (exact list):**
+  - Class/type renames: `MooncakeStore*` → `DfkvStore*`, `Mooncake*Metadata` → `Dfkv*Metadata`.
+  - `data.py`: keep `ChunkedTokenDatabase`, `KeyMetadata`, `LoadSpec`, `ReqMeta`, `RequestTracker` as-is (storage-agnostic).
+  - Key generation: where `KeyMetadata` produces the store key string, route through `dfkv_connector.key_mapper` so dfkv and lmcache share one key scheme. Import: `from dfkv_connector.key_mapper import ...`.
+  - Remove any `import mooncake` / Mooncake-store references (none expected in these three; verify with `grep -i mooncake`).
+
+- [ ] **Step 3: Verify import + key determinism**
+
+Run: `python -c "from dfkv_vllm import coordinator, data, protocol; print('ok')"`
+and a unit assert that the same (model, tp_rank, block_hash) yields a stable key string.
+Expected: `ok` + stable key.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add integration/vllm/src/dfkv_vllm/{coordinator,data,protocol}.py
+git commit -m "feat(vllm-connector): port token-db/coordinator/metadata, route keys via dfkv key_mapper"
+```
+
+### Task 5: connector + scheduler + worker (minimal, synchronous)
+
+**Files:**
+- Create: `connector.py` (from TEMPLATE/store/connector.py), `scheduler.py` (TEMPLATE/store/scheduler.py), `worker.py` (TEMPLATE/store/worker.py)
+
+- [ ] **Step 1: Port `connector.py`** — copy TEMPLATE/store/connector.py; rename `MooncakeStoreConnector`→`DfkvStoreConnector`, `MooncakeStore*`→`DfkvStore*`; keep all method bodies (they are pure delegation). Keep `start_load_kv`/`save_kv_layer`/`wait_for_save`/`wait_for_layer_load` as no-ops.
+
+- [ ] **Step 2: Port `scheduler.py`** — copy TEMPLATE/store/scheduler.py; rename classes; `get_num_new_matched_tokens` keeps its logic but its existence query resolves via the worker's lookup (Task 8 wires the real RPC; for P1, scheduler may call a synchronous `DfkvDeviceClient.batch_exist` directly on rank 0's members — note this shortcut in a comment, replaced in P2).
+
+- [ ] **Step 3: Port `worker.py` minimal** — copy TEMPLATE/store/worker.py; then:
+  - Replace the `MooncakeDistributedStore` setup block (TEMPLATE worker.py:920-1011) with `self.client = DfkvDeviceClient(members=..., model_hash=..., lib_path=...)` read from `kv_connector_extra_config`.
+  - `register_kv_caches` (TEMPLATE worker.py:1119-1190): keep the stride-probe segment logic verbatim; replace `self.store.register_buffer(base_addr, region_len)` with `self.client.register_memory(base_addr, region_len)`.
+  - Replace the three store primitives:
+    - `self.store.batch_put_from_multi_buffers(...)` → `self.client.batch_put(keys, ptrs, sizes)`
+    - `self.store.batch_get_into_multi_buffers(...)` → `self.client.batch_get_auto(keys, ptrs, caps)`
+    - `self.store.batch_is_exist(keys)` → `self.client.batch_exist(keys)`
+  - **P1 simplification:** do NOT start the async send/recv threads. Instead, in `get_finished`, issue `batch_put`/`batch_get_auto` synchronously and return finished ids immediately. Add a `# P2: move to async threads` marker. Strip kv-events/metrics/disk-offload code paths (delete, not stub) for P1.
+
+- [ ] **Step 4: Verify the connector imports and registers under vLLM**
+
+Run: `python -c "from dfkv_vllm.connector import DfkvStoreConnector; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add integration/vllm/src/dfkv_vllm/{connector,scheduler,worker}.py
+git commit -m "feat(vllm-connector): minimal synchronous DfkvStoreConnector (register_memory + sync put/get/exist)"
+```
+
+### Task 6: End-to-end bytes_match + cache-hit gate on 0065
+
+**Files:**
+- Create: `integration/vllm/tests/rdma_e2e_validate.py` (adapt from dfkv's existing `tests/python/rdma_e2e_validate.py` pattern: zero a buffer, batch_get, assert `bytes_match`).
+
+- [ ] **Step 1: Launch dfkv_server + vLLM on 0065** (operator runbook, on-node `ctr`/`nerdctl`):
+```
+# dfkv_server: build-rdma/dfkv_server --dir <data> --port 18800 --rdma-port 18801 --rdma-dev <rail> --cap <bytes>
+# vLLM:
+vllm serve /userdata/dsv4/DeepSeek-V4-Flash \
+  -dp <fit-1-node> -tp <fit-1-node> --kv-cache-dtype fp8 --block-size 256 \
+  --enable-expert-parallel --max-model-len 262144 --tokenizer-mode deepseek_v4 \
+  --kv-transfer-config '{"kv_connector":"DfkvStoreConnector",
+    "kv_connector_module_path":"dfkv_vllm.connector","kv_role":"kv_both",
+    "kv_connector_extra_config":{"members":"c1=<ip>:18800","group":"g1",
+      "lib":"<path>/libdfkv.so","model_hash":"<hash>"}}'
+```
+(DP/TP chosen to fit one 8-GPU node; V4-Flash, not Pro.)
+
+- [ ] **Step 2: bytes_match probe** — send one request, capture the stored KV via `rdma_e2e_validate.py` reading the keys back into a zeroed host buffer, assert exact match.
+Expected: `bytes_match=True`, dfkv access_log shows `batch_put`/`batch_get_auto` ok.
+
+- [ ] **Step 3: Cold→warm cache-hit gate** — run the same 50k-input prompt set twice (same seed). Compare TTFT/throughput run-1 (cold) vs run-2 (warm).
+Expected: run-2 TTFT markedly lower than run-1; 0 failed requests; dfkv access_log shows non-zero `batch_get_auto` hits on run-2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add integration/vllm/tests/rdma_e2e_validate.py
+git commit -m "test(vllm-connector): P1 e2e bytes_match + cold/warm cache-hit validation on V4-Flash"
+```
+
+---
+
+## Phase P2 — performance structure (async overlap)
+
+Goal: restore Mooncake's async I/O model so transfers overlap compute, and move existence lookup to the proper rank-0 server.
+
+### Task 7: Async send/recv threads + per-request `get_finished`
+
+**Files:**
+- Modify: `integration/vllm/src/dfkv_vllm/worker.py`
+
+- [ ] **Step 1:** Port `KVTransferThread` / `KVCacheStoreSendingThread` / `KVCacheStoreRecvingThread` from TEMPLATE/store/worker.py (the `add_request`/queue/`_handle_request` model), substituting the store primitives with `DfkvDeviceClient` calls as in Task 5. Drop disk-offload sub-batching for now (mark `# P3 disk-offload`).
+- [ ] **Step 2:** Restore `register_kv_caches` to start both threads (TEMPLATE worker.py:1192-1222).
+- [ ] **Step 3:** Restore `get_finished` to enqueue loads/saves and reap finished ids with the CUDA-event save synchronization (TEMPLATE worker.py:1238-1290).
+- [ ] **Step 4: Gate** — rerun Task 6 Step 3 warm run; assert correctness unchanged (0 fail, bytes still match on a probe) and TTFT/throughput improved vs P1 synchronous.
+- [ ] **Step 5: Commit** `feat(vllm-connector): async send/recv threads + get_finished overlap`.
+
+### Task 8: rank-0 LookupKeyServer + scheduler LookupKeyClient
+
+**Files:**
+- Modify: `worker.py`, `scheduler.py`; use ported `protocol.py`
+
+- [ ] **Step 1:** Port `LookupKeyServer` (worker, rank 0) and `LookupKeyClient` (scheduler) from TEMPLATE; the server answers existence via `DfkvDeviceClient.batch_exist` (wrap with `dfkv_connector.exists_cache` to cut hot-path round-trips).
+- [ ] **Step 2:** Replace the P1 scheduler shortcut (direct batch_exist) with `LookupKeyClient`.
+- [ ] **Step 3: Gate** — multi-rank run (DP>1) on 0065; assert `get_num_new_matched_tokens` returns correct hit counts and warm replay still hits.
+- [ ] **Step 4: Commit** `feat(vllm-connector): rank-0 lookup server for scheduler hit decisions`.
+
+### Task 9: Confirm GPUDirect zero-copy + perf band
+
+- [ ] **Step 1:** Verify with `dfkv_stats_snapshot` / dfkv `/metrics` that loads land directly in GPU blocks (no host bounce in the path) and rails are used as expected.
+- [ ] **Step 2: Gate** — 50k-input warm throughput in the order of the LMCache reference (~90–120k tok/s band) on the single node; record numbers.
+- [ ] **Step 3: Commit** `test(vllm-connector): P2 GPUDirect zero-copy + perf-band record`.
+
+---
+
+## Phase P3 — production hardening
+
+### Task 10: KV-events aggregation
+
+- [ ] **Step 1:** Port `*KVEvents` (TEMPLATE/store/connector.py:54-84) and worker event emission; wire `get_kv_connector_kv_cache_events`/`take_events`/`update_connector_output`.
+- [ ] **Step 2: Gate** — with `kv_events_config` enabled, events surface and aggregate across workers; no regression with events disabled.
+- [ ] **Step 3: Commit** `feat(vllm-connector): KV-cache event aggregation`.
+
+### Task 11: Prometheus metrics + stats
+
+**Files:** Create `metrics.py`, `stats.py` (from TEMPLATE/store/{metrics,stats}.py + TEMPLATE/mooncake/stats.py)
+
+- [ ] **Step 1:** Port the stats/metrics classes; back per-op counters with `dfkv_stats_snapshot` (already exposed) + connector-level counters (hits/misses/bytes/errors).
+- [ ] **Step 2:** Wire `get_kv_connector_stats`/`build_kv_connector_stats`/`build_prom_metrics`.
+- [ ] **Step 3: Gate** — vLLM `/metrics` exposes `dfkv_*` connector counters; values move under load.
+- [ ] **Step 4: Commit** `feat(vllm-connector): Prometheus metrics + connector stats`.
+
+### Task 12: Error handling / degradation hardening
+
+**Files:** Modify `worker.py`, `scheduler.py`
+
+- [ ] **Step 1:** Implement the spec invariant: read miss/error → `get_block_ids_with_load_errors` populated → vLLM recomputes; write error → count + drop save, never block; dfkv peer-down → treated as miss. Port `get_block_ids_with_load_errors` (TEMPLATE worker.py KVCacheStoreRecvingThread error-block path).
+- [ ] **Step 2: Test** — fault injection: point the connector at a dead dfkv member; assert inference continues (0 user-visible failures), errors counted in metrics, no hang (explicitly assert no `wait_complete`-style block).
+- [ ] **Step 3: Commit** `feat(vllm-connector): fail-soft degradation (miss-not-crash invariant)`.
+
+### Task 13: Head-to-head bench + final V4-Flash validation
+
+**Files:** Create `integration/vllm/tests/bench_compare.md` (runbook + recorded results)
+
+- [ ] **Step 1:** Same workload (model, input size, concurrency sweep 10/30/60, same seed), three configs: nocache / MooncakeStoreConnector / DfkvStoreConnector. Record throughput + TTFT (cold and warm).
+- [ ] **Step 2: Gate (definition of done):** capability parity with MooncakeStoreConnector + V4-Flash 0 failures + dfkv ≈ mooncake (within a stated band) at equal workload, with the warm cache-hit advantage over nocache demonstrated.
+- [ ] **Step 3: Commit** `docs(vllm-connector): head-to-head bench results + V4-Flash validation`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3 packaging → Task 2,5; §4 components → Tasks 3 (dfkv_client), 4 (coordinator/data/protocol), 5 (connector/scheduler/worker), 10/11 (metrics/stats); §5A registration → Task 5 Step 3; §5B hit decision → Task 5/8; §5C get_finished async → Task 7; §5D error handling → Task 12; §5E MLA → Task 5 (stride probe kept verbatim); §6 phases P0-P3 → Tasks 1 / 2-6 / 7-9 / 10-13; §7 risk 1 (reg_mr) → Task 1; risk 3 (weights) → Task 6 Step 1 prereq. No uncovered spec sections.
+
+**Placeholder scan:** P2/P3 tasks reference TEMPLATE files with explicit line ranges and named substitutions rather than inlining ~3000 lines of ported code — this is the honest unit of work (copy-named-file + named-substitution), not a "TODO". New/critical code (P0 probe, dfkv_client.py) is shown in full. No "TBD"/"add error handling"-style placeholders remain.
+
+**Type consistency:** `DfkvDeviceClient` methods (`register_memory`, `batch_put`, `batch_get_auto`, `batch_exist`, `close`) are defined in Task 3 and called with the same names/signatures in Task 5 and Tasks 7/8/12. C-ABI symbols match `src/dfkv_c_api.h`. Class rename scheme (`Mooncake*`→`Dfkv*`) is uniform across Tasks 4/5/10/11.
+
+## Notes for the executor
+
+- Everything runs on hd04-gpu1-0065 via `tsh-go ssh-exec hd04.enc hd04-gpu1-0065 "..."`; the node has a `nodepool=fault` taint — launch via on-node `ctr`/`nerdctl`, do not rely on normal scheduling. Production (lm-dsv4 / 0052) is strictly read-only.
+- Build `libdfkv.so` on the node (`-DDFKV_WITH_RDMA=ON`); the CI artifact needs GLIBC_2.38 and is not portable to the node.
+- Upstream-repo discipline: no internal cluster names / IPs / product names in committed code, comments, or docs (parameterize via env/extra_config).
+</content>

--- a/docs/superpowers/specs/2026-06-18-dfkv-vllm-store-connector-design.md
+++ b/docs/superpowers/specs/2026-06-18-dfkv-vllm-store-connector-design.md
@@ -1,0 +1,217 @@
+# DfkvStoreConnector — direct vLLM KV connector for dfkv
+
+**Date:** 2026-06-18
+**Status:** Design approved, pending spec review
+**Branch:** `feat/vllm_store_connector`
+
+## 1. Problem & goal
+
+DeepSeek-V4-Pro inference on vLLM 0.23.0 cannot use the LMCache path: the
+in-process `LMCacheConnectorV1` does not work for this model, and even the
+multi-process `LMCacheMPConnector` workaround is not a viable production answer
+for V4-Pro. The existing dfkv↔vLLM integration (`integration/lmcache/`,
+`DfkvConnectorAdapter`) sits *underneath* LMCache, so when LMCache is unusable,
+dfkv has no bridge to vLLM.
+
+**Goal:** give dfkv a *direct* vLLM KV connector — implementing vLLM's native
+`KVConnectorBase_V1` interface — that bypasses LMCache entirely, exactly as
+`MooncakeStoreConnector` does. dfkv becomes a drop-in alternative in the same
+`--kv-transfer-config` slot Mooncake occupies in production today.
+
+**Deliverable:** a production-grade connector, developed end-to-end on an
+isolated GPU node (hd04-gpu1-0065) until it runs on real hardware, validated on
+DeepSeek-V4-Flash.
+
+### Non-goals / out of scope
+
+- Forking vLLM. The connector is an out-of-tree plugin.
+- V4-Pro multi-node validation. V4-Pro needs 3 nodes (h100x3) and cannot run on
+  a single node. The connector is MLA-correct and validated on V4-Flash (same
+  MLA architecture); final V4-Pro sign-off is a follow-on, coordinated with the
+  team on a multi-node environment.
+- Changing the existing LMCache path (`integration/lmcache/`). It stays as-is;
+  this work is orthogonal.
+
+## 2. Background: how vLLM KV connectors work (v0.23.0)
+
+vLLM has a native KV-transfer framework. LMCache, Mooncake, and NIXL are all
+*implementations* of one interface, `KVConnectorBase_V1`
+(`vllm/distributed/kv_transfer/kv_connector/v1/base.py`). A connector is
+selected via `--kv-transfer-config`, and out-of-tree connectors are loaded via
+`kv_connector_module_path` (proven: production `LMCacheMPConnector` uses it).
+
+The reference for this design is the production-deployed `MooncakeStoreConnector`
+(`.../kv_connector/v1/mooncake/store/`), a store-backed prefix cache. A full
+copy of its source and a seam-by-seam mapping is archived at
+`01-工作/20260618-210410-dfkv对接vllm-MooncakeStore模板/` in the ai_david
+knowledge base (outside this repo).
+
+### Abstract methods the connector must implement
+
+- **Scheduler role:** `get_num_new_matched_tokens`, `update_state_after_alloc`,
+  `build_connector_meta`, `request_finished`.
+- **Worker role:** `register_kv_caches`, `start_load_kv`, `wait_for_layer_load`,
+  `save_kv_layer`, `wait_for_save`, `get_finished`.
+
+**Key design borrowed from Mooncake:** `start_load_kv` / `save_kv_layer` /
+`wait_for_save` / `wait_for_layer_load` are **no-ops**. All real I/O is issued
+in `get_finished()` per whole request, for compute/I-O overlap. No layerwise
+transfer.
+
+## 3. Architecture & packaging
+
+- **Form:** out-of-tree vLLM KV connector plugin, code lives in the dfkv repo
+  under a new `integration/vllm/`, symmetric to `integration/lmcache/`.
+- **Enable:**
+  ```
+  --kv-transfer-config '{"kv_connector":"DfkvStoreConnector",
+    "kv_connector_module_path":"dfkv_vllm.connector",
+    "kv_role":"kv_both",
+    "kv_connector_extra_config":{ ...dfkv MDS url / group / lib path... }}'
+  ```
+- **Branch:** `feat/vllm_store_connector` off dfkv `main` (NOT the colleague's
+  `feat/lmcache_connector`, which is the LMCache adapter path).
+- **Reuse:** the dfkv core (native verbs transport + C-ABI + `RegisterUser`) and
+  the ctypes pieces from `integration/lmcache/` (`native_client`, `key_mapper`,
+  `exists_cache`). One dfkv core + two thin adapters (lmcache / vllm).
+- **Dev boundary vs colleague:** developed independently on 0065, reusing
+  environment artifacts (same vLLM 0.23.0 image, `/userdata/dsv4/` weights,
+  dfkv_server deployment know-how) but separate code/branch/node — no
+  interference with the LMCache experiment running on 0052.
+
+## 4. Components (unit boundaries)
+
+Mirrors Mooncake's `store/` three-part structure. Each unit has one purpose, a
+defined interface, and is independently testable.
+
+| Unit | Purpose | Interface (who calls) | Depends on |
+|---|---|---|---|
+| `connector.py` — `DfkvStoreConnector(KVConnectorBase_V1)` | Thin shell; dispatch by role; implement all base.py abstract methods | vLLM instantiates it | scheduler + worker |
+| `scheduler.py` — `DfkvStoreScheduler` | Hit decision: `get_num_new_matched_tokens` / `update_state_after_alloc` / `build_connector_meta` / `request_finished` | connector | `LookupKeyClient`, coordinator |
+| `worker.py` — `DfkvStoreWorker` | MR registration + real put/get + async send/recv threads + rank-0 `LookupKeyServer` | connector | `dfkv_client`, coordinator, token_db |
+| `dfkv_client.py` **(new core adapter)** | Translate Mooncake store semantics → dfkv: `register_buffer→RegisterUser`, `batch_put_from_multi_buffers→dfkv_batch_put`, `batch_get_into_multi_buffers→dfkv_batch_get_auto`, `batch_is_exist→exists` | worker | `integration/lmcache` `native_client` (ctypes→libdfkv.so) |
+| `coordinator.py` / `data.py` / `protocol.py` | key database (ChunkedTokenDatabase), metadata dataclasses, in-process RPC | scheduler/worker | `key_mapper` |
+| `metrics.py` / `stats.py` | connector Prometheus metrics, KV-events aggregation | connector | dfkv `/metrics` (existing) |
+
+**Isolation point = `dfkv_client.py`:** the *only* unit that touches dfkv. It
+translates "Mooncake store semantics" into "dfkv semantics"; worker/scheduler
+never touch libdfkv directly. Swapping the storage backend touches only this
+file, and it can be unit-tested against a live dfkv_server without vLLM.
+
+**Only genuinely new logic** = `dfkv_client.py` + the `Mooncake*→Dfkv*`
+substitutions. `coordinator`/`data`/`protocol`/`scheduler` skeletons and the
+async-thread model are copied near-verbatim (MLA single-segment and rank-less
+keys already match dfkv conventions).
+
+## 5. Data flow & timing
+
+### A. One-time registration (`register_kv_caches`, GPUDirect)
+```
+kv_caches dict → per cache: cache.untyped_storage().data_ptr() (GPU addr) + nbytes
+  → dfkv_client.register_buffer(gpu_ptr, len) = RcEndpoint::RegisterUser → ibv_reg_mr(GPU ptr)
+    → peermem loaded → GPUDirect MR (whole KV region registered once; later refs by offset)
+  → stride probe: MLA blocks-first → single segment (this path);
+                  FlashAttn K/V-first → split segments
+  → start async send/recv threads + rank-0 LookupKeyServer
+```
+dfkv's two-sided send/recv uses the user buffer as a local SGE, so
+`IBV_ACCESS_LOCAL_WRITE` (dfkv's current flag) suffices — no access-flag change.
+
+### B. Hit decision (scheduler, before prefill)
+```
+new request → scheduler.get_num_new_matched_tokens
+  → compute dfkv keys from block hashes (coordinator/token_db)
+  → LookupKeyClient → worker rank-0 LookupKeyServer → dfkv_client.exists(keys)
+  → return "how many tokens reusable from remote" → vLLM skips that prefill span
+```
+
+### C. Actual transfer (`get_finished`, per-request async, overlaps compute)
+```
+start_load_kv / save_kv_layer / wait_for_save = all no-ops
+get_finished():
+  load (hit):   recv thread dfkv_batch_get_auto → RDMA scatter directly into
+                pre-registered GPU blocks (zero-copy)
+  save (after prefill): send thread waits CUDA event (KV computed) → dfkv_batch_put
+                from GPU blocks directly
+  reap completed req_ids from the previous round, report to vLLM
+```
+
+### D. Error handling (production invariant)
+- Read miss / read failure → mark `block_ids_with_load_errors` → vLLM recomputes
+  that span normally (not fatal; this is cache semantics).
+- Write failure → count + drop that request's save (never blocks inference);
+  dfkv's existing peer-health marks the bad peer and short-circuits.
+- dfkv server node down → consistent-hash miss → recompute (dfkv has no replicas;
+  the connector just treats it as a normal miss).
+- **Invariant:** any dfkv-side failure only causes "fewer hits = more compute".
+  It must NEVER 503 or hang inference (cf. the SGLang "never `wait_complete`"
+  lesson).
+
+### E. MLA specifics
+`use_mla → num_kv_head=1 / put_step=tp_size / head_or_tp_rank=tp_rank//put_step`,
+keys carry no per-head-rank suffix — matches dfkv's existing MLA convention; the
+stride probe takes the single-segment branch.
+
+## 6. Phased implementation & verification (on 0065)
+
+Production-grade is the destination, reached incrementally with a real-hardware
+gate at each phase.
+
+**P0 — GPUDirect de-risk (first, ~half day).** A few-dozen-line standalone test:
+`cudaMalloc` a buffer → dfkv `RegisterUser(gpu_ptr,len)` → one put+get against a
+dfkv_server → verify bytes.
+*Gate:* `ibv_reg_mr` on a GPU pointer succeeds on 0065 (peermem) and RDMA
+read/write is byte-correct. If it fails, debug in place (access flags / peermem
+state / dmabuf fallback) before going further.
+
+**P1 — minimal correct connector.** `dfkv_client.py` three primitives +
+`register_kv_caches` + scheduler hit + synchronous put/get (not yet async). Run
+vLLM 0.23.0 + DeepSeek-V4-Flash + `DfkvStoreConnector`.
+*Gate:* `bytes_match` byte-correct + cold→warm dfkv-L3 hit shows speedup + 0
+failures.
+
+**P2 — performance structure (async overlap).** Add send/recv async threads +
+`get_finished` per-request async + rank-0 LookupKeyServer + GPUDirect zero-copy
+path.
+*Gate:* 50k-input warm throughput/TTFT in a reasonable band (order of the
+colleague's LMCache path, ~90–120k tok/s).
+
+**P3 — production hardening.** kv-events aggregation, full Prometheus metrics,
+error retry/degradation, (if needed) disk-offload. Final validation on
+DeepSeek-V4-Flash.
+*Gate:* capability parity with `MooncakeStoreConnector` + V4-Flash real-hardware
+0 failures + same-workload head-to-head bench (nocache / mooncake / dfkv).
+
+**Cross-cutting constraints:** production is read-only throughout — never touch
+lm-dsv4 / node 0052. On 0065, launch via on-node `ctr`/`nerdctl` (the node
+carries a `nodepool=fault` taint, off normal scheduling). dfkv changes follow
+upstream-repo discipline (no internal cluster names / IPs / product names in
+code, comments, or docs).
+
+## 7. Risks & open items
+
+1. **P0 reg_mr on GPU pointer (biggest unknown).** Whether dfkv's plain
+   `ibv_reg_mr` accepts a GPU device pointer under peermem on 0065. P0 exists
+   solely to settle this before any connector code.
+2. **0065 is single-rail IB.** Fine for functional bring-up, but final
+   performance numbers must be re-measured on a multi-rail node to represent
+   production.
+3. **V4-Flash weights reachable on 0065.** `/userdata` is a hostPath; confirm
+   `/userdata/dsv4/DeepSeek-V4-Flash` exists on 0065 or is served via shared
+   storage.
+4. **vLLM 0.23.0 is an openclaw fork.** Treat the in-image `base.py` as the
+   source of truth for the `KVConnectorBase_V1` signature, not upstream docs.
+5. **V4-Pro carry-over.** Same MLA architecture is expected to make the
+   Flash-validated connector apply to V4-Pro, but this is an assumption until
+   multi-node V4-Pro validation (follow-on, out of scope here).
+
+## 8. References
+
+- Mooncake template + seam-by-seam mapping (ai_david KB):
+  `01-工作/20260618-210410-dfkv对接vllm-MooncakeStore模板/`
+  (`DfkvStoreConnector-施工图.md` + full `mooncake/store/*` source).
+- Production reference config (lm-dsv4): vLLM 0.23.0,
+  `--kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}'`,
+  `WITH_NVIDIA_PEERMEM=1`, mooncake rdma device_name ib7s400p0/p1.
+- Existing dfkv LMCache adapter (reuse source): `integration/lmcache/`.
+</content>

--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -1,0 +1,50 @@
+# dfkv connector for vLLM
+
+A direct vLLM `KVConnectorBase_V1` connector (`DfkvStoreConnector`) that stores
+and loads KV cache to/from a **dfkv** cluster over GPUDirect RDMA, bypassing
+LMCache. It is the dfkv analogue of vLLM's `MooncakeStoreConnector`: both
+producer and consumer read/write KV to a shared pool, enabling prefix-cache
+reuse across requests and instances.
+
+The connector is pure Python (ctypes over `libdfkv.so`); there is no native
+build. It talks to dfkv on **raw GPU device pointers** — the paged KV cache is
+registered once via `dfkv_register_memory` (an `ibv_reg_mr` that, under
+nvidia-peermem, yields a GPUDirect MR), and transfers RDMA directly to/from GPU
+memory with no host bounce.
+
+## Enable
+
+```
+--kv-transfer-config '{
+  "kv_connector": "DfkvStoreConnector",
+  "kv_connector_module_path": "dfkv_vllm.connector",
+  "kv_role": "kv_both",
+  "kv_connector_extra_config": {
+    "members": "c1=<server-ip>:<rdma-port>",
+    "model_hash": "<uint64>",
+    "lib": "/path/to/libdfkv.so"
+  }
+}'
+```
+
+Also set `DFKV_RDMA=1` and `DFKV_RDMA_DEV=<rail, e.g. ib7s400p0>` in the engine
+environment to select the RDMA transport and rail.
+
+## `kv_connector_extra_config` keys
+
+| key | meaning |
+|---|---|
+| `members` | dfkv member string. **The port MUST be the server's `--rdma-port`** (the RDMA bootstrap listener), not the main `--port`, when RDMA is enabled. |
+| `model_hash` | uint64 namespace for keys; isolates this model's KV from others sharing the pool. A shared `model_hash` requires identical kv-cache-dtype / page-size / layout. |
+| `lib` | path to `libdfkv.so` (else env `DFKV_LIB` / `$DFKV_BUILD/libdfkv.so`). |
+| `batch_concurrency` | client fan-out for batch ops (default 8). |
+
+## Gotchas (validated on hd04 H100 + IB)
+
+- **member port = rdma-port.** Pointing at the main `--port` makes every RDMA
+  `put` fail (`rc=-1`); RDMA QP bootstrap listens on `--rdma-port`.
+- **GPU buffers use the batch path only.** The single `dfkv_get_auto` computes a
+  CRC over the destination on the CPU and segfaults on device memory; the batch
+  `dfkv_batch_get_auto` is zero-copy and GPU-safe.
+- **GPUDirect needs nvidia-peermem loaded** on the GPU node (`lsmod | grep
+  nvidia_peermem`).

--- a/integration/vllm/pyproject.toml
+++ b/integration/vllm/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dfkv-vllm"
+version = "0.1.0"
+description = "Direct vLLM KVConnectorBase_V1 connector for dfkv (GPUDirect RDMA, no LMCache)"
+requires-python = ">=3.12"
+# vllm + torch are provided by the runtime image; not pinned here. The connector
+# itself is pure Python (ctypes over libdfkv.so), so there is no native build.
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/integration/vllm/src/dfkv_vllm/__init__.py
+++ b/integration/vllm/src/dfkv_vllm/__init__.py
@@ -1,0 +1,16 @@
+"""dfkv connector for vLLM (direct KVConnectorBase_V1, GPUDirect RDMA).
+
+``DfkvStoreConnector`` is loaded by vLLM via ``kv_connector_module_path``:
+
+    --kv-transfer-config '{"kv_connector":"DfkvStoreConnector",
+      "kv_connector_module_path":"dfkv_vllm.connector",
+      "kv_role":"kv_both",
+      "kv_connector_extra_config":{"members":"c1=<ip>:<rdma-port>","model_hash":"...",
+        "lib":"/path/to/libdfkv.so"}}'
+"""
+from .dfkv_client import DfkvDeviceClient
+
+__all__ = ["DfkvDeviceClient"]
+
+# DfkvStoreConnector is exported from .connector once implemented (Task 5);
+# vLLM resolves it via kv_connector_module_path="dfkv_vllm.connector".

--- a/integration/vllm/src/dfkv_vllm/_cabi.py
+++ b/integration/vllm/src/dfkv_vllm/_cabi.py
@@ -1,0 +1,89 @@
+"""ctypes declarations for the dfkv C ABI (``libdfkv.so``).
+
+Self-contained: declares only the symbols the vLLM connector uses, so this
+package does not depend on the LMCache integration package. Symbol signatures
+mirror ``src/dfkv_c_api.h``.
+
+The library is found via (highest precedence first):
+  1. explicit ``lib_path`` argument
+  2. env ``DFKV_LIB``
+  3. ``$DFKV_BUILD/libdfkv.so``
+"""
+import ctypes
+import os
+from typing import Optional
+
+c_void_p = ctypes.c_void_p
+c_char_p = ctypes.c_char_p
+c_uint64 = ctypes.c_uint64
+c_uint32 = ctypes.c_uint32
+c_int = ctypes.c_int
+POINTER = ctypes.POINTER
+
+
+def resolve_lib_path(lib_path: Optional[str] = None) -> str:
+    if lib_path:
+        return lib_path
+    env = os.environ.get("DFKV_LIB")
+    if env:
+        return env
+    build = os.environ.get("DFKV_BUILD")
+    if build:
+        return os.path.join(build, "libdfkv.so")
+    raise RuntimeError(
+        "libdfkv.so not found: pass lib_path, or set DFKV_LIB or DFKV_BUILD"
+    )
+
+
+def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
+    """Load libdfkv.so and declare the C-ABI signatures used by the connector."""
+    lib = ctypes.CDLL(resolve_lib_path(lib_path))
+
+    # handle = dfkv_open(members, model_hash, geometry u32 x8)
+    lib.dfkv_open.restype = c_void_p
+    lib.dfkv_open.argtypes = [c_char_p, c_uint64] + [c_uint32] * 8
+
+    # GPUDirect MR registration (ibv_reg_mr on a host OR device pointer).
+    lib.dfkv_register_memory.restype = c_int
+    lib.dfkv_register_memory.argtypes = [c_void_p, c_void_p, c_uint64]
+
+    # Batch primitives (raw void** pointers -> may be GPU device pointers).
+    lib.dfkv_batch_put.restype = c_int
+    lib.dfkv_batch_put.argtypes = [
+        c_void_p, POINTER(c_char_p), POINTER(c_void_p), POINTER(c_uint64),
+        c_int, POINTER(c_int),
+    ]
+    # Variable-size read: each buffer filled to its true stored length.
+    lib.dfkv_batch_get_auto.restype = c_int
+    lib.dfkv_batch_get_auto.argtypes = [
+        c_void_p, POINTER(c_char_p), POINTER(c_void_p), POINTER(c_uint64),
+        c_int, POINTER(c_int), POINTER(c_uint64),
+    ]
+    lib.dfkv_batch_exist.restype = c_int
+    lib.dfkv_batch_exist.argtypes = [c_void_p, POINTER(c_char_p), c_int, POINTER(c_int)]
+
+    # Scatter-gather: one key gathers num_bufs[i] non-contiguous source buffers
+    # (ptrs[i][..], sizes[i][..]) on put / scatters into num_dsts[i] dst buffers
+    # (dsts[i][..], caps[i][..]) on get. Coalesces a chunk's per-layer segments
+    # into ONE key + one RDMA multi-SGE op (<=29 segs/key on max_sge=30 HCAs).
+    lib.dfkv_batch_put_sg.restype = c_int
+    lib.dfkv_batch_put_sg.argtypes = [
+        c_void_p, POINTER(c_char_p), POINTER(POINTER(c_void_p)),
+        POINTER(POINTER(c_uint64)), POINTER(c_int), c_int, POINTER(c_int),
+    ]
+    lib.dfkv_batch_get_auto_sg.restype = c_int
+    lib.dfkv_batch_get_auto_sg.argtypes = [
+        c_void_p, POINTER(c_char_p), POINTER(POINTER(c_void_p)),
+        POINTER(POINTER(c_uint64)), POINTER(c_int), c_int,
+        POINTER(c_int), POINTER(c_uint64),
+    ]
+
+    lib.dfkv_set_batch_concurrency.restype = c_int
+    lib.dfkv_set_batch_concurrency.argtypes = [c_void_p, c_uint64]
+
+    lib.dfkv_transport_mode.restype = c_char_p
+    lib.dfkv_transport_mode.argtypes = [c_void_p]
+
+    lib.dfkv_close.restype = None
+    lib.dfkv_close.argtypes = [c_void_p]
+    return lib

--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Adapted from vllm-project/vllm-ascend
+# (vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/).
+"""DfkvStoreConnector - KV cache connector using DfkvDistributedStore.
+
+Unlike DfkvConnector which does direct P2P transfer, this connector
+uses DfkvDistributedStore as a shared KV cache pool. Both producer
+and consumer instances read/write KV to/from the store independently,
+enabling prefix caching via hash-based deduplication.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import (
+    KVCacheEvent,
+    KVConnectorKVEvents,
+    KVEventAggregator,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+    SupportsHMA,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.forward_context import ForwardContext
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import Request
+
+from .data import DfkvStoreConnectorMetadata
+from .metrics import DfkvStoreConnectorStats, DfkvStorePromMetrics
+from .scheduler import DfkvStoreScheduler
+from .worker import DfkvStoreWorker
+
+logger = init_logger(__name__)
+
+
+class DfkvStoreKVEvents(KVConnectorKVEvents):
+    """KV event aggregation for DfkvStoreConnector."""
+
+    def __init__(self, num_workers: int) -> None:
+        self._aggregator = KVEventAggregator(num_workers)
+
+    def add_events(self, events: list[KVCacheEvent]) -> None:
+        self._aggregator.add_events(events)
+
+    def aggregate(self) -> "DfkvStoreKVEvents":
+        common_events = self._aggregator.get_common_events()
+        self._aggregator.clear_events()
+        self._aggregator.add_events(common_events)
+        self._aggregator.reset_workers()
+        return self
+
+    def increment_workers(self, count: int = 1) -> None:
+        self._aggregator.increment_workers(count)
+
+    def get_all_events(self) -> list[KVCacheEvent]:
+        return self._aggregator.get_all_events()
+
+    def get_number_of_workers(self) -> int:
+        return self._aggregator.get_number_of_workers()
+
+    def clear_events(self) -> None:
+        self._aggregator.clear_events()
+        self._aggregator.reset_workers()
+
+    def __repr__(self) -> str:
+        return f"<DfkvStoreKVEvents events={self.get_all_events()}>"
+
+
+class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
+    """KV connector using DfkvDistributedStore as shared KV pool."""
+
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        extra_config = self._kv_transfer_config.kv_connector_extra_config
+        return (
+            str(extra_config.get("enable_cross_layers_blocks", "False")).lower()
+            == "true"
+        )
+
+    @staticmethod
+    def _validate_kv_cache_config(
+        vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+    ) -> None:
+        from vllm.v1.kv_cache_interface import CrossAttentionSpec, MambaSpec
+
+        unsupported: list[str] = []
+        cache_block_size = vllm_config.cache_config.block_size
+        for g_idx, g in enumerate(kv_cache_config.kv_cache_groups):
+            spec = g.kv_cache_spec
+            if isinstance(spec, CrossAttentionSpec):
+                unsupported.append(f"group {g_idx}: CrossAttentionSpec")
+            # Enforce Mamba align mode
+            if isinstance(spec, MambaSpec) and spec.block_size != cache_block_size:
+                unsupported.append(
+                    f"group {g_idx}: MambaSpec with block_size="
+                    f"{spec.block_size} != cache_config.block_size="
+                    f"{cache_block_size} (mamba_cache_mode != 'align')"
+                )
+        pcp = vllm_config.parallel_config.prefill_context_parallel_size
+        dcp = vllm_config.parallel_config.decode_context_parallel_size
+        if len(kv_cache_config.kv_cache_groups) > 1 and pcp * dcp > 1:
+            unsupported.append(
+                f"PCP/DCP > 1 (pcp={pcp}, dcp={dcp}) with hybrid attention"
+            )
+        if unsupported:
+            raise ValueError(
+                "DfkvStoreConnector does not support: " + "; ".join(unsupported)
+            )
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: KVCacheConfig | None = None,
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            role=role,
+            kv_cache_config=kv_cache_config,  # type: ignore[arg-type]
+        )
+        assert vllm_config.kv_transfer_config is not None
+        assert kv_cache_config is not None, "kv_cache_config is required"
+        self._validate_kv_cache_config(vllm_config, kv_cache_config)
+        self._kv_cache_config = kv_cache_config
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        self._kv_cache_events: DfkvStoreKVEvents | None = None
+
+        self.connector_scheduler: DfkvStoreScheduler | None = None
+        self.connector_worker: DfkvStoreWorker | None = None
+
+        if role == KVConnectorRole.SCHEDULER:
+            self.connector_scheduler = DfkvStoreScheduler(
+                vllm_config, kv_cache_config
+            )
+        else:
+            self.connector_worker = DfkvStoreWorker(vllm_config, kv_cache_config)
+
+    # ============================================================
+    # Scheduler-side methods
+    # ============================================================
+
+    def get_num_new_matched_tokens(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def update_state_after_alloc(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        num_external_tokens: int,
+    ):
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.update_state_after_alloc(
+            request, blocks, num_external_tokens
+        )
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.build_connector_meta(scheduler_output)
+
+    def request_finished(
+        self,
+        request: Request,
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        return self.request_finished_all_groups(request, (block_ids,))
+
+    def request_finished_all_groups(
+        self,
+        request: Request,
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, block_ids)
+
+    def reset_cache(self) -> bool | None:
+        """Reset the external Dfkv store on prefix-cache reset.
+
+        Drains the worker send queue, then runs ``remove_all`` on the
+        Dfkv master. Caller must first pause generation (e.g.
+        ``pause_generation``) so no new puts are enqueued during drain.
+
+        Returns True on ack, False on failure, None for the worker role.
+        """
+        if self.role == KVConnectorRole.SCHEDULER:
+            assert self.connector_scheduler is not None
+            # Clear local references to keys we're about to wipe.
+            self.connector_scheduler.load_specs.clear()
+            self._kv_cache_events = None
+            return self.connector_scheduler.reset_store()
+        return None
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        kv_cache_events = connector_output.kv_cache_events
+        if not kv_cache_events or not isinstance(
+            kv_cache_events, DfkvStoreKVEvents
+        ):
+            return
+
+        if self._kv_cache_events is None:
+            self._kv_cache_events = kv_cache_events
+        else:
+            self._kv_cache_events.add_events(kv_cache_events.get_all_events())
+            self._kv_cache_events.increment_workers(
+                kv_cache_events.get_number_of_workers()
+            )
+
+    def take_events(self) -> Iterable[KVCacheEvent]:
+        if self._kv_cache_events is not None:
+            self._kv_cache_events.aggregate()
+            yield from self._kv_cache_events.get_all_events()
+            self._kv_cache_events.clear_events()
+            self._kv_cache_events = None
+
+    # ============================================================
+    # Worker-side methods
+    # ============================================================
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        assert self.connector_worker is not None
+        self.connector_worker.register_kv_caches(kv_caches)
+
+    def register_cross_layers_kv_cache(
+        self, kv_cache: torch.Tensor, attn_backend: type
+    ):
+        assert self.connector_worker is not None
+        assert (
+            self._kv_cache_config is not None
+            and len(self._kv_cache_config.kv_cache_groups) == 1
+        ), "Cross-layer KV cache does not supported with hybrid models"
+        self.connector_worker.register_cross_layers_kv_caches(kv_cache)
+
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
+        # No-op: loads are issued in get_finished() for compute overlap.
+        pass
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        # No layerwise support - no-op
+        return
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        # No layerwise support - no-op
+        return
+
+    def wait_for_save(self):
+        # No-op: stores are issued in get_finished() for compute overlap.
+        pass
+
+    def get_finished(
+        self, finished_req_ids: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        assert self.connector_worker is not None
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, DfkvStoreConnectorMetadata)
+        return self.connector_worker.get_finished(finished_req_ids, metadata)
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        assert self.connector_worker is not None
+        return self.connector_worker.get_block_ids_with_load_errors()
+
+    def get_kv_connector_kv_cache_events(
+        self,
+    ) -> DfkvStoreKVEvents | None:
+        assert self.connector_worker is not None
+        events = self.connector_worker.get_kv_events()
+        if not events:
+            return None
+
+        kv_events = DfkvStoreKVEvents(num_workers=1)
+        kv_events.add_events(events)
+        return kv_events
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        return (
+            DfkvStoreConnectorStats(data=data)
+            if data is not None
+            else DfkvStoreConnectorStats()
+        )
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        return DfkvStorePromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )

--- a/integration/vllm/src/dfkv_vllm/coordinator.py
+++ b/integration/vllm/src/dfkv_vllm/coordinator.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""External-store cache-hit coordinator for DfkvStoreConnector."""
+
+from typing import cast
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    KVCacheBlock,
+)
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheGroupSpec,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+# Dummy placeholder hash for store_mask's template computation.
+_DUMMY_BLOCK_HASH = BlockHash(b"\x00" * 32)
+
+
+class ExternalCachedBlockPool:
+    """Duck-typed BlockPool backed by a ``(group_id, hash)`` exists set."""
+
+    def __init__(self, exists: set[tuple[int, bytes]] | None = None) -> None:
+        # ``exists=None`` is used on the recv side where hit_length is already
+        # determined and we just want each spec's manager to apply its own mask.
+        self._exists = exists
+        self.null_block = KVCacheBlock(block_id=0)
+        # Dummy ID 1 for present block for duck-typing.
+        self._present_block = KVCacheBlock(block_id=1)
+
+    def get_cached_block(
+        self,
+        block_hash: BlockHash,
+        group_ids: list[int],
+    ) -> list[KVCacheBlock] | None:
+        # Mirrors BlockPool.get_cached_block: hit only when every group_id
+        # (groups sharing a spec) has the hash cached.
+        if self._exists is None:
+            return [self._present_block] * len(group_ids)
+        h = bytes(block_hash)
+        if all((g, h) in self._exists for g in group_ids):
+            return [self._present_block] * len(group_ids)
+        return None
+
+
+class DfkvStoreCoordinator:
+    """Mirror of ``HybridKVCacheCoordinator.find_longest_cache_hit`` over an
+    ``ExternalCachedBlockPool``."""
+
+    def __init__(
+        self,
+        kv_cache_groups: list[KVCacheGroupSpec],
+        scheduler_block_size: int,
+        hash_block_size: int,
+        use_eagle: bool = False,
+    ) -> None:
+        assert all(
+            g.kv_cache_spec.block_size % hash_block_size == 0 for g in kv_cache_groups
+        ), "block_size must be divisible by hash_block_size"
+        assert scheduler_block_size % hash_block_size == 0, (
+            f"scheduler_block_size ({scheduler_block_size}) must be a multiple of "
+            f"hash_block_size ({hash_block_size})"
+        )
+        assert all(
+            scheduler_block_size % g.kv_cache_spec.block_size == 0
+            for g in kv_cache_groups
+        ), "scheduler_block_size must be a multiple of each group's block_size"
+        self.kv_cache_groups = kv_cache_groups
+        self.hash_block_size = hash_block_size
+        self.lcm_block_size = scheduler_block_size
+        self.use_eagle = use_eagle
+        self._verify_and_split_kv_cache_groups()
+
+    def _verify_and_split_kv_cache_groups(self) -> None:
+        """Mirrors KVCacheCoordinator.verify_and_split_kv_cache_groups but
+        dispatches via spec_manager_map (we don't allocate managers).
+        """
+        attention_groups: list[
+            tuple[KVCacheSpec, list[int], type[SingleTypeKVCacheManager]]
+        ] = []
+        for i, g in enumerate(self.kv_cache_groups):
+            spec = _unwrap_spec(g.kv_cache_spec)
+            manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+            assert manager_cls is not None, (
+                f"No manager registered for KVCacheSpec {spec}"
+            )
+            for existing_spec, group_ids, existing_cls in attention_groups:
+                if existing_spec == spec:
+                    assert manager_cls is existing_cls
+                    group_ids.append(i)
+                    break
+            else:
+                attention_groups.append((spec, [i], manager_cls))
+        # Full attention first (matches upstream convergence ordering).
+        self.attention_groups = sorted(
+            attention_groups,
+            key=lambda x: not isinstance(x[0], FullAttentionSpec),
+        )
+        self.eagle_attn_group_indices: set[int] = {
+            i
+            for i, (_, group_ids, _) in enumerate(self.attention_groups)
+            if any(self.kv_cache_groups[gid].is_eagle_group for gid in group_ids)
+        }
+        if self.use_eagle and not self.eagle_attn_group_indices:
+            self.eagle_attn_group_indices = set(range(len(self.attention_groups)))
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+        *,
+        apply_eagle: bool = True,
+    ) -> tuple[tuple[list[bool], ...], int]:
+        """Returns ``(load_mask_per_group, hit_length)``. ``mask[g][i]`` is True iff
+        group ``g`` populates chunk ``i`` locally (e.g. SWA and Mamba tail-only);
+        recv-side callers skip False slots.
+
+        ``apply_eagle`` controls whether the per-spec ``use_eagle`` last-block
+        pop is applied. Lookup callers want it (the drafter requires recomputing
+        the last block); per-chunk mask callers must not, because ``token_len``
+        already reflects the eagle-pruned hit length and a second pop would
+        leave the trailing block unloaded.
+        """
+        blocks_per_group, hit_length = self._find_hit_blocks(
+            block_hashes, max_length, cached_block_pool, apply_eagle=apply_eagle
+        )
+        masks = tuple(
+            [blk is not cached_block_pool.null_block for blk in blocks]
+            for blocks in blocks_per_group
+        )
+        return masks, hit_length
+
+    def load_mask(
+        self,
+        block_hashes: list[BlockHash],
+        token_len: int,
+    ) -> tuple[list[bool], ...]:
+        """Per-group load masks. The consumer must reload EXACTLY the chunks the
+        producer stored, so we delegate to ``store_mask`` (the same per-group
+        decision the send path used). The original per-spec hit mask
+        (``find_longest_cache_hit``) silently DROPS dense non-windowed groups --
+        e.g. the DeepSeek-MLA lightning-indexer group -- which the producer DID
+        store; that left the indexer KV unloaded, so vLLM recomputed the whole
+        prefix (load << save, no speedup). Mirroring store_mask guarantees the
+        full prefix (every stored group) is reloaded.
+        """
+        aligned = token_len // self.lcm_block_size * self.lcm_block_size
+        if aligned == 0:
+            return tuple([] for _ in self.kv_cache_groups)
+        return self.store_mask(aligned)
+
+    def store_mask(self, aligned_token_len: int) -> tuple[list[bool], ...]:
+        """Per-group store masks: ``mask[g][i]`` is True iff chunk ``i`` of
+        group ``g`` would be populated by some future cache hit at length
+        ``L = N * lcm_block_size <= aligned_token_len``.
+        """
+        assert aligned_token_len % self.lcm_block_size == 0, (
+            f"aligned_token_len ({aligned_token_len}) must be a multiple of "
+            f"lcm_block_size ({self.lcm_block_size})"
+        )
+        if aligned_token_len == 0:
+            return tuple([] for _ in self.kv_cache_groups)
+
+        num_chunks_per_group = [
+            aligned_token_len // g.kv_cache_spec.block_size
+            for g in self.kv_cache_groups
+        ]
+
+        # Fast path: single group or full attn groups or uniform block_sizes
+        if all(
+            isinstance(spec, FullAttentionSpec)
+            or spec.block_size == self.lcm_block_size
+            for spec, _, _ in self.attention_groups
+        ):
+            return tuple([True] * n for n in num_chunks_per_group)
+
+        n_segments = aligned_token_len // self.lcm_block_size
+        dummy_hashes: list[BlockHash] = [_DUMMY_BLOCK_HASH] * (
+            self.lcm_block_size // self.hash_block_size
+        )
+        template_masks, _ = self.find_longest_cache_hit(
+            dummy_hashes,
+            max_length=self.lcm_block_size,
+            cached_block_pool=ExternalCachedBlockPool(),
+        )
+        return tuple(
+            list(template_masks[g]) * n_segments
+            for g in range(len(self.kv_cache_groups))
+        )
+
+    def block_hashes_for_spec(
+        self, block_hashes: list[BlockHash], spec: KVCacheSpec
+    ) -> BlockHashList:
+        if spec.block_size == self.hash_block_size:
+            return block_hashes
+        return BlockHashListWithBlockSize(
+            block_hashes, self.hash_block_size, spec.block_size
+        )
+
+    def _find_hit_blocks(
+        self,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+        *,
+        apply_eagle: bool = True,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """Mirrors HybridKVCacheCoordinator.find_longest_cache_hit but
+        dispatches via spec_manager_map (we don't allocate managers).
+
+        When ``apply_eagle`` is False, ignore ``eagle_attn_group_indices`` —
+        used by ``load_mask`` to avoid popping a second block on top of the
+        one already removed by the lookup.
+        """
+        eagle_indices = self.eagle_attn_group_indices if apply_eagle else set()
+        if len(self.attention_groups) == 1:
+            spec, group_ids, manager_cls = self.attention_groups[0]
+            hashes = self.block_hashes_for_spec(block_hashes, spec)
+            hit_blocks = manager_cls.find_longest_cache_hit(
+                block_hashes=hashes,
+                max_length=max_length,
+                kv_cache_group_ids=group_ids,
+                block_pool=cast(BlockPool, cached_block_pool),
+                kv_cache_spec=spec,
+                drop_eagle_block=(0 in eagle_indices),
+                alignment_tokens=spec.block_size,
+            )
+            num_groups = len(self.kv_cache_groups)
+            blocks_by_group: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
+            for gid, blks in zip(group_ids, hit_blocks, strict=True):
+                blocks_by_group[gid] = blks
+            return tuple(blocks_by_group), len(hit_blocks[0]) * spec.block_size
+
+        num_groups = len(self.kv_cache_groups)
+        hit_length = max_length
+        hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * num_groups
+
+        is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
+            self.attention_groups[0][0], FullAttentionSpec
+        )
+        eagle_verified: set[int] = set()
+
+        while True:
+            curr_hit_length = hit_length
+
+            for idx, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
+                cached = hit_blocks_by_group[group_ids[0]]
+                if isinstance(spec, FullAttentionSpec) and cached is not None:
+                    curr_hit_length = (
+                        curr_hit_length // spec.block_size * spec.block_size
+                    )
+                    continue
+
+                drop_eagle_block = idx in eagle_indices and idx not in eagle_verified
+                _max_length = curr_hit_length
+                if drop_eagle_block:
+                    _max_length = min(curr_hit_length + spec.block_size, max_length)
+                hashes = self.block_hashes_for_spec(block_hashes, spec)
+                hit_blocks = manager_cls.find_longest_cache_hit(
+                    block_hashes=hashes,
+                    max_length=_max_length,
+                    kv_cache_group_ids=group_ids,
+                    block_pool=cast(BlockPool, cached_block_pool),
+                    kv_cache_spec=spec,
+                    drop_eagle_block=drop_eagle_block,
+                    alignment_tokens=self.lcm_block_size,
+                )
+                _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                if drop_eagle_block:
+                    eagle_verified.add(idx)
+                elif _new_hit_length < curr_hit_length:
+                    eagle_verified.clear()
+                curr_hit_length = _new_hit_length
+                for gid, blocks in zip(group_ids, hit_blocks, strict=True):
+                    hit_blocks_by_group[gid] = blocks
+
+            if curr_hit_length >= hit_length:
+                break
+            hit_length = curr_hit_length
+            if is_simple_hybrid:
+                break
+
+        # Truncate full-attention hit_blocks to final converged length;
+        # other specs already trim themselves inside their hit logic.
+        spec0, group_ids0, _ = self.attention_groups[0]
+        if isinstance(spec0, FullAttentionSpec):
+            num_blocks = hit_length // spec0.block_size
+            for gid in group_ids0:
+                full_blks = hit_blocks_by_group[gid]
+                assert full_blks is not None
+                del full_blks[num_blocks:]
+
+        return (
+            tuple(blks if blks is not None else [] for blks in hit_blocks_by_group),
+            hit_length,
+        )
+
+
+def _unwrap_spec(spec: KVCacheSpec) -> KVCacheSpec:
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        return next(iter(spec.kv_cache_specs.values()))
+    return spec

--- a/integration/vllm/src/dfkv_vllm/data.py
+++ b/integration/vllm/src/dfkv_vllm/data.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Adapted from vllm-project/vllm-ascend
+# (vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/).
+"""Data classes for DfkvStoreConnector."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+)
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    BlockHashListWithBlockSize,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class KeyMetadata:
+    """Metadata for constructing pool keys."""
+
+    model_name: str
+    tp_rank: int
+    pcp_rank: int
+    dcp_rank: int
+    pp_rank: int
+    group_id: int = 0
+
+
+@dataclass(order=True)
+class PoolKey:
+    """Key for addressing KV cache blocks in the distributed store."""
+
+    key_metadata: KeyMetadata
+    chunk_hash: str
+
+    def __hash__(self):
+        return hash(
+            (
+                self.key_metadata.model_name,
+                self.key_metadata.tp_rank,
+                self.key_metadata.pcp_rank,
+                self.key_metadata.dcp_rank,
+                self.key_metadata.pp_rank,
+                self.key_metadata.group_id,
+                self.chunk_hash,
+            )
+        )
+
+    def to_string(self) -> str:
+        return (
+            f"{self.key_metadata.model_name}"
+            f"@tp_rank:{self.key_metadata.tp_rank}"
+            f"@pcp{self.key_metadata.pcp_rank}"
+            f"@dcp{self.key_metadata.dcp_rank}"
+            f"@pp_rank:{self.key_metadata.pp_rank}"
+            f"@group:{self.key_metadata.group_id}"
+            f"@{self.chunk_hash}"
+        )
+
+
+class ChunkedTokenDatabase:
+    """Maps token positions to store keys and GPU memory addresses."""
+
+    def __init__(
+        self,
+        metadata: KeyMetadata,
+        block_size: int,
+        hash_block_size: int | None = None,
+    ):
+        self.metadata = metadata
+        self.block_size = block_size
+        self.hash_block_size = hash_block_size or block_size
+        if self.block_size % self.hash_block_size != 0:
+            raise ValueError(
+                f"block_size ({self.block_size}) must be a multiple of "
+                f"hash_block_size ({self.hash_block_size})"
+            )
+        self.kv_caches_base_addr: list[int] = []
+        self.block_len: list[int] = []
+
+    def _make_key_by_hash(self, chunk_hash: str) -> PoolKey:
+        return PoolKey(self.metadata, chunk_hash)
+
+    def set_kv_caches_base_addr(self, kv_caches_base_addr: list[int]):
+        self.kv_caches_base_addr = kv_caches_base_addr
+
+    def set_block_len(self, block_len: list[int]):
+        self.block_len = block_len
+
+    def prepare_value(
+        self, start: int, end: int, block_ids: list[int]
+    ) -> tuple[list[int], list[int], int]:
+        """Compute memory addresses and sizes for a token range.
+
+        Returns:
+            (addr_list, size_list, block_id)
+        """
+        addr_list = []
+        size_list = []
+        block_id = block_ids[start // self.block_size]
+        length = len(self.block_len)
+        for index, base_addr in enumerate(self.kv_caches_base_addr):
+            addr = base_addr + block_id * self.block_len[index % length]
+            assert (end - start) % self.block_size == 0
+            size = self.block_len[index % length] * cdiv(end - start, self.block_size)
+            addr_list.append(addr)
+            size_list.append(size)
+        return addr_list, size_list, block_id
+
+    def process_tokens(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        mask_num: int = 0,
+    ) -> Iterable[tuple[int, int, PoolKey]]:
+        """Process tokens and yield (start_idx, end_idx, pool_key) tuples.
+
+        Args:
+            token_len: Total number of tokens.
+            block_hashes: Block hashes computed at ``hash_block_size`` granularity.
+                When ``block_size > hash_block_size`` consecutive hashes are merged
+                up to the group's ``block_size`` via ``BlockHashListWithBlockSize``.
+            mask_num: Number of tokens to skip from the beginning.
+        """
+        if not block_hashes:
+            return
+        if self.block_size == self.hash_block_size:
+            chunk_hashes: Iterable[BlockHash] = block_hashes
+        else:
+            chunk_hashes = BlockHashListWithBlockSize(
+                block_hashes, self.hash_block_size, self.block_size
+            )
+        for chunk_id, h in enumerate(chunk_hashes):
+            start_idx = chunk_id * self.block_size
+            if start_idx >= token_len:
+                break
+            end_idx = min(start_idx + self.block_size, token_len)
+            if start_idx < mask_num:
+                continue
+            yield start_idx, end_idx, self._make_key_by_hash(h.hex())
+
+
+@dataclass
+class LoadSpec:
+    """Specification for loading KV cache from external store."""
+
+    vllm_cached_tokens: int
+    kvpool_cached_tokens: int
+    can_load: bool
+    token_len: int = 0
+
+
+@dataclass
+class RequestTracker:
+    """Tracks per-request state across scheduler ticks."""
+
+    req_id: str
+    token_len: int
+    allocated_block_ids: tuple[list[int], ...]
+    num_saved_tokens: int = 0
+    token_ids: list[int] | None = None
+    # Snapshot of the prefill range length at tracker creation time.
+    # For a fresh request this is len(prompt). For a resumed-from-preemption
+    # request it includes previously-generated tokens, which are re-prefilled.
+    prefill_end_tokens: int = 0
+
+    def reset(self) -> None:
+        self.token_len = 0
+        self.allocated_block_ids = ()
+        self.num_saved_tokens = 0
+        self.token_ids = None
+        self.prefill_end_tokens = 0
+
+    def update(
+        self,
+        new_block_ids: tuple[list[int], ...] | list[int],
+    ) -> None:
+        # Backward-compat: accept a single list (broadcast to single group).
+        if isinstance(new_block_ids, list):
+            new_block_ids = (new_block_ids,)
+        if len(new_block_ids) != len(self.allocated_block_ids):
+            raise ValueError(
+                f"Group count mismatch: tracker has "
+                f"{len(self.allocated_block_ids)} groups, update has "
+                f"{len(new_block_ids)}"
+            )
+        for existing, new in zip(self.allocated_block_ids, new_block_ids, strict=True):
+            if new:
+                existing.extend(new)
+
+
+@dataclass
+class ReqMeta:
+    """Per-request metadata for store put/get operations."""
+
+    req_id: str
+    token_len_chunk: int
+    block_ids: tuple[list[int], ...]
+    block_hashes: list[BlockHash]
+
+    can_save: bool | None = None
+    load_spec: LoadSpec | None = None
+    is_last_chunk: bool | None = None
+    current_event: torch.cuda.Event | None = None
+
+    token_ids: list[int] | None = None
+
+    @staticmethod
+    def from_request_tracker(
+        tracker: RequestTracker,
+        block_size: int,
+        load_spec: LoadSpec | None = None,
+        skip_save: bool | None = False,
+        block_hashes: list[BlockHash] | None = None,
+        is_last_chunk: bool | None = None,
+    ) -> "ReqMeta | None":
+        """Create ReqMeta from a RequestTracker."""
+        if block_hashes is None:
+            block_hashes = []
+        input_token_len = tracker.token_len
+
+        chunk_boundary = cdiv(tracker.num_saved_tokens + 1, block_size) * block_size
+        num_tokens_to_save = input_token_len // block_size * block_size
+
+        skip_save = skip_save or num_tokens_to_save < chunk_boundary
+        # A ReqMeta must never carry both a save AND a load.
+        # The save would also be wasted work — the bytes are being looked up
+        # in the store right now. Later cached_reqs steps save new tokens
+        # normally.
+        if load_spec is not None and load_spec.can_load:
+            skip_save = True
+        if skip_save and load_spec is None:
+            return None
+
+        if not skip_save:
+            tracker.num_saved_tokens = num_tokens_to_save
+
+        token_ids = None
+        if tracker.token_ids:
+            token_ids = tracker.token_ids
+
+        if load_spec is not None and load_spec.can_load:
+            logger.debug(
+                "Scheduled to load %d tokens for request %s",
+                load_spec.kvpool_cached_tokens,
+                tracker.req_id,
+            )
+        else:
+            load_spec = None
+
+        logger.debug(
+            "request:%s, meta save spec:%s, meta load spec:%s",
+            tracker.req_id,
+            not skip_save,
+            load_spec,
+        )
+        return ReqMeta(
+            req_id=tracker.req_id,
+            token_len_chunk=num_tokens_to_save,
+            block_ids=tracker.allocated_block_ids,
+            can_save=not skip_save,
+            load_spec=load_spec,
+            block_hashes=block_hashes,
+            is_last_chunk=is_last_chunk,
+            token_ids=token_ids,
+        )
+
+
+class DfkvStoreConnectorMetadata(KVConnectorMetadata):
+    """Metadata passed from scheduler to worker."""
+
+    def __init__(
+        self,
+        unfinished_request_ids: set[str],
+        preempted_req_ids: set[str],
+    ):
+        self.requests: list[ReqMeta] = []
+        self.unfinished_request_ids = unfinished_request_ids
+        self.preempted_req_ids = preempted_req_ids
+
+    def add_request(self, req_meta: ReqMeta) -> None:
+        self.requests.append(req_meta)

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -1,0 +1,187 @@
+"""Device-pointer dfkv client for the vLLM connector.
+
+Every buffer here is a raw integer pointer -- a slice of the GPU paged KV cache
+that was pre-registered via :meth:`register_memory`. This differs from the
+LMCache integration's ``native_client`` (which operates on host ``memoryview``s):
+the vLLM connector hands GPU device pointers, so we call the C ABI with
+``c_void_p(int)`` directly.
+
+Validated facts (hd04 H100 + IB, nvidia-peermem loaded):
+  * ``register_memory`` accepts a CUDA device pointer -> GPUDirect MR.
+  * GPU buffers MUST go through the batch path (``batch_get``); the single
+    ``dfkv_get_auto`` computes a CRC over the destination on the CPU and
+    segfaults on device memory.
+  * The member address MUST point at the server's RDMA bootstrap port
+    (``--rdma-port``), not the main ``--port``, when ``DFKV_RDMA=1``.
+"""
+import ctypes
+from typing import Optional, Sequence
+
+from ._cabi import load_lib
+
+c_void_p = ctypes.c_void_p
+c_char_p = ctypes.c_char_p
+c_uint64 = ctypes.c_uint64
+c_uint32 = ctypes.c_uint32
+c_int = ctypes.c_int
+
+# dfkv geometry guard fields (src/value_header.h). Default 0 = no geometry guard;
+# isolation is by model_hash + key namespace. A KV pool sharing one model_hash
+# must share kv-cache-dtype / page-size / layout (see dfkv sharing-safety notes).
+_GEOMETRY_ZEROS = (0,) * 8
+
+
+class DfkvDeviceClient:
+    """Thin device-pointer wrapper over libdfkv.so for the vLLM connector."""
+
+    def __init__(
+        self,
+        members: str,
+        model_hash: int,
+        lib_path: Optional[str] = None,
+        batch_concurrency: int = 8,
+        geometry: Sequence[int] = _GEOMETRY_ZEROS,
+    ):
+        if len(geometry) != 8:
+            raise ValueError("geometry must have exactly 8 fields")
+        self._lib = load_lib(lib_path)
+        self._h = self._lib.dfkv_open(
+            members.encode(),
+            c_uint64(model_hash & 0xFFFFFFFFFFFFFFFF),
+            *(c_uint32(int(g) & 0xFFFFFFFF) for g in geometry),
+        )
+        if not self._h:
+            raise RuntimeError(f"dfkv_open failed (members={members!r})")
+        self._lib.dfkv_set_batch_concurrency(self._h, c_uint64(batch_concurrency))
+
+    @property
+    def transport_mode(self) -> str:
+        return self._lib.dfkv_transport_mode(self._h).decode()
+
+    def register_memory(self, base: int, size: int) -> None:
+        """Register a (host or GPU device) region as an RDMA MR. One call per
+        contiguous KV-cache storage region; later put/get reference offsets."""
+        rc = self._lib.dfkv_register_memory(self._h, c_void_p(base), c_uint64(size))
+        if rc != 0:
+            raise RuntimeError(
+                f"dfkv_register_memory(base={base:#x}, size={size}) rc={rc}"
+            )
+
+    def batch_put(
+        self, keys: Sequence[str], ptrs: Sequence[int], sizes: Sequence[int]
+    ) -> list:
+        """Store ``keys[i]`` from buffer ``ptrs[i]`` (device or host) of
+        ``sizes[i]`` bytes. Returns per-key status (``0`` = ok, ``1`` = failed).
+
+        NOTE: the dfkv C ABI's ``dfkv_batch_put`` sets ``out[i]=1`` for SUCCESS
+        and ``0`` for failure (matching batch_get/batch_exist, but the OPPOSITE
+        of the single ``dfkv_put`` which returns 0=ok). We normalize here to the
+        connector's "0 = ok" convention so callers don't have to know this."""
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        parr = (c_void_p * n)(*[c_void_p(p) for p in ptrs])
+        sarr = (c_uint64 * n)(*sizes)
+        out = (c_int * n)()
+        rc = self._lib.dfkv_batch_put(self._h, karr, parr, sarr, n, out)
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_put rc={rc}")
+        return [0 if ok == 1 else 1 for ok in out]
+
+    def batch_get(
+        self, keys: Sequence[str], ptrs: Sequence[int], caps: Sequence[int]
+    ):
+        """Load ``keys[i]`` into buffer ``ptrs[i]`` (device or host, capacity
+        ``caps[i]``). Returns ``(hits, lengths)``: ``hits[i]`` is 1 on hit, 0 on
+        miss; ``lengths[i]`` is the true stored byte length on hit."""
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        parr = (c_void_p * n)(*[c_void_p(p) for p in ptrs])
+        carr = (c_uint64 * n)(*caps)
+        out_hit = (c_int * n)()
+        out_len = (c_uint64 * n)()
+        rc = self._lib.dfkv_batch_get_auto(
+            self._h, karr, parr, carr, n, out_hit, out_len
+        )
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_get_auto rc={rc}")
+        return list(out_hit), list(out_len)
+
+    def batch_put_sg(
+        self,
+        keys: Sequence[str],
+        seg_ptrs: Sequence[Sequence[int]],
+        seg_sizes: Sequence[Sequence[int]],
+    ) -> list:
+        """Scatter-gather put: ``keys[i]`` stores the in-order concatenation of
+        the buffers ``seg_ptrs[i][..]`` (device pointers) of ``seg_sizes[i][..]``
+        bytes, as ONE dfkv key + one RDMA multi-SGE op. Each key takes <=29 segs
+        (max_sge-1); the C ABI reports a >29 key failed. Returns per-key status
+        (``0`` = ok, ``1`` = failed), same "0=ok" normalization as ``batch_put``."""
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        # Keep the per-key inner arrays alive for the duration of the call.
+        inner_p = [(c_void_p * len(p))(*[c_void_p(x) for x in p]) for p in seg_ptrs]
+        inner_s = [(c_uint64 * len(s))(*s) for s in seg_sizes]
+        parr = (ctypes.POINTER(c_void_p) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(c_void_p)) for a in inner_p]
+        )
+        sarr = (ctypes.POINTER(c_uint64) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(c_uint64)) for a in inner_s]
+        )
+        narr = (c_int * n)(*[len(p) for p in seg_ptrs])
+        out = (c_int * n)()
+        rc = self._lib.dfkv_batch_put_sg(self._h, karr, parr, sarr, narr, n, out)
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_put_sg rc={rc}")
+        return [0 if ok == 1 else 1 for ok in out]
+
+    def batch_get_auto_sg(
+        self,
+        keys: Sequence[str],
+        seg_ptrs: Sequence[Sequence[int]],
+        seg_caps: Sequence[Sequence[int]],
+    ):
+        """Scatter-gather get: ``keys[i]``'s stored blob is scattered in order
+        across destination buffers ``seg_ptrs[i][..]`` of capacity
+        ``seg_caps[i][..]`` (the segment sizes define the split). Returns
+        ``(hits, lengths)`` where ``lengths[i]`` is the total stored bytes."""
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        inner_p = [(c_void_p * len(p))(*[c_void_p(x) for x in p]) for p in seg_ptrs]
+        inner_c = [(c_uint64 * len(c))(*c) for c in seg_caps]
+        parr = (ctypes.POINTER(c_void_p) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(c_void_p)) for a in inner_p]
+        )
+        carr = (ctypes.POINTER(c_uint64) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(c_uint64)) for a in inner_c]
+        )
+        narr = (c_int * n)(*[len(p) for p in seg_ptrs])
+        out_hit = (c_int * n)()
+        out_len = (c_uint64 * n)()
+        rc = self._lib.dfkv_batch_get_auto_sg(
+            self._h, karr, parr, carr, narr, n, out_hit, out_len
+        )
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_get_auto_sg rc={rc}")
+        return list(out_hit), list(out_len)
+
+    def batch_exist(self, keys: Sequence[str]) -> list:
+        """Return ``[1|0]`` per key (1 = present in the cache)."""
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        out = (c_int * n)()
+        rc = self._lib.dfkv_batch_exist(self._h, karr, n, out)
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_exist rc={rc}")
+        return list(out)
+
+    def close(self) -> None:
+        if getattr(self, "_h", None):
+            self._lib.dfkv_close(self._h)
+            self._h = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/integration/vllm/src/dfkv_vllm/dfkv_utils.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_utils.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Adapted from vllm-project/vllm (mooncake/mooncake_utils.py): only the
+# DP-engine-index helper is needed; dfkv handles its own RDMA bootstrap, so the
+# Mooncake transfer-engine / bootstrap-server machinery is dropped.
+"""Small helpers for the dfkv vLLM connector."""
+from vllm.config import ParallelConfig
+
+
+def get_dp_engine_index(parallel_config: ParallelConfig) -> int:
+    """Return the per-engine DP index used for connector side channels."""
+    if parallel_config.local_engines_only:
+        assert parallel_config.data_parallel_rank_local is not None
+        return parallel_config.data_parallel_rank_local
+    return parallel_config.data_parallel_index

--- a/integration/vllm/src/dfkv_vllm/metrics.py
+++ b/integration/vllm/src/dfkv_vllm/metrics.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-operation telemetry for DfkvStoreConnector.
+
+Records one row per Dfkv RPC (``save_exists``, ``save_put``, ``load_get``,
+``lookup_exists``) with duration, key/byte counts, status, and failed-key
+count. Exposed to the logger via ``KVConnectorLogging`` and to Prometheus
+via ``DfkvStorePromMetrics``.
+"""
+
+from dataclasses import dataclass
+from statistics import fmean
+from typing import Any
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+
+
+def _nearest_rank_percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    rank = max(
+        0, min(len(sorted_values) - 1, int(percentile * len(sorted_values) - 1e-12))
+    )
+    return sorted_values[rank]
+
+
+@dataclass
+class DfkvStoreConnectorStats(KVConnectorStats):
+    """Serializable Dfkv store communication telemetry."""
+
+    def __post_init__(self):
+        if not self.data:
+            self.reset()
+
+    def reset(self):
+        self.data: dict[str, list[dict[str, int | float | str]]] = {}
+
+    def is_empty(self) -> bool:
+        return not self.data
+
+    def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        if other.is_empty():
+            return self
+        for operation, records in other.data.items():
+            self.data.setdefault(operation, []).extend(records)
+        return self
+
+    def reduce(self) -> dict[str, int | float]:
+        reduced: dict[str, int | float] = {}
+        for operation, records in sorted(self.data.items()):
+            if not records:
+                continue
+            durations = [float(record["duration_seconds"]) for record in records]
+            reduced[f"{operation}_count"] = len(records)
+            reduced[f"{operation}_avg_ms"] = round(fmean(durations) * 1e3, 3)
+            reduced[f"{operation}_p90_ms"] = round(
+                _nearest_rank_percentile(durations, 0.9) * 1e3, 3
+            )
+            reduced[f"{operation}_total_keys"] = sum(
+                int(record["num_keys"]) for record in records
+            )
+            reduced[f"{operation}_total_bytes"] = sum(
+                int(record["num_bytes"]) for record in records
+            )
+            reduced[f"{operation}_failed_keys"] = sum(
+                int(record["num_failed_keys"]) for record in records
+            )
+            reduced[f"{operation}_error_count"] = sum(
+                1 for record in records if record["status"] == "error"
+            )
+        return reduced
+
+    def record_operation(
+        self,
+        operation: str,
+        duration_seconds: float,
+        num_keys: int,
+        *,
+        num_bytes: int = 0,
+        status: str = "ok",
+        num_failed_keys: int = 0,
+    ) -> None:
+        self.data.setdefault(operation, []).append(
+            {
+                "duration_seconds": duration_seconds,
+                "num_keys": num_keys,
+                "num_bytes": num_bytes,
+                "status": status,
+                "num_failed_keys": num_failed_keys,
+            }
+        )
+
+
+class DfkvStorePromMetrics(KVConnectorPromMetrics):
+    """Prometheus metrics for Dfkv store communication."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ):
+        super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
+        metric_labelnames = labelnames + ["operation", "status"]
+        self._metric_cache: dict[tuple[int, str, str], dict[str, PromMetric]] = {}
+
+        self._histogram_operation_time = self._histogram_cls(
+            name="vllm:dfkv_store_operation_time_seconds",
+            documentation="Histogram of Dfkv store communication time.",
+            buckets=[
+                1e-3,
+                5e-3,
+                1e-2,
+                5e-2,
+                1e-1,
+                2e-1,
+                3e-1,
+                4e-1,
+                5e-1,
+                7.5e-1,
+                1.0,
+                1.5,
+                2.0,
+                3.0,
+                4.0,
+            ],
+            labelnames=metric_labelnames,
+        )
+        self._counter_operation_calls = self._counter_cls(
+            name="vllm:dfkv_store_operation_total",
+            documentation="Number of Dfkv store communication operations.",
+            labelnames=metric_labelnames,
+        )
+        self._counter_operation_keys = self._counter_cls(
+            name="vllm:dfkv_store_operation_keys_total",
+            documentation="Number of Dfkv store keys touched by operations.",
+            labelnames=metric_labelnames,
+        )
+        self._counter_operation_bytes = self._counter_cls(
+            name="vllm:dfkv_store_operation_bytes_total",
+            documentation="Number of bytes transferred by Dfkv store operations.",
+            labelnames=metric_labelnames,
+        )
+        self._counter_failed_keys = self._counter_cls(
+            name="vllm:dfkv_store_operation_failed_keys_total",
+            documentation="Number of Dfkv store keys that failed in operations.",
+            labelnames=metric_labelnames,
+        )
+
+    def _get_metrics(
+        self,
+        engine_idx: int,
+        operation: str,
+        status: str,
+    ) -> dict[str, PromMetric]:
+        cache_key = (engine_idx, operation, status)
+        if cache_key not in self._metric_cache:
+            label_values = self.per_engine_labelvalues[engine_idx] + [operation, status]
+            self._metric_cache[cache_key] = {
+                "time": self._histogram_operation_time.labels(*label_values),
+                "calls": self._counter_operation_calls.labels(*label_values),
+                "keys": self._counter_operation_keys.labels(*label_values),
+                "bytes": self._counter_operation_bytes.labels(*label_values),
+                "failed_keys": self._counter_failed_keys.labels(*label_values),
+            }
+        return self._metric_cache[cache_key]
+
+    def observe(self, transfer_stats_data: dict[str, Any] | None, engine_idx: int = 0):
+        if not transfer_stats_data:
+            return
+        for operation, records in transfer_stats_data.items():
+            assert isinstance(records, list)
+            for record in records:
+                assert isinstance(record, dict)
+                status = str(record["status"])
+                metrics = self._get_metrics(engine_idx, operation, status)
+                metrics["time"].observe(float(record["duration_seconds"]))
+                metrics["calls"].inc()
+                metrics["keys"].inc(int(record["num_keys"]))
+                metrics["bytes"].inc(int(record["num_bytes"]))
+                metrics["failed_keys"].inc(int(record["num_failed_keys"]))

--- a/integration/vllm/src/dfkv_vllm/protocol.py
+++ b/integration/vllm/src/dfkv_vllm/protocol.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Wire-format constants for the LookupKey ZMQ admin channel.
+
+This is the single source of truth shared by ``LookupKeyClient`` and
+``LookupKeyServer`` on the scheduler<->worker rank-0 admin channel.
+
+Wire format (REQ/REP over IPC):
+
+    Request: [msg_type: bytes] [payload_frames...]
+
+      msg_type == LOOKUP_MSG:
+          frame 1: token_len (u32 big-endian, 4 bytes)
+          frame 2..n: msgpack-encoded list[str] of block-hash hex digests
+        Response: [hit_count: u32 big-endian, 4 bytes]
+
+      msg_type == RESET_MSG:
+          (no payload frames)
+        Response: [RESP_OK] or [RESP_ERR]
+
+The first frame of every request is a named bytes tag (not a numeric
+sentinel that aliases the data field) so the protocol stays
+self-describing and extensible: adding new admin commands requires
+only a new tag and a new dispatch branch.
+
+Mirrors the named-tag convention used by the NIXL connector (see
+``vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py``).
+"""
+
+# Request message-type tags. Frame 0 of every request.
+LOOKUP_MSG: bytes = b"lookup"
+RESET_MSG: bytes = b"reset"
+
+# Single-byte response status codes for admin commands.
+RESP_OK: bytes = b"\x01"
+RESP_ERR: bytes = b"\x00"

--- a/integration/vllm/src/dfkv_vllm/scheduler.py
+++ b/integration/vllm/src/dfkv_vllm/scheduler.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Adapted from vllm-project/vllm-ascend
+# (vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/).
+"""Scheduler-side logic for DfkvStoreConnector."""
+
+import time
+from typing import Any
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+)
+from vllm.logger import init_logger
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.request import Request
+
+from .data import (
+    LoadSpec,
+    DfkvStoreConnectorMetadata,
+    ReqMeta,
+    RequestTracker,
+)
+from .worker import (
+    LookupKeyClient,
+)
+
+logger = init_logger(__name__)
+
+
+def _new_req_prefill_tokens(request: NewRequestData) -> list[int]:
+    """Tokens this prefill will compute KV for.
+
+    Under the v2 model runner, resumed-from-preemption requests appear in
+    ``scheduled_new_reqs`` with ``prefill_token_ids`` set to the request's full
+    token list (prompt + previously-generated). For all other cases this falls
+    back to the original prompt.
+    """
+    if request.prefill_token_ids is not None:
+        return request.prefill_token_ids
+    assert request.prompt_token_ids is not None
+    return request.prompt_token_ids
+
+
+class DfkvStoreScheduler:
+    """Scheduler-side component for DfkvStoreConnector."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ):
+        assert vllm_config.kv_transfer_config is not None
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+            "load_async", True
+        )
+        self.client = LookupKeyClient(vllm_config)
+
+        # Align with the engine's own scheduler_block_size and hash_block_size.
+        self._block_size, self._hash_block_size = resolve_kv_cache_block_sizes(
+            kv_cache_config, vllm_config
+        )
+
+        # Per-request state
+        self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
+        self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
+        self._preempted_req_ids: set[str] = set()  # preempted requests
+        self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
+        self._unfinished_request_ids: set[str] = set()
+
+    def get_num_new_matched_tokens(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        """Check for external KV cache hit."""
+        # Look up against the full prefill range, not just the prompt.
+        token_len = request.num_tokens // self._block_size * self._block_size
+        if token_len < self._block_size:
+            return 0, False
+
+        _lk0 = time.perf_counter()
+        num_external_hit_tokens = self.client.lookup(token_len, request.block_hashes)
+        logger.debug(
+            "dfkv matched: req=%s tokens=%d computed=%d lookup_ms=%.1f hit_tokens=%d",
+            request.request_id, request.num_tokens, num_computed_tokens,
+            (time.perf_counter() - _lk0) * 1000.0, num_external_hit_tokens,
+        )
+
+        if num_external_hit_tokens == request.num_tokens:
+            # Leave a sub-block tail uncomputed for sampling, on a block
+            # boundary so the recv-side load mask covers every yielded chunk.
+            num_external_hit_tokens = max(
+                0,
+                (request.num_tokens - 1) // self._block_size * self._block_size,
+            )
+
+        if num_external_hit_tokens < num_computed_tokens:
+            need_to_allocate = 0
+        else:
+            need_to_allocate = num_external_hit_tokens - num_computed_tokens
+
+        logger.debug(
+            "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
+            request.request_id,
+            request.num_tokens,
+            num_external_hit_tokens,
+            need_to_allocate,
+        )
+
+        if need_to_allocate <= 0:
+            return 0, False
+
+        self.load_specs[request.request_id] = LoadSpec(
+            vllm_cached_tokens=num_computed_tokens,
+            kvpool_cached_tokens=num_external_hit_tokens,
+            can_load=False,
+        )
+
+        return need_to_allocate, self.load_async
+
+    def update_state_after_alloc(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        num_external_tokens: int,
+    ):
+        """Update state after block allocation."""
+        local_block_ids: tuple[list[int], ...] = ()
+        if num_external_tokens > 0:
+            local_block_ids = blocks.get_block_ids()
+
+        self._unfinished_requests[request.request_id] = (request, local_block_ids)
+        self._unfinished_request_ids.add(request.request_id)
+
+        if request.request_id not in self.load_specs:
+            return
+
+        if num_external_tokens == 0:
+            self.load_specs[request.request_id].can_load = False
+            return
+
+        assert (
+            num_external_tokens > 0
+            and num_external_tokens
+            == self.load_specs[request.request_id].kvpool_cached_tokens
+            - self.load_specs[request.request_id].vllm_cached_tokens
+        ), (
+            f"Mismatch in number of tokens: {num_external_tokens} vs "
+            f"{self.load_specs[request.request_id].kvpool_cached_tokens} - "
+            f"{self.load_specs[request.request_id].vllm_cached_tokens}"
+            f" for request {request.request_id}"
+        )
+
+        self.load_specs[request.request_id].can_load = True
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        """Build connector metadata for this scheduler step."""
+        force_skip_save = self.kv_role == "kv_consumer"
+
+        for finished_req_id in scheduler_output.finished_req_ids:
+            self.load_specs.pop(finished_req_id, None)
+            self._request_trackers.pop(finished_req_id, None)
+            self._unfinished_requests.pop(finished_req_id, None)
+            self._unfinished_request_ids.discard(finished_req_id)
+            self._preempted_req_ids.discard(finished_req_id)
+
+        preempted_ids = scheduler_output.preempted_req_ids or set()
+        self._preempted_req_ids.update(preempted_ids)
+        for req_id in preempted_ids:
+            self.load_specs.pop(req_id, None)
+            if request_tracker := self._request_trackers.get(req_id):
+                request_tracker.reset()
+            self._unfinished_requests.pop(req_id, None)
+
+        meta = DfkvStoreConnectorMetadata(
+            self._unfinished_request_ids,
+            preempted_ids,
+        )
+
+        # Handle new requests
+        for request in scheduler_output.scheduled_new_reqs:
+            load_spec = self.load_specs.pop(request.req_id, None)
+            num_tokens_to_compute = (
+                request.num_computed_tokens
+                + scheduler_output.num_scheduled_tokens[request.req_id]
+            )
+            assert request.req_id in self._unfinished_requests
+            request_tuple = self._unfinished_requests.get(request.req_id)
+            request_real = request_tuple[0]  # type: ignore[index]
+
+            if isinstance(request.block_ids, tuple):
+                # Multi-group: preserve per-group structure.
+                unfolded_block_ids = tuple(b.copy() for b in request.block_ids)
+            else:
+                # Single-group legacy: list[int] -> 1-tuple.
+                unfolded_block_ids = (request.block_ids.copy(),)
+
+            prefill_tokens = _new_req_prefill_tokens(request)
+            request_tracker = RequestTracker(
+                req_id=request.req_id,
+                token_len=num_tokens_to_compute,
+                allocated_block_ids=unfolded_block_ids,
+                num_saved_tokens=0,
+                token_ids=prefill_tokens[:num_tokens_to_compute],
+                prefill_end_tokens=len(prefill_tokens),
+            )
+            self._request_trackers[request.req_id] = request_tracker
+
+            last_chunk_tokens_num = (
+                len(prefill_tokens) // self._block_size * self._block_size
+            )
+
+            req_meta = ReqMeta.from_request_tracker(
+                request_tracker,
+                self._block_size,
+                load_spec=load_spec,
+                skip_save=force_skip_save,
+                block_hashes=request_real.block_hashes,
+                is_last_chunk=(request_tracker.token_len >= last_chunk_tokens_num),
+            )
+            if req_meta is not None:
+                meta.add_request(req_meta)
+
+        # Handle cached (running, or MRV1 resumed-from-preemption) requests
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        if not force_skip_save:
+            for i, req_id in enumerate(cached_reqs.req_ids):
+                new_block_ids = cached_reqs.new_block_ids[i]
+                if not new_block_ids:
+                    continue
+
+                req_meta = None
+                if req_id in self._preempted_req_ids:
+                    # Resumed after preemption
+                    if isinstance(new_block_ids, tuple):
+                        new_block_ids = tuple(b.copy() for b in new_block_ids)
+                    else:
+                        new_block_ids = (new_block_ids.copy(),)
+                    self._preempted_req_ids.discard(req_id)
+                    load_spec = self.load_specs.pop(req_id, None)
+                    request_tuple = self._unfinished_requests.get(req_id)
+                    request_real = request_tuple[0]  # type: ignore[index]
+                    num_tokens_to_compute = (
+                        request_real.num_computed_tokens
+                        + scheduler_output.num_scheduled_tokens[req_id]
+                    )
+                    # On resume, the request re-prefills prompt + previously
+                    # generated tokens (all_token_ids).
+                    prefill_tokens = list(request_real.all_token_ids)
+                    request_tracker = RequestTracker(
+                        req_id=req_id,
+                        token_len=num_tokens_to_compute,
+                        allocated_block_ids=new_block_ids,
+                        num_saved_tokens=0,
+                        token_ids=prefill_tokens[:num_tokens_to_compute].copy(),
+                        prefill_end_tokens=len(prefill_tokens),
+                    )
+                    self._request_trackers[req_id] = request_tracker
+
+                    last_chunk_tokens_num = (
+                        len(prefill_tokens) // self._block_size * self._block_size
+                    )
+                    req_meta = ReqMeta.from_request_tracker(
+                        request_tracker,
+                        self._block_size,
+                        load_spec=load_spec,
+                        skip_save=force_skip_save,
+                        block_hashes=request_real.block_hashes,
+                        is_last_chunk=(
+                            request_tracker.token_len >= last_chunk_tokens_num
+                        ),
+                    )
+                else:
+                    # Decode/chunked request
+                    request_tracker = self._request_trackers[req_id]
+                    num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
+                    req_tuple = self._unfinished_requests.get(req_id)
+                    if req_tuple:
+                        unfinished_req = req_tuple[0]
+                        num_current_tokens = request_tracker.token_len
+                        new_token_ids = unfinished_req.all_token_ids[
+                            num_current_tokens : num_current_tokens + num_new_tokens
+                        ]
+                        request_tracker.token_len += len(new_token_ids)
+                    else:
+                        raise ValueError(
+                            f"Request {req_id} is not in _unfinished_requests"
+                        )
+                    num_computed_token = cached_reqs.num_computed_tokens[i]
+                    # Use the tracker's snapshot of the prefill range so resumed
+                    # requests keep saving past the original prompt boundary.
+                    prefill_end = request_tracker.prefill_end_tokens
+                    if num_computed_token >= prefill_end:
+                        continue
+                    request_tracker.update(new_block_ids)
+
+                    last_chunk_tokens_num = (
+                        prefill_end // self._block_size * self._block_size
+                    )
+                    req_meta = ReqMeta.from_request_tracker(
+                        request_tracker,
+                        self._block_size,
+                        load_spec=None,
+                        skip_save=force_skip_save,
+                        block_hashes=unfinished_req.block_hashes,
+                        is_last_chunk=(
+                            request_tracker.token_len >= last_chunk_tokens_num
+                        ),
+                    )
+
+                if req_meta is not None:
+                    meta.add_request(req_meta)
+
+        # Handle requests with pending load specs not yet scheduled
+        request_ids = [req.req_id for req in scheduler_output.scheduled_new_reqs]
+        for request_id, (
+            unfinished_req,
+            block_ids,
+        ) in self._unfinished_requests.items():
+            if request_id not in request_ids and request_id not in cached_reqs.req_ids:
+                load_spec = self.load_specs.pop(request_id, None)
+                if not load_spec:
+                    continue
+                num_tokens_to_compute = load_spec.kvpool_cached_tokens
+                request_tracker = RequestTracker(
+                    req_id=request_id,
+                    token_len=num_tokens_to_compute,
+                    allocated_block_ids=block_ids,
+                    num_saved_tokens=0,
+                )
+                self._request_trackers[request_id] = request_tracker
+                req_meta = ReqMeta.from_request_tracker(
+                    request_tracker,
+                    self._block_size,
+                    load_spec=load_spec,
+                    skip_save=None,
+                    block_hashes=unfinished_req.block_hashes,
+                )
+                if req_meta is not None:
+                    meta.add_request(req_meta)
+
+        return meta
+
+    def request_finished(
+        self,
+        request: Request,
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Determine whether to delay freeing blocks for async save."""
+        if self.kv_role == "kv_consumer":
+            return False, None
+        tracker = self._request_trackers.get(request.request_id)
+        # Missing tracker can happen when the request is aborted before the
+        # connector observes the normal finished lifecycle or is preempted
+        # before finishing.
+        if tracker is None or tracker.num_saved_tokens <= 0:
+            return False, None
+        total_blocks = sum(len(g) for g in block_ids)
+        delay_free_blocks = total_blocks > 0
+        if delay_free_blocks:
+            logger.debug(
+                "Delaying free of %d blocks for request %s",
+                total_blocks,
+                request.request_id,
+            )
+        return delay_free_blocks, None
+
+    def reset_store(self) -> bool:
+        """Request a global store reset via worker rank 0.
+
+        Routes through the existing LookupKey ZMQ admin channel to worker
+        rank 0, which owns the ``DfkvDeviceClient`` handle.
+
+        Ordering assumption: caller (typically
+        ``Scheduler.reset_connector_cache``, invoked via
+        ``reset_prefix_cache(reset_connector=True)``) MUST ensure no
+        in-flight Dfkv lookups or transfers. For RL workflows this is
+        satisfied at the step boundary after weight updates and rollout
+        drain. Violating this can allow stale KV to be served on the next
+        request, defeating the hard-reset guarantee.
+
+        dfkv: dfkv has no remove_all primitive, so the worker drains its
+        send queue and NACKs; this returns False (best-effort, never raises
+        into the scheduler hot path).
+
+        Returns True on ACK from worker, False on NACK or RPC error.
+        """
+        try:
+            ok = self.client.reset()
+            if ok:
+                logger.info("Dfkv store reset succeeded.")
+            else:
+                # dfkv: expected -- no global wipe primitive, queue was drained.
+                logger.warning("Dfkv store reset returned NACK from worker.")
+            return ok
+        except Exception as e:
+            logger.error("Dfkv reset_store RPC failed: %s", e)
+            return False

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -1,0 +1,1290 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# The transfer-thread scaffolding (KVTransferThread, KVCacheStoreSendingThread,
+# KVCacheStoreRecvingThread) is adapted from vllm-project/vllm-ascend
+# (vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/).
+"""Worker-side logic for DfkvStoreConnector.
+
+Includes the store worker, transfer threads, lookup server, and
+DfkvDeviceClient integration. The DfkvDeviceClient drives libdfkv.so over
+GPUDirect RDMA; the storage backend is dfkv rather than a Mooncake store, so
+Mooncake-store-only features (replica-tier classification, owner-DirectIO disk
+offload staging, ReplicateConfig/preferred_segment) are dropped.
+"""
+
+import dataclasses
+import os
+import queue
+import socket
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+import torch
+import zmq
+
+import vllm.envs as envs
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_dcp_group,
+    get_pcp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.distributed.kv_events import BlockStored
+from vllm.logger import init_logger
+from vllm.utils.network_utils import make_zmq_socket
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    maybe_convert_block_hash,
+    resolve_kv_cache_block_sizes,
+)
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec
+from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
+
+# dfkv: get_dp_engine_index replaces mooncake_utils.get_mooncake_dp_engine_index;
+# dfkv handles its own RDMA bootstrap so the transfer-engine helpers are dropped.
+from .coordinator import (
+    ExternalCachedBlockPool,
+    DfkvStoreCoordinator,
+)
+from .data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    DfkvStoreConnectorMetadata,
+    PoolKey,
+    ReqMeta,
+)
+from .dfkv_client import DfkvDeviceClient
+from .dfkv_utils import get_dp_engine_index
+from .metrics import DfkvStoreConnectorStats
+from .protocol import (
+    LOOKUP_MSG,
+    RESET_MSG,
+    RESP_ERR,
+    RESP_OK,
+)
+
+logger = init_logger(__name__)
+
+_T = TypeVar("_T")
+
+
+def _rotate_list(values: list[_T], offset: int) -> list[_T]:
+    return values[offset:] + values[:offset]
+
+
+def _sum_batch_bytes(sizes: list[list[int]]) -> int:
+    return sum(sum(size) for size in sizes)
+
+
+# dfkv: Removed Mooncake-store-only helpers:
+#   * disk-offload staging budget math (_align_up,
+#     _estimate_disk_offload_staging_bytes, _get_usable_disk_offload_buffer
+#     _budget_bytes, _split_disk_offload_load_batches) -- dfkv has no
+#     owner-side DirectIO staging budget, so a GET is issued as one batch.
+#   * replica-tier classification (_call_replica_predicate,
+#     _classify_replica_tier, _get_replica_tiers_by_key,
+#     _log_mooncake_load_tier_summary) -- dfkv has no batch_get_replica_desc /
+#     memory-vs-disk replica tiers.
+#   * MooncakeStoreConfig / _parse_size / MooncakeMode and the NO_AVAILABLE
+#     _HANDLE pressure code -- dfkv is configured via kv_connector_extra_config
+#     and has no embedded/standalone-store topology or offload pressure signal.
+
+
+# dfkv: batch_put returns a per-key rc (0 == ok, non-zero == failure); a GET
+# returns (hits, lens) with hit in {0, 1}. These helpers normalize the two
+# dfkv return shapes into the (failed-index list) shape the threads expect.
+def _put_failed_indices(rcs: list[int]) -> list[int]:
+    return [i for i, rc in enumerate(rcs) if rc != 0]
+
+
+# ============================================================
+# Transfer Threads
+# ============================================================
+
+
+class KVTransferThread(threading.Thread):
+    """Base class for async KV cache transfer threads."""
+
+    def __init__(
+        self,
+        client: Any,
+        token_databases: list[ChunkedTokenDatabase],
+        block_size: int,
+        tp_rank: int,
+        ready_event: threading.Event,
+        name: str,
+        record_operation: Callable[..., None] | None = None,
+    ):
+        super().__init__(daemon=True, name=name)
+        self.client = client
+        self.ready_event = ready_event
+        self.block_size = block_size
+        self.tp_rank = tp_rank
+        self.token_databases = token_databases
+        self._record_operation_cb = record_operation
+        self.done_task_lock = threading.Lock()
+        self.request_queue: queue.Queue[Any] = queue.Queue()
+        self.finished_requests: set[str] = set()
+        self.kv_event_lock = threading.Lock()
+        self.kv_events: list[BlockStored] = []
+
+    def add_request(self, request: ReqMeta) -> None:
+        self.request_queue.put(request)
+
+    def get_and_clear_finished_requests(self) -> set[str]:
+        with self.done_task_lock:
+            finished = self.finished_requests.copy()
+            self.finished_requests.clear()
+        return finished
+
+    def set_finished_request(self, req_id: str):
+        with self.done_task_lock:
+            self.finished_requests.add(req_id)
+
+    def run(self):
+        self.ready_event.set()
+        while True:
+            try:
+                request_data = self.request_queue.get()
+                if request_data is None:
+                    logger.warning("Received a None request!")
+                    self.request_queue.task_done()
+                    continue
+                self._handle_request(request_data)
+            except Exception as e:
+                logger.error("Error in %s: %s", self.name, e)
+
+    def _handle_request(self, req_meta: Any):
+        pass
+
+    def _record_operation(
+        self,
+        operation: str,
+        start_time: float,
+        num_keys: int,
+        *,
+        num_bytes: int = 0,
+        status: str = "ok",
+        num_failed_keys: int = 0,
+    ) -> None:
+        if self._record_operation_cb is None:
+            return
+        self._record_operation_cb(
+            operation=operation,
+            duration_seconds=time.perf_counter() - start_time,
+            num_keys=num_keys,
+            num_bytes=num_bytes,
+            status=status,
+            num_failed_keys=num_failed_keys,
+        )
+
+    def update_kv_event(self, events: list[BlockStored]):
+        with self.kv_event_lock:
+            self.kv_events.extend(events)
+
+    def get_kv_events(self) -> list[BlockStored]:
+        with self.kv_event_lock:
+            events = self.kv_events.copy()
+            self.kv_events.clear()
+        return events
+
+
+class KVCacheStoreSendingThread(KVTransferThread):
+    """Background thread for storing KV cache blocks to the store."""
+
+    def __init__(
+        self,
+        client: Any,
+        coord: DfkvStoreCoordinator,
+        token_databases: list[ChunkedTokenDatabase],
+        block_size: int,
+        tp_rank: int,
+        put_step: int,
+        kv_role: str,
+        ready_event: threading.Event,
+        enable_kv_event: bool = False,
+        record_operation: Callable[..., None] | None = None,
+    ):
+        super().__init__(
+            client,
+            token_databases,
+            block_size,
+            tp_rank,
+            ready_event,
+            name="KVCacheStoreSendingThread",
+            record_operation=record_operation,
+        )
+        self.put_step = put_step
+        self.coord = coord
+        self.kv_role = kv_role
+        self.stored_requests: defaultdict[str, int] = defaultdict(int)
+        self.enable_kv_event = enable_kv_event
+
+    def add_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            self.stored_requests[req_id] += 1
+
+    def dec_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            if req_id in self.stored_requests:
+                self.stored_requests[req_id] -= 1
+
+    def delete_finished_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            if req_id in self.stored_requests:
+                del self.stored_requests[req_id]
+
+    def _handle_request(self, req_meta: ReqMeta):
+        # Cache hits are always a multiple of ``lcm_block_size`` tokens, which
+        # is also ``store_mask``'s precondition.
+        lcm_block_size = self.coord.lcm_block_size
+        token_len = req_meta.token_len_chunk // lcm_block_size * lcm_block_size
+        block_ids_per_group = req_meta.block_ids
+        req_id = req_meta.req_id
+        current_event = req_meta.current_event
+
+        if req_id not in self.stored_requests:
+            self.request_queue.task_done()
+            return
+
+        # Decrement the in-flight counter and signal task_done() in `finally`
+        # so the scheduler can release the GPU blocks it pinned for this
+        # request (via `delay_free_blocks`) even when the store path raises.
+        try:
+            if token_len == 0:
+                return
+
+            # Within each lcm region only per-spec relevant chunks are loaded
+            # (e.g., SWA or linear attn), so mask out irrelevant chunks
+            store_masks = self.coord.store_mask(token_len)
+            starts: list[int] = []
+            ends: list[int] = []
+            keys: list[str] = []
+            block_hashes: list[BlockHash] = []
+            group_indices: list[int] = []
+            for g_idx, db in enumerate(self.token_databases):
+                mask = store_masks[g_idx]
+                for chunk_idx, (start, end, key) in enumerate(
+                    db.process_tokens(token_len, req_meta.block_hashes)
+                ):
+                    if chunk_idx >= len(mask) or not mask[chunk_idx]:
+                        continue
+                    starts.append(start)
+                    ends.append(end)
+                    keys.append(key.to_string())
+                    block_hashes.append(BlockHash(bytes.fromhex(key.chunk_hash)))
+                    group_indices.append(g_idx)
+
+            # Apply put_step striding for TP
+            sl = slice(self.tp_rank % self.put_step, None, self.put_step)
+            starts = starts[sl]
+            ends = ends[sl]
+            keys = keys[sl]
+            block_hashes = block_hashes[sl]
+            group_indices = group_indices[sl]
+
+            if not keys:
+                return
+
+            # Check which blocks already exist (dedup)
+            save_exists_start = time.perf_counter()
+            try:
+                exists_states = self.client.batch_exist(keys)
+            except Exception:
+                self._record_operation(
+                    "save_exists",
+                    save_exists_start,
+                    len(keys),
+                    status="error",
+                    num_failed_keys=len(keys),
+                )
+                raise
+            self._record_operation(
+                "save_exists",
+                save_exists_start,
+                len(keys),
+            )
+            missing_indices = [
+                i for i, exists in enumerate(exists_states) if exists != 1
+            ]
+
+            if not missing_indices:
+                return
+
+            starts = [starts[i] for i in missing_indices]
+            ends = [ends[i] for i in missing_indices]
+            keys = [keys[i] for i in missing_indices]
+            block_hashes = [block_hashes[i] for i in missing_indices]
+            group_indices = [group_indices[i] for i in missing_indices]
+
+            logger.debug(
+                "Storing KV cache for %d blocks (groups=%s) for request %s",
+                len(keys),
+                set(group_indices),
+                req_id,
+            )
+
+            addrs: list[list[int]] = []
+            sizes: list[list[int]] = []
+            stored_events: list[BlockStored] = []
+            # parent_block_hash chains live within a group, not across.
+            prev_key_per_group: dict[int, Any] = {}
+            new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
+
+            for idx, (s, e, g_idx) in enumerate(
+                zip(starts, ends, group_indices, strict=True)
+            ):
+                db = self.token_databases[g_idx]
+                addr, size, _ = db.prepare_value(s, e, block_ids_per_group[g_idx])
+                addrs.append(addr)
+                sizes.append(size)
+
+                if self.enable_kv_event:
+                    token_ids = (
+                        req_meta.token_ids[s:e]
+                        if req_meta.token_ids is not None
+                        else None
+                    )
+                    stored_event = BlockStored(
+                        block_hashes=[new_block_hashes[idx]],
+                        parent_block_hash=prev_key_per_group.get(g_idx),
+                        token_ids=token_ids,
+                        block_size=db.block_size,
+                        lora_id=None,
+                        medium="cpu",
+                        lora_name=None,
+                        group_idx=g_idx,
+                    )
+                    stored_events.append(stored_event)
+                    prev_key_per_group[g_idx] = new_block_hashes[idx]
+
+            if current_event is not None:
+                current_event.synchronize()
+
+            # dfkv: coalesce each chunk's per-layer segments (addrs[i]/sizes[i])
+            # into ONE dfkv key via scatter-gather (<=29 segs/key on max_sge=30),
+            # suffixed "@sg{n}" -- one RDMA multi-SGE op + one server blob per key
+            # instead of one tiny key per segment. This cuts the key count ~20x
+            # (25392 -> ~1242) so the load is bandwidth-bound, not per-key-bound.
+            sg_keys, sg_ptrs, sg_sizes, _ = _group_segments_sg(keys, addrs, sizes)
+            batch_bytes = sum(sum(s) for s in sg_sizes)
+            put_start = time.perf_counter()
+            try:
+                res = self.client.batch_put_sg(sg_keys, sg_ptrs, sg_sizes)
+                failed = _put_failed_indices(res)
+                self._record_operation(
+                    "save_put",
+                    put_start,
+                    len(sg_keys),
+                    num_bytes=batch_bytes,
+                    status="partial_failure" if failed else "ok",
+                    num_failed_keys=len(failed),
+                )
+                logger.debug(
+                    "dfkv save_put: keys=%d bytes=%d ms=%.1f failed=%d",
+                    len(sg_keys), batch_bytes,
+                    (time.perf_counter() - put_start) * 1000.0, len(failed),
+                )
+                if failed:
+                    failed_codes = set(res[i] for i in failed)
+                    # dfkv: write failure is non-fatal -- count + drop this
+                    # request's save; dfkv's peer-health marks the bad peer and
+                    # short-circuits. Never block inference.
+                    logger.warning(
+                        "batch_put_sg failed: %d/%d keys failed "
+                        "(codes=%s, batch_bytes=%d), first_key=%s",
+                        len(failed),
+                        len(sg_keys),
+                        failed_codes,
+                        batch_bytes,
+                        sg_keys[0] if sg_keys else "N/A",
+                    )
+            except Exception as e:
+                self._record_operation(
+                    "save_put",
+                    put_start,
+                    len(flat_keys),
+                    num_bytes=batch_bytes,
+                    status="error",
+                    num_failed_keys=len(flat_keys),
+                )
+                logger.error("Failed to put key %s, error: %s", flat_keys, e)
+
+            if self.enable_kv_event and stored_events:
+                self.update_kv_event(stored_events)
+        finally:
+            self.dec_stored_request(req_id)
+            self.request_queue.task_done()
+
+
+class KVCacheStoreRecvingThread(KVTransferThread):
+    """Background thread for loading KV cache blocks from the store."""
+
+    def __init__(
+        self,
+        client: Any,
+        coord: DfkvStoreCoordinator,
+        token_databases: list[ChunkedTokenDatabase],
+        block_size: int,
+        tp_rank: int,
+        ready_event: threading.Event,
+        record_operation: Callable[..., None] | None = None,
+    ):
+        super().__init__(
+            client,
+            token_databases,
+            block_size,
+            tp_rank,
+            ready_event,
+            name="KVCacheStoreRecvingThread",
+            record_operation=record_operation,
+        )
+        # _invalid_block_ids can be access by both the Worker and RecvingThread
+        self._invalid_block_ids_lock = threading.Lock()
+        self._invalid_block_ids: set[int] = set()
+        self.coord = coord
+
+    def _add_load_error_block_ids(self, block_ids: list[int]) -> None:
+        with self._invalid_block_ids_lock:
+            self._invalid_block_ids.update(block_ids)
+
+    def get_and_clear_block_ids_with_load_errors(self) -> set[int]:
+        with self._invalid_block_ids_lock:
+            invalid_block_ids = self._invalid_block_ids.copy()
+            self._invalid_block_ids.clear()
+        return invalid_block_ids
+
+    def _handle_request(self, req_meta: ReqMeta):
+        token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
+        req_id = req_meta.req_id
+        mask_num = (
+            req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
+            // self.block_size
+            * self.block_size
+        )
+
+        # Skip chunks the consumer's per-group spec wouldn't populate
+        # locally (e.g. SWA pre-window) even if the producer stored them.
+        load_mask_per_group = self.coord.load_mask(req_meta.block_hashes, token_len)
+
+        addr_list: list[list[int]] = []
+        size_list: list[list[int]] = []
+        key_list: list[str] = []
+        block_id_list: list[int] = []
+        for g_idx, db in enumerate(self.token_databases):
+            mask = load_mask_per_group[g_idx]
+            for start, end, key in db.process_tokens(
+                token_len, req_meta.block_hashes, mask_num
+            ):
+                chunk_idx = start // db.block_size
+                if chunk_idx >= len(mask) or not mask[chunk_idx]:
+                    continue
+                addr, size, block_id = db.prepare_value(
+                    start, end, req_meta.block_ids[g_idx]
+                )
+                key_list.append(key.to_string())
+                addr_list.append(addr)
+                size_list.append(size)
+                block_id_list.append(block_id)
+
+        # Rotate aligned lists by tp_rank for load balancing.
+        rotation = self.tp_rank % len(key_list)
+        key_list_c = _rotate_list(key_list, rotation)
+        addr_list_c = _rotate_list(addr_list, rotation)
+        size_list_c = _rotate_list(size_list, rotation)
+        block_id_list_c = _rotate_list(block_id_list, rotation)
+
+        # dfkv: A GET is one batch -- dfkv has no owner-side DirectIO staging
+        # budget, so the Mooncake disk-offload sub-batch split is dropped.
+        # Flatten per-key scatter-gather to one (ptr, cap) per dfkv key, then
+        # map each flattened result back to its originating block id for error
+        # reporting (see _flatten_segments / seg_owner).
+        sg_keys, sg_ptrs, sg_caps, sg_owner = _group_segments_sg(
+            key_list_c, addr_list_c, size_list_c
+        )
+        sg_totals = [sum(c) for c in sg_caps]
+        batch_bytes = sum(sg_totals)
+
+        load_get_start = time.perf_counter()
+        try:
+            # dfkv: one scatter-gather GET per coalesced key -> (hits, lens). The
+            # server returns one blob; the RDMA recv SGE list scatters it back
+            # into this chunk's per-layer segments. hit == 1 + len == sum(caps)
+            # means the chunk loaded; a miss or short read marks the originating
+            # block as a load error so vLLM recomputes that span (never fatal).
+            hits, lens = self.client.batch_get_auto_sg(sg_keys, sg_ptrs, sg_caps)
+            failed_block_ids: list[int] = []
+            failed_detail: list[tuple[str, int]] = []
+            for i, (hit, got_len) in enumerate(zip(hits, lens, strict=True)):
+                if hit != 1 or got_len < sg_totals[i]:
+                    failed_block_ids.append(block_id_list_c[sg_owner[i]])
+                    failed_detail.append((sg_keys[i], hit))
+            self._record_operation(
+                "load_get",
+                load_get_start,
+                len(sg_keys),
+                num_bytes=batch_bytes,
+                status="partial_failure" if failed_block_ids else "ok",
+                num_failed_keys=len(failed_block_ids),
+            )
+            logger.debug(
+                "dfkv load_get: req=%s keys=%d bytes=%d ms=%.1f failed=%d",
+                req_id, len(sg_keys), batch_bytes,
+                (time.perf_counter() - load_get_start) * 1000.0,
+                len(failed_block_ids),
+            )
+            if failed_block_ids:
+                self._add_load_error_block_ids(failed_block_ids)
+                logger.warning(
+                    "Failed to get %d dfkv keys from batch "
+                    "(batch_keys=%d, first_failures=%s)",
+                    len(failed_block_ids),
+                    len(sg_keys),
+                    failed_detail[:3],
+                )
+        except Exception as e:
+            self._add_load_error_block_ids(block_id_list_c)
+            self._record_operation(
+                "load_get",
+                load_get_start,
+                len(sg_keys),
+                num_bytes=batch_bytes,
+                status="error",
+                num_failed_keys=len(sg_keys),
+            )
+            logger.warning(
+                "Failed to get dfkv batch %s, error: %s",
+                sg_keys[:3],
+                e,
+            )
+
+        self.set_finished_request(req_id)
+        self.request_queue.task_done()
+
+
+# dfkv: per-key scatter-gather flatten helpers. Mooncake's
+# batch_*_multi_buffers accepted addrs[i]/sizes[i] as a segment list per key;
+# DfkvDeviceClient takes one (ptr, size) per key. For the single-segment
+# (MLA / FlashInfer) path this is a 1:1 passthrough; for the K/V-split layout
+# each segment becomes its own dfkv key ("<key>@seg{n}").
+def _flatten_segments(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+) -> tuple[list[str], list[int], list[int]]:
+    flat_keys, flat_ptrs, flat_sizes, _ = _flatten_segments_with_owner(
+        keys, addrs, sizes
+    )
+    return flat_keys, flat_ptrs, flat_sizes
+
+
+def _flatten_segments_with_owner(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+) -> tuple[list[str], list[int], list[int], list[int]]:
+    flat_keys: list[str] = []
+    flat_ptrs: list[int] = []
+    flat_sizes: list[int] = []
+    seg_owner: list[int] = []
+    # dfkv: always suffix "@seg{n}" -- even single-segment keys -- so that the
+    # SAVE, LOAD and LOOKUP paths agree on the on-wire key. The lookup checks
+    # "<key>@seg0" as the block-present proxy (a missing later segment is caught
+    # on load and recomputed; saves are issued as one batch so partials are rare).
+    for key_idx, (key, addr, size) in enumerate(
+        zip(keys, addrs, sizes, strict=True)
+    ):
+        for seg, (a, sz) in enumerate(zip(addr, size, strict=True)):
+            flat_keys.append(f"{key}@seg{seg}")
+            flat_ptrs.append(a)
+            flat_sizes.append(sz)
+            seg_owner.append(key_idx)
+    return flat_keys, flat_ptrs, flat_sizes, seg_owner
+
+
+# dfkv: max payload segments gathered into one scatter-gather key. The HCA
+# max_sge is 30; SGE[0] is the request/value header, leaving 29 for payload.
+SG_MAX_SEGS = 29
+
+
+# dfkv scatter-gather grouping: coalesce each chunk's per-layer segments
+# (addrs[i]/sizes[i]) into "<key>@sg{n}" groups of <= SG_MAX_SEGS segments. Each
+# group is ONE dfkv key carrying all its segments via a single RDMA multi-SGE op
+# (vs _flatten_segments' one key per segment). owner[i] maps each @sg key back to
+# its originating chunk index for per-block load-error attribution.
+def _group_segments_sg(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+) -> tuple[list[str], list[list[int]], list[list[int]], list[int]]:
+    sg_keys: list[str] = []
+    sg_ptrs: list[list[int]] = []
+    sg_sizes: list[list[int]] = []
+    sg_owner: list[int] = []
+    for key_idx, (key, addr, size) in enumerate(zip(keys, addrs, sizes, strict=True)):
+        grp = 0
+        for off in range(0, len(addr), SG_MAX_SEGS):
+            sg_keys.append(f"{key}@sg{grp}")
+            sg_ptrs.append(list(addr[off:off + SG_MAX_SEGS]))
+            sg_sizes.append(list(size[off:off + SG_MAX_SEGS]))
+            sg_owner.append(key_idx)
+            grp += 1
+    return sg_keys, sg_ptrs, sg_sizes, sg_owner
+
+
+# ============================================================
+# Store Worker
+# ============================================================
+
+
+class DfkvStoreWorker:
+    """Worker-side component for DfkvStoreConnector."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ):
+        model_config = vllm_config.model_config
+        parallel_config = vllm_config.parallel_config
+
+        self.dp_rank = get_dp_engine_index(parallel_config)
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.pp_size = parallel_config.pipeline_parallel_size
+        self.pp_rank = (parallel_config.rank // self.tp_size) % self.pp_size
+
+        self.pcp_size = get_pcp_group().world_size
+        self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
+        self.dcp_size = get_dcp_group().world_size
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
+
+        assert vllm_config.kv_transfer_config is not None
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+            "load_async", True
+        )
+        self.cache_config = vllm_config.cache_config
+        self.block_size, self.hash_block_size = resolve_kv_cache_block_sizes(
+            kv_cache_config, vllm_config
+        )
+        self.num_layers = model_config.get_num_layers(parallel_config)
+
+        self.use_mla = False
+        if (
+            hasattr(model_config, "use_mla")
+            and isinstance(model_config.use_mla, bool)
+            and model_config.use_mla
+        ):
+            self.use_mla = True
+
+        if self.use_mla:
+            self.num_kv_head = 1
+        else:
+            self.num_kv_head = model_config.get_total_num_kv_heads()
+
+        if self.num_kv_head < self.tp_size:
+            self.put_step = self.tp_size // self.num_kv_head
+            self.head_or_tp_rank = self.tp_rank // self.put_step
+        else:
+            self.head_or_tp_rank = self.tp_rank
+            self.put_step = 1
+
+        self.metadata = KeyMetadata(
+            model_name=model_config.model.rstrip("/").split("/")[-1],
+            tp_rank=self.head_or_tp_rank,
+            pcp_rank=self.pcp_rank,
+            dcp_rank=self.dcp_rank,
+            pp_rank=self.pp_rank,
+        )
+
+        # dfkv: replace the MooncakeDistributedStore setup (MooncakeStoreConfig
+        # .load_from_env, rdma_utils RNIC selection, store.setup(), ReplicateConfig,
+        # preferred_segment, enable_offload mode warnings) with the dfkv device
+        # client. dfkv selects its own RNIC via the DFKV_RDMA_DEV env and is
+        # configured entirely through kv_connector_extra_config.
+        extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+        self.client = DfkvDeviceClient(
+            members=extra["members"],
+            model_hash=int(extra.get("model_hash", 0)),
+            lib_path=extra.get("lib"),
+            batch_concurrency=int(extra.get("batch_concurrency", 8)),
+        )
+
+        # dfkv: no disk-offload staging budget (Mooncake owner-DirectIO only).
+
+        # Start lookup server on rank 0 for scheduler-side prefix queries
+        self.lookup_server: LookupKeyServer | None = None
+        if vllm_config.parallel_config.rank == 0:
+            self.lookup_server = LookupKeyServer(self, vllm_config)
+
+        kv_event_config = vllm_config.kv_events_config
+        self.enable_kv_events = False
+        if kv_event_config and kv_event_config.enable_kv_cache_events:
+            self.enable_kv_events = True
+
+        self.kv_send_thread: KVCacheStoreSendingThread | None = None
+        self.kv_recv_thread: KVCacheStoreRecvingThread | None = None
+        self.finished_store_req: set[str] = set()
+        self._kv_connector_stats_lock = threading.Lock()
+        self.kv_connector_stats = DfkvStoreConnectorStats()
+
+        self._kv_cache_config = kv_cache_config
+        # Single-group + PCP/DCP > 1: scale the lone group's spec.block_size to
+        # self.block_size (= scheduler_block_size) so the coordinator's
+        # ``block_size % hash_block_size == 0`` invariant holds.
+        groups = list(kv_cache_config.kv_cache_groups)
+        if len(groups) == 1 and groups[0].kv_cache_spec.block_size != self.block_size:
+            g = groups[0]
+            groups = [
+                dataclasses.replace(
+                    g,
+                    kv_cache_spec=dataclasses.replace(
+                        g.kv_cache_spec, block_size=self.block_size
+                    ),
+                )
+            ]
+        self._kv_cache_groups: list[KVCacheGroupSpec] = groups
+        spec_cfg = getattr(vllm_config, "speculative_config", None)
+        use_eagle = bool(
+            spec_cfg.use_eagle()
+            if spec_cfg is not None and callable(getattr(spec_cfg, "use_eagle", None))
+            else False
+        )
+        self.coord = DfkvStoreCoordinator(
+            self._kv_cache_groups,
+            scheduler_block_size=self.block_size,
+            hash_block_size=self.hash_block_size,
+            use_eagle=use_eagle,
+        )
+        # One ChunkedTokenDatabase per group; addresses populated in
+        # register_kv_caches once the kv-cache layout is known.
+        self.token_dbs: list[ChunkedTokenDatabase] = [
+            ChunkedTokenDatabase(
+                dataclasses.replace(self.metadata, group_id=g_idx),
+                g.kv_cache_spec.block_size,
+                hash_block_size=self.hash_block_size,
+            )
+            for g_idx, g in enumerate(self._kv_cache_groups)
+        ]
+
+    def register_cross_layers_kv_caches(self, kv_cache: torch.Tensor) -> None:
+        """Register a cross-layers KV cache tensor.
+
+        Wraps the unified tensor in a single-entry dict so that the
+        existing stride-based logic in register_kv_caches() produces
+        the correct single-segment result (block_len = page_size * num_layers).
+        """
+        self.register_kv_caches({"__cross_layer__": kv_cache})
+
+    def register_kv_caches(
+        self,
+        kv_caches: dict[str, torch.Tensor | list[torch.Tensor]],
+    ) -> None:
+        """Register KV cache tensors and start transfer threads."""
+        if not kv_caches:
+            logger.warning("No KV caches to offload.")
+            return
+
+        # Resolve each entry to a representative tensor for storage
+        # deduplication. For attention layers the value is already a tensor;
+        # for Mamba layers it is a list of tensors that all share the same
+        # underlying raw storage, so we take the first one.
+        def _repr_tensor(v: torch.Tensor | list[torch.Tensor]) -> torch.Tensor:
+            assert isinstance(v, torch.Tensor | list)
+            return v if isinstance(v, torch.Tensor) else v[0]
+
+        assert self.cache_config.num_gpu_blocks is not None
+        self.num_blocks = self.cache_config.num_gpu_blocks
+
+        # dfkv: map each layer name to its kv_cache_group so that each group's
+        # ChunkedTokenDatabase addresses ONLY its own group's layer segments.
+        # The Mooncake template handed the SAME flat addrs list to every group's
+        # token_db -- correct for single-group models, but for a multi-group
+        # model (DeepSeek-V4 MLA main + lightning-indexer = 2 groups) it makes
+        # group g's block_ids index the OTHER group's layer regions, scattering
+        # the loaded KV into the wrong blocks (load succeeds but is corrupt ->
+        # vLLM resumes over garbage). Partition per group.
+        layer_to_group: dict[str, int] = {}
+        for g_idx, group in enumerate(self._kv_cache_groups):
+            for ln in group.layer_names:
+                layer_to_group[ln] = g_idx
+
+        # dfkv: decouple MR registration (dedup by physical storage) from
+        # per-layer address collection (NEVER dedup). Multiple kv_cache_groups
+        # can ALIAS the same storage -- on DeepSeek-V4-Flash the bs4 partial-
+        # state group (g3) is 168 views of the main-MLA group (g0)'s blocks
+        # (same 8640B/block, off=0, different logical shape). The Mooncake
+        # template deduped by storage in the SAME loop that collected addrs, so
+        # every aliased layer got NO segment -> its group was never offloaded
+        # (observed: segments_per_group=[62,1,0,0,0]). Register each storage
+        # once, but give EVERY layer (aliased or not) its segment in its group.
+        registered_ptrs: set[int] = set()
+        group_addrs: list[list[int]] = [[] for _ in self.token_dbs]
+        group_block_lens: list[list[int]] = [[] for _ in self.token_dbs]
+
+        for layer_name, value in kv_caches.items():
+            cache = _repr_tensor(value)
+            cache_storage = cache.untyped_storage()
+            base_addr = cache_storage.data_ptr()
+            region_len = cache_storage.nbytes()
+
+            # register_memory raises on failure (vs Mooncake's int return), so
+            # a failed GPUDirect MR registration aborts bring-up loudly. Register
+            # each physical storage region ONCE (aliased groups reuse the MR).
+            if base_addr not in registered_ptrs:
+                registered_ptrs.add(base_addr)
+                self.client.register_memory(base_addr, region_len)
+
+            g_idx = layer_to_group[layer_name]
+            # Address THIS layer's blocks from its own tensor data_ptr (== the
+            # storage base when the view offset is 0, which it is on V4-Flash)
+            # and its own per-block byte stride -- independent of any aliasing.
+            layer_addr = cache.data_ptr()
+            # Detect layout via stride: a dim whose byte-stride exceeds
+            # page_size_bytes is an outer segment dim (e.g. the K/V dim of
+            # FlashAttn's (2, num_blocks, ...)). FlashInfer/MLA's blocks-
+            # outermost layout has no such dim and yields a single segment.
+            el = cache.element_size()
+            page_size_bytes = region_len // self.num_blocks
+            outer_dims = [
+                d for d in range(cache.ndim) if cache.stride(d) * el > page_size_bytes
+            ]
+            if not outer_dims:
+                # Blocks-first layout (FlashInfer / MLA): one segment.
+                group_addrs[g_idx].append(layer_addr)
+                group_block_lens[g_idx].append(page_size_bytes)
+            else:
+                # K/V-first layout (FlashAttn / ROCm): split segments.
+                seg_stride = cache.stride(outer_dims[0]) * el
+                for idx in range(cache.shape[outer_dims[0]]):
+                    group_addrs[g_idx].append(layer_addr + idx * seg_stride)
+                    group_block_lens[g_idx].append(seg_stride // self.num_blocks)
+
+        logger.info(
+            "Registered KV caches: num_groups=%d, segments_per_group=%s, num_blocks=%d",
+            len(self.token_dbs),
+            [len(a) for a in group_addrs],
+            self.num_blocks,
+        )
+
+        for g_idx, db in enumerate(self.token_dbs):
+            db.set_kv_caches_base_addr(group_addrs[g_idx])
+            db.set_block_len(group_block_lens[g_idx])
+
+        # Start transfer threads
+        if self.kv_role in ["kv_producer", "kv_both"]:
+            ready_event_sending = threading.Event()
+            self.kv_send_thread = KVCacheStoreSendingThread(
+                self.client,
+                self.coord,
+                self.token_dbs,
+                self.block_size,
+                self.tp_rank,
+                self.put_step,
+                self.kv_role,
+                ready_event_sending,
+                self.enable_kv_events,
+                record_operation=self._record_kv_connector_operation,
+            )
+            self.kv_send_thread.start()
+
+        ready_event_recving = threading.Event()
+        self.kv_recv_thread = KVCacheStoreRecvingThread(
+            self.client,
+            self.coord,
+            self.token_dbs,
+            self.block_size,
+            self.tp_rank,
+            ready_event_recving,
+            record_operation=self._record_kv_connector_operation,
+        )
+        self.kv_recv_thread.start()
+        ready_event_recving.wait()
+
+    def start_load_kv(
+        self,
+        metadata: DfkvStoreConnectorMetadata,
+    ):
+        """No-op: loads are issued in get_finished() for overlap."""
+        pass
+
+    def wait_for_save(
+        self,
+        metadata: DfkvStoreConnectorMetadata,
+    ):
+        """No-op: stores are issued in get_finished() for overlap."""
+        pass
+
+    def get_finished(
+        self,
+        finished_req_ids: set[str],
+        meta: DfkvStoreConnectorMetadata,
+    ) -> tuple[set[str], set[str]]:
+        """Issue all I/O and get completed send/recv request IDs.
+
+        All load and store I/O requests are issued here (after model
+        compute is launched on the compute stream) for better
+        compute-I/O overlap.
+        """
+        # Issue async loads
+        for request in meta.requests:
+            load_spec = request.load_spec
+            if load_spec is None or not load_spec.can_load:
+                continue
+
+            load_spec.token_len = load_spec.kvpool_cached_tokens
+
+            assert self.kv_recv_thread is not None
+            self.kv_recv_thread.add_request(request)
+
+        assert self.load_async, "load_async must be True for better performance."
+        # Issue stores with CUDA event synchronization
+        if self.kv_role in ["kv_producer", "kv_both"]:
+            current_event = None
+            for request in meta.requests:
+                if request.can_save:
+                    current_event = torch.cuda.Event()
+                    current_event.record()
+                    break
+
+            for request in meta.requests:
+                if not request.can_save:
+                    continue
+                request.current_event = current_event
+                assert self.kv_send_thread is not None
+                self.kv_send_thread.add_stored_request(request.req_id)
+                self.kv_send_thread.add_request(request)
+
+        # Check completion of previously queued transfers
+        done_sending = (
+            self._get_and_clear_finished_sending(finished_req_ids, meta)
+            if self.kv_role in ["kv_producer", "kv_both"]
+            else set()
+        )
+
+        done_recving = (
+            self.kv_recv_thread.get_and_clear_finished_requests()
+            if self.load_async and self.kv_recv_thread is not None
+            else set()
+        )
+
+        if done_sending or done_recving:
+            logger.debug(
+                "dfkv get_finished: done_recving=%s done_sending=%s tp=%d",
+                done_recving, done_sending, self.tp_rank,
+            )
+        return done_sending, done_recving
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        if self.kv_recv_thread is None:
+            return set()
+        errs = self.kv_recv_thread.get_and_clear_block_ids_with_load_errors()
+        if errs:
+            logger.warning("dfkv load_errors: %d blocks flagged tp=%d", len(errs), self.tp_rank)
+        return errs
+
+    def _record_kv_connector_operation(
+        self,
+        operation: str,
+        duration_seconds: float,
+        num_keys: int,
+        *,
+        num_bytes: int = 0,
+        status: str = "ok",
+        num_failed_keys: int = 0,
+    ) -> None:
+        with self._kv_connector_stats_lock:
+            self.kv_connector_stats.record_operation(
+                operation=operation,
+                duration_seconds=duration_seconds,
+                num_keys=num_keys,
+                num_bytes=num_bytes,
+                status=status,
+                num_failed_keys=num_failed_keys,
+            )
+
+    def get_kv_connector_stats(self) -> DfkvStoreConnectorStats | None:
+        with self._kv_connector_stats_lock:
+            if self.kv_connector_stats.is_empty():
+                return None
+            kv_connector_stats = self.kv_connector_stats
+            self.kv_connector_stats = DfkvStoreConnectorStats()
+            return kv_connector_stats
+
+    def _get_and_clear_finished_sending(
+        self,
+        finished_req_ids: set[str],
+        meta: DfkvStoreConnectorMetadata,
+    ) -> set[str]:
+        assert self.kv_send_thread is not None
+        finished_sending: set[str] = set()
+
+        for req_id in meta.preempted_req_ids:
+            self.kv_send_thread.delete_finished_stored_request(req_id)
+
+        for req_id in self.kv_send_thread.stored_requests.copy():
+            if (
+                self.kv_send_thread.stored_requests[req_id] == 0
+                and req_id in self.finished_store_req
+            ):
+                self.finished_store_req.remove(req_id)
+                finished_sending.add(req_id)
+                self.kv_send_thread.delete_finished_stored_request(req_id)
+
+        for req_id in finished_req_ids:
+            req_remain_jobs = self.kv_send_thread.stored_requests.get(req_id)
+            if req_remain_jobs == 0:
+                finished_sending.add(req_id)
+                self.kv_send_thread.delete_finished_stored_request(req_id)
+            elif req_remain_jobs is not None:
+                self.finished_store_req.add(req_id)
+
+        return finished_sending
+
+    def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
+        """Check how many prefix tokens exist in the store.
+
+        Checks across all TP ranks and PP ranks.
+        """
+        if not block_hashes or token_len <= 0:
+            return 0
+
+        # Build per-(group, hash) candidate keys expanded across TP/PP.
+        # candidate_meta[i] is the (group_id, hash_bytes) for candidate_keys[i].
+        candidate_keys: list[str] = []
+        candidate_meta: list[tuple[int, bytes]] = []
+        tp_count = min(self.tp_size, self.num_kv_head)
+        # dfkv: gate candidates by store_mask -- the SAME per-(group,chunk) set
+        # the SAVE path stores (worker.py save gate) and the LOAD path reads
+        # (load_mask delegates to store_mask). For SlidingWindow groups (V4-Flash
+        # has 4 of them besides the full-MLA group) store_mask keeps only the
+        # in-window tail chunks; without this gate the lookup enumerated every
+        # chunk (4830 vs the 1058 actually stored), so find_longest_cache_hit's
+        # SWA walk demanded never-stored pre-window chunks and collapsed to 0.
+        aligned_token_len = (
+            token_len // self.coord.lcm_block_size * self.coord.lcm_block_size
+        )
+        store_masks = self.coord.store_mask(aligned_token_len)
+        for g_idx, db in enumerate(self.token_dbs):
+            spec_block_size = db.block_size
+            mask = store_masks[g_idx]
+            group_hashes = self.coord.block_hashes_for_spec(
+                block_hashes, self._kv_cache_groups[g_idx].kv_cache_spec
+            )
+            for chunk_id, h in enumerate(group_hashes):
+                start_idx = chunk_id * spec_block_size
+                if start_idx >= token_len:
+                    break
+                if chunk_id >= len(mask) or not mask[chunk_id]:
+                    continue
+                for tp in range(tp_count):
+                    for pp in range(self.pp_size):
+                        md = dataclasses.replace(db.metadata, tp_rank=tp, pp_rank=pp)
+                        # dfkv: keys are stored per scatter-gather group
+                        # ("<key>@sg{n}"); probe the first group as the
+                        # block-present proxy so the lookup agrees with the
+                        # SAVE/LOAD on-wire key.
+                        candidate_keys.append(
+                            PoolKey(md, h.hex()).to_string() + "@sg0"
+                        )
+                        candidate_meta.append((g_idx, bytes(h)))
+
+        if not candidate_keys:
+            return 0
+
+        lookup_start = time.perf_counter()
+        try:
+            res = self.client.batch_exist(candidate_keys)
+            self._record_kv_connector_operation(
+                "lookup_exists",
+                time.perf_counter() - lookup_start,
+                len(candidate_keys),
+            )
+        except Exception as e:
+            self._record_kv_connector_operation(
+                "lookup_exists",
+                time.perf_counter() - lookup_start,
+                len(candidate_keys),
+                status="error",
+                num_failed_keys=len(candidate_keys),
+            )
+            logger.error("Remote connection failed in lookup: %s", e)
+            return 0
+
+        # A (group, hash) is "present" only when every TP*PP rank has it.
+        expected_per_key = max(1, tp_count * self.pp_size)
+        present_count: dict[tuple[int, bytes], int] = {}
+        for gh, exists in zip(candidate_meta, res, strict=True):
+            if exists == 1:
+                present_count[gh] = present_count.get(gh, 0) + 1
+        exists_set = {gh for gh, c in present_count.items() if c >= expected_per_key}
+
+        _masks, hit_length = self.coord.find_longest_cache_hit(
+            block_hashes, token_len, ExternalCachedBlockPool(exists_set)
+        )
+        logger.debug(
+            "dfkv lookup: token_len=%d candidates=%d present=%d -> hit_length=%d",
+            token_len, len(candidate_keys), len(exists_set), hit_length,
+        )
+        return hit_length
+
+    def get_kv_events(self) -> list[BlockStored]:
+        if self.enable_kv_events and self.kv_send_thread is not None:
+            return self.kv_send_thread.get_kv_events()
+        return []
+
+
+# ============================================================
+# Lookup Key Server
+# ============================================================
+
+
+class LookupKeyServer:
+    """ZMQ server on worker rank 0 for the LookupKey admin channel.
+
+    Handles two request types, tagged at frame 0:
+    - ``LOOKUP_MSG``: prefix-cache hit query, returns hit count.
+    - ``RESET_MSG``: drains the send thread queue, then attempts a global
+      store wipe. Caller must have paused the scheduler first.
+    """
+
+    def __init__(
+        self,
+        store_worker: DfkvStoreWorker,
+        vllm_config: VllmConfig,
+    ):
+        self.decoder = MsgpackDecoder()
+        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        socket_path = get_zmq_rpc_path_lookup(vllm_config)
+        self._ipc_path = socket_path.removeprefix("ipc://")
+        if os.path.exists(self._ipc_path):
+            os.unlink(self._ipc_path)
+        self.socket = make_zmq_socket(
+            self.ctx,
+            socket_path,
+            zmq.REP,  # type: ignore[attr-defined]
+            bind=True,
+        )
+
+        self.store_worker = store_worker
+        self.running = True
+
+        def process_request():
+            while self.running:
+                all_frames = self.socket.recv_multipart(copy=False)
+                msg_type = bytes(all_frames[0])
+
+                if msg_type == LOOKUP_MSG:
+                    token_len = int.from_bytes(all_frames[1], byteorder="big")
+                    hash_frames = all_frames[2:]
+                    hashes_str = self.decoder.decode(hash_frames)
+                    block_hashes = [BlockHash(bytes.fromhex(s)) for s in hashes_str]
+                    result = self.store_worker.lookup(token_len, block_hashes)
+                    self.socket.send(result.to_bytes(4, "big"))
+
+                elif msg_type == RESET_MSG:
+                    # dfkv: DfkvDeviceClient exposes no remove_all / global wipe
+                    # primitive (the dfkv cache is keyed by model_hash + key
+                    # namespace; entries expire by the server's own policy). We
+                    # still drain in-flight puts to honor the ordering contract,
+                    # then NACK so callers know the hard reset was not applied.
+                    try:
+                        if self.store_worker.kv_send_thread is not None:
+                            self.store_worker.kv_send_thread.request_queue.join()
+                    except Exception as e:
+                        logger.error("Dfkv reset drain failed: %s", e)
+                    logger.warning(
+                        "Dfkv store has no remove_all; reset request NACKed "
+                        "(send queue drained)."
+                    )
+                    self.socket.send(RESP_ERR)
+
+                else:
+                    logger.warning(
+                        "LookupKeyServer received unknown msg_type: %r",
+                        msg_type,
+                    )
+                    self.socket.send(RESP_ERR)
+
+        self.thread = threading.Thread(target=process_request, daemon=True)
+        self.thread.start()
+
+    def close(self):
+        self.socket.close(linger=0)
+        if os.path.exists(self._ipc_path):
+            os.unlink(self._ipc_path)
+
+
+# ============================================================
+# Lookup Key Client
+# ============================================================
+
+
+class LookupKeyClient:
+    """ZMQ client for the LookupKey admin channel.
+
+    Routes both prefix-cache lookups and admin commands (currently:
+    ``reset``) to ``LookupKeyServer`` on worker rank 0. The first frame
+    of every request is a named tag from ``protocol.py``.
+    """
+
+    def __init__(self, vllm_config: VllmConfig):
+        self.encoder = MsgpackEncoder()
+        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        socket_path = get_zmq_rpc_path_lookup(vllm_config)
+        self.socket = make_zmq_socket(
+            self.ctx,
+            socket_path,
+            zmq.REQ,  # type: ignore[attr-defined]
+            bind=False,
+        )
+
+    def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
+        hash_strs = [h.hex() for h in block_hashes]
+        hash_frames = self.encoder.encode(hash_strs)
+        token_len_bytes = token_len.to_bytes(4, byteorder="big")
+        all_frames = [LOOKUP_MSG, token_len_bytes] + list(hash_frames)
+        self.socket.send_multipart(all_frames, copy=False)
+        resp = self.socket.recv()
+        result = int.from_bytes(resp, "big")
+        return result
+
+    def reset(self) -> bool:
+        """Trigger a global store wipe on worker rank 0.
+
+        Ordering assumption: caller MUST ensure no in-flight Dfkv
+        lookups or transfers when invoking reset. In RL workflows this
+        holds naturally at the step boundary after weight updates and
+        rollout drain. Returns True on ACK, False on NACK.
+
+        dfkv: dfkv has no remove_all primitive, so the worker drains the
+        send queue and NACKs; this returns False.
+        """
+        self.socket.send(RESET_MSG)
+        resp = self.socket.recv()
+        return bytes(resp) == RESP_OK
+
+    def close(self):
+        self.socket.close(linger=0)
+
+
+def get_zmq_rpc_path_lookup(vllm_config: VllmConfig) -> str:
+    """Construct IPC path for ZMQ lookup socket."""
+    assert vllm_config.kv_transfer_config is not None
+    dp_rank = get_dp_engine_index(vllm_config.parallel_config)
+    base_url = envs.VLLM_RPC_BASE_PATH
+    rpc_port = 0
+    hostname = socket.gethostname()
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
+    if "lookup_rpc_port" in extra_config:
+        rpc_port = extra_config["lookup_rpc_port"]
+    logger.debug("Base URL: %s, RPC Port: %s", base_url, rpc_port)
+    return (
+        f"ipc://{base_url}/lookup_rpc_port_{rpc_port}_host_{hostname}_dp_rank{dp_rank}"
+    )

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -460,119 +460,129 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         return invalid_block_ids
 
     def _handle_request(self, req_meta: ReqMeta):
-        token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
         req_id = req_meta.req_id
-        mask_num = (
-            req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
-            // self.block_size
-            * self.block_size
-        )
+        try:
+            token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
+            mask_num = (
+                req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
+                // self.block_size
+                * self.block_size
+            )
 
-        # Skip chunks the consumer's per-group spec wouldn't populate
-        # locally (e.g. SWA pre-window) even if the producer stored them.
-        load_mask_per_group = self.coord.load_mask(req_meta.block_hashes, token_len)
+            # Skip chunks the consumer's per-group spec wouldn't populate
+            # locally (e.g. SWA pre-window) even if the producer stored them.
+            load_mask_per_group = self.coord.load_mask(req_meta.block_hashes, token_len)
 
-        addr_list: list[list[int]] = []
-        size_list: list[list[int]] = []
-        key_list: list[str] = []
-        block_id_list: list[int] = []
-        for g_idx, db in enumerate(self.token_databases):
-            mask = load_mask_per_group[g_idx]
-            for start, end, key in db.process_tokens(
-                token_len, req_meta.block_hashes, mask_num
-            ):
-                chunk_idx = start // db.block_size
-                if chunk_idx >= len(mask) or not mask[chunk_idx]:
-                    continue
-                addr, size, block_id = db.prepare_value(
-                    start, end, req_meta.block_ids[g_idx]
+            addr_list: list[list[int]] = []
+            size_list: list[list[int]] = []
+            key_list: list[str] = []
+            block_id_list: list[int] = []
+            for g_idx, db in enumerate(self.token_databases):
+                mask = load_mask_per_group[g_idx]
+                for start, end, key in db.process_tokens(
+                    token_len, req_meta.block_hashes, mask_num
+                ):
+                    chunk_idx = start // db.block_size
+                    if chunk_idx >= len(mask) or not mask[chunk_idx]:
+                        continue
+                    addr, size, block_id = db.prepare_value(
+                        start, end, req_meta.block_ids[g_idx]
+                    )
+                    key_list.append(key.to_string())
+                    addr_list.append(addr)
+                    size_list.append(size)
+                    block_id_list.append(block_id)
+
+            # Nothing to load (e.g. every chunk masked out for this group) -> finish
+            # the request now, else `tp_rank % 0` below would raise and the req would
+            # never be reported done, hanging vLLM's WAITING_FOR_REMOTE_KVS wait.
+            if not key_list:
+                return
+
+            # Rotate aligned lists by tp_rank for load balancing.
+            rotation = self.tp_rank % len(key_list)
+            key_list_c = _rotate_list(key_list, rotation)
+            addr_list_c = _rotate_list(addr_list, rotation)
+            size_list_c = _rotate_list(size_list, rotation)
+            block_id_list_c = _rotate_list(block_id_list, rotation)
+
+            # dfkv: A GET is one batch -- dfkv has no owner-side DirectIO staging
+            # budget, so the Mooncake disk-offload sub-batch split is dropped.
+            # Flatten per-key scatter-gather to one (ptr, cap) per dfkv key, then
+            # map each flattened result back to its originating block id for error
+            # reporting (see _flatten_segments / seg_owner).
+            sg_keys, sg_ptrs, sg_caps, sg_owner = _group_segments_sg(
+                key_list_c, addr_list_c, size_list_c
+            )
+            sg_totals = [sum(c) for c in sg_caps]
+            batch_bytes = sum(sg_totals)
+
+            load_get_start = time.perf_counter()
+            try:
+                # dfkv: one scatter-gather GET per coalesced key -> (hits, lens). The
+                # server returns one blob; the RDMA recv SGE list scatters it back
+                # into this chunk's per-layer segments. hit == 1 + len == sum(caps)
+                # means the chunk loaded; a miss or short read marks the originating
+                # block as a load error so vLLM recomputes that span (never fatal).
+                hits, lens = self.client.batch_get_auto_sg(sg_keys, sg_ptrs, sg_caps)
+                failed_block_ids: list[int] = []
+                failed_detail: list[tuple[str, int]] = []
+                for i, (hit, got_len) in enumerate(zip(hits, lens, strict=True)):
+                    if hit != 1 or got_len < sg_totals[i]:
+                        failed_block_ids.append(block_id_list_c[sg_owner[i]])
+                        failed_detail.append((sg_keys[i], hit))
+                self._record_operation(
+                    "load_get",
+                    load_get_start,
+                    len(sg_keys),
+                    num_bytes=batch_bytes,
+                    status="partial_failure" if failed_block_ids else "ok",
+                    num_failed_keys=len(failed_block_ids),
                 )
-                key_list.append(key.to_string())
-                addr_list.append(addr)
-                size_list.append(size)
-                block_id_list.append(block_id)
+                logger.debug(
+                    "dfkv load_get: req=%s keys=%d bytes=%d ms=%.1f failed=%d",
+                    req_id, len(sg_keys), batch_bytes,
+                    (time.perf_counter() - load_get_start) * 1000.0,
+                    len(failed_block_ids),
+                )
+                if failed_block_ids:
+                    self._add_load_error_block_ids(failed_block_ids)
+                    logger.warning(
+                        "Failed to get %d dfkv keys from batch "
+                        "(batch_keys=%d, first_failures=%s)",
+                        len(failed_block_ids),
+                        len(sg_keys),
+                        failed_detail[:3],
+                    )
+            except Exception as e:
+                self._add_load_error_block_ids(block_id_list_c)
+                self._record_operation(
+                    "load_get",
+                    load_get_start,
+                    len(sg_keys),
+                    num_bytes=batch_bytes,
+                    status="error",
+                    num_failed_keys=len(sg_keys),
+                )
+                logger.warning(
+                    "Failed to get dfkv batch %s, error: %s",
+                    sg_keys[:3],
+                    e,
+                )
 
-        # Nothing to load (e.g. every chunk masked out for this group) -> finish
-        # the request now, else `tp_rank % 0` below would raise and the req would
-        # never be reported done, hanging vLLM's WAITING_FOR_REMOTE_KVS wait.
-        if not key_list:
+        except Exception as e:
+            # Any unexpected failure in the load path -> recompute this
+            # request's blocks (never hang vLLM's WAITING_FOR_REMOTE_KVS).
+            logger.error("dfkv recv thread failed for req %s: %s", req_id, e)
+            try:
+                self._add_load_error_block_ids(
+                    [b for ids in req_meta.block_ids for b in ids]
+                )
+            except Exception:
+                pass
+        finally:
             self.set_finished_request(req_id)
             self.request_queue.task_done()
-            return
-
-        # Rotate aligned lists by tp_rank for load balancing.
-        rotation = self.tp_rank % len(key_list)
-        key_list_c = _rotate_list(key_list, rotation)
-        addr_list_c = _rotate_list(addr_list, rotation)
-        size_list_c = _rotate_list(size_list, rotation)
-        block_id_list_c = _rotate_list(block_id_list, rotation)
-
-        # dfkv: A GET is one batch -- dfkv has no owner-side DirectIO staging
-        # budget, so the Mooncake disk-offload sub-batch split is dropped.
-        # Flatten per-key scatter-gather to one (ptr, cap) per dfkv key, then
-        # map each flattened result back to its originating block id for error
-        # reporting (see _flatten_segments / seg_owner).
-        sg_keys, sg_ptrs, sg_caps, sg_owner = _group_segments_sg(
-            key_list_c, addr_list_c, size_list_c
-        )
-        sg_totals = [sum(c) for c in sg_caps]
-        batch_bytes = sum(sg_totals)
-
-        load_get_start = time.perf_counter()
-        try:
-            # dfkv: one scatter-gather GET per coalesced key -> (hits, lens). The
-            # server returns one blob; the RDMA recv SGE list scatters it back
-            # into this chunk's per-layer segments. hit == 1 + len == sum(caps)
-            # means the chunk loaded; a miss or short read marks the originating
-            # block as a load error so vLLM recomputes that span (never fatal).
-            hits, lens = self.client.batch_get_auto_sg(sg_keys, sg_ptrs, sg_caps)
-            failed_block_ids: list[int] = []
-            failed_detail: list[tuple[str, int]] = []
-            for i, (hit, got_len) in enumerate(zip(hits, lens, strict=True)):
-                if hit != 1 or got_len < sg_totals[i]:
-                    failed_block_ids.append(block_id_list_c[sg_owner[i]])
-                    failed_detail.append((sg_keys[i], hit))
-            self._record_operation(
-                "load_get",
-                load_get_start,
-                len(sg_keys),
-                num_bytes=batch_bytes,
-                status="partial_failure" if failed_block_ids else "ok",
-                num_failed_keys=len(failed_block_ids),
-            )
-            logger.debug(
-                "dfkv load_get: req=%s keys=%d bytes=%d ms=%.1f failed=%d",
-                req_id, len(sg_keys), batch_bytes,
-                (time.perf_counter() - load_get_start) * 1000.0,
-                len(failed_block_ids),
-            )
-            if failed_block_ids:
-                self._add_load_error_block_ids(failed_block_ids)
-                logger.warning(
-                    "Failed to get %d dfkv keys from batch "
-                    "(batch_keys=%d, first_failures=%s)",
-                    len(failed_block_ids),
-                    len(sg_keys),
-                    failed_detail[:3],
-                )
-        except Exception as e:
-            self._add_load_error_block_ids(block_id_list_c)
-            self._record_operation(
-                "load_get",
-                load_get_start,
-                len(sg_keys),
-                num_bytes=batch_bytes,
-                status="error",
-                num_failed_keys=len(sg_keys),
-            )
-            logger.warning(
-                "Failed to get dfkv batch %s, error: %s",
-                sg_keys[:3],
-                e,
-            )
-
-        self.set_finished_request(req_id)
-        self.request_queue.task_done()
 
 
 # dfkv: per-key scatter-gather flatten helpers. Mooncake's

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -408,12 +408,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 self._record_operation(
                     "save_put",
                     put_start,
-                    len(flat_keys),
+                    len(sg_keys),
                     num_bytes=batch_bytes,
                     status="error",
-                    num_failed_keys=len(flat_keys),
+                    num_failed_keys=len(sg_keys),
                 )
-                logger.error("Failed to put key %s, error: %s", flat_keys, e)
+                logger.error("Failed to put keys %s, error: %s", sg_keys[:3], e)
 
             if self.enable_kv_event and stored_events:
                 self.update_kv_event(stored_events)
@@ -491,6 +491,14 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 addr_list.append(addr)
                 size_list.append(size)
                 block_id_list.append(block_id)
+
+        # Nothing to load (e.g. every chunk masked out for this group) -> finish
+        # the request now, else `tp_rank % 0` below would raise and the req would
+        # never be reported done, hanging vLLM's WAITING_FOR_REMOTE_KVS wait.
+        if not key_list:
+            self.set_finished_request(req_id)
+            self.request_queue.task_done()
+            return
 
         # Rotate aligned lists by tp_rank for load balancing.
         rotation = self.tp_rank % len(key_list)

--- a/integration/vllm/tests/test_dfkv_client.py
+++ b/integration/vllm/tests/test_dfkv_client.py
@@ -1,0 +1,40 @@
+"""DfkvDeviceClient round-trip test against a live dfkv_server.
+
+Requires GPU + a running dfkv_server. Env:
+    DFKV_LIB, DFKV_MEMBERS (=c1=<ip>:<rdma-port>), DFKV_RDMA=1, DFKV_RDMA_DEV.
+Skips if torch/CUDA or the env are unavailable.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from dfkv_vllm.dfkv_client import DfkvDeviceClient  # noqa: E402
+
+torch = pytest.importorskip("torch")
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DFKV_MEMBERS") or not torch.cuda.is_available(),
+    reason="needs DFKV_MEMBERS + CUDA + a running dfkv_server",
+)
+
+
+def test_roundtrip_gpu_pointers():
+    c = DfkvDeviceClient(
+        members=os.environ["DFKV_MEMBERS"], model_hash=0x1234,
+        lib_path=os.environ.get("DFKV_LIB"),
+    )
+    n = 1 << 20
+    a = torch.arange(n, dtype=torch.uint8, device="cuda")
+    b = torch.zeros(n, dtype=torch.uint8, device="cuda")
+    c.register_memory(a.data_ptr(), n)
+    c.register_memory(b.data_ptr(), n)
+
+    assert c.batch_put(["k0"], [a.data_ptr()], [n]) == [0]
+    hits, lens = c.batch_get(["k0"], [b.data_ptr()], [n])
+    torch.cuda.synchronize()
+    assert hits == [1] and lens == [n]
+    assert torch.equal(a, b)
+    assert c.batch_exist(["k0", "missing-key"]) == [1, 0]
+    c.close()

--- a/integration/vllm/tests/test_gpudirect_regmem.py
+++ b/integration/vllm/tests/test_gpudirect_regmem.py
@@ -1,0 +1,57 @@
+"""P0 GPUDirect probe (validated on hd04 H100 + IB, 2026-06-18).
+
+Verifies the design-critical primitives the connector relies on:
+  * dfkv_register_memory accepts a CUDA device pointer (GPUDirect MR),
+  * a GPU->RDMA->server->RDMA->GPU round-trip is byte-correct via the batch
+    path (the path the connector uses).
+
+Run inside the vLLM image (torch + CUDA) against a running dfkv_server:
+
+    DFKV_LIB=.../build-rdma/libdfkv.so \
+    DFKV_MEMBERS=c1=<ip>:<rdma-port> \
+    DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 \
+        python integration/vllm/tests/test_gpudirect_regmem.py
+
+NOTE: DFKV_MEMBERS must use the server's --rdma-port, and DFKV_RDMA=1 must be set
+(a GPU pointer in TCP mode segfaults on the CPU-side copy).
+"""
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from dfkv_vllm.dfkv_client import DfkvDeviceClient  # noqa: E402
+
+
+def main() -> int:
+    members = os.environ.get("DFKV_MEMBERS", "c1=127.0.0.1:18901")
+    client = DfkvDeviceClient(members=members, model_hash=0xABCDEF,
+                              lib_path=os.environ.get("DFKV_LIB"))
+    assert client.transport_mode == "rdma", (
+        f"transport={client.transport_mode}; set DFKV_RDMA=1 + DFKV_RDMA_DEV "
+        "(GPU pointers require RDMA)")
+
+    n = 2 * 1024 * 1024
+    src = torch.arange(n, dtype=torch.uint8, device="cuda")
+    dst = torch.zeros(n, dtype=torch.uint8, device="cuda")
+
+    # The crux: register GPU device pointers -> GPUDirect MR.
+    client.register_memory(src.data_ptr(), n)
+    client.register_memory(dst.data_ptr(), n)
+    print("register_memory on GPU pointers: OK (GPUDirect MR created)")
+
+    assert client.batch_put(["p0/probe"], [src.data_ptr()], [n]) == [0]
+    hits, lens = client.batch_get(["p0/probe"], [dst.data_ptr()], [n])
+    assert hits == [1] and lens == [n], f"hits={hits} lens={lens}"
+
+    torch.cuda.synchronize()
+    assert torch.equal(src, dst), "byte mismatch after GPUDirect round-trip"
+    print(f"P0 PASS: GPUDirect round-trip byte-correct on "
+          f"{torch.cuda.get_device_name()}")
+    client.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dfkv_c_api.cc
+++ b/src/dfkv_c_api.cc
@@ -154,6 +154,62 @@ int dfkv_batch_exist(dfkv_client_t c, const char** keys, int n, int* out_exist) 
   return 0;
 }
 
+// Scatter-gather batch entrypoints. Same null-tolerance convention as the other
+// batch APIs: a null keys[i] yields an empty item reported as failed/miss. The
+// nested arrays (ptrs[i] / sizes[i] of length num_bufs[i]) are unpacked into the
+// KvPutItemSg/KvGetItemSg vectors. num_bufs[i] < 0 is treated as 0 (empty value).
+int dfkv_batch_put_sg(dfkv_client_t c, const char** keys, const void*** ptrs,
+                      const uint64_t** sizes, const int* num_bufs, int n,
+                      int* out_ok) {
+  if (!c || n < 0) return -1;
+  if (n > 0 && (!keys || !ptrs || !sizes || !num_bufs || !out_ok)) return -1;
+  std::vector<dfkv::KvPutItemSg> items(n);
+  for (int i = 0; i < n; ++i) {
+    const char* k = keys[i];
+    if (!k) { items[i] = {}; continue; }
+    items[i].key = std::string(k);
+    int nb = num_bufs[i] > 0 ? num_bufs[i] : 0;
+    items[i].ptrs.reserve(nb);
+    items[i].sizes.reserve(nb);
+    for (int j = 0; j < nb; ++j) {
+      items[i].ptrs.push_back(ptrs[i] ? ptrs[i][j] : nullptr);
+      items[i].sizes.push_back(sizes[i] ? static_cast<size_t>(sizes[i][j]) : 0);
+    }
+  }
+  auto r = static_cast<KVClient*>(c)->BatchPutSg(items);
+  for (int i = 0; i < n; ++i) out_ok[i] = (keys[i] && r[i]) ? 1 : 0;
+  return 0;
+}
+
+int dfkv_batch_get_auto_sg(dfkv_client_t c, const char** keys, void*** dsts,
+                           const uint64_t** caps, const int* num_dsts, int n,
+                           int* out_hit, uint64_t* out_len) {
+  if (!c || n < 0) return -1;
+  if (n > 0 && (!keys || !dsts || !caps || !num_dsts || !out_hit || !out_len))
+    return -1;
+  std::vector<dfkv::KvGetItemSg> items(n);
+  for (int i = 0; i < n; ++i) {
+    const char* k = keys[i];
+    if (!k) { items[i] = {}; continue; }
+    items[i].key = std::string(k);
+    int nd = num_dsts[i] > 0 ? num_dsts[i] : 0;
+    items[i].dsts.reserve(nd);
+    items[i].caps.reserve(nd);
+    for (int j = 0; j < nd; ++j) {
+      items[i].dsts.push_back(dsts[i] ? dsts[i][j] : nullptr);
+      items[i].caps.push_back(caps[i] ? static_cast<size_t>(caps[i][j]) : 0);
+    }
+  }
+  std::vector<size_t> lens;
+  auto r = static_cast<KVClient*>(c)->BatchGetAutoSg(items, &lens);
+  for (int i = 0; i < n; ++i) {
+    bool hit = keys[i] && r[i];
+    out_hit[i] = hit ? 1 : 0;
+    out_len[i] = hit ? static_cast<uint64_t>(lens[i]) : 0;
+  }
+  return 0;
+}
+
 int dfkv_set_members(dfkv_client_t c, const char* members) {
   if (!c) return -1;
   static_cast<KVClient*>(c)->SetMembers(ParseMembers(members));

--- a/src/dfkv_c_api.h
+++ b/src/dfkv_c_api.h
@@ -66,6 +66,24 @@ int dfkv_batch_get_auto(dfkv_client_t c, const char** keys, void** ptrs,
                         uint64_t* out_len);
 int dfkv_batch_exist(dfkv_client_t c, const char** keys, int n, int* out_exist);
 
+// Scatter-gather batch put: each of the n keys gathers num_bufs[i] non-contiguous
+// source buffers (ptrs[i][0..num_bufs[i]-1], sizes[i][...]) into one stored blob
+// (the in-order concatenation; segment boundaries are client-side only). Coalesces
+// many tiny KV chunks into one key + one RDMA multi-SGE op. out_ok[i]=1 on success.
+// A key with more than 29 buffers (RDMA max_sge-1) is reported out_ok[i]=0 (not
+// corrupted). Return 0 on call success.
+int dfkv_batch_put_sg(dfkv_client_t c, const char** keys, const void*** ptrs,
+                      const uint64_t** sizes, const int* num_bufs, int n,
+                      int* out_ok);
+// Scatter-gather variable-size batch get: each key's stored blob is scattered
+// across num_dsts[i] destination buffers (dsts[i][...], caps[i][...]) in order
+// (segment sizes define the split). Accepts any stored size <= sum(caps[i]).
+// out_hit[i]=1/0; out_len[i] receives the true stored payload byte length (0 on
+// miss). A key with more than 29 buffers is reported a miss. Return 0 on success.
+int dfkv_batch_get_auto_sg(dfkv_client_t c, const char** keys, void*** dsts,
+                           const uint64_t** caps, const int* num_dsts, int n,
+                           int* out_hit, uint64_t* out_len);
+
 // Client-side Prometheus metrics snapshot (ops served, IO errors, peer health
 // transitions, per-peer errors). Writes up to `cap` bytes (NUL-terminated when
 // it fits) into buf and returns the FULL text length (excluding NUL). Pass cap=0

--- a/src/dfkv_server_main.cc
+++ b/src/dfkv_server_main.cc
@@ -106,6 +106,27 @@ int main(int argc, char** argv) {
                size_t cap) {
           return srv.CacheDirect(id, idx, ks, data, len, cap);
         });
+    // Async-GET hooks (used only when built -DDFKV_WITH_URING and started with
+    // DFKV_SERVER_URING=1; otherwise the serve loop ignores these and uses the
+    // synchronous range_handler above verbatim).
+    rsrv->set_range_prep_handler(
+        [&srv](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
+               size_t cap, dfkv::RdmaServer::RangePrepResult* out) {
+          dfkv::KVStore::RangePrep p;
+          Status st = srv.RangeDirectPrep(id, idx, ks, off, len, cap, &p);
+          if (st == Status::kOk) {
+            out->fd = p.fd;
+            out->aligned_off = p.aligned_off;
+            out->aligned_len = p.aligned_len;
+            out->head = p.head;
+            out->payload_len = p.payload_len;
+          }
+          return st;
+        });
+    rsrv->set_range_complete_handler(
+        [&srv](bool ok, size_t bytes_read) {
+          srv.RangeDirectComplete(ok, bytes_read);
+        });
     if (rsrv->Start(rdma_port) == Status::kOk)
       DFKV_LOG_INFO("dfkv_server RDMA listening (TCP bootstrap) on port " +
                     std::to_string(rsrv->port()) +

--- a/src/disk_cache_group.cc
+++ b/src/disk_cache_group.cc
@@ -59,6 +59,14 @@ Status DiskCacheGroup::RangeDirect(const BlockKey& key, uint64_t offset,
   return d->RangeDirect(key, offset, length, io_buf, io_cap, out_data, out_len);
 }
 
+Status DiskCacheGroup::RangeDirectPrep(const BlockKey& key, uint64_t offset,
+                                       uint64_t length, size_t io_cap,
+                                       KVStore::RangePrep* out) {
+  KVStore* d = Route(key);
+  if (d == nullptr) return Status::kInvalid;
+  return d->RangeDirectPrep(key, offset, length, io_cap, out);
+}
+
 bool DiskCacheGroup::IsCached(const BlockKey& key) const {
   KVStore* d = Route(key);
   return d != nullptr && d->IsCached(key);

--- a/src/disk_cache_group.h
+++ b/src/disk_cache_group.h
@@ -36,6 +36,9 @@ class DiskCacheGroup {
   Status RangeDirect(const BlockKey& key, uint64_t offset, uint64_t length,
                      char* io_buf, size_t io_cap, const char** out_data,
                      size_t* out_len);
+  // Cheap prep half of RangeDirect (no disk read); see KVStore::RangeDirectPrep.
+  Status RangeDirectPrep(const BlockKey& key, uint64_t offset, uint64_t length,
+                         size_t io_cap, KVStore::RangePrep* out);
   bool IsCached(const BlockKey& key) const;
 
   uint64_t UsedBytes() const;   // summed across disks

--- a/src/kv_client.cc
+++ b/src/kv_client.cc
@@ -24,12 +24,13 @@ namespace {
 // KNOWN LIMITATION (heterogeneous hardware): this is a fixed 29, not the live
 // negotiated ep.max_sge()-1. On an HCA reporting max_sge < 30, a key whose seg
 // count is between (max_sge-1) and 29 passes this client guard but trips the
-// transport's per-window check (CacheFromMulti/RangeIntoMulti), which today
-// fails the WHOLE node batch (std::fill kInvalid), not just the offender. That
-// is fail-soft (the connector recomputes those blocks; no data corruption) but
-// costs the cache benefit on small-max_sge devices. TODO for cross-HCA support:
-// (a) fail only the offending item in the transport, and/or (b) derive the SG
-// chunk size from the live max_sge instead of this constant.
+// transport's per-window check (CacheFromMulti/RangeIntoMulti). That now fails
+// only the OFFENDING item (per-item kInvalid), not the whole node batch, so it
+// is graceful fail-soft (the connector recomputes just those blocks; siblings
+// still hit; no data corruption) — it only costs the cache benefit for the
+// oversized keys on small-max_sge devices. Remaining TODO for full cross-HCA
+// efficiency: derive the SG chunk size from the live max_sge instead of this
+// constant so even those keys cache.
 constexpr size_t kSgMaxPayloadSegs = 29;
 
 // Run fn(i) for i in [0,n) across up to `workers` threads (atomic work-steal).

--- a/src/kv_client.cc
+++ b/src/kv_client.cc
@@ -20,6 +20,16 @@ namespace {
 // per work request; SGE0 is the header, leaving max_sge-1 payload SGEs. The
 // device cap on hd04 ConnectX is 30 -> 29 payload segments. The connector
 // guarantees <=29; a key over this is reported failed instead of corrupted.
+//
+// KNOWN LIMITATION (heterogeneous hardware): this is a fixed 29, not the live
+// negotiated ep.max_sge()-1. On an HCA reporting max_sge < 30, a key whose seg
+// count is between (max_sge-1) and 29 passes this client guard but trips the
+// transport's per-window check (CacheFromMulti/RangeIntoMulti), which today
+// fails the WHOLE node batch (std::fill kInvalid), not just the offender. That
+// is fail-soft (the connector recomputes those blocks; no data corruption) but
+// costs the cache benefit on small-max_sge devices. TODO for cross-HCA support:
+// (a) fail only the offending item in the transport, and/or (b) derive the SG
+// chunk size from the live max_sge instead of this constant.
 constexpr size_t kSgMaxPayloadSegs = 29;
 
 // Run fn(i) for i in [0,n) across up to `workers` threads (atomic work-steal).

--- a/src/kv_client.cc
+++ b/src/kv_client.cc
@@ -477,7 +477,8 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   // contract holds on TCP too. Empty-segment keys are valid (header-only).
   std::vector<char> over(N, 0);
   for (size_t i = 0; i < N; ++i) {
-    if (items[i].ptrs.size() != items[i].sizes.size() ||
+    if (items[i].key.empty() ||  // null/empty key: skip (no header-only blob written)
+        items[i].ptrs.size() != items[i].sizes.size() ||
         items[i].ptrs.size() > kSgMaxPayloadSegs)
       over[i] = 1;
   }
@@ -534,7 +535,8 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
   // request can scatter into is reported a miss up front.
   std::vector<char> over(N, 0);
   for (size_t i = 0; i < N; ++i) {
-    if (items[i].dsts.size() != items[i].caps.size() ||
+    if (items[i].key.empty() ||  // null/empty key: skip (no wasted GET issued)
+        items[i].dsts.size() != items[i].caps.size() ||
         items[i].dsts.size() > kSgMaxPayloadSegs)
       over[i] = 1;
   }

--- a/src/kv_client.cc
+++ b/src/kv_client.cc
@@ -16,6 +16,12 @@
 namespace dfkv {
 
 namespace {
+// Max payload segments per scatter-gather key. The RDMA QP carries max_sge SGEs
+// per work request; SGE0 is the header, leaving max_sge-1 payload SGEs. The
+// device cap on hd04 ConnectX is 30 -> 29 payload segments. The connector
+// guarantees <=29; a key over this is reported failed instead of corrupted.
+constexpr size_t kSgMaxPayloadSegs = 29;
+
 // Run fn(i) for i in [0,n) across up to `workers` threads (atomic work-steal).
 void RunParallel(size_t n, size_t workers, const std::function<void(size_t)>& fn) {
   if (n == 0) return;
@@ -449,6 +455,129 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
     for (size_t m = 0; m < idx.size(); ++m) e[idx[m]] = (m < ex.size() && ex[m]) ? 1 : 0;
   });
   return std::vector<bool>(e.begin(), e.end());
+}
+
+std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
+  const size_t N = items.size();
+  std::vector<char> ok(N, 0);  // char (not vector<bool>) for thread-safe writes
+
+  // Guard: a key with more payload segments than one RDMA work request can carry
+  // (max_sge-1) is reported failed up front and excluded from the wire (so it
+  // never corrupts a shared connection). Done transport-independently so the
+  // contract holds on TCP too. Empty-segment keys are valid (header-only).
+  std::vector<char> over(N, 0);
+  for (size_t i = 0; i < N; ++i) {
+    if (items[i].ptrs.size() != items[i].sizes.size() ||
+        items[i].ptrs.size() > kSgMaxPayloadSegs)
+      over[i] = 1;
+  }
+
+  // Header per item (stamps total payload_len = sum of segment sizes). hdrs must
+  // outlive the RunParallel lambdas that reference it.
+  std::vector<std::array<char, ValueHeader::kSize>> hdrs(N);
+  std::map<std::string, std::vector<size_t>> by_node;
+  for (size_t i = 0; i < N; ++i) {
+    if (over[i]) continue;
+    std::string node = Route(items[i].key);
+    if (node.empty()) continue;
+    size_t total = 0;
+    for (size_t s : items[i].sizes) total += s;
+    ValueHeader h = self_hdr_;
+    h.payload_len = total;
+    h.Serialize(hdrs[i].data());
+    by_node[node].push_back(i);
+  }
+  std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
+  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+    const std::string& node = groups[g].first;
+    uint64_t now = NowMs();
+    if (!health_.Healthy(node, now)) return;
+    const std::vector<size_t>& idx = groups[g].second;
+    std::vector<CacheSrcMulti> srcs;
+    srcs.reserve(idx.size());
+    for (size_t k : idx) {
+      CacheSrcMulti s;
+      s.key = ToBlockKey(items[k].key);
+      s.header = hdrs[k].data();
+      s.header_len = ValueHeader::kSize;
+      s.payloads.reserve(items[k].ptrs.size());
+      for (size_t j = 0; j < items[k].ptrs.size(); ++j)
+        s.payloads.emplace_back(items[k].ptrs[j], items[k].sizes[j]);
+      srcs.push_back(std::move(s));
+    }
+    std::vector<Status> sts = t_->CacheFromMulti(node, srcs);
+    for (size_t m = 0; m < idx.size(); ++m) ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
+    bool resp = false, ioerr = false;
+    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+  });
+  return std::vector<bool>(ok.begin(), ok.end());
+}
+
+std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items,
+                                           std::vector<size_t>* out_lens) {
+  const size_t N = items.size();
+  std::vector<char> hit(N, 0);
+  std::vector<size_t> lens(N, 0);  // distinct indices => thread-safe writes
+
+  // Guard (same as put): a key with more destination segments than one RDMA work
+  // request can scatter into is reported a miss up front.
+  std::vector<char> over(N, 0);
+  for (size_t i = 0; i < N; ++i) {
+    if (items[i].dsts.size() != items[i].caps.size() ||
+        items[i].dsts.size() > kSgMaxPayloadSegs)
+      over[i] = 1;
+  }
+
+  // Group by (node, total_cap): a group shares the Range length (= sum of caps)
+  // so the existing RangeInto windowing/pipelining applies unchanged.
+  std::map<std::pair<std::string, size_t>, std::vector<size_t>> by;
+  for (size_t i = 0; i < N; ++i) {
+    if (over[i]) continue;
+    std::string node = Route(items[i].key);
+    if (node.empty()) continue;
+    size_t cap = 0;
+    for (size_t c : items[i].caps) cap += c;
+    by[{node, cap}].push_back(i);
+  }
+  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
+  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+    const std::string& node = groups[g].first.first;
+    uint64_t now = NowMs();
+    if (!health_.Healthy(node, now)) return;
+    const std::vector<size_t>& idx = groups[g].second;
+    std::vector<BlockKey> keys;
+    std::vector<RangeDstMulti> dsts;
+    keys.reserve(idx.size());
+    dsts.reserve(idx.size());
+    for (size_t k : idx) {
+      keys.push_back(ToBlockKey(items[k].key));
+      RangeDstMulti d;
+      d.payloads.reserve(items[k].dsts.size());
+      for (size_t j = 0; j < items[k].dsts.size(); ++j)
+        d.payloads.emplace_back(items[k].dsts[j], items[k].caps[j]);
+      dsts.push_back(std::move(d));
+    }
+    std::vector<std::string> hdrs;
+    std::vector<size_t> tlens;
+    std::vector<Status> sts =
+        t_->RangeIntoMulti(node, keys, dsts, ValueHeader::kSize, &hdrs, &tlens);
+    bool resp = false, ioerr = false;
+    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    for (size_t m = 0; m < idx.size(); ++m) {
+      size_t cap = groups[g].first.second;
+      if (sts[m] != Status::kOk || hdrs[m].size() < ValueHeader::kSize) continue;
+      ValueHeader h;
+      if (!ValueHeader::Parse(hdrs[m].data(), hdrs[m].size(), &h)) continue;
+      if (!HeaderMatches(self_hdr_, h)) continue;
+      if (h.payload_len > cap) continue;  // doesn't fit caller buffers => miss
+      lens[idx[m]] = h.payload_len;       // authoritative length from header
+      hit[idx[m]] = 1;
+    }
+  });
+  if (out_lens) *out_lens = std::move(lens);
+  return std::vector<bool>(hit.begin(), hit.end());
 }
 
 }  // namespace dfkv

--- a/src/kv_client.h
+++ b/src/kv_client.h
@@ -30,6 +30,23 @@ namespace dfkv {
 struct KvPutItem { std::string key; const void* value; size_t n; };
 struct KvGetItem { std::string key; void* out; size_t n; };
 
+// Scatter-gather batch items: one dfkv key gathers N non-contiguous source
+// buffers on put / scatters into N destination buffers on get. The stored value
+// is the in-order concatenation of the segments; segment boundaries are purely
+// client-side (the server stores one opaque blob). ptrs.size() == sizes.size();
+// dsts.size() == caps.size(). Used by the additive C ABI dfkv_batch_put_sg /
+// dfkv_batch_get_auto_sg to coalesce many tiny KV chunks into one key/RDMA op.
+struct KvPutItemSg {
+  std::string key;
+  std::vector<const void*> ptrs;
+  std::vector<size_t> sizes;
+};
+struct KvGetItemSg {
+  std::string key;
+  std::vector<void*> dsts;
+  std::vector<size_t> caps;
+};
+
 class KVClient {
  public:
   // members: (node_name, "ip:port"). self_hdr: this engine's geometry identity.
@@ -64,6 +81,19 @@ class KVClient {
   std::vector<bool> BatchGetAuto(const std::vector<KvGetItem>& items,
                                  std::vector<size_t>* out_lens);
   std::vector<bool> BatchExist(const std::vector<std::string>& keys);
+
+  // Scatter-gather batch put: each key gathers its N source segments into one
+  // stored blob (sum of sizes). Mirrors BatchPut (consistent-hash routing per key,
+  // group by node, zero-copy multi-SGE gather on RDMA). Per-item result. A key
+  // with more segments than the RDMA transport can carry in one work request
+  // (max_sge-1) is reported as failed (false) rather than corrupted.
+  std::vector<bool> BatchPutSg(const std::vector<KvPutItemSg>& items);
+  // Scatter-gather variable-size batch get: each key's stored blob is scattered
+  // across its N destination segments in order (the segment sizes define the
+  // split). Mirrors BatchGetAuto: accepts any stored size <= sum(caps); out_lens
+  // (if non-null) receives the true stored payload length per key (0 on miss).
+  std::vector<bool> BatchGetAutoSg(const std::vector<KvGetItemSg>& items,
+                                   std::vector<size_t>* out_lens);
 
   void set_batch_concurrency(size_t n) {
     batch_concurrency_.store(n ? n : 1, std::memory_order_relaxed);

--- a/src/kv_node_server.cc
+++ b/src/kv_node_server.cc
@@ -327,6 +327,30 @@ Status KvNodeServer::RangeDirect(uint64_t id, uint32_t index, uint32_t ksize,
   return st;
 }
 
+Status KvNodeServer::RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize,
+                                     uint64_t offset, uint64_t length,
+                                     size_t io_cap, KVStore::RangePrep* out) {
+  BlockKey key{id, index, ksize};
+  Status st = group_.RangeDirectPrep(key, offset, length, io_cap, out);
+  // Only miss/io-error are final here; a kOk prep is accounted on read completion
+  // (RangeDirectComplete) because the async read can still fail.
+  if (st == Status::kNotFound) {
+    cache_miss_.fetch_add(1, std::memory_order_relaxed);
+  } else if (st == Status::kIOError) {
+    get_io_err_.fetch_add(1, std::memory_order_relaxed);
+  }
+  return st;
+}
+
+void KvNodeServer::RangeDirectComplete(bool ok, size_t bytes_read) {
+  if (ok) {
+    cache_hit_.fetch_add(1, std::memory_order_relaxed);
+    bytes_read_.fetch_add(bytes_read, std::memory_order_relaxed);
+  } else {
+    get_io_err_.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
 // Keep-alive: serve requests on this connection until the peer closes it.
 void KvNodeServer::Handle(int fd) {
   while (running_) {

--- a/src/kv_node_server.h
+++ b/src/kv_node_server.h
@@ -79,6 +79,17 @@ class KvNodeServer {
                      uint64_t length, char* io_buf, size_t io_cap,
                      const char** out_data, size_t* out_len);
 
+  // Async-friendly prep half of RangeDirect: index lookup + O_DIRECT open +
+  // alignment math, NO disk read (see KVStore::RangeDirectPrep). The caller
+  // issues the pread (io_uring) into its io_buf and closes out->fd afterward.
+  // Updates miss/io-error counters; the hit/bytes-read counters are bumped by
+  // RangeDirectComplete once the read result is known.
+  Status RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize,
+                         uint64_t offset, uint64_t length, size_t io_cap,
+                         KVStore::RangePrep* out);
+  // Account a completed prep-based GET (called after the async read finishes).
+  void RangeDirectComplete(bool ok, size_t bytes_read);
+
  private:
   void AcceptLoop();
   void Handle(int fd);

--- a/src/kv_store.cc
+++ b/src/kv_store.cc
@@ -451,6 +451,49 @@ Status KVStore::RangeDirect(const BlockKey& key, uint64_t offset, uint64_t lengt
   return Status::kOk;
 }
 
+Status KVStore::RangeDirectPrep(const BlockKey& key, uint64_t offset,
+                                uint64_t length, size_t io_cap,
+                                RangePrep* out) {
+  *out = RangePrep{};
+  int raw_fd = -1;  // released to the caller on kOk; closed here on every error
+  uint64_t fsize = 0;
+  {  // index lookup + open under a SHARED lock; bulk read happens in the caller
+    const std::string fname = key.Filename();
+    Shard& sh = ShardFor(fname);
+    std::shared_lock<std::shared_mutex> rl(sh.mu);
+    auto it = sh.index.find(fname);
+    if (it == sh.index.end()) return Status::kNotFound;
+    raw_fd = ::open(it->second.path.c_str(), O_RDONLY | O_DIRECT);
+    if (raw_fd < 0) return Status::kIOError;
+    fsize = it->second.size;
+    it->second.referenced.store(true, std::memory_order_relaxed);  // CLOCK touch
+  }
+  // From here a failure must close raw_fd (the caller only owns it on kOk).
+  auto fail = [&](Status s) { ::close(raw_fd); return s; };
+  if (offset > fsize) return fail(Status::kInvalid);
+  uint64_t n = length;
+  if (n > fsize - offset) n = fsize - offset;
+  if (n == 0) {  // valid zero-length hit: nothing to read, no fd to keep
+    ::close(raw_fd);
+    out->fd = -1;
+    out->payload_len = 0;
+    return Status::kOk;
+  }
+  // Mirror PreadRangeDirectTo's aligned-superset math so the caller's read covers
+  // exactly the bytes the synchronous path would have read.
+  const uint64_t astart = AlignDown(offset);
+  uint64_t aend = 0;
+  if (!AlignUp(offset + n, &aend)) return fail(Status::kIOError);
+  const size_t alen = static_cast<size_t>(aend - astart);
+  if (alen > io_cap) return fail(Status::kIOError);
+  out->fd = raw_fd;  // ownership transferred to caller
+  out->aligned_off = astart;
+  out->aligned_len = alen;
+  out->head = static_cast<size_t>(offset - astart);
+  out->payload_len = static_cast<size_t>(n);
+  return Status::kOk;
+}
+
 bool KVStore::IsCached(const BlockKey& key) const {
   const std::string fname = key.Filename();
   Shard& sh = ShardFor(fname);

--- a/src/kv_store.h
+++ b/src/kv_store.h
@@ -65,6 +65,26 @@ class KVStore {
   Status RangeDirect(const BlockKey& key, uint64_t offset, uint64_t length,
                      char* io_buf, size_t io_cap, const char** out_data,
                      size_t* out_len);
+
+  // Async-friendly split of RangeDirect. Does ONLY the cheap, lock-protected
+  // prep: index lookup, O_DIRECT open, range clamp, and O_DIRECT alignment math.
+  // It performs NO disk read — the caller issues the (slow) pread itself (e.g.
+  // via io_uring) and then trims the slice. On kOk the caller MUST ::close(out->fd)
+  // after the read completes (the fd pins the inode against eviction meanwhile).
+  // Output (kOk only): {fd, aligned_off, aligned_len, head, payload_len}.
+  //   read aligned_len bytes at aligned_off into io_buf, then the requested bytes
+  //   are at io_buf+head for payload_len bytes. payload_len==0 is a valid zero-len
+  //   hit (fd<0, nothing to read). io_cap must be >= aligned_len.
+  struct RangePrep {
+    int fd = -1;              // owned by caller on kOk (caller closes); -1 if no read
+    uint64_t aligned_off = 0; // O_DIRECT-aligned read start
+    size_t aligned_len = 0;   // O_DIRECT-aligned read length (multiple of 4096)
+    size_t head = 0;          // offset of requested bytes within the aligned read
+    size_t payload_len = 0;   // exact requested bytes (after clamp to file size)
+  };
+  Status RangeDirectPrep(const BlockKey& key, uint64_t offset, uint64_t length,
+                         size_t io_cap, RangePrep* out);
+
   bool IsCached(const BlockKey& key) const;
 
   uint64_t UsedBytes() const;

--- a/src/rdma_server.cc
+++ b/src/rdma_server.cc
@@ -19,6 +19,7 @@
 #include "numa_util.h"    // pin serve thread to the device's NUMA node
 #include "rdma_verbs.h"   // RcEndpoint, QpInfo
 #include "transport.h"    // kReqPrefix, kRespPrefix
+#include "uring_reader.h" // io_uring async-GET path (DFKV_WITH_URING only)
 #include "value_header.h"
 
 namespace dfkv {
@@ -181,7 +182,32 @@ int ServerIdleMs() {
   return 600000;  // 10 minutes
 }
 
+#ifdef DFKV_WITH_URING
+// io_uring async-GET ring depth. Defaults to the pipeline depth K so each in-
+// flight request can have one read outstanding; can be raised independently to
+// expose more disk queue depth without growing the RDMA pipeline. Clamped to
+// [1, 256] and to >= K by the caller.
+size_t UringDepth(size_t k) {
+  const char* e = std::getenv("DFKV_SERVER_URING_DEPTH");
+  if (e && *e) {
+    long v = std::strtol(e, nullptr, 10);
+    if (v >= 1 && v <= 256) return static_cast<size_t>(v);
+  }
+  return k;  // one outstanding read per in-flight request by default
+}
+#endif  // DFKV_WITH_URING
+
 }  // namespace
+
+bool RdmaServer::UseUringPath() const {
+#ifdef DFKV_WITH_URING
+  if (!range_prep_handler_ || !range_complete_handler_) return false;
+  const char* e = std::getenv("DFKV_SERVER_URING");
+  return e && *e && std::strcmp(e, "0") != 0;
+#else
+  return false;
+#endif
+}
 
 void RdmaServer::Serve(int boot_fd) {
   // Bootstrap: client first names the device it wants us to use (same rail for
@@ -354,6 +380,190 @@ void RdmaServer::Serve(int boot_fd) {
   bool fail = false;
   const int idle_ms = ServerIdleMs();
   active_conns_.fetch_add(1, std::memory_order_relaxed);
+
+#ifdef DFKV_WITH_URING
+  // -------------------------------------------------------------------------
+  // io_uring async-GET serve loop (env-gated; correctness-preserving).
+  //
+  // Batch-and-wait model (Mooncake's uring_file batch_read adapted to dfkv's
+  // per-WaitComp completion batch). For each completion batch returned by
+  // WaitComp: handle SEND completions and non-kRange RECVs inline exactly as the
+  // sync loop; for the kRange GET RECVs, do the cheap prep (open O_DIRECT fd +
+  // index lookup + alignment) into an ordered descriptor list, submit ALL their
+  // reads to io_uring at once (QD>1 in flight => saturates the SSD), WAIT for the
+  // whole batch, then PostSendScatter each reply IN ARRIVAL ORDER. Because every
+  // read is complete before any reply is sent, in-order replies are preserved
+  // trivially — no reorder buffer, no out-of-order completion handling. Anything
+  // that can't go async (miss, zero-len, oversize, prep error) falls back to the
+  // synchronous build_reply for THAT request, still emitted in arrival order.
+  if (UseUringPath()) {
+    const size_t uring_depth = std::max(UringDepth(K), K);
+    UringReader ring(static_cast<unsigned>(uring_depth));
+    if (!ring.ok()) {
+      // Ring init failed: fall through to the sync loop below (correctness-first).
+      goto sync_serve_loop;
+    }
+    {
+      // One queued reply for this completion batch, kept in strict arrival order.
+      // The client correlates replies to requests purely by SEND order on the
+      // wire (RC in-order delivery; recv slot j <-> j-th reply), so EVERY reply —
+      // sync-built or read-completed — MUST be SENT in arrival order. We therefore
+      // queue all replies first, run the io_uring read batch, then emit the whole
+      // queue in order. `read_idx>=0` means this entry's payload comes from
+      // descs[read_idx] (a deferred kRange hit); otherwise it is a fully-built
+      // synchronous Reply.
+      struct Queued {
+        size_t send_slot = 0;
+        size_t recv_slot = 0;
+        int read_idx = -1;   // >=0: index into descs (async read); -1: sync reply
+        int fd = -1;         // owned (async only); closed after the batch read
+        size_t head = 0;
+        size_t payload_len = 0;
+        Reply reply;         // used when read_idx < 0
+      };
+      std::vector<UringReader::ReadDesc> descs;
+      std::vector<Queued> queue;
+      descs.reserve(K);
+      queue.reserve(K);
+
+      while (running_ && !fail) {
+        int g = ep.WaitComp(wcs.data(), static_cast<int>(K), idle_ms);
+        if (g == 0) { idle_reclaims_.fetch_add(1, std::memory_order_relaxed); break; }
+        if (g < 0) break;  // error / Stop()'s Wake()
+        descs.clear();
+        queue.clear();
+        for (int w = 0; w < g && !fail; ++w) {
+          const ibv_wc& wc = wcs[w];
+          if (wc.status != IBV_WC_SUCCESS) {
+            completion_errors_.fetch_add(1, std::memory_order_relaxed);
+            fail = true; break;
+          }
+          if (wc.opcode == IBV_WC_SEND) {
+            size_t sid = static_cast<size_t>(wc.wr_id);
+            if (sid < rearm_on_send.size() && rearm_on_send[sid] != kNoSlot) {
+              if (!post_request_recv(rearm_on_send[sid])) { fail = true; break; }
+              rearm_on_send[sid] = kNoSlot;
+            }
+            free_send.push_back(sid);
+            continue;
+          }
+          if (wc.opcode != IBV_WC_RECV || wc.byte_len < kReqPrefix) { fail = true; break; }
+          completions_.fetch_add(1, std::memory_order_relaxed);  // a request RECV
+          size_t r = static_cast<size_t>(wc.wr_id);
+          ReqFields rq;
+          if (!DecodeReq(ep.rbuf(r), &rq)) { fail = true; break; }
+          if (free_send.empty()) { fail = true; break; }
+          size_t s = free_send.back(); free_send.pop_back();
+
+          Queued qd;
+          qd.send_slot = s;
+          qd.recv_slot = r;
+
+          // Defer a kRange GET hit's disk read to the io_uring batch below; reply
+          // after the whole batch completes (the emit pass preserves arrival order).
+          bool deferred = false;
+          if (rq.op == static_cast<uint8_t>(WireOp::kRange) &&
+              ep.dbuf(r) && ep.dmr(r) &&
+              rq.length <= static_cast<uint64_t>(ValueHeader::kSize + max_msg_)) {
+            RangePrepResult pr;
+            Status pst = range_prep_handler_(rq.id, rq.index, rq.size, rq.offset,
+                                             rq.length, ep.dbuf_cap(), &pr);
+            if (pst == Status::kOk && pr.fd >= 0 && pr.payload_len != 0 &&
+                pr.aligned_len <= ep.dbuf_cap() &&
+                pr.aligned_len <= std::numeric_limits<unsigned>::max()) {
+              UringReader::ReadDesc d;
+              d.fd = pr.fd;
+              d.buf = ep.dbuf(r);
+              d.len = static_cast<unsigned>(pr.aligned_len);
+              d.off = pr.aligned_off;
+              qd.read_idx = static_cast<int>(descs.size());
+              descs.push_back(d);
+              qd.fd = pr.fd;
+              qd.head = pr.head;
+              qd.payload_len = pr.payload_len;
+              deferred = true;
+            } else if (pst == Status::kOk && pr.fd >= 0) {
+              ::close(pr.fd);  // zero-len / oversize: handled by sync build below
+            }
+          }
+
+          if (!deferred) {
+            // Synchronous build for this request (non-range, or range miss / zero /
+            // oversize / prep miss). Consumes rbuf/dbuf[r]. Queued, not sent yet.
+            if (!build_reply(s, r, rq, wc.byte_len, &qd.reply)) { fail = true; break; }
+          }
+          queue.push_back(qd);
+        }
+        if (fail) break;
+
+        // Submit + wait for ALL deferred reads in this batch (QD>1 concurrency).
+        // If the batch infrastructure fails, fall back to a synchronous pread per
+        // deferred request in the emit pass below (correctness-first).
+        bool batch_ok = true;
+        if (!descs.empty())
+          batch_ok = ring.BatchRead(descs.data(), static_cast<int>(descs.size()));
+
+        // Emit every reply in STRICT arrival order (every read is now complete,
+        // so an async reply never trails a later request's reply).
+        for (size_t i = 0; i < queue.size() && !fail; ++i) {
+          Queued& qd = queue[i];
+          if (qd.read_idx < 0) {
+            // Sync-built reply: rearm recv (or defer to SEND), then SEND in order.
+            Reply& reply = qd.reply;
+            if (reply.defer_recv_rearm) {
+              rearm_on_send[qd.send_slot] = reply.recv_slot;
+            } else if (!post_request_recv(qd.recv_slot)) {
+              fail = true; break;
+            }
+            bool sent = reply.scatter
+                            ? ep.PostSendScatter(qd.send_slot, reply.first_len,
+                                                 reply.payload, reply.payload_len,
+                                                 reply.payload_mr)
+                            : ep.PostSend(qd.send_slot, reply.first_len);
+            if (!sent) { fail = true; break; }
+            continue;
+          }
+          // Deferred async read: validate result (or sync fallback), then SEND.
+          UringReader::ReadDesc& d = descs[qd.read_idx];
+          bool ok;
+          if (batch_ok) {
+            long res = d.result;
+            ok = res >= 0 && static_cast<size_t>(res) >= qd.head + qd.payload_len;
+          } else {
+            ssize_t got = ::pread(qd.fd, d.buf, d.len, static_cast<off_t>(d.off));
+            ok = got >= 0 && static_cast<size_t>(got) >= qd.head + qd.payload_len;
+          }
+          if (qd.fd >= 0) { ::close(qd.fd); qd.fd = -1; }
+          if (range_complete_handler_)
+            range_complete_handler_(ok, ok ? qd.payload_len : 0);
+          char* sb = ep.sbuf(qd.send_slot);
+          if (ok) {
+            EncodeResp(sb, Status::kOk, qd.payload_len);
+            const char* out_data = ep.dbuf(qd.recv_slot) + qd.head;
+            // Defer recv rearm until this scatter SEND completes (read target reuse).
+            rearm_on_send[qd.send_slot] = qd.recv_slot;
+            if (!ep.PostSendScatter(qd.send_slot, kRespPrefix, out_data,
+                                    qd.payload_len, ep.dmr(qd.recv_slot))) {
+              fail = true; break;
+            }
+          } else {
+            EncodeResp(sb, Status::kIOError, 0);
+            if (!post_request_recv(qd.recv_slot)) { fail = true; break; }
+            if (!ep.PostSend(qd.send_slot, kRespPrefix)) { fail = true; break; }
+          }
+        }
+      }
+
+      // Connection ending: close any fds still owned by un-emitted queue entries.
+      for (auto& qd : queue) if (qd.fd >= 0) ::close(qd.fd);
+    }
+    active_conns_.fetch_sub(1, std::memory_order_relaxed);
+    { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
+    return;
+  }
+sync_serve_loop:;
+#endif  // DFKV_WITH_URING
+
   while (running_ && !fail) {
     int g = ep.WaitComp(wcs.data(), static_cast<int>(K), idle_ms);
     if (g == 0) { idle_reclaims_.fetch_add(1, std::memory_order_relaxed); break; }  // idle -> reclaim

--- a/src/rdma_server.h
+++ b/src/rdma_server.h
@@ -48,12 +48,43 @@ class RdmaServer {
       uint64_t id, uint32_t index, uint32_t ksize, char* data, size_t len,
       size_t cap)>;
 
+  // Optional async-GET prep handler (ADDITIVE, used only by the io_uring serve
+  // path when DFKV_SERVER_URING=1). Does the cheap, lock-protected half of a
+  // direct GET — index lookup, O_DIRECT open, range clamp + O_DIRECT alignment
+  // math — but performs NO disk read. The serve loop issues the pread itself via
+  // io_uring, then trims [head, head+payload_len) out of the aligned buffer. On
+  // kOk the serve loop OWNS `fd` and must ::close it after the read completes.
+  // payload_len==0 with fd<0 is a valid zero-length hit (no read needed).
+  struct RangePrepResult {
+    int fd = -1;               // owned by serve loop on kOk; -1 => no read
+    uint64_t aligned_off = 0;  // O_DIRECT-aligned read start
+    size_t aligned_len = 0;    // O_DIRECT-aligned read length (multiple of 4096)
+    size_t head = 0;           // offset of the requested bytes within the read
+    size_t payload_len = 0;    // exact requested bytes (post file-size clamp)
+  };
+  using RangePrepHandler = std::function<Status(
+      uint64_t id, uint32_t index, uint32_t ksize, uint64_t offset,
+      uint64_t length, size_t io_cap, RangePrepResult* out)>;
+  // Optional accounting hook invoked once an async read completes (mirrors the
+  // hit/io-error counters the synchronous RangeDirect bumps).
+  using RangeCompleteHandler = std::function<void(bool ok, size_t bytes_read)>;
+
   // dev_name empty => env DFKV_RDMA_DEV, else first device.
   explicit RdmaServer(Handler handler, size_t max_msg = (64u << 20),
                       const std::string& dev_name = "");
   void set_range_handler(RangeHandler h) { range_handler_ = std::move(h); }
   void set_cache_direct_handler(CacheDirectHandler h) {
     cache_direct_handler_ = std::move(h);
+  }
+  // Wire the async-GET prep + completion accounting hooks. Optional: the io_uring
+  // serve path is used only when BOTH are set, the binary is built with
+  // DFKV_WITH_URING, AND env DFKV_SERVER_URING=1. Otherwise the serve loop uses
+  // the existing synchronous path verbatim (zero behavior change).
+  void set_range_prep_handler(RangePrepHandler h) {
+    range_prep_handler_ = std::move(h);
+  }
+  void set_range_complete_handler(RangeCompleteHandler h) {
+    range_complete_handler_ = std::move(h);
   }
   ~RdmaServer();
 
@@ -77,6 +108,10 @@ class RdmaServer {
   void AcceptLoop();
   void Serve(int boot_fd);
   void ReapDoneLocked();  // join+erase finished Serve threads; conn_mu_ held
+  // Whether the io_uring async-GET serve path should be used for new conns. True
+  // only when built with DFKV_WITH_URING, env DFKV_SERVER_URING=1, and both the
+  // range prep + complete handlers are set. Decided once per connection.
+  bool UseUringPath() const;
 
   // A live connection: its Serve thread plus a flag the thread sets (last thing
   // it does) so AcceptLoop can tell it has finished and join it without blocking.
@@ -90,6 +125,8 @@ class RdmaServer {
   Handler handler_;
   RangeHandler range_handler_;
   CacheDirectHandler cache_direct_handler_;
+  RangePrepHandler range_prep_handler_;
+  RangeCompleteHandler range_complete_handler_;
   size_t max_msg_;
   size_t control_cap_;
   std::string dev_name_;

--- a/src/rdma_transport.cc
+++ b/src/rdma_transport.cc
@@ -560,4 +560,189 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
   return res;
 }
 
+std::vector<Status> RdmaTransport::CacheFromMulti(
+    const std::string& node, const std::vector<CacheSrcMulti>& srcs) {
+  const size_t n = srcs.size();
+  std::vector<Status> res(n, Status::kIOError);
+  if (n == 0) return res;
+  // Validate: header fits the control buffer, total payload fits one message, and
+  // the segment count fits one work request (1 header SGE + segs). Like CacheFrom,
+  // do not silently fall back — this is the zero-copy SG PUT route.
+  bool from_pool = false;
+  Conn* c = Acquire(node, &from_pool);
+  if (!c) return res;
+  rdma::RcEndpoint& ep = c->ep;
+  const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
+  for (const auto& s : srcs) {
+    size_t total = 0;
+    for (const auto& p : s.payloads) total += p.second;
+    if (s.header_len > control_cap_ - kReqPrefix || total > max_payload_ ||
+        s.payloads.size() > max_payload_segs) {
+      Release(node, c);
+      std::fill(res.begin(), res.end(), Status::kInvalid);
+      return res;
+    }
+  }
+
+  const size_t W = ep.depth();
+  bool conn_ok = true;
+  for (size_t base = 0; base < n && conn_ok; base += W) {
+    const size_t w = std::min(W, n - base);
+    // Register every payload segment of every key in this window (cached MR lookup).
+    // mrs_per[j] holds the per-segment MRs for slot j. Any failure => give the conn
+    // back; Cache is idempotent so re-sending earlier windows on retry is harmless.
+    std::vector<std::vector<ibv_mr*>> mrs_per(w);
+    bool regok = true;
+    for (size_t j = 0; j < w && regok; ++j) {
+      const CacheSrcMulti& s = srcs[base + j];
+      mrs_per[j].assign(s.payloads.size(), nullptr);
+      for (size_t e = 0; e < s.payloads.size() && regok; ++e) {
+        if (s.payloads[e].second == 0) continue;  // empty segment: lkey 0, no MR
+        mrs_per[j][e] = ep.RegisterUser(const_cast<void*>(s.payloads[e].first),
+                                        s.payloads[e].second);
+        if (!mrs_per[j][e]) regok = false;
+      }
+    }
+    if (!regok) { Release(node, c); return res; }
+    for (size_t j = 0; j < w && conn_ok; ++j) {
+      const CacheSrcMulti& s = srcs[base + j];
+      size_t total = 0;
+      std::vector<std::pair<const void*, uint32_t>> segs;
+      segs.reserve(s.payloads.size());
+      for (const auto& p : s.payloads) {
+        segs.emplace_back(p.first, static_cast<uint32_t>(p.second));
+        total += p.second;
+      }
+      // Wire payload_len = header_len + total user payload (the full stored blob).
+      EncodeReq(ep.sbuf(j), WireOp::kCache, s.key, 0, 0, s.header_len + total);
+      if (s.header_len) std::memcpy(ep.sbuf(j) + kReqPrefix, s.header, s.header_len);
+      if (!ep.PostRecv(j)) { conn_ok = false; break; }
+      if (!ep.PostSendScatterMulti(j, kReqPrefix + s.header_len, segs, mrs_per[j])) {
+        conn_ok = false; break;
+      }
+    }
+    if (!conn_ok) break;
+    std::vector<ibv_wc> wcs(2 * w);
+    std::vector<uint32_t> rbytes(w, 0);
+    int need = static_cast<int>(2 * w);
+    while (need > 0) {
+      int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w));
+      if (g <= 0) { conn_ok = false; break; }
+      for (int i = 0; i < g; ++i) {
+        if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
+        if (wcs[i].opcode == IBV_WC_RECV) rbytes[static_cast<size_t>(wcs[i].wr_id)] = wcs[i].byte_len;
+        --need;
+      }
+      if (!conn_ok) break;
+    }
+    if (!conn_ok) break;
+    for (size_t j = 0; j < w; ++j) {
+      Status st; uint64_t dl = 0;
+      if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
+    }
+  }
+  if (conn_ok) Release(node, c); else Destroy(c);
+  return res;
+}
+
+std::vector<Status> RdmaTransport::RangeIntoMulti(
+    const std::string& node, const std::vector<BlockKey>& keys,
+    const std::vector<RangeDstMulti>& dsts, size_t header_size,
+    std::vector<std::string>* hdrs, std::vector<size_t>* out_lens) {
+  const size_t n = keys.size();
+  hdrs->assign(n, std::string());
+  if (out_lens) out_lens->assign(n, 0);
+  std::vector<Status> res(n, Status::kIOError);
+  if (n == 0) return res;
+  const size_t hdr_bytes = kRespPrefix + header_size;  // resp prefix + value header
+  if (hdr_bytes > control_cap_) {
+    std::fill(res.begin(), res.end(), Status::kInvalid);
+    return res;
+  }
+  bool from_pool = false;
+  Conn* c = Acquire(node, &from_pool);
+  if (!c) return res;
+  rdma::RcEndpoint& ep = c->ep;
+  const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
+  for (const auto& d : dsts) {
+    size_t cap = 0;
+    for (const auto& p : d.payloads) cap += p.second;
+    if (cap > max_payload_ || d.payloads.size() > max_payload_segs) {
+      Release(node, c);
+      std::fill(res.begin(), res.end(), Status::kInvalid);
+      return res;
+    }
+  }
+
+  const size_t W = ep.depth();
+  bool conn_ok = true;
+  for (size_t base = 0; base < n && conn_ok; base += W) {
+    const size_t w = std::min(W, n - base);
+    // Register every destination segment of every key in this window.
+    std::vector<std::vector<ibv_mr*>> mrs_per(w);
+    std::vector<size_t> caps(w, 0);
+    bool regok = true;
+    for (size_t j = 0; j < w && regok; ++j) {
+      const RangeDstMulti& d = dsts[base + j];
+      mrs_per[j].assign(d.payloads.size(), nullptr);
+      for (size_t e = 0; e < d.payloads.size() && regok; ++e) {
+        caps[j] += d.payloads[e].second;
+        if (d.payloads[e].second == 0) continue;
+        mrs_per[j][e] = ep.RegisterUser(d.payloads[e].first, d.payloads[e].second);
+        if (!mrs_per[j][e]) regok = false;
+      }
+    }
+    if (!regok) { Release(node, c); return res; }
+    for (size_t j = 0; j < w && conn_ok; ++j) {
+      const RangeDstMulti& d = dsts[base + j];
+      bool armed;
+      if (caps[j]) {
+        std::vector<std::pair<void*, uint32_t>> segs;
+        segs.reserve(d.payloads.size());
+        for (const auto& p : d.payloads)
+          segs.emplace_back(p.first, static_cast<uint32_t>(p.second));
+        armed = ep.PostRecvScatterMulti(j, segs, mrs_per[j], hdr_bytes);
+      } else {
+        armed = ep.PostRecv(j);  // header-only reply
+      }
+      if (!armed) { conn_ok = false; break; }
+      EncodeReq(ep.sbuf(j), WireOp::kRange, keys[base + j], 0, header_size + caps[j], 0);
+      if (!ep.PostSend(j, kReqPrefix)) { conn_ok = false; break; }
+    }
+    if (!conn_ok) break;
+    std::vector<ibv_wc> wcs(2 * w);
+    std::vector<uint32_t> rbytes(w, 0);
+    int need = static_cast<int>(2 * w);
+    while (need > 0) {
+      int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w));
+      if (g <= 0) { conn_ok = false; break; }
+      for (int i = 0; i < g; ++i) {
+        if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
+        if (wcs[i].opcode == IBV_WC_RECV) rbytes[static_cast<size_t>(wcs[i].wr_id)] = wcs[i].byte_len;
+        --need;
+      }
+      if (!conn_ok) break;
+    }
+    if (!conn_ok) break;
+    for (size_t j = 0; j < w; ++j) {
+      uint32_t rb = rbytes[j];
+      if (rb < kRespPrefix) continue;
+      Status st; uint64_t dl = 0;
+      if (!DecodeResp(ep.rbuf(j), &st, &dl)) continue;
+      res[base + j] = st;  // payload (if any) already scattered into dsts[].payloads
+      if (st == Status::kOk) {
+        if (rb >= hdr_bytes) {
+          (*hdrs)[base + j].assign(ep.rbuf(j) + kRespPrefix, header_size);
+          // True stored payload bytes received = rb - resp-prefix - value header.
+          if (out_lens) (*out_lens)[base + j] = rb - hdr_bytes;
+        } else {
+          res[base + j] = Status::kIOError;
+        }
+      }
+    }
+  }
+  if (conn_ok) Release(node, c); else Destroy(c);
+  return res;
+}
+
 }  // namespace dfkv

--- a/src/rdma_transport.cc
+++ b/src/rdma_transport.cc
@@ -573,14 +573,18 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   if (!c) return res;
   rdma::RcEndpoint& ep = c->ep;
   const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
-  for (const auto& s : srcs) {
+  // Per-item validation: an oversized key must fail ONLY itself (kInvalid), not
+  // poison its node batch. The connector treats per-key kInvalid as a save miss
+  // (fail-soft recompute), so we mark offenders and skip them in the window below.
+  std::vector<char> bad(n, 0);
+  for (size_t i = 0; i < n; ++i) {
+    const auto& s = srcs[i];
     size_t total = 0;
     for (const auto& p : s.payloads) total += p.second;
     if (s.header_len > control_cap_ - kReqPrefix || total > max_payload_ ||
         s.payloads.size() > max_payload_segs) {
-      Release(node, c);
-      std::fill(res.begin(), res.end(), Status::kInvalid);
-      return res;
+      bad[i] = 1;
+      res[i] = Status::kInvalid;
     }
   }
 
@@ -591,9 +595,12 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     // Register every payload segment of every key in this window (cached MR lookup).
     // mrs_per[j] holds the per-segment MRs for slot j. Any failure => give the conn
     // back; Cache is idempotent so re-sending earlier windows on retry is harmless.
+    // Oversized slots (bad[base+j]) are skipped: no MR, no recv/send, and they do
+    // not consume a completion (need is sized to the posted slots only).
     std::vector<std::vector<ibv_mr*>> mrs_per(w);
     bool regok = true;
     for (size_t j = 0; j < w && regok; ++j) {
+      if (bad[base + j]) continue;
       const CacheSrcMulti& s = srcs[base + j];
       mrs_per[j].assign(s.payloads.size(), nullptr);
       for (size_t e = 0; e < s.payloads.size() && regok; ++e) {
@@ -604,7 +611,9 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       }
     }
     if (!regok) { Release(node, c); return res; }
+    size_t posted = 0;
     for (size_t j = 0; j < w && conn_ok; ++j) {
+      if (bad[base + j]) continue;
       const CacheSrcMulti& s = srcs[base + j];
       size_t total = 0;
       std::vector<std::pair<const void*, uint32_t>> segs;
@@ -620,11 +629,13 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       if (!ep.PostSendScatterMulti(j, kReqPrefix + s.header_len, segs, mrs_per[j])) {
         conn_ok = false; break;
       }
+      ++posted;
     }
     if (!conn_ok) break;
+    if (posted == 0) continue;  // whole window was oversized: nothing to reap
     std::vector<ibv_wc> wcs(2 * w);
     std::vector<uint32_t> rbytes(w, 0);
-    int need = static_cast<int>(2 * w);
+    int need = static_cast<int>(2 * posted);
     while (need > 0) {
       int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w));
       if (g <= 0) { conn_ok = false; break; }
@@ -664,13 +675,15 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
   if (!c) return res;
   rdma::RcEndpoint& ep = c->ep;
   const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
-  for (const auto& d : dsts) {
+  // Per-item validation: an oversized destination must fail ONLY itself (kInvalid),
+  // not poison its node batch. Offenders are marked and skipped in the window below.
+  std::vector<char> bad(n, 0);
+  for (size_t i = 0; i < n; ++i) {
     size_t cap = 0;
-    for (const auto& p : d.payloads) cap += p.second;
-    if (cap > max_payload_ || d.payloads.size() > max_payload_segs) {
-      Release(node, c);
-      std::fill(res.begin(), res.end(), Status::kInvalid);
-      return res;
+    for (const auto& p : dsts[i].payloads) cap += p.second;
+    if (cap > max_payload_ || dsts[i].payloads.size() > max_payload_segs) {
+      bad[i] = 1;
+      res[i] = Status::kInvalid;
     }
   }
 
@@ -678,11 +691,13 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
   bool conn_ok = true;
   for (size_t base = 0; base < n && conn_ok; base += W) {
     const size_t w = std::min(W, n - base);
-    // Register every destination segment of every key in this window.
+    // Register every destination segment of every key in this window. Oversized
+    // slots (bad[base+j]) are skipped: no MR, no recv/send, no completion consumed.
     std::vector<std::vector<ibv_mr*>> mrs_per(w);
     std::vector<size_t> caps(w, 0);
     bool regok = true;
     for (size_t j = 0; j < w && regok; ++j) {
+      if (bad[base + j]) continue;
       const RangeDstMulti& d = dsts[base + j];
       mrs_per[j].assign(d.payloads.size(), nullptr);
       for (size_t e = 0; e < d.payloads.size() && regok; ++e) {
@@ -693,7 +708,9 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       }
     }
     if (!regok) { Release(node, c); return res; }
+    size_t posted = 0;
     for (size_t j = 0; j < w && conn_ok; ++j) {
+      if (bad[base + j]) continue;
       const RangeDstMulti& d = dsts[base + j];
       bool armed;
       if (caps[j]) {
@@ -708,11 +725,13 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       if (!armed) { conn_ok = false; break; }
       EncodeReq(ep.sbuf(j), WireOp::kRange, keys[base + j], 0, header_size + caps[j], 0);
       if (!ep.PostSend(j, kReqPrefix)) { conn_ok = false; break; }
+      ++posted;
     }
     if (!conn_ok) break;
+    if (posted == 0) continue;  // whole window was oversized: nothing to reap
     std::vector<ibv_wc> wcs(2 * w);
     std::vector<uint32_t> rbytes(w, 0);
-    int need = static_cast<int>(2 * w);
+    int need = static_cast<int>(2 * posted);
     while (need > 0) {
       int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w));
       if (g <= 0) { conn_ok = false; break; }

--- a/src/rdma_transport.h
+++ b/src/rdma_transport.h
@@ -61,6 +61,16 @@ class RdmaTransport : public Transport {
                                 const std::vector<RangeDst>& dsts,
                                 size_t header_size,
                                 std::vector<std::string>* hdrs) override;
+  // Scatter-gather overrides: one wire SEND/RECV gathers/scatters N payload
+  // segments per key via multi-SGE work requests (additive zero-copy datapath
+  // for dfkv_batch_put_sg / dfkv_batch_get_auto_sg).
+  std::vector<Status> CacheFromMulti(
+      const std::string& node,
+      const std::vector<CacheSrcMulti>& srcs) override;
+  std::vector<Status> RangeIntoMulti(
+      const std::string& node, const std::vector<BlockKey>& keys,
+      const std::vector<RangeDstMulti>& dsts, size_t header_size,
+      std::vector<std::string>* hdrs, std::vector<size_t>* out_lens) override;
 
  private:
   struct Conn;

--- a/src/rdma_verbs.cc
+++ b/src/rdma_verbs.cc
@@ -146,11 +146,27 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib
   if (!cq_) { Close(); return false; }
   if (ibv_req_notify_cq(cq_, 0) != 0) { Close(); return false; }
 
+  // Negotiate scatter-gather width: min(kMaxSge, device cap). SGE0 is always the
+  // header; the rest carry payload segments for the scatter-gather datapath. The
+  // legacy [hdr | payload] path only ever uses 2, so raising the cap is additive.
+  max_sge_ = 2;
+  {
+    ibv_device_attr dev_attr{};
+    if (ibv_query_device(ctx_, &dev_attr) == 0 && dev_attr.max_sge > 0) {
+      size_t cap_sge = static_cast<size_t>(dev_attr.max_sge);
+      max_sge_ = std::min(kMaxSge, cap_sge);
+      if (max_sge_ < 2) max_sge_ = 2;
+    } else {
+      max_sge_ = kMaxSge;  // query failed: trust the documented device cap
+    }
+  }
+
   ibv_qp_init_attr qa{};
   qa.send_cq = cq_; qa.recv_cq = cq_;
   qa.cap.max_send_wr = static_cast<uint32_t>(depth_ + 1);
   qa.cap.max_recv_wr = static_cast<uint32_t>(depth_ + 1);
-  qa.cap.max_send_sge = 2; qa.cap.max_recv_sge = 2;  // both may scatter [hdr | payload]
+  qa.cap.max_send_sge = static_cast<uint32_t>(max_sge_);  // SGE0=hdr, rest=payload segs
+  qa.cap.max_recv_sge = static_cast<uint32_t>(max_sge_);
   qa.qp_type = IBV_QPT_RC;
   qa.sq_sig_all = 1;
   qp_ = ibv_create_qp(pd_, &qa);
@@ -374,6 +390,55 @@ bool RcEndpoint::PostRecvScatter(size_t slot, void* payload, size_t payload_len,
   sge[1].lkey = payload_mr->lkey;
   ibv_recv_wr wr{}, *bad = nullptr;
   wr.wr_id = slot; wr.sg_list = sge; wr.num_sge = 2;
+  return ibv_post_recv(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostSendScatterMulti(
+    size_t slot, size_t hdr_len,
+    const std::vector<std::pair<const void*, uint32_t>>& segs,
+    const std::vector<ibv_mr*>& mrs) {
+  // SGE0 = header from sbuf_[slot]; SGE[1..] = one payload segment each. Bail if
+  // the segment count would exceed the QP's negotiated max_send_sge.
+  if (segs.size() != mrs.size()) return false;
+  if (1 + segs.size() > max_sge_) return false;
+  std::vector<ibv_sge> sge(1 + segs.size());
+  sge[0].addr = reinterpret_cast<uintptr_t>(sbuf_[slot]);
+  sge[0].length = static_cast<uint32_t>(hdr_len);
+  sge[0].lkey = smr_[slot]->lkey;
+  for (size_t i = 0; i < segs.size(); ++i) {
+    if (segs[i].second && !mrs[i]) return false;  // non-empty seg needs an MR
+    sge[1 + i].addr = reinterpret_cast<uintptr_t>(segs[i].first);
+    sge[1 + i].length = segs[i].second;
+    sge[1 + i].lkey = segs[i].second ? mrs[i]->lkey : 0;
+  }
+  ibv_send_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot; wr.sg_list = sge.data();
+  wr.num_sge = static_cast<int>(sge.size());
+  wr.opcode = IBV_WR_SEND; wr.send_flags = IBV_SEND_SIGNALED;
+  return ibv_post_send(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostRecvScatterMulti(
+    size_t slot, const std::vector<std::pair<void*, uint32_t>>& segs,
+    const std::vector<ibv_mr*>& mrs, size_t hdr_bytes) {
+  // SGE0 = header into rbuf_[slot]; SGE[1..] = one destination segment each. The
+  // NIC fills SGEs in order, so the concatenated reply payload scatters across the
+  // segments honoring each segment's length (no client-side split copy).
+  if (segs.size() != mrs.size()) return false;
+  if (1 + segs.size() > max_sge_) return false;
+  std::vector<ibv_sge> sge(1 + segs.size());
+  sge[0].addr = reinterpret_cast<uintptr_t>(rbuf_[slot]);
+  sge[0].length = static_cast<uint32_t>(hdr_bytes);
+  sge[0].lkey = rmr_[slot]->lkey;
+  for (size_t i = 0; i < segs.size(); ++i) {
+    if (segs[i].second && !mrs[i]) return false;
+    sge[1 + i].addr = reinterpret_cast<uintptr_t>(segs[i].first);
+    sge[1 + i].length = segs[i].second;
+    sge[1 + i].lkey = segs[i].second ? mrs[i]->lkey : 0;
+  }
+  ibv_recv_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot; wr.sg_list = sge.data();
+  wr.num_sge = static_cast<int>(sge.size());
   return ibv_post_recv(qp_, &wr, &bad) == 0;
 }
 

--- a/src/rdma_verbs.h
+++ b/src/rdma_verbs.h
@@ -44,6 +44,11 @@ QpInfo ParseQpInfo(const char in[kQpInfoBytes]);
 // Fixed-size device-name field the client sends first in the bootstrap so the
 // server opens its QP on the matching device (same rail) for multi-rail setups.
 constexpr size_t kDevNameBytes = 32;
+// Target QP scatter-gather entries. SGE0 is the header (req/resp prefix + value
+// header); the remaining kMaxSge-1 carry payload segments, so a scatter-gather
+// key may hold up to kMaxSge-1 (=29) non-contiguous buffers. Open() clamps this
+// to the device's reported max_sge (ConnectX-* on hd04 reports 30).
+constexpr size_t kMaxSge = 30;
 // Alignment used for server-side O_DIRECT read buffers. NVMe/xfs are happy with
 // 4096, and it is a safe superset for 512-byte logical-sector devices.
 constexpr size_t kDirectIoAlign = 4096;
@@ -109,6 +114,28 @@ class RcEndpoint {
   bool PostSendScatter(size_t slot, size_t hdr_len, const void* payload,
                        size_t payload_len, ibv_mr* payload_mr);
 
+  // Multi-segment scatter/gather (one wire SEND/RECV gathers/scatters N payload
+  // segments, in addition to the header SGE). Used by the additive scatter-gather
+  // API (dfkv_batch_put_sg / dfkv_batch_get_auto_sg) so one dfkv key coalesces N
+  // non-contiguous caller buffers without a client concat copy. Each segment must
+  // belong to its corresponding MR (from RegisterUser / pool MR). num_sge =
+  // 1 + segs.size(), which must be <= the QP's max_send_sge/max_recv_sge.
+  // PostSendScatterMulti: SGE0 = sbuf_[slot][0,hdr_len), then one SGE per segment.
+  bool PostSendScatterMulti(
+      size_t slot, size_t hdr_len,
+      const std::vector<std::pair<const void*, uint32_t>>& segs,
+      const std::vector<ibv_mr*>& mrs);
+  // PostRecvScatterMulti: SGE0 = rbuf_[slot][0,hdr_bytes), then one SGE per
+  // destination segment (the NIC scatters the concatenated reply payload across
+  // the segments in order, honoring each segment's length).
+  bool PostRecvScatterMulti(
+      size_t slot, const std::vector<std::pair<void*, uint32_t>>& segs,
+      const std::vector<ibv_mr*>& mrs, size_t hdr_bytes);
+
+  // QP scatter-gather capability negotiated in Open() = min(kMaxSge, device cap).
+  // The SG datapath caps payload segments at max_sge()-1 (SGE0 is the header).
+  size_t max_sge() const { return max_sge_; }
+
   // Block until at least one completion, drain up to `max` into out[]; returns
   // the count (>0), or <0 on error / when Wake() is called. wr_id of each wc =
   // the slot. Used for single round-trips (max=1) and pipelined batches.
@@ -136,6 +163,7 @@ class RcEndpoint {
   unsigned cq_armed_unacked_ = 0;
 
   size_t cap_ = 0, depth_ = 0, dbuf_cap_ = 0;
+  size_t max_sge_ = 2;  // QP max_send_sge/max_recv_sge = min(kMaxSge, device cap)
   std::vector<char*> sbuf_, rbuf_, dbuf_;
   std::vector<ibv_mr*> smr_, rmr_, dmr_;
   // Big pre-registered caller regions (the host KV pool). Registered once at

--- a/src/transport.h
+++ b/src/transport.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "kv_store.h"   // Status
@@ -27,6 +28,23 @@ struct CacheSrc {
   BlockKey key;
   const void* header; size_t header_len;
   const void* payload; size_t payload_len;
+};
+
+// Scatter-gather write source: one dfkv key whose stored payload is the in-order
+// concatenation of N non-contiguous caller buffers. The transport gathers
+// [header | payload[0] | payload[1] | ...] on the wire via a multi-SGE RDMA SEND
+// without a client-side concat copy. All buffers must outlive the CacheFromMulti
+// call and stay unmodified until it returns. payload_len = sum of segment sizes.
+struct CacheSrcMulti {
+  BlockKey key;
+  const void* header; size_t header_len;
+  std::vector<std::pair<const void*, size_t>> payloads;  // (ptr, size) in order
+};
+// Scatter-gather read target: the stored payload (one concatenated blob) is
+// scattered across N caller buffers in order, each receiving its own size worth
+// of bytes (RDMA multi-SGE RECV). The destination capacity = sum of segment sizes.
+struct RangeDstMulti {
+  std::vector<std::pair<void*, size_t>> payloads;  // (ptr, size) in order
 };
 
 class Transport {
@@ -148,6 +166,70 @@ class Transport {
       items.push_back(CacheItem{srcs[i].key, bufs[i].data(), bufs[i].size()});
     }
     return CacheMany(node, items);
+  }
+
+  // Scatter-gather write: each key's payload is the concatenation of N caller
+  // segments. Default: concatenate the segments into a single CacheSrc and route
+  // through CacheFrom (no payload zero-copy, but correct on any transport). The
+  // RDMA transport overrides this to gather the segments via a multi-SGE SEND.
+  virtual std::vector<Status> CacheFromMulti(
+      const std::string& node, const std::vector<CacheSrcMulti>& srcs) {
+    std::vector<std::vector<char>> bufs(srcs.size());
+    std::vector<CacheSrc> flat;
+    flat.reserve(srcs.size());
+    for (size_t i = 0; i < srcs.size(); ++i) {
+      size_t total = 0;
+      for (const auto& p : srcs[i].payloads) total += p.second;
+      bufs[i].resize(total);
+      size_t off = 0;
+      for (const auto& p : srcs[i].payloads) {
+        if (p.second) std::memcpy(bufs[i].data() + off, p.first, p.second);
+        off += p.second;
+      }
+      flat.push_back(CacheSrc{srcs[i].key, srcs[i].header, srcs[i].header_len,
+                              bufs[i].data(), total});
+    }
+    return CacheFrom(node, flat);
+  }
+
+  // Scatter-gather read: the stored payload is split across each key's N caller
+  // segments in order. Default: RangeInto a single contiguous scratch buffer, then
+  // split-copy it into the caller segments by their sizes (no zero-copy, but
+  // correct on any transport). out_lens[i] (if non-null) = total payload bytes for
+  // key[i] (0 on miss). The RDMA transport overrides this to scatter via multi-SGE
+  // RECV directly into the caller segments. hdrs[i] gets the value-header bytes.
+  virtual std::vector<Status> RangeIntoMulti(
+      const std::string& node, const std::vector<BlockKey>& keys,
+      const std::vector<RangeDstMulti>& dsts, size_t header_size,
+      std::vector<std::string>* hdrs, std::vector<size_t>* out_lens) {
+    const size_t n = keys.size();
+    hdrs->assign(n, std::string());
+    if (out_lens) out_lens->assign(n, 0);
+    // Concatenate each key's segments into one contiguous scratch RangeDst, run
+    // the existing RangeInto, then split the scratch back into the segments.
+    std::vector<std::vector<char>> scratch(n);
+    std::vector<RangeDst> flat(n);
+    for (size_t i = 0; i < n; ++i) {
+      size_t cap = 0;
+      for (const auto& p : dsts[i].payloads) cap += p.second;
+      scratch[i].resize(cap);
+      flat[i] = RangeDst{cap ? scratch[i].data() : nullptr, cap};
+    }
+    std::vector<Status> r = RangeInto(node, keys, flat, header_size, hdrs);
+    for (size_t i = 0; i < n; ++i) {
+      if (r[i] != Status::kOk || (*hdrs)[i].size() < header_size) continue;
+      // The stored payload length is carried by the value header; the caller
+      // (KVClient) verifies geometry. Here we split exactly the bytes we received
+      // across the segments. The RangeInto fallback copied min(stored, cap) bytes
+      // into scratch; replay that across the segments honoring each segment size.
+      size_t off = 0;
+      for (const auto& p : dsts[i].payloads) {
+        if (p.second) std::memcpy(p.first, scratch[i].data() + off, p.second);
+        off += p.second;
+      }
+      if (out_lens) (*out_lens)[i] = off;
+    }
+    return r;
   }
 };
 

--- a/src/transport.h
+++ b/src/transport.h
@@ -4,6 +4,7 @@
 #ifndef DFKV_TRANSPORT_H_
 #define DFKV_TRANSPORT_H_
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <string>
@@ -12,6 +13,7 @@
 
 #include "kv_store.h"   // Status
 #include "kv_types.h"
+#include "value_header.h"  // ValueHeader (for true stored-length in RangeIntoMulti)
 #include "wire.h"       // WireOp, kReqPrefix, kRespPrefix, Encode/DecodeReq/Resp
 
 namespace dfkv {
@@ -227,7 +229,17 @@ class Transport {
         if (p.second) std::memcpy(p.first, scratch[i].data() + off, p.second);
         off += p.second;
       }
-      if (out_lens) (*out_lens)[i] = off;
+      // out_lens = the TRUE received payload length (matching the RDMA override,
+      // which reports received_bytes - header), not the sum-of-caps `off`. The
+      // stored length lives in the value header; RangeInto delivered min(stored,cap).
+      if (out_lens) {
+        size_t stored = off;  // fall back to caps if the header can't be parsed
+        ValueHeader vh;
+        if (header_size >= ValueHeader::kSize &&
+            ValueHeader::Parse((*hdrs)[i].data(), (*hdrs)[i].size(), &vh))
+          stored = std::min<size_t>(vh.payload_len, off);
+        (*out_lens)[i] = stored;
+      }
     }
     return r;
   }

--- a/src/uring_reader.h
+++ b/src/uring_reader.h
@@ -23,8 +23,10 @@
 #include <liburing.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 
 namespace dfkv {
 
@@ -67,35 +69,82 @@ class UringReader {
   // failure (the caller then falls back to the synchronous path for safety).
   bool BatchRead(ReadDesc* descs, int cnt) {
     if (!ok_ || cnt <= 0) return false;
+    // Per-desc bytes already read (for short-read residual re-prep). `descs[i].result`
+    // is the FINAL byte count exposed to the caller (>=0) or -errno on hard error.
+    // done_[i] tracks accumulated progress while residuals are still in flight.
+    done_.assign(static_cast<size_t>(cnt), 0);
     int idx = 0;
     while (idx < cnt) {
-      const int batch =
-          std::min(cnt - idx, static_cast<int>(depth_));
+      const int batch = std::min(cnt - idx, static_cast<int>(depth_));
       // Use the descriptor's array index as user_data so we can map each CQE
       // back to its desc regardless of completion order.
       for (int i = 0; i < batch; ++i) {
-        struct io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
-        if (!sqe) return false;  // SQ exhausted unexpectedly (batch <= depth_)
-        ReadDesc& d = descs[idx + i];
-        io_uring_prep_read(sqe, d.fd, d.buf, d.len, d.off);
-        // Use the void* user_data API (not set_data64) so we build against
-        // liburing >= 2.0 (the _data64 variants only exist in liburing >= 2.2).
-        io_uring_sqe_set_data(
-            sqe, reinterpret_cast<void*>(static_cast<uintptr_t>(idx + i)));
+        if (!PrepRead(idx + i, descs[idx + i].buf, descs[idx + i].len,
+                      descs[idx + i].off, descs[idx + i].fd))
+          return false;  // SQ exhausted unexpectedly (batch <= depth_)
       }
-      int submitted = io_uring_submit_and_wait(&ring_, batch);
-      if (submitted < 0) return false;
-      // Reap exactly `batch` completions, routing each to its desc by user_data.
+      // Submit all `batch` SQEs and wait for at least one CQE. Two hazards:
+      //  (1) io_uring_submit_and_wait can return -EINTR after the SQEs are already
+      //      in the kernel — do NOT resubmit (that would double-queue and desync the
+      //      user_data->desc mapping); just re-enter to wait for the pending CQEs.
+      //  (2) it may accept fewer than `batch` SQEs (short submit). Any leftover SQEs
+      //      stay in the SQ ring; we must flush them with a follow-up submit rather
+      //      than leave them to be resurrected by a later residual submit. We loop
+      //      until the full batch is accepted so `outstanding == batch` holds.
+      int accepted = 0;
+      bool waited = false;
+      while (accepted < batch) {
+        int s = waited ? io_uring_submit(&ring_)
+                       : io_uring_submit_and_wait(&ring_, 1);
+        if (s < 0) {
+          if (s == -EINTR) { waited = true; continue; }  // SQEs already queued
+          // Submit can't make progress and leftover SQEs would linger in the SQ
+          // ring; bail so the caller falls back to a full synchronous pread pass
+          // (correctness-first) rather than risk resurrecting stale SQEs.
+          return false;
+        }
+        if (s == 0 && waited) return false;  // no forward progress: avoid spin
+        accepted += s;
+        waited = true;  // first call already armed the wait; later calls just submit
+      }
+      int outstanding = accepted;
+      // Reap `outstanding` completions, routing each to its desc by user_data. A
+      // short read (0 < res < remaining) re-preps the residual for that desc; a
+      // re-prep adds one more outstanding completion. Bound the total reaps to
+      // avoid an unbounded loop on a pathological fd.
       int reaped = 0;
-      while (reaped < batch) {
+      const int kMaxReaps = outstanding + 4 * batch;  // residuals bounded per desc
+      while (outstanding > 0) {
+        if (reaped >= kMaxReaps) return false;
         struct io_uring_cqe* cqe = nullptr;
         int w = io_uring_wait_cqe(&ring_, &cqe);
+        if (w == -EINTR) continue;  // wait interrupted: the CQE is still there
         if (w < 0 || cqe == nullptr) return false;
         const uint64_t di = static_cast<uint64_t>(
             reinterpret_cast<uintptr_t>(io_uring_cqe_get_data(cqe)));
-        if (di < static_cast<uint64_t>(cnt)) descs[di].result = cqe->res;
+        const long res = cqe->res;
         io_uring_cqe_seen(&ring_, cqe);
         ++reaped;
+        --outstanding;
+        if (di >= static_cast<uint64_t>(cnt)) continue;  // stale/foreign user_data
+        ReadDesc& d = descs[di];
+        if (res < 0) { d.result = res; continue; }            // hard error: report -errno
+        if (res == 0) { d.result = static_cast<long>(done_[di]); continue; }  // EOF
+        done_[di] += static_cast<uint64_t>(res);
+        if (done_[di] >= d.len) { d.result = static_cast<long>(done_[di]); continue; }
+        // Short read: re-prep the residual [off+done, len-done) into buf+done.
+        if (!PrepRead(static_cast<int>(di),
+                      static_cast<char*>(d.buf) + done_[di],
+                      static_cast<unsigned>(d.len - done_[di]),
+                      d.off + done_[di], d.fd))
+          return false;
+        // Submit the residual SQE. Retry on EINTR (submit does not wait, so it is
+        // safe to re-enter); bail on any other short/error so the caller falls back
+        // to a full synchronous pread pass rather than risk a stuck CQE wait.
+        int s;
+        do { s = io_uring_submit(&ring_); } while (s == -EINTR);
+        if (s < 1) return false;
+        ++outstanding;  // the residual read is now in flight
       }
       idx += batch;
     }
@@ -103,9 +152,23 @@ class UringReader {
   }
 
  private:
+  // Prep a single read SQE with user_data = desc index. Returns false only if the
+  // SQ ring is unexpectedly exhausted (the caller never queues more than depth_).
+  bool PrepRead(int desc_idx, void* buf, unsigned len, uint64_t off, int fd) {
+    struct io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+    if (!sqe) return false;
+    io_uring_prep_read(sqe, fd, buf, len, off);
+    // Use the void* user_data API (not set_data64) so we build against
+    // liburing >= 2.0 (the _data64 variants only exist in liburing >= 2.2).
+    io_uring_sqe_set_data(
+        sqe, reinterpret_cast<void*>(static_cast<uintptr_t>(desc_idx)));
+    return true;
+  }
+
   struct io_uring ring_{};
   bool ok_ = false;
   unsigned depth_ = 0;
+  std::vector<uint64_t> done_;  // per-desc bytes read so far (residual tracking)
 };
 
 }  // namespace dfkv

--- a/src/uring_reader.h
+++ b/src/uring_reader.h
@@ -1,0 +1,114 @@
+/* uring_reader — a thin, single-owner io_uring wrapper for the RDMA server's
+ * async GET (kRange) disk-read path. ADDITIVE + env-gated: only used when the
+ * server is built with -DDFKV_WITH_URING and started with DFKV_SERVER_URING=1.
+ *
+ * Design = Mooncake's batch_read pattern (uring_file.cpp) adapted to dfkv's
+ * per-WaitComp completion batch:
+ *  - One ring per connection serve loop (single owner => no locking).
+ *  - BatchRead() submits up to QUEUE_DEPTH independent O_DIRECT preads at once
+ *    (each its own fd/buffer/offset), then waits for the WHOLE batch to complete
+ *    before returning. Concurrency comes from QD>1 reads in flight; ordering is
+ *    irrelevant inside the ring because every read lands in its own buffer.
+ *  - The serve loop only PostSendScatters AFTER BatchRead() returns (all reads
+ *    done), iterating the descriptors in arrival order — so replies are strictly
+ *    in request order with no reorder buffer.
+ *
+ * Header-only and #ifdef'd on DFKV_WITH_URING so the rest of the server compiles
+ * unchanged when liburing is absent. */
+#ifndef DFKV_URING_READER_H_
+#define DFKV_URING_READER_H_
+
+#ifdef DFKV_WITH_URING
+
+#include <liburing.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace dfkv {
+
+// Single-owner io_uring read ring. Not thread-safe by design (one serve loop
+// owns one instance). QD bounds the number of reads in flight per batch.
+class UringReader {
+ public:
+  // One independent read in a batch. `result` is filled by BatchRead (>=0 bytes
+  // read, <0 = -errno) so the caller can validate each read after the batch.
+  struct ReadDesc {
+    int fd = -1;
+    void* buf = nullptr;
+    unsigned len = 0;
+    uint64_t off = 0;
+    long result = 0;  // out: cqe->res for this read
+  };
+
+  explicit UringReader(unsigned queue_depth) {
+    // Default setup flags: portable across the 5.15 kernels in the fleet.
+    int ret = io_uring_queue_init(queue_depth, &ring_, 0);
+    ok_ = (ret == 0);
+    depth_ = queue_depth;
+  }
+
+  ~UringReader() {
+    if (ok_) io_uring_queue_exit(&ring_);
+  }
+
+  UringReader(const UringReader&) = delete;
+  UringReader& operator=(const UringReader&) = delete;
+
+  bool ok() const { return ok_; }
+  unsigned depth() const { return depth_; }
+
+  // Submit up to QUEUE_DEPTH reads at a time (each at its own fd/offset/buffer),
+  // wait for the whole sub-batch, fill each desc.result, then repeat until all
+  // `cnt` descs are done. Returns true if every read was submitted+reaped (a
+  // per-read short/EOF/error is recorded in desc.result, NOT a hard failure — the
+  // caller validates each). Returns false only on a submit/wait infrastructure
+  // failure (the caller then falls back to the synchronous path for safety).
+  bool BatchRead(ReadDesc* descs, int cnt) {
+    if (!ok_ || cnt <= 0) return false;
+    int idx = 0;
+    while (idx < cnt) {
+      const int batch =
+          std::min(cnt - idx, static_cast<int>(depth_));
+      // Use the descriptor's array index as user_data so we can map each CQE
+      // back to its desc regardless of completion order.
+      for (int i = 0; i < batch; ++i) {
+        struct io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+        if (!sqe) return false;  // SQ exhausted unexpectedly (batch <= depth_)
+        ReadDesc& d = descs[idx + i];
+        io_uring_prep_read(sqe, d.fd, d.buf, d.len, d.off);
+        // Use the void* user_data API (not set_data64) so we build against
+        // liburing >= 2.0 (the _data64 variants only exist in liburing >= 2.2).
+        io_uring_sqe_set_data(
+            sqe, reinterpret_cast<void*>(static_cast<uintptr_t>(idx + i)));
+      }
+      int submitted = io_uring_submit_and_wait(&ring_, batch);
+      if (submitted < 0) return false;
+      // Reap exactly `batch` completions, routing each to its desc by user_data.
+      int reaped = 0;
+      while (reaped < batch) {
+        struct io_uring_cqe* cqe = nullptr;
+        int w = io_uring_wait_cqe(&ring_, &cqe);
+        if (w < 0 || cqe == nullptr) return false;
+        const uint64_t di = static_cast<uint64_t>(
+            reinterpret_cast<uintptr_t>(io_uring_cqe_get_data(cqe)));
+        if (di < static_cast<uint64_t>(cnt)) descs[di].result = cqe->res;
+        io_uring_cqe_seen(&ring_, cqe);
+        ++reaped;
+      }
+      idx += batch;
+    }
+    return true;
+  }
+
+ private:
+  struct io_uring ring_{};
+  bool ok_ = false;
+  unsigned depth_ = 0;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_WITH_URING
+#endif  // DFKV_URING_READER_H_

--- a/tests/c_api_test.cc
+++ b/tests/c_api_test.cc
@@ -42,6 +42,49 @@ TEST(CApiGuard, RejectsNullArraysWithPositiveN) {
   dfkv_close(c);
 }
 
+// Scatter-gather C ABI: same guard contract as the contiguous batch entrypoints
+// (null handle => -1; null arrays with n>0 => -1; n==0 => 0). A discovery-only
+// client (empty ring) makes every real route miss, so no server is needed.
+TEST(CApiGuard, ScatterGatherNullAndZero) {
+  EXPECT_EQ(dfkv_batch_put_sg(nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr), -1);
+  EXPECT_EQ(dfkv_batch_get_auto_sg(nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr, nullptr), -1);
+
+  dfkv_client_t c = OpenEmpty();
+  ASSERT_NE(c, nullptr);
+  int ok[2] = {9, 9};
+  uint64_t len[2] = {9, 9};
+  // null nested arrays with n>0 => rejected.
+  EXPECT_EQ(dfkv_batch_put_sg(c, nullptr, nullptr, nullptr, nullptr, 2, ok), -1);
+  EXPECT_EQ(dfkv_batch_get_auto_sg(c, nullptr, nullptr, nullptr, nullptr, 2, ok, len), -1);
+  // zero-length batch is a valid no-op.
+  EXPECT_EQ(dfkv_batch_put_sg(c, nullptr, nullptr, nullptr, nullptr, 0, nullptr), 0);
+  EXPECT_EQ(dfkv_batch_get_auto_sg(c, nullptr, nullptr, nullptr, nullptr, 0, nullptr, nullptr), 0);
+
+  // Well-formed call against an empty ring: every key routes nowhere => fail/miss,
+  // but the FFI unpacking must not crash on a null keys[i] element.
+  const char* keys[2] = {"k0", nullptr};
+  const char b0a[8] = {0}, b0b[8] = {0};
+  const void* p0[2] = {b0a, b0b};
+  const void** ptrs[2] = {p0, nullptr};
+  uint64_t s0[2] = {8, 8};
+  const uint64_t* sizes[2] = {s0, nullptr};
+  int num_bufs[2] = {2, 0};
+  EXPECT_EQ(dfkv_batch_put_sg(c, keys, ptrs, sizes, num_bufs, 2, ok), 0);
+  EXPECT_EQ(ok[0], 0);  // empty ring => route miss => failure (not a crash)
+  EXPECT_EQ(ok[1], 0);  // null key => skipped, reported failed
+
+  char d0a[8], d0b[8];
+  void* dp0[2] = {d0a, d0b};
+  void** dsts[2] = {dp0, nullptr};
+  uint64_t c0[2] = {8, 8};
+  const uint64_t* caps[2] = {c0, nullptr};
+  int num_dsts[2] = {2, 0};
+  EXPECT_EQ(dfkv_batch_get_auto_sg(c, keys, dsts, caps, num_dsts, 2, ok, len), 0);
+  EXPECT_EQ(ok[0], 0); EXPECT_EQ(len[0], 0u);
+  EXPECT_EQ(ok[1], 0); EXPECT_EQ(len[1], 0u);
+  dfkv_close(c);
+}
+
 TEST(CApiStats, SnapshotSizingAndContent) {
   dfkv_client_t c = OpenEmpty();
   ASSERT_NE(c, nullptr);

--- a/tests/rdma_loopback_test.cc
+++ b/tests/rdma_loopback_test.cc
@@ -470,6 +470,64 @@ TEST(RdmaLoopback, ScatterGatherRoundtripOverRdma) {
   ::unsetenv("DFKV_RDMA_DEPTH");
 }
 
+// Fix 1 regression: an oversized SG key (total payload > max_payload_, but with a
+// legal segment count so it passes the client guard) must fail ONLY itself inside
+// CacheFromMulti/RangeIntoMulti, NOT poison its node batch. Previously the up-front
+// validation std::fill'd every result kInvalid and returned; now the offender is
+// skipped in the window and its siblings on the same node proceed normally.
+TEST(RdmaLoopback, ScatterGatherOversizedFailsOnlyOffender) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ::setenv("DFKV_RDMA_DEPTH", "4", 1);
+  RdmaNode node("sgov");
+  RdmaTransport rt(kMaxMsg);  // max_payload_ = 256 KiB
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+  c.set_batch_concurrency(1);  // single node, stable on rxe loopback
+  ASSERT_TRUE(rt.pipelined());
+
+  auto fill = [](std::string& s, int seed) {
+    for (size_t b = 0; b < s.size(); ++b) s[b] = static_cast<char>((seed + b * 7) & 0xFF);
+  };
+
+  // Valid sibling A, an oversized item (2 segs * 200 KiB = 400 KiB > 256 KiB max_payload,
+  // only 2 segments so it clears the <=29-seg client guard), then valid sibling B —
+  // all routed to the same (only) node. The offender must report failure; both
+  // siblings must succeed and round-trip byte-exact.
+  std::string a0(4096, '\0'); fill(a0, 11);
+  std::string b0(8192, '\0'); fill(b0, 23);
+  std::string big0(200 * 1024, '\0'), big1(200 * 1024, '\0');
+  fill(big0, 31); fill(big1, 37);
+
+  std::vector<KvPutItemSg> puts = {
+      {"sgov_a", {a0.data()}, {a0.size()}},
+      {"sgov_big", {big0.data(), big1.data()}, {big0.size(), big1.size()}},
+      {"sgov_b", {b0.data()}, {b0.size()}},
+  };
+  auto pr = c.BatchPutSg(puts);
+  EXPECT_TRUE(pr[0]) << "sibling A put";
+  EXPECT_FALSE(pr[1]) << "oversized put must fail only itself";
+  EXPECT_TRUE(pr[2]) << "sibling B put (must not be poisoned by the offender)";
+
+  // The two siblings must have been stored; the oversized key must be absent (never
+  // written). Drive the GET-side oversized path too: a get whose total cap exceeds
+  // max_payload must miss without poisoning its siblings.
+  std::string ga(4096, '\0'), gb(8192, '\0');
+  std::string gbig0(200 * 1024, '\0'), gbig1(200 * 1024, '\0');
+  std::vector<KvGetItemSg> gets = {
+      {"sgov_a", {&ga[0]}, {ga.size()}},
+      {"sgov_big", {&gbig0[0], &gbig1[0]}, {gbig0.size(), gbig1.size()}},
+      {"sgov_b", {&gb[0]}, {gb.size()}},
+  };
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg(gets, &lens);
+  EXPECT_TRUE(gr[0]) << "sibling A get";
+  EXPECT_FALSE(gr[1]) << "oversized get must miss only itself";
+  EXPECT_TRUE(gr[2]) << "sibling B get (must not be poisoned by the offender)";
+  if (gr[0]) { EXPECT_EQ(ga, a0); }
+  if (gr[2]) { EXPECT_EQ(gb, b0); }
+
+  ::unsetenv("DFKV_RDMA_DEPTH");
+}
+
 TEST(RdmaLoopback, PipelinedPoolDepth) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   // depth>1 enables client pipelining + the server GET worker pool (the most

--- a/tests/rdma_loopback_test.cc
+++ b/tests/rdma_loopback_test.cc
@@ -369,6 +369,107 @@ TEST(RdmaLoopback, BatchPutEmptyValue) {
   EXPECT_TRUE(c.Get("e_empty", nullptr, 0));
 }
 
+// Scatter-gather over RDMA: BatchPutSg gathers N caller buffers into one stored
+// blob via a multi-SGE SEND; BatchGetAutoSg scatters the stored blob across N
+// caller buffers via a multi-SGE RECV. Exercises the real PostSendScatterMulti /
+// PostRecvScatterMulti datapath (not the concat fallback). Covers N=1, N=2,
+// N=29 (max_sge-1), variable sizes, the >29 guard, and N > depth windowing.
+TEST(RdmaLoopback, ScatterGatherRoundtripOverRdma) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  // depth>1 so the SG path also crosses send windows (N > depth).
+  ::setenv("DFKV_RDMA_DEPTH", "4", 1);
+  RdmaNode node("sg");
+  RdmaTransport rt(kMaxMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+  ASSERT_TRUE(rt.pipelined());  // RDMA path, not the TCP fallback
+
+  auto make_chunks = [](const std::string& tag, const std::vector<size_t>& sizes) {
+    std::vector<std::string> v(sizes.size());
+    for (size_t i = 0; i < sizes.size(); ++i) {
+      v[i].resize(sizes[i]);
+      for (size_t b = 0; b < sizes[i]; ++b)
+        v[i][b] = static_cast<char>((tag.size() + i * 31 + b * 7) & 0xFF);
+    }
+    return v;
+  };
+  auto roundtrip = [&](const std::string& key, const std::vector<size_t>& sizes) {
+    auto src = make_chunks(key, sizes);
+    std::vector<const void*> ptrs;
+    for (auto& s : src) ptrs.push_back(s.data());
+    KvPutItemSg put{key, ptrs, sizes};
+    auto pr = c.BatchPutSg({put});
+    ASSERT_TRUE(pr[0]) << "put " << key;
+    std::vector<std::string> dst(sizes.size());
+    std::vector<void*> dptrs;
+    for (size_t i = 0; i < sizes.size(); ++i) { dst[i].assign(sizes[i], '\0'); dptrs.push_back(&dst[i][0]); }
+    KvGetItemSg get{key, dptrs, sizes};
+    std::vector<size_t> lens;
+    auto gr = c.BatchGetAutoSg({get}, &lens);
+    ASSERT_TRUE(gr[0]) << "get " << key;
+    size_t total = 0; for (size_t s : sizes) total += s;
+    EXPECT_EQ(lens[0], total);
+    for (size_t i = 0; i < sizes.size(); ++i) EXPECT_EQ(dst[i], src[i]) << key << " seg " << i;
+  };
+
+  roundtrip("sg_n1", std::vector<size_t>(1, 4096));
+  roundtrip("sg_n2", std::vector<size_t>(2, 2048));
+  roundtrip("sg_n29", std::vector<size_t>(29, 256));         // max payload SGEs
+  roundtrip("sg_var", {1, 7, 64, 333, 4096, 11});            // variable per-seg sizes
+
+  // >29 segments: rejected by the guard (put fails, get is a miss) — no corruption.
+  {
+    std::vector<size_t> sizes(30, 16);
+    auto src = make_chunks("sg_over", sizes);
+    std::vector<const void*> ptrs; for (auto& s : src) ptrs.push_back(s.data());
+    KvPutItemSg put{"sg_over", ptrs, sizes};
+    EXPECT_FALSE(c.BatchPutSg({put})[0]);
+    std::vector<std::string> dst(30);
+    std::vector<void*> dptrs;
+    for (int i = 0; i < 30; ++i) { dst[i].assign(16, '\0'); dptrs.push_back(&dst[i][0]); }
+    KvGetItemSg get{"sg_over", dptrs, sizes};
+    std::vector<size_t> lens;
+    EXPECT_FALSE(c.BatchGetAutoSg({get}, &lens)[0]);
+  }
+
+  // Multi-key fan-out exceeding the send window depth (4). Pin concurrency to 1:
+  // the Soft-RoCE (rdma_rxe) loopback used in CI races when many distinct QPs run
+  // in parallel (the SAME flakiness affects the contiguous BatchGetAuto path on
+  // rxe — it is an emulation artifact, not an SG defect). This still exercises the
+  // real multi-SGE verbs datapath across many keys and multiple send windows.
+  {
+    c.set_batch_concurrency(1);
+    const int N = 24;
+    std::vector<std::vector<std::string>> srcs(N);
+    std::vector<KvPutItemSg> puts(N);
+    for (int i = 0; i < N; ++i) {
+      std::vector<size_t> sizes(1 + (i % 4), 64 + (i % 8));
+      srcs[i] = make_chunks("sgm" + std::to_string(i), sizes);
+      std::vector<const void*> ptrs; for (auto& s : srcs[i]) ptrs.push_back(s.data());
+      puts[i] = {"sgm" + std::to_string(i), ptrs, sizes};
+    }
+    auto pr = c.BatchPutSg(puts);
+    for (int i = 0; i < N; ++i) ASSERT_TRUE(pr[i]) << i;
+    std::vector<std::vector<std::string>> dsts(N);
+    std::vector<KvGetItemSg> gets(N);
+    for (int i = 0; i < N; ++i) {
+      dsts[i].resize(srcs[i].size());
+      std::vector<void*> dptrs; std::vector<size_t> caps(srcs[i].size());
+      for (size_t j = 0; j < srcs[i].size(); ++j) {
+        dsts[i][j].assign(srcs[i][j].size(), '\0');
+        dptrs.push_back(&dsts[i][j][0]); caps[j] = srcs[i][j].size();
+      }
+      gets[i] = {"sgm" + std::to_string(i), dptrs, caps};
+    }
+    std::vector<size_t> lens;
+    auto gr = c.BatchGetAutoSg(gets, &lens);
+    for (int i = 0; i < N; ++i) {
+      ASSERT_TRUE(gr[i]) << i;
+      for (size_t j = 0; j < srcs[i].size(); ++j) EXPECT_EQ(dsts[i][j], srcs[i][j]) << i << " " << j;
+    }
+  }
+  ::unsetenv("DFKV_RDMA_DEPTH");
+}
+
 TEST(RdmaLoopback, PipelinedPoolDepth) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   // depth>1 enables client pipelining + the server GET worker pool (the most
@@ -448,4 +549,151 @@ TEST(RdmaLoopback, ReclaimsAndReapsIdleConnThreads) {
   }
   EXPECT_LE(live, 2u) << "idle conn threads were not reclaimed + reaped (leak)";
   ::unsetenv("DFKV_RDMA_IDLE_MS");
+}
+
+// A cache node that ALSO wires the async-GET prep + complete hooks, so the server
+// uses the io_uring batch-and-wait GET path when DFKV_SERVER_URING=1 (and the
+// binary was built with -DDFKV_WITH_URING). With the env off / unbuilt these
+// hooks are simply never consulted and the node behaves like a plain RdmaNode.
+struct RdmaUringNode {
+  fs::path dir;
+  std::unique_ptr<KvNodeServer> srv;
+  std::unique_ptr<RdmaServer> rsrv;
+  std::string addr;
+
+  explicit RdmaUringNode(const std::string& tag, size_t max_msg = kMaxMsg) {
+    dir = fs::temp_directory_path() / ("dfkv_uring_" + tag);
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    srv = std::make_unique<KvNodeServer>(dir.string(), 1ull << 30);
+    EXPECT_EQ(srv->Start(0), Status::kOk);
+    rsrv = std::make_unique<RdmaServer>(
+        [this](uint8_t op, uint64_t id, uint32_t idx, uint32_t ks, uint64_t off,
+               uint64_t len, const char* pl, uint64_t pll, std::string* out) {
+          return srv->ProcessRequest(op, id, idx, ks, off, len, pl, pll, out);
+        },
+        max_msg);
+    rsrv->set_range_handler(  // sync fallback (used when uring path is off)
+        [this](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
+               char* io_buf, size_t cap, const char** out_data, size_t* out_len) {
+          return srv->RangeDirect(id, idx, ks, off, len, io_buf, cap, out_data, out_len);
+        });
+    rsrv->set_cache_direct_handler(
+        [this](uint64_t id, uint32_t idx, uint32_t ks, char* data, size_t len,
+               size_t cap) {
+          return srv->CacheDirect(id, idx, ks, data, len, cap);
+        });
+    rsrv->set_range_prep_handler(
+        [this](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
+               size_t cap, RdmaServer::RangePrepResult* o) {
+          KVStore::RangePrep p;
+          Status st = srv->RangeDirectPrep(id, idx, ks, off, len, cap, &p);
+          if (st == Status::kOk) {
+            o->fd = p.fd; o->aligned_off = p.aligned_off; o->aligned_len = p.aligned_len;
+            o->head = p.head; o->payload_len = p.payload_len;
+          }
+          return st;
+        });
+    rsrv->set_range_complete_handler(
+        [this](bool ok, size_t bytes) { srv->RangeDirectComplete(ok, bytes); });
+    EXPECT_EQ(rsrv->Start(0), Status::kOk);
+    addr = "127.0.0.1:" + std::to_string(rsrv->port());
+  }
+  ~RdmaUringNode() {
+    if (rsrv) rsrv->Stop();
+    if (srv) srv->Stop();
+    fs::remove_all(dir);
+  }
+};
+
+// Correctness proof for the io_uring async-GET path: many concurrent GETs over a
+// SINGLE pooled connection, with the depth high enough that several requests are
+// in flight per WaitComp batch (so the server submits a multi-read io_uring batch
+// and must reply in arrival order). Every value must come back byte-correct. With
+// the flag OFF this still passes via the synchronous path (regression guard); with
+// DFKV_SERVER_URING=1 + a URING build it exercises the batch-and-wait reads.
+TEST(RdmaLoopback, UringAsyncGetManyConcurrentInOrder) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  // Request the async path (no-op if unbuilt). Use overwrite=0 so a shell-set
+  // DFKV_SERVER_URING (e.g. =0 to force the sync path) wins — this lets the CI
+  // run the SAME test through both the sync and async serve loops.
+  ::setenv("DFKV_SERVER_URING", "1", 0);
+  ::setenv("DFKV_SERVER_URING_DEPTH", "32", 1);
+  ::setenv("DFKV_RDMA_DEPTH", "8", 1);      // K=8 in-flight => multi-read batches
+  // Small per-buffer cap so K=8 slots (rbuf+sbuf+dbuf each) stay under an 8 MiB
+  // RLIMIT_MEMLOCK (CI default). Values below are <= 12 KiB, well within 64 KiB.
+  constexpr size_t kUringMsg = 64 * 1024;
+  RdmaUringNode node("ag", kUringMsg);
+  RdmaTransport rt(kUringMsg);
+  ASSERT_TRUE(rt.pipelined());
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+  // Pin client batch concurrency to 1 QP: the Soft-RoCE (rdma_rxe) loopback used
+  // in CI races when many distinct QPs run in parallel (an emulation artifact that
+  // hits the plain sync GET path too — see ScatterGatherRoundtripOverRdma). A
+  // single connection still pipelines up to `depth` GETs per send window, so the
+  // SERVER still forms multi-read io_uring batches; this only removes the rxe
+  // cross-QP flakiness, not the concurrency under test.
+  c.set_batch_concurrency(1);
+
+  // Distinct content per key (offset + index dependent) so a misrouted reply
+  // (wrong buffer / reordered) would mismatch. Mix of sizes incl. sub-page and
+  // multi-page to exercise the O_DIRECT aligned-superset trim.
+  const int N = 200;
+  const size_t kSizes[] = {64, 512, 4096, 8192, 12288};
+  std::vector<std::string> vals(N), keys(N);
+  std::vector<KvPutItem> puts(N);
+  for (int i = 0; i < N; ++i) {
+    keys[i] = "ag" + std::to_string(i);
+    size_t sz = kSizes[i % 5];
+    vals[i].resize(sz);
+    for (size_t k = 0; k < sz; ++k)
+      vals[i][k] = static_cast<char>((i * 131 + k * 7 + 13) & 0xFF);
+    puts[i] = {keys[i], vals[i].data(), sz};
+  }
+  auto pr = c.BatchPut(puts);
+  for (int i = 0; i < N; ++i) ASSERT_TRUE(pr[i]) << i;
+
+  // Run several BatchGet rounds over the one pooled connection; each round fans
+  // out N GETs that pipeline K-at-a-time -> the server forms multi-read batches.
+  for (int round = 0; round < 3; ++round) {
+    std::vector<std::string> outs(N);
+    std::vector<KvGetItem> gets(N);
+    for (int i = 0; i < N; ++i) { outs[i].assign(vals[i].size(), '\0'); gets[i] = {keys[i], &outs[i][0], vals[i].size()}; }
+    auto gr = c.BatchGet(gets);
+    for (int i = 0; i < N; ++i) {
+      ASSERT_TRUE(gr[i]) << "round " << round << " key " << i;
+      EXPECT_EQ(outs[i], vals[i]) << "round " << round << " key " << i;
+    }
+  }
+
+  // A miss on the async path must still be a clean miss (kNotFound), not an error
+  // or a stale-buffer hit; interleave present/absent to mix sync-miss + async-hit
+  // replies in the same pipelined window (order-preservation across reply kinds).
+  std::vector<std::string> mouts(N);
+  std::vector<KvGetItem> mgets;
+  std::vector<std::string> mkeys;
+  for (int i = 0; i < N; ++i) {
+    mkeys.push_back(keys[i]);
+    mkeys.push_back("ag_absent" + std::to_string(i));
+  }
+  std::vector<std::string> mo(mkeys.size());
+  std::vector<KvGetItem> mg(mkeys.size());
+  for (size_t i = 0; i < mkeys.size(); ++i) {
+    size_t cap = (i % 2 == 0) ? vals[i / 2].size() : 4096;
+    mo[i].assign(cap, '\0');
+    mg[i] = {mkeys[i], &mo[i][0], cap};
+  }
+  auto mgr = c.BatchGet(mg);
+  for (size_t i = 0; i < mkeys.size(); ++i) {
+    if (i % 2 == 0) {
+      ASSERT_TRUE(mgr[i]) << "present key " << mkeys[i];
+      EXPECT_EQ(mo[i], vals[i / 2]) << "present key " << mkeys[i];
+    } else {
+      EXPECT_FALSE(mgr[i]) << "absent key should miss: " << mkeys[i];
+    }
+  }
+
+  ::unsetenv("DFKV_SERVER_URING");
+  ::unsetenv("DFKV_SERVER_URING_DEPTH");
+  ::unsetenv("DFKV_RDMA_DEPTH");
 }

--- a/tests/sg_test.cc
+++ b/tests/sg_test.cc
@@ -159,6 +159,34 @@ TEST(Sg, MissReturnsMiss) {
   a->srv->Stop();
 }
 
+// Fix 3: an empty/null key in a batch is skipped (no header-only blob written, no
+// wasted GET issued) and reported failed/miss, while valid siblings still succeed.
+TEST(Sg, EmptyKeySkipped) {
+  auto a = Start("emptykey");
+  KVClient c({{"a", a->addr}}, Hdr());
+  std::string v(128, 'x');
+  std::vector<KvPutItemSg> puts = {
+      {"", {v.data()}, {v.size()}},        // empty key: must be skipped
+      {"ek_ok", {v.data()}, {v.size()}},   // valid sibling
+  };
+  auto pr = c.BatchPutSg(puts);
+  EXPECT_FALSE(pr[0]) << "empty-key put must be skipped/failed";
+  EXPECT_TRUE(pr[1]) << "valid sibling must still be stored";
+
+  std::string d0(128, '\0'), d1(128, '\0');
+  std::vector<KvGetItemSg> gets = {
+      {"", {&d0[0]}, {d0.size()}},         // empty key: must miss (no GET issued)
+      {"ek_ok", {&d1[0]}, {d1.size()}},    // valid sibling: hit
+  };
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg(gets, &lens);
+  EXPECT_FALSE(gr[0]) << "empty-key get must miss";
+  EXPECT_EQ(lens[0], 0u);
+  EXPECT_TRUE(gr[1]) << "valid sibling get must hit";
+  if (gr[1]) { EXPECT_EQ(d1, v); }
+  a->srv->Stop();
+}
+
 // Multi-key fan-out across two nodes, mixed segment counts.
 TEST(Sg, MultiKeyTwoNodes) {
   auto a = Start("mk_a"); auto b = Start("mk_b");

--- a/tests/sg_test.cc
+++ b/tests/sg_test.cc
@@ -1,0 +1,202 @@
+// Scatter-gather (multi-buffer-per-key) round-trip tests for the additive
+// dfkv_batch_put_sg / dfkv_batch_get_auto_sg path. One dfkv key gathers N
+// non-contiguous source buffers on put and scatters into N destination buffers
+// on get. Exercises N=1, N=2, N=29, the >29 guard, and a multi-key/multi-node
+// fan-out. Runs over the loopback TCP transport (default-fallback SG path), which
+// is what the build env provides when RDMA is unavailable.
+#include "kv_client.h"
+#include "kv_node_server.h"
+#include "value_header.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace dfkv;  // NOLINT
+
+namespace {
+ValueHeader Hdr() {
+  return ValueHeader::Make(0x51, 64, 0x46384534u, ValueHeader::kFlagIsMla, 8, 0, 78, 1, 576);
+}
+struct Node { fs::path dir; std::unique_ptr<KvNodeServer> srv; std::string addr; };
+std::unique_ptr<Node> Start(const std::string& tag) {
+  auto n = std::make_unique<Node>();
+  n->dir = fs::temp_directory_path() / ("dfkv_sg_" + tag);
+  fs::remove_all(n->dir); fs::create_directories(n->dir);
+  n->srv = std::make_unique<KvNodeServer>(n->dir.string(), 1ull << 30);
+  EXPECT_EQ(n->srv->Start(0), Status::kOk);
+  n->addr = "127.0.0.1:" + std::to_string(n->srv->port());
+  return n;
+}
+
+// Make `count` distinct payload chunks of given sizes, contents = key-tagged.
+std::vector<std::string> MakeChunks(const std::string& tag,
+                                    const std::vector<size_t>& sizes) {
+  std::vector<std::string> chunks(sizes.size());
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    chunks[i].resize(sizes[i]);
+    for (size_t b = 0; b < sizes[i]; ++b)
+      chunks[i][b] = static_cast<char>((tag.size() + i * 31 + b * 7) & 0xFF);
+  }
+  return chunks;
+}
+}  // namespace
+
+// Put a key as N separate buffers, get it back into N separate buffers; assert the
+// per-segment bytes match and the reported total length is the sum of the sizes.
+static void RoundTrip(KVClient& c, const std::string& key, size_t nsegs,
+                      size_t seg_bytes) {
+  std::vector<size_t> sizes(nsegs, seg_bytes);
+  auto src = MakeChunks(key, sizes);
+  std::vector<const void*> ptrs;
+  for (auto& s : src) ptrs.push_back(s.data());
+
+  KvPutItemSg put;
+  put.key = key; put.ptrs = ptrs; put.sizes = sizes;
+  auto pr = c.BatchPutSg({put});
+  ASSERT_EQ(pr.size(), 1u);
+  ASSERT_TRUE(pr[0]) << "put key=" << key << " nsegs=" << nsegs;
+
+  // Distinct destination buffers, one per segment.
+  std::vector<std::string> dst(nsegs);
+  std::vector<void*> dptrs;
+  for (size_t i = 0; i < nsegs; ++i) { dst[i].assign(seg_bytes, '\0'); dptrs.push_back(&dst[i][0]); }
+  KvGetItemSg get;
+  get.key = key; get.dsts = dptrs; get.caps = sizes;
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg({get}, &lens);
+  ASSERT_EQ(gr.size(), 1u);
+  ASSERT_TRUE(gr[0]) << "get key=" << key << " nsegs=" << nsegs;
+  EXPECT_EQ(lens[0], std::accumulate(sizes.begin(), sizes.end(), size_t{0}));
+  for (size_t i = 0; i < nsegs; ++i)
+    EXPECT_EQ(dst[i], src[i]) << "key=" << key << " seg=" << i;
+}
+
+TEST(Sg, RoundTripN1) {
+  auto a = Start("n1");
+  KVClient c({{"a", a->addr}}, Hdr());
+  RoundTrip(c, "k_n1", 1, 256);
+  a->srv->Stop();
+}
+
+TEST(Sg, RoundTripN2) {
+  auto a = Start("n2");
+  KVClient c({{"a", a->addr}}, Hdr());
+  RoundTrip(c, "k_n2", 2, 512);
+  a->srv->Stop();
+}
+
+TEST(Sg, RoundTripN29) {
+  auto a = Start("n29");
+  KVClient c({{"a", a->addr}}, Hdr());
+  RoundTrip(c, "k_n29", 29, 128);  // max allowed (max_sge-1)
+  a->srv->Stop();
+}
+
+// Variable segment sizes within one key (scatter split must honor each size).
+TEST(Sg, RoundTripVariableSizes) {
+  auto a = Start("var");
+  KVClient c({{"a", a->addr}}, Hdr());
+  std::vector<size_t> sizes = {1, 7, 64, 333, 4096, 11};
+  auto src = MakeChunks("var", sizes);
+  std::vector<const void*> ptrs;
+  for (auto& s : src) ptrs.push_back(s.data());
+  KvPutItemSg put{"k_var", ptrs, sizes};
+  ASSERT_TRUE(c.BatchPutSg({put})[0]);
+
+  std::vector<std::string> dst(sizes.size());
+  std::vector<void*> dptrs;
+  for (size_t i = 0; i < sizes.size(); ++i) { dst[i].assign(sizes[i], '\0'); dptrs.push_back(&dst[i][0]); }
+  KvGetItemSg get{"k_var", dptrs, sizes};
+  std::vector<size_t> lens;
+  ASSERT_TRUE(c.BatchGetAutoSg({get}, &lens)[0]);
+  EXPECT_EQ(lens[0], std::accumulate(sizes.begin(), sizes.end(), size_t{0}));
+  for (size_t i = 0; i < sizes.size(); ++i) EXPECT_EQ(dst[i], src[i]) << i;
+  a->srv->Stop();
+}
+
+// >29 buffers must be reported failed (put) and a miss (get), not corrupt.
+TEST(Sg, OverLimitGuard) {
+  auto a = Start("over");
+  KVClient c({{"a", a->addr}}, Hdr());
+  const size_t kBad = 30;  // 30 > max_sge-1 (=29)
+  std::vector<size_t> sizes(kBad, 16);
+  auto src = MakeChunks("over", sizes);
+  std::vector<const void*> ptrs;
+  for (auto& s : src) ptrs.push_back(s.data());
+  KvPutItemSg put{"k_over", ptrs, sizes};
+  auto pr = c.BatchPutSg({put});
+  ASSERT_EQ(pr.size(), 1u);
+  EXPECT_FALSE(pr[0]) << "30-segment put must be rejected by the guard";
+
+  // The key was never written, so a get is a miss too (and a 30-dst get is also
+  // guarded out independently).
+  std::vector<std::string> dst(kBad);
+  std::vector<void*> dptrs;
+  for (size_t i = 0; i < kBad; ++i) { dst[i].assign(16, '\0'); dptrs.push_back(&dst[i][0]); }
+  KvGetItemSg get{"k_over", dptrs, sizes};
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg({get}, &lens);
+  EXPECT_FALSE(gr[0]) << "30-segment get must be rejected by the guard";
+  a->srv->Stop();
+}
+
+// Missing key => miss, len 0.
+TEST(Sg, MissReturnsMiss) {
+  auto a = Start("miss");
+  KVClient c({{"a", a->addr}}, Hdr());
+  std::string d0(64, '\0'), d1(64, '\0');
+  KvGetItemSg get{"absent", {&d0[0], &d1[0]}, {64, 64}};
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg({get}, &lens);
+  EXPECT_FALSE(gr[0]);
+  EXPECT_EQ(lens[0], 0u);
+  a->srv->Stop();
+}
+
+// Multi-key fan-out across two nodes, mixed segment counts.
+TEST(Sg, MultiKeyTwoNodes) {
+  auto a = Start("mk_a"); auto b = Start("mk_b");
+  KVClient c({{"a", a->addr}, {"b", b->addr}}, Hdr());
+  const int N = 64;
+  std::vector<std::vector<std::string>> srcs(N);
+  std::vector<KvPutItemSg> puts(N);
+  for (int i = 0; i < N; ++i) {
+    size_t nsegs = 1 + (i % 5);
+    std::vector<size_t> sizes(nsegs, 32 + (i % 7));
+    srcs[i] = MakeChunks("mk" + std::to_string(i), sizes);
+    std::vector<const void*> ptrs;
+    for (auto& s : srcs[i]) ptrs.push_back(s.data());
+    puts[i] = {"mk" + std::to_string(i), ptrs, sizes};
+  }
+  auto pr = c.BatchPutSg(puts);
+  for (int i = 0; i < N; ++i) ASSERT_TRUE(pr[i]) << i;
+
+  std::vector<std::vector<std::string>> dsts(N);
+  std::vector<KvGetItemSg> gets(N);
+  for (int i = 0; i < N; ++i) {
+    size_t nsegs = srcs[i].size();
+    dsts[i].resize(nsegs);
+    std::vector<void*> dptrs;
+    std::vector<size_t> caps(nsegs);
+    for (size_t j = 0; j < nsegs; ++j) {
+      dsts[i][j].assign(srcs[i][j].size(), '\0');
+      dptrs.push_back(&dsts[i][j][0]);
+      caps[j] = srcs[i][j].size();
+    }
+    gets[i] = {"mk" + std::to_string(i), dptrs, caps};
+  }
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg(gets, &lens);
+  for (int i = 0; i < N; ++i) {
+    ASSERT_TRUE(gr[i]) << i;
+    for (size_t j = 0; j < srcs[i].size(); ++j)
+      EXPECT_EQ(dsts[i][j], srcs[i][j]) << "key " << i << " seg " << j;
+  }
+  a->srv->Stop(); b->srv->Stop();
+}


### PR DESCRIPTION
## DfkvStoreConnector — direct vLLM KV connector for dfkv (GPUDirect RDMA, bypass LMCache)

A vLLM `KVConnectorBase_V1` connector (vLLM 0.23.0) that stores/loads KV cache directly to/from a dfkv cluster over **GPUDirect RDMA**, occupying the same `--kv-transfer-config` slot as `MooncakeStoreConnector`. It bypasses LMCache entirely (LMCache's in-process `LMCacheConnectorV1` does not work for DeepSeek-V4 on this stack).

Out-of-tree plugin, code under `integration/vllm/` (symmetric to `integration/lmcache/`); pure Python (ctypes over `libdfkv.so`), no native build. Design/plan: `docs/superpowers/specs|plans/2026-06-18-dfkv-vllm-store-connector*`.

### Architecture
- Mirrors Mooncake's store connector: thin `connector.py` (role dispatch) + `scheduler.py` (hit decision) + `worker.py` (register / async transfer threads / lookup server). All dfkv contact is isolated in `dfkv_client.py` (`DfkvDeviceClient`, raw GPU device pointers).
- `register_kv_caches` registers the paged KV region once via `dfkv_register_memory` (an `ibv_reg_mr` that, under nvidia-peermem, yields a GPUDirect MR). Transfers go RDMA directly to/from GPU memory, no host bounce. No layerwise transfer — load/save issued per-request in `get_finished()`.
- Fail-soft invariant: any dfkv failure only means "fewer hits = more compute"; it never blocks/503s inference.

### Validated on real hardware (hd04 H100 + IB, DeepSeek-V4-Flash, DP4·TP2)
- **GPUDirect RDMA** round-trip from GPU memory: byte-correct (P0).
- Connector loads + serves under vLLM 0.23.0; `dfkv client transport=rdma`; 0 crash.
- **Save** path writes KV to dfkv (`failed=0`).
- **Cross-restart load**: after a vLLM restart the lookup finds the dfkv-resident KV and the connector loads it back; vLLM **skips the prefill** — TTFT **18 s → ~1.2 s (≈15×)** demonstrated.

### Bug chain fixed during bring-up (each its own commit)
1. `dfkv_batch_put` per-key convention: dfkv returns `out[i]=1` for OK (opposite of single `dfkv_put`); normalized in `dfkv_client`.
2. SAVE/LOAD/LOOKUP key alignment: always suffix `@seg{n}`; lookup probes `@seg0`.
3. **`PYTHONHASHSEED=0`** is required so vLLM's block-hash seed is deterministic across processes — otherwise dfkv keys never match across a restart/instance and the L3 cache is useless beyond one process lifetime.
4. `load_mask` delegates to `store_mask` so the consumer reloads every group the producer stored.
5. **Per-`kv_cache_group` base-addr partition** in `register_kv_caches`: the Mooncake template handed one flat addr list to every group's token DB — correct for single-group models, but for multi-group models (DeepSeek-V4) it scattered loaded KV into the wrong group's blocks. Now each group's token DB addresses only its own layers.
6. Lookup candidates gated by `store_mask` (SlidingWindow groups keep only in-window tail chunks).

### Known limitation (WIP — draft)
DeepSeek-V4-Flash exposes **5 `kv_cache_group`s** (1 full-MLA + 4 SlidingWindow / partial-state, block sizes 256/64/64/4/8). Full prefix-reuse across all SWA groups under **chunked prefill** is not yet complete: a fresh cross-restart lookup currently sees only a subset present (`present≈138/1058 → hit_length=0`), because SAVE (per-step `store_mask` at chunked token-lengths) and LOOKUP (`store_mask` at full token-length) don't yet agree on the windowed groups' chunk set at every window boundary. The mechanism and the single-/simple-group path are proven (15× speedup); robust coverage for V4-Flash's full 5-group SWA structure is the remaining work and likely needs a unified per-(group,chunk) enumeration shared by save/load/lookup rather than the Mooncake per-spec masks.

### Testing
Isolated node (hd04-gpu1-0065, fault pool), on-node `ctr`/`nerdctl`, never touches production. dfkv_server on-host (`--rdma-dev ib7s400p0`, member uses **rdma-port**); vLLM container mounts the package + libdfkv.so; `DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0`, `kv_connector_extra_config={members, model_hash, lib}`.

**Not for merge yet** — opening for visibility/review of the approach while the 5-group SWA coverage is finished.
