### PR TITLE
docs(vllm): DfkvStoreConnector — README + deploy guide + config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,25 @@ Full rollout runbook (etcd + MDS + systemd units): `docs/DEPLOY.md`.
 src/        portable C++ core (headers + .cc) + dfkv_server_main.cc + dfkv_mds_main.cc
 python/     dfkv_hicache.py  (SGLang dynamic backend plugin)
 integration/lmcache/  dfkv_connector  (LMCache RemoteConnector, ctypes over libdfkv.so)
+integration/vllm/     dfkv_vllm       (vLLM KVConnectorBase_V1, GPUDirect RDMA, bypass LMCache)
 tests/      gtest suites + tests/python (unittest + no-torch sglang shim)
 docs/       DEPLOY.md (standalone rollout) · INTEGRATION.md (fuse into dingo-cache)
 docs/hicache/  SGLang HiCache plugin docs (access_log, module README)
 docs/lmcache/  LMCache connector docs (DESIGN · IMPLEMENTATION · DEPLOY)
+docs/vllm/     vLLM connector docs (DEPLOY — config reference + recommended settings)
 ```
 
 ## Engine integrations
 - **SGLang HiCache**: `python/dfkv_hicache.py` — see `docs/hicache/` and `docs/DEPLOY.md`.
 - **LMCache**: `integration/lmcache/` (`dfkv_connector`) — see `docs/lmcache/DESIGN.md`,
   `docs/lmcache/IMPLEMENTATION.md`, `docs/lmcache/DEPLOY.md`.
+- **vLLM (direct)**: `integration/vllm/` (`dfkv_vllm`) — a `KVConnectorBase_V1`
+  connector occupying the same `--kv-transfer-config` slot as `MooncakeStoreConnector`,
+  storing/loading KV **directly over GPUDirect RDMA** (no LMCache, no host bounce).
+  Pure-Python ctypes over `libdfkv.so`; uses the scatter-gather batch API to coalesce
+  per-chunk keys. Validated on H100 + IB with DeepSeek-V4 (multi kv_cache_group / MLA +
+  SWA), full cross-restart and cross-DP prefix hit. See `docs/vllm/DEPLOY.md` (config
+  reference + recommended settings) and `integration/vllm/README.md`.
 
 ## Operability & performance features
 - **Connection pooling + keep-alive** (TCP_NODELAY): ~250× lower latency vs dial-per-call.
@@ -127,6 +136,6 @@ docs/lmcache/  LMCache connector docs (DESIGN · IMPLEMENTATION · DEPLOY)
 - **Packaging**: CPack (deb/rpm/tgz) + Dockerfile; **graceful shutdown**; leveled logging.
 
 ## Status
-TDD; **53 C++ ctest entries + 7 Python tests green**, 0 warnings, **ThreadSanitizer-clean**.
-CI: gcc/clang build+test, TSan, RDMA compile-check, static-artifact build. License: Apache-2.0.
+TDD; **88 C++ ctest entries + Python plugin & connector tests green**, 0 warnings, **ThreadSanitizer-clean**.
+CI: gcc/clang build+test, TSan, RDMA datapath (Soft-RoCE loopback), RDMA compile-check, static-artifact build. License: Apache-2.0.
 See `docs/DEPLOY.md` (rollout) and the round report in the ai_david KB.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-# dfkv — distributed KV cache for SGLang HiCache
+# dfkv — distributed KV cache for LLM inference (SGLang · LMCache · vLLM)
 
 [![CI](https://github.com/dingodb/dfkv/actions/workflows/ci.yml/badge.svg)](https://github.com/dingodb/dfkv/actions/workflows/ci.yml)
 
-A small, **self-contained** distributed key-value cache that plugs into SGLang's
-HiCache as its L3 external KV store. Built to pool GPU-node NVMe SSDs into a
-shared, large-capacity KVCache pool for LLM inference (e.g. GLM-5.1 / MLA),
-**without any DingoFS / brpc / MDS / S3-RADOS dependency** — it runs on its own.
+A small, **self-contained** distributed key-value cache that pools GPU-node NVMe
+SSDs into a shared, large-capacity KV pool for LLM inference (e.g. GLM-5.1 / MLA,
+DeepSeek-V4), **without any DingoFS / brpc / S3-RADOS dependency** — it runs on
+its own (only its built-in MDS + etcd for dynamic membership). It plugs into
+three engines through thin adapters over one portable core:
+
+- **SGLang HiCache** as an L3 external KV store (`--hicache-storage-backend dynamic`).
+- **LMCache** as a `RemoteConnector`.
+- **vLLM** directly as a `KVConnectorBase_V1` (GPUDirect RDMA, no LMCache).
 
 > Origin: extracted from the DingoFS branch `feat/kvcache-sglang`
 > (`src/cache/kvclient`). The portable core has zero coupling to DingoFS, so it

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -162,9 +162,13 @@ export DFKV_RDMA=1                       # 启用 RDMA 数据面（否则 TCP）
 export DFKV_REQUIRE_RDMA=1               # 可选：禁止悄悄 TCP fallback
 export DFKV_RDMA_DEV=ib7s400p0           # 数据面设备；多轨用逗号列表 ib7s400p0,ib7s400p1,...
 export DFKV_RDMA_MAX_PAYLOAD_BYTES=67108864  # 可选：单 chunk payload 上限，默认 64MiB
-# 可选: DFKV_RDMA_DEPTH=16 (单连接 pipeline, K 个请求在途; 利于 PUT; client+server 两端都要设)
+# 可选: DFKV_RDMA_DEPTH (单连接 pipeline, K 个请求在途; 仅网络延迟隐藏、对吞吐 flat——见下注; 默认 1 即可)
 ```
-> 写流水也可写进 extra_config 的 `"rdma_depth":16`（插件在 dfkv_open 前自动设 DFKV_RDMA_DEPTH，免去手动 export）；**dfkv_server 仍须在自己的 env 里设同值或更大**（client depth ≤ server depth）。MLA 单 rank 写是延迟受限，depth>1 让多个 PUT 在途、隐藏单 op 延迟，实测抬高写带宽。
+> ⚠️ **depth 是延迟隐藏、不是吞吐旋钮(2026-06 实测更正)**：server 单连接 serve loop 串行处理,
+> 实测 **PUT 与 GET 的吞吐对 depth 都是 flat**(1≈8≈16≈32)。早先"depth>1 抬高写带宽"的说法不成立。
+> 写/读吞吐的真正杠杆是 **`batch_concurrency`(多连接跨节点 fan-out,客户端默认 8)** 与**少而大的 key**;
+> depth 只在网络延迟受限的链路上有意义,**默认 1 即可**,见 `docs/datapath-perf-notes.md`。
+> (机制仍在:extra_config `"rdma_depth":K` 会在 dfkv_open 前自动设 DFKV_RDMA_DEPTH,且 client depth ≤ server depth;但一般无需设。)
 
 > **多轨 NUMA 选轨**（v1.2.0 起）：设 extra_config `"rdma_numa":1`（或 env `DFKV_RDMA_NUMA=1`）+ 多轨 `DFKV_RDMA_DEV`，**C++ 客户端在建连时按调用线程的 NUMA 节点自动选本地轨**（无本地轨→轮转全轨）。SGLang/vLLM 两端通吃，无需各自改，仅在新建连接触发（热路径零开销）。
 > - ⚠️ **旧 `"rail_affinity"` 已废弃为 no-op**（v1.2.0）：它按 `tp_rank` 收窄，但 DP-attention 下每 rank `tp_rank=0`→塌缩到单轨。配了只打 stderr 告警、不再生效；改用上面的 `rdma_numa`。
@@ -241,3 +245,32 @@ sglang serve ... \
 - SGLang `--enable-cache-report` 的 HiCache storage hit/miss、TTFT。
 - 生产只读：不改现网组件；dfkv 端口（含 `/metrics`）仅内网开放、无鉴权勿暴露公网。
 - 线协议带 1B 版本号，混版本部署会被 server 拒（不静默错读）；升级时整集群同版本。**指标均为新增、不改 wire，v1.3.0 节点与 v1.4.0 客户端互通。**
+
+## 9. 引擎与特性边界（HiCache 侧）
+
+dfkv 现在同时服务三种引擎：**SGLang HiCache**（本 runbook）、**LMCache**（`docs/lmcache/`）、
+**vLLM 直连**（`docs/vllm/DEPLOY.md`）。后续给 vLLM 连接器加的几个特性**并不适用于 HiCache 侧**，
+不是漏配，是数据形状不匹配——HiCache 维持常规路径即可：
+
+- **scatter-gather（SG，合并 key）— HiCache 不用。** SG 把"一个 chunk 的多个层段"合成一个多-SGE
+  RDMA key，是为 vLLM 连接器的变长 chunk × 多层段做的。HiCache MLA **每页就是一个打包 latent 对象
+  （~2.74 MiB）**，本来一页一 key、无碎段可合，SG 在此无收益。（仅 MHA 的 `_k`/`_v` 对或未来多池
+  HiCache v2 才理论上有边际收益，且需改插件代码、非开关。）
+- **io_uring async GET（`DFKV_SERVER_URING`）— HiCache 不要开。** 实测单盘上对吞吐 **flat/无收益**
+  （瓶颈是盘不是读提交），默认关。HiCache 单盘场景开它纯属白费。
+- **`DFKV_RDMA_DEPTH` — 保持默认 1**（见 §5：实测对 PUT/GET 吞吐都 flat）。
+- HiCache 真正需要的硬化与可观测性（RDMA 空闲回收、CLOCK 持久指针、MDS 硬化、Prometheus 指标）
+  **已在 v1.5.2 内**，无需额外动作。
+
+### vLLM 实例与 HiCache 实例（即便同一模型）能否共用同一个池？
+
+- **共用同一套 dfkv 集群 / 同一个哈希环：可以。** 环只负责把 key 路由到节点；两种引擎指同一 `members`
+  即可共用存储池与容量（共享 LRU）。
+- **但二者不会复用彼此的 KV（同模型也不行）。** SGLang HiCache 与 vLLM 连接器用**完全不同的 key 方案**
+  （前缀/哈希/`@sg` 后缀/tp_rank 处理都不同）**和不同的 KV 字节布局**（MLA 单页打包对象 vs 连接器的
+  逐组分段）。同一模型、同一段 token，两边算出的 **key 不同、字节也不兼容**——只是共存于同一池、
+  keyspace 互不相交，谈不上跨引擎前缀命中。
+- **推荐：给两者不同的命名空间隔离 keyspace**（vLLM 侧 `model_hash` / `served-model-name` 与 HiCache 侧
+  取不同值）。这样即使理论上撞到同名 key，也因命名空间不同而不会发生"同 key 不同字节"的静默错读
+  （dfkv 值头只守 `payload_len` 字节大小，大小相同而布局不同会读成脏数据）。结论：**共享节点与容量、
+  隔离 keyspace**。

--- a/docs/vllm/DEPLOY.md
+++ b/docs/vllm/DEPLOY.md
@@ -1,0 +1,201 @@
+# dfkv vLLM connector — 部署与配置指南
+
+`DfkvStoreConnector` 是 vLLM `KVConnectorBase_V1` 直连连接器：把 KV cache 经
+**GPUDirect RDMA** 直接读写到 dfkv 集群,**绕开 LMCache**,占据与
+`MooncakeStoreConnector` 相同的 `--kv-transfer-config` 槽位。生产者和消费者读写同一
+共享池,实现跨请求、跨实例、跨重启的前缀复用。
+
+本文是端到端部署 + **各参数推荐配置**。快速参考见 `integration/vllm/README.md`。
+
+---
+
+## 0. 角色与前置条件
+
+| 角色 | 要求 |
+|---|---|
+| **dfkv 存储节点** | NVMe SSD + 400G RDMA 网卡(IB/RoCE);跑 `dfkv_server`(可选 `dfkv_mds`+etcd 做动态成员) |
+| **推理节点** | H100/A100 等 GPU + 同一 RDMA fabric;跑 vLLM(≥0.23.0) |
+| **GPUDirect** | GPU 节点须加载 `nvidia-peermem`(`lsmod \| grep nvidia_peermem`),否则 `ibv_reg_mr` 拿不到 GPU MR |
+| **KV 可再生** | dfkv 是纯 cache:节点丢失 = miss = 重算,无副本、无对象存储兜底 |
+
+> dfkv 与 vLLM 可同机(GPU 节点既跑 server 又跑 vLLM,池化本机 NVMe),也可分离。
+
+---
+
+## 第 1 步:编译 dfkv(带 RDMA)
+
+```bash
+cmake -S . -B build -DDFKV_WITH_RDMA=ON          # 数据面 400G 必须开;可选 -DDFKV_WITH_URING=ON
+cmake --build build -j
+ldd build/dfkv_server | grep ibverbs              # 确认链接了 RDMA 库
+# 产物:build/dfkv_server  build/dfkv_mds  build/libdfkv.so
+```
+
+`libdfkv.so` 是连接器唯一的原生依赖,拷到推理节点即可(或挂载共享盘)。
+
+---
+
+## 第 2 步:启动 dfkv 存储集群
+
+每台缓存节点起一个 `dfkv_server`。**关键:`--rdma-port` 是 RDMA QP bootstrap 端口,
+连接器的 `members` 必须指向它,而不是 `--port`。** `--advertise` 也用 rdma-port。
+
+```bash
+dfkv_server \
+  --dir /mnt/disk1/dfkv,/mnt/disk2/dfkv,/mnt/disk3/dfkv \   # 多盘逗号分隔,节点内 Ketama
+  --port 28000 --rdma-port 28001 --rdma-dev ib7s400p0 \      # port=TCP bootstrap; rdma-port=RDMA bootstrap; rdma-dev=数据面400G口
+  --cap 6597069766656 \                                      # 总容量(字节),按盘均分,自带 LRU 自限
+  --mds 10.0.0.1:9400,10.0.0.2:9400 --group glm \            # 可选:接 MDS 动态成员(否则连接器用静态 members)
+  --id n1 --advertise 192.168.1.1:28001                      # advertise 端口 = rdma-port
+```
+
+- **容量隔离**:`--cap` 设保守值,确认 `现网用量 + dfkv cap + 预留 < 物理总量`。
+- **MDS(可选)**:多副本无状态 `dfkv_mds --listen 9400 --etcd ...` + 节点 `--mds`;连接器目前用
+  **静态 `members`**,MDS 主要服务 SGLang 侧,vLLM 侧直接列服务端 rdma 地址即可。
+- 观测:加 `--metrics-port 28110` 开 Prometheus `/metrics`(off 时无监听,见 `docs/METRICS.md`)。
+
+---
+
+## 第 3 步:在推理节点安装 connector
+
+```bash
+pip install -e integration/vllm        # 提供 dfkv_vllm 包(纯 Python)
+# libdfkv.so 路径通过 extra_config.lib 或 env DFKV_LIB 指定
+```
+
+---
+
+## 第 4 步:启动 vLLM
+
+```bash
+PYTHONHASHSEED=0 \                       # ★ 必设,见下方说明,否则跨进程/重启不命中
+DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 \    # 选 RDMA 传输 + 数据面轨
+DFKV_LIB=/opt/dfkv/libdfkv.so \
+vllm serve <model> \
+  --tensor-parallel-size 2 --data-parallel-size 4 \
+  --kv-transfer-config '{
+    "kv_connector": "DfkvStoreConnector",
+    "kv_connector_module_path": "dfkv_vllm.connector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "members": "n1=192.168.1.1:28001,n2=192.168.1.2:28001",
+      "model_hash": "1234567890",
+      "batch_concurrency": "8"
+    }
+  }'
+```
+
+> **`PYTHONHASHSEED=0` 是头号坑。** dfkv key 的 chunk_hash 源自 vLLM 的 block hash,
+> 而 vLLM 0.23.0 的块哈希用 Python `hash()`——默认每进程随机化。DP 各 rank 是**独立进程**,
+> 不固定 seed 则同样的 token 在不同 rank/重启后算出**不同的 key**,跨进程/跨重启复用静默掉到 ~0
+> (写成功、读永不命中)。每个 rank 都要设,且全实例一致。
+
+---
+
+## 第 5 步:验证
+
+1. **首轮(cold)**:发一个长 prompt,记 TTFT。
+2. **重启 vLLM**(或换一个 DP 实例)后**发同一 prompt**:若连接器工作,vLLM 跳过 prefill
+   (调度日志 `num_computed_tokens` 接近满、`WAITING_FOR_REMOTE_KVS`),TTFT 大幅下降,
+   **输出与 cold 逐字一致**。
+3. server 侧 `dfkvctl stat --all` 或 `/metrics` 看 get 命中、写入量。
+
+不命中排查顺序:`PYTHONHASHSEED` → `members` 端口是否 rdma-port → `nvidia-peermem` →
+`model_hash`/几何是否一致(见下)。
+
+---
+
+## 配置项参考
+
+### A. 环境变量(每个 vLLM 引擎进程都要设)
+
+| env | 默认 | 推荐 | 说明 |
+|---|---|---|---|
+| `DFKV_RDMA` | 未设=TCP | `1` | 选 RDMA 传输;未设则 TCP 回退 |
+| `DFKV_RDMA_DEV` | — | 本机 400G 口名(`ib7s400p0`) | RDMA 轨,逗号列表=多轨;`DFKV_RDMA=1` 时必填 |
+| **`PYTHONHASHSEED`** | 未设 | **`0`(全 rank/实例一致)** | 跨进程/跨重启 key 确定性,**不设=不命中** |
+| `DFKV_RDMA_DEPTH` | `1` | **保持 1** | 每连接在途请求数;延迟隐藏、**非吞吐旋钮**(GET/PUT 都 depth-flat,server 单连接串行) |
+| `DFKV_RDMA_NUMA` | `0` | 多 NUMA 大机可设 `1` | 绑 buffer/线程到轨的 NUMA 节点 + 选 NUMA-local 轨 |
+| `DFKV_LIB` / `DFKV_BUILD` | — | `libdfkv.so` 路径 | 被 extra_config.lib 覆盖 |
+
+### B. `kv_connector_extra_config`
+
+| key | 默认 | 推荐 | 说明 |
+|---|---|---|---|
+| `members` | 必填 | `n=ip:rdma-port,...` | **端口必须是 server 的 `--rdma-port`**,不是 `--port` |
+| `model_hash` | `0` | 每模型一个固定 uint64 | key 命名空间;共享需几何一致(见下) |
+| `lib` | env 兜底 | `libdfkv.so` 绝对路径 | |
+| `batch_concurrency` | `8` | **大池可调高到≈节点数** | 跨节点 fan-out,**真正的吞吐杠杆**(depth 是平的) |
+| `load_async` | `True` | **保持 True** | 异步 load,走 `WAITING_FOR_REMOTE_KVS`、不占关键路径 |
+| `enable_cross_layers_blocks` | `False` | 默认 False | 仅当引擎分页布局层内交错时开 |
+| `lookup_rpc_port` | ipc 自动 | 一般不设 | rank0 前缀查询 RPC,仅 socket 名冲突时设 |
+
+### C. dfkv_server 关键 flag
+
+| flag | 推荐 | 说明 |
+|---|---|---|
+| `--dir` | 多块 NVMe 逗号分隔 | 节点内 Ketama 分散 |
+| `--port` / `--rdma-port` | 错开两个端口 | TCP bootstrap / RDMA bootstrap |
+| `--rdma-dev` | 数据面 400G 口名 | |
+| `--cap` | 保守值(留现网余量) | LRU 自限 |
+| `--mds`/`--group`/`--id`/`--advertise` | 接 MDS 时配 | advertise 端口=rdma-port |
+
+---
+
+## 按场景的推荐配置
+
+**单实例 / 单 DP**:`PYTHONHASHSEED=0`(跨重启复用仍需)+ `DFKV_RDMA=1` + `batch_concurrency=8`
+默认即可,depth 保持 1。
+
+**多 DP / 多实例共享池**:除上面外,**所有 rank、所有实例的 `PYTHONHASHSEED` 必须同值**,
+且 `model_hash` 相同 + 几何一致(见下)。这是跨 DP 复用能成立的前提。
+
+**大集群 / 宽池**:把 `batch_concurrency` 提到接近 dfkv 节点数,让一批 KV 在更多节点并行;
+depth 仍保持 1(无用)。吞吐杠杆永远是**多连接 fan-out + 少而大的 key**,不是 depth。
+
+**长上下文(50k+)**:load 带宽随上下文线性增长,单盘会成为瓶颈;靠**分布式存储环**(多
+server、多盘)摊带宽,而非调 depth。首请求 JIT 见下。
+
+---
+
+## 几何守卫(共享池务必确认)
+
+实例 A 写的 KV,只有当张量几何与实例 B 一致时才能安全被 B 读回。共享 `model_hash` 前确认
+全部相同:**`--kv-cache-dtype`、page/block size、KV 内存布局、`--max-model-len`**。dfkv 值
+头只守 `payload_len`(字节大小)——**同大小不同布局会被静默读成脏数据**。要隔离就用不同的
+`served-model-name` / `model_hash`。
+
+---
+
+## 实测结果(hd04 H100 + IB,DeepSeek-V4-Flash,参考)
+
+- **功能**:5 个 kv_cache_group(MLA + 多组 SWA)全部正确 offload,跨重启 + 跨 DP 命中
+  (present=1058/1058、failed=0),输出与 cold 逐字一致,vLLM 真跳 prefill。
+- **首请求 JIT**:每个 DP rank 的**第一个**请求付一次性 ~2s Triton JIT(resumed-prefill +
+  SWA-index kernel);暖后 12k 上下文 WARM≈2s < COLD 2.7s。在意首 token 延迟就在启动后给每个
+  rank 打一个合成命中预热。
+- **SG 合并**:每 chunk 一个 key(而非每层段一个),25392→1242 key(~20×),减少 per-key 磁盘读。
+- **depth 平**:裸 GET 单连接 depth 1 = depth 32 ≈ 1.24 GB/s,完全一样;不要指望调 depth 提速。
+- **传输层**:裸 GET 8 连接 5.2 GB/s、16 连接 6.2 GB/s(详见 `docs/datapath-perf-notes.md`)。
+
+---
+
+## 已知问题 / 排查
+
+| 现象 | 原因 / 解 |
+|---|---|
+| 写成功但**读永不命中** | `PYTHONHASHSEED` 没设或各 rank 不一致(头号坑);或 `model_hash`/几何不一致 |
+| 每个 RDMA `put` 失败 `rc=-1` | `members` 指了 `--port` 而非 `--rdma-port` |
+| GPU buffer 上 `dfkv_get_auto` 段错误 | 单 get 在 CPU 上算 CRC;连接器只走 zero-copy 的 batch 路径(已内置) |
+| `ibv_reg_mr` 失败 / 无 GPUDirect | GPU 节点没加载 `nvidia-peermem` |
+| 首 token 偶发慢 ~2s | 每 DP rank 一次性 Triton JIT(非 bug);预热可消 |
+| 异构 HCA(`max_sge<30`)某些 key 不缓存 | SG 段数客户端固定 29;超限的 key 只 fail 自己(降级重算,siblings 正常),非 corruption |
+
+---
+
+## 相关文档
+- `integration/vllm/README.md` — 快速参考
+- `docs/datapath-perf-notes.md` — RDMA 数据面性能笔记(depth-flat、coalescing 等)
+- `docs/METRICS.md` — Prometheus 观测
+- `docs/DEPLOY.md` — dfkv 集群(server + MDS)标准 rollout
+- `docs/superpowers/specs/2026-06-18-dfkv-vllm-store-connector-design.md` — 设计文档

--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -10,7 +10,12 @@ The connector is pure Python (ctypes over `libdfkv.so`); there is no native
 build. It talks to dfkv on **raw GPU device pointers** — the paged KV cache is
 registered once via `dfkv_register_memory` (an `ibv_reg_mr` that, under
 nvidia-peermem, yields a GPUDirect MR), and transfers RDMA directly to/from GPU
-memory with no host bounce.
+memory with no host bounce. Per-chunk layer segments are coalesced into one dfkv
+key via the **scatter-gather** batch API (one multi-SGE RDMA per chunk instead of
+one per layer-segment), cutting key/disk-read count ~20x.
+
+> **Full deployment walkthrough + recommended settings: [`docs/vllm/DEPLOY.md`](../../docs/vllm/DEPLOY.md).**
+> This README is the quick reference.
 
 ## Enable
 
@@ -27,24 +32,52 @@ memory with no host bounce.
 }'
 ```
 
-Also set `DFKV_RDMA=1` and `DFKV_RDMA_DEV=<rail, e.g. ib7s400p0>` in the engine
-environment to select the RDMA transport and rail.
+## Environment variables (engine process)
+
+Read by `libdfkv.so` (the C client) and the connector, so set them in **every**
+vLLM engine process — each DP rank is its own process.
+
+| env | default | meaning |
+|---|---|---|
+| `DFKV_RDMA` | unset (TCP) | `1` selects the RDMA transport; unset ⇒ TCP fallback. |
+| `DFKV_RDMA_DEV` | — | RDMA rail by name (`ib7s400p0`; comma-list = multi-rail). Required when `DFKV_RDMA=1`. |
+| **`PYTHONHASHSEED`** | unset | **Set to `0` (any fixed value, identical on every rank and instance).** vLLM's block hashes feed the dfkv key and use Python `hash()`, which is per-process randomized by default. Without a fixed seed, DP ranks and restarts compute **different keys for the same tokens** ⇒ cross-process / cross-restart prefix reuse silently drops to ~0. The single most common "no hit" misconfig. |
+| `DFKV_RDMA_DEPTH` | `1` | Requests in flight per connection. A latency hider, **not** a throughput knob (GET/PUT are depth-flat — the per-connection serve loop is in-order). Leave at default. |
+| `DFKV_RDMA_NUMA` | `0` | `1` pins buffers/threads to the rail's NUMA node and picks a NUMA-local rail per connection. Optional. |
+| `DFKV_LIB` / `DFKV_BUILD` | — | `libdfkv.so` path (overridden by the `lib` extra-config key). |
 
 ## `kv_connector_extra_config` keys
 
-| key | meaning |
-|---|---|
-| `members` | dfkv member string. **The port MUST be the server's `--rdma-port`** (the RDMA bootstrap listener), not the main `--port`, when RDMA is enabled. |
-| `model_hash` | uint64 namespace for keys; isolates this model's KV from others sharing the pool. A shared `model_hash` requires identical kv-cache-dtype / page-size / layout. |
-| `lib` | path to `libdfkv.so` (else env `DFKV_LIB` / `$DFKV_BUILD/libdfkv.so`). |
-| `batch_concurrency` | client fan-out for batch ops (default 8). |
+| key | default | meaning |
+|---|---|---|
+| `members` | (required) | dfkv member string. **The port MUST be the server's `--rdma-port`** (the RDMA bootstrap listener), not the main `--port`, when RDMA is enabled. |
+| `model_hash` | `0` | uint64 namespace for keys; isolates this model's KV from others sharing the pool. A shared `model_hash` requires identical kv-cache-dtype / page-size / layout (see geometry guard below). |
+| `lib` | env `DFKV_LIB` / `$DFKV_BUILD/libdfkv.so` | path to `libdfkv.so`. |
+| `batch_concurrency` | `8` | client fan-out across nodes for batch ops; the real throughput lever (depth is flat). Raise toward the cluster's node count for wider pools. |
+| `load_async` | `True` | async KV load: the scheduler returns `WAITING_FOR_REMOTE_KVS` and the load runs off the critical path. Keep `True`. |
+| `enable_cross_layers_blocks` | `False` | opt-in for engines whose paged layout interleaves layers within a block. Leave `False` unless you know the layout needs it. |
+| `lookup_rpc_port` | (ipc auto) | port for the rank-0 scheduler-side prefix-lookup RPC; set only if the default IPC socket name collides. |
+
+## Geometry guard (instances sharing one pool)
+
+KV written by instance A is only safe to read by instance B when their tensor
+geometry matches. Before sharing a `model_hash` across instances, confirm all of:
+**`--kv-cache-dtype`, page/block size, KV memory layout, `--max-model-len`** are
+identical. The dfkv value header guards `payload_len` (byte size) only — same-size
+but different-layout KV would be read back as **silent garbage**. To isolate
+instead of share, give each a distinct `served-model-name` / `model_hash`.
 
 ## Gotchas (validated on hd04 H100 + IB)
 
 - **member port = rdma-port.** Pointing at the main `--port` makes every RDMA
   `put` fail (`rc=-1`); RDMA QP bootstrap listens on `--rdma-port`.
+- **`PYTHONHASHSEED=0` on every rank** (see env table) — the #1 cause of "writes
+  succeed but reads never hit".
 - **GPU buffers use the batch path only.** The single `dfkv_get_auto` computes a
   CRC over the destination on the CPU and segfaults on device memory; the batch
   `dfkv_batch_get_auto` is zero-copy and GPU-safe.
 - **GPUDirect needs nvidia-peermem loaded** on the GPU node (`lsmod | grep
   nvidia_peermem`).
+- **First request per DP rank pays a one-time ~2s Triton JIT** (resumed-prefill +
+  SWA-index kernels). Warm it with a synthetic hit per rank at startup if first-token
+  latency matters.


### PR DESCRIPTION
Follow-up to #46 (the vLLM connector merge), which shipped with only a terse `integration/vllm/README` and no deploy doc.

## What
- **README.md**: add the vLLM connector to *Engine integrations* + *Layout*; bump the test count (53 → 88 ctest entries) and add the RDMA-datapath CI job.
- **integration/vllm/README.md**: complete the env-var table — including the critical **`PYTHONHASHSEED=0`** (cross-process / cross-restart key determinism; the #1 'writes succeed but reads never hit' misconfig) — plus the full `kv_connector_extra_config` keys with defaults (`load_async`, `enable_cross_layers_blocks`, `lookup_rpc_port`), a **geometry guard** for shared pools, and the SG + first-request-JIT notes.
- **docs/vllm/DEPLOY.md (new)**: end-to-end deploy (build → dfkv cluster → connector → vLLM → verify) with a **full config reference** and **per-scenario recommended settings** (single / multi-DP / shared-pool / long-context), the geometry guard, measured results, and a troubleshooting table. Mirrors `docs/lmcache/DEPLOY.md`.

## Accuracy
All params verified against the merged source: env vars read by `libdfkv.so` + the connector, `extra_config` defaults read from `connector.py`/`scheduler.py`/`worker.py`, server flags from `dfkv_server_main.cc`, and the perf/JIT/depth-flat findings from the on-hardware validation. Docs-only; no code change.