### PR TITLE
feat(vllm): MDS discovery for connector + deploy-docs restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ dfkv_server --dir /mnt/disk1/dfkv,/mnt/disk2/dfkv,/mnt/disk3/dfkv \
 # OR legacy static path (single-node / simple setups)
 #    dfkv_open("n1=10.0.0.10:12000,...", ...)
 ```
-Full rollout runbook (etcd + MDS + systemd units): `docs/DEPLOY.md`.
+Full dfkv CLUSTER deploy runbook (etcd + MDS + systemd units): `docs/DEPLOY.md`.
+Per-engine connect/config: `docs/hicache/DEPLOY.md` · `docs/vllm/DEPLOY.md` · `docs/lmcache/DEPLOY.md`.
 
 ## Layout
 ```
@@ -86,14 +87,15 @@ python/     dfkv_hicache.py  (SGLang dynamic backend plugin)
 integration/lmcache/  dfkv_connector  (LMCache RemoteConnector, ctypes over libdfkv.so)
 integration/vllm/     dfkv_vllm       (vLLM KVConnectorBase_V1, GPUDirect RDMA, bypass LMCache)
 tests/      gtest suites + tests/python (unittest + no-torch sglang shim)
-docs/       DEPLOY.md (standalone rollout) · INTEGRATION.md (fuse into dingo-cache)
-docs/hicache/  SGLang HiCache plugin docs (access_log, module README)
+docs/       DEPLOY.md (dfkv CLUSTER deploy: etcd + MDS + server + systemd) · INTEGRATION.md (fuse into dingo-cache)
+docs/hicache/  SGLang HiCache connector docs (DEPLOY — connect/config/use)
 docs/lmcache/  LMCache connector docs (DESIGN · IMPLEMENTATION · DEPLOY)
 docs/vllm/     vLLM connector docs (DEPLOY — config reference + recommended settings)
 ```
 
 ## Engine integrations
-- **SGLang HiCache**: `python/dfkv_hicache.py` — see `docs/hicache/` and `docs/DEPLOY.md`.
+- **SGLang HiCache**: `python/dfkv_hicache.py` — see `docs/hicache/DEPLOY.md` (connect/config/use;
+  cluster deploy is `docs/DEPLOY.md`).
 - **LMCache**: `integration/lmcache/` (`dfkv_connector`) — see `docs/lmcache/DESIGN.md`,
   `docs/lmcache/IMPLEMENTATION.md`, `docs/lmcache/DEPLOY.md`.
 - **vLLM (direct)**: `integration/vllm/` (`dfkv_vllm`) — a `KVConnectorBase_V1`

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -6,6 +6,8 @@
 > 前提：GLM-5.1 = MLA（每页 KV ≈ 2.74 MiB 单对象、跨 TP 复制、仅 tp_rank0 写）。
 > 已在 400G InfiniBand 上端到端验证（两端零拷贝，单口 GET ~93% 线速）。
 
+> **本文只讲 dfkv 集群自身的部署;各推理引擎如何对接/配置 dfkv 见 [docs/hicache/DEPLOY.md](hicache/DEPLOY.md)、[docs/vllm/DEPLOY.md](vllm/DEPLOY.md)、[docs/lmcache/DEPLOY.md](lmcache/DEPLOY.md)。**
+
 ---
 
 ## 0. 网络模型（关键）
@@ -126,7 +128,7 @@ journalctl -u dfkv -n 10 --no-pager
 #      + "dfkv_server registered with MDS group=default id=n57 advertise=192.168.1.57:28001"
 ```
 > server 的 bootstrap 监听 `0.0.0.0`，靠防火墙限制在内网。优雅关闭已修（`systemctl stop` 约 1s 退出）。
-> **多轨**：让客户端在多张 400G 口间分散即可（见 §5 `DFKV_RDMA_DEV` 列表）；server 会按客户端请求的设备名在同轨开 QP，无需为多轨改 server 配置（保留 `--rdma-dev` 作默认）。
+> **多轨**：让客户端在多张 400G 口间分散即可（客户端 `DFKV_RDMA_DEV` 逗号列表，见各引擎对接文档如 [hicache/DEPLOY.md](hicache/DEPLOY.md)）；server 会按客户端请求的设备名在同轨开 QP，无需为多轨改 server 配置（保留 `--rdma-dev` 作默认）。
 > ⚠️ 同机 8×400G 多轨受 NUMA 限制（NIC 跨双 socket，单内存域）；单口已近线速，多轨叠加需 NUMA 感知，暂不必配。
 
 ## 4. 集群成员管理
@@ -152,64 +154,7 @@ n57=192.168.1.57:28001,n58=192.168.1.58:28001,...
 增减节点 = 改成员字符串并重载 SGLang 端。`dfkv_server` 此时不带 `--mds` 启动。
 建议 N≥4 降低单点 miss 影响。
 
-## 5. SGLang 侧接入（免 fork，dynamic 侧载）
-
-把 `libdfkv.so` + `python/dfkv_hicache.py` 放到 pod 可访问路径，启动 `sglang serve` 前注入环境：
-```bash
-export PYTHONPATH=/userdata/dfkv:$PYTHONPATH
-export DFKV_LIB=/userdata/dfkv/libdfkv.so
-export DFKV_RDMA=1                       # 启用 RDMA 数据面（否则 TCP）
-export DFKV_REQUIRE_RDMA=1               # 可选：禁止悄悄 TCP fallback
-export DFKV_RDMA_DEV=ib7s400p0           # 数据面设备；多轨用逗号列表 ib7s400p0,ib7s400p1,...
-export DFKV_RDMA_MAX_PAYLOAD_BYTES=67108864  # 可选：单 chunk payload 上限，默认 64MiB
-# 可选: DFKV_RDMA_DEPTH (单连接 pipeline, K 个请求在途; 仅网络延迟隐藏、对吞吐 flat——见下注; 默认 1 即可)
-```
-> ⚠️ **depth 是延迟隐藏、不是吞吐旋钮(2026-06 实测更正)**：server 单连接 serve loop 串行处理,
-> 实测 **PUT 与 GET 的吞吐对 depth 都是 flat**(1≈8≈16≈32)。早先"depth>1 抬高写带宽"的说法不成立。
-> 写/读吞吐的真正杠杆是 **`batch_concurrency`(多连接跨节点 fan-out,客户端默认 8)** 与**少而大的 key**;
-> depth 只在网络延迟受限的链路上有意义,**默认 1 即可**,见 `docs/datapath-perf-notes.md`。
-> (机制仍在:extra_config `"rdma_depth":K` 会在 dfkv_open 前自动设 DFKV_RDMA_DEPTH,且 client depth ≤ server depth;但一般无需设。)
-
-> **多轨 NUMA 选轨**（v1.2.0 起）：设 extra_config `"rdma_numa":1`（或 env `DFKV_RDMA_NUMA=1`）+ 多轨 `DFKV_RDMA_DEV`，**C++ 客户端在建连时按调用线程的 NUMA 节点自动选本地轨**（无本地轨→轮转全轨）。SGLang/vLLM 两端通吃，无需各自改，仅在新建连接触发（热路径零开销）。
-> - ⚠️ **旧 `"rail_affinity"` 已废弃为 no-op**（v1.2.0）：它按 `tp_rank` 收窄，但 DP-attention 下每 rank `tp_rank=0`→塌缩到单轨。配了只打 stderr 告警、不再生效；改用上面的 `rdma_numa`。
-
-**方案 A — MDS 动态发现（推荐）**：配置 `mds_endpoints` + `mds_group`；插件内部调用
-`dfkv_start_mds_discovery` 自动轮询 MDS，epoch 变化时重建环，无需重启。
-```bash
-sglang serve ... \
-  --enable-hierarchical-cache --hicache-write-policy write_through \
-  --hicache-mem-layout page_first_direct --hicache-io-backend direct \
-  --hicache-storage-backend dynamic \
-  --hicache-storage-backend-extra-config '{
-    "backend_name":"dfkv","module_path":"dfkv_hicache","class_name":"DfkvHiCache",
-    "interface_v1":1,
-    "mds_endpoints":"10.0.0.1:9400,10.0.0.2:9400",
-    "mds_group":"default",
-    "model_hash": 81, "page_size":64, "dtype_tag":1178092852,
-    "layer_num":78, "head_num":1, "head_dim":576 }'
-```
-
-**方案 B — 静态成员表（遗留）**：无 MDS 时配置 `members` 字段，节点增减需重启 SGLang。
-```bash
-sglang serve ... \
-  --enable-hierarchical-cache --hicache-write-policy write_through \
-  --hicache-mem-layout page_first_direct --hicache-io-backend direct \
-  --hicache-storage-backend dynamic \
-  --hicache-storage-backend-extra-config '{
-    "backend_name":"dfkv","module_path":"dfkv_hicache","class_name":"DfkvHiCache",
-    "interface_v1":1,
-    "members":"n57=192.168.1.57:28001,n58=192.168.1.58:28001",
-    "model_hash": 81, "page_size":64, "dtype_tag":1178092852,
-    "layer_num":78, "head_num":1, "head_dim":576 }'
-```
-> **`interface_v1:1` 是必填项**，插件 `__init__` 强校验：缺失即 `raise ValueError` 启动失败。原因——对 `dynamic` 后端，SGLang 仅在 `interface_v1` 为真时才走零拷贝 `batch_set_v1/get_v1`；否则退回 generic `set/get` 路径，而 dfkv 的 generic `get/batch_get` 是未实现的桩，会导致**写成功、L3 读静默失败**（线上踩过：launch 脚本漏配此项，14GB 写入但 prefetch 全部 miss）。
-> `interface_v1:1` 触发零拷贝 `batch_set_v1/get_v1` —— GET payload 经 RDMA 散射**直落 HiCache 宿主页**（client 端零拷贝），server 端 O_DIRECT 直读入已注册 direct buffer 并 scatter-send（server 端无 payload memcpy），两端零拷贝。
-> MLA 下插件自动单对象、无 rank 后缀、`backup_skip`（仅 tp_rank0 写）。decode 共享前缀配同 members。
-> 多池模型（Mamba/SWA/DeepSeek-V4）用 v2 PoolTransfer 接口（插件已实现）。
-> 排查命中率/慢操作：可开启 access log（`access_log`/`access_log_path` 或 `DFKV_ACCESS_LOG_*`），见 [access_log.md](hicache/access_log.md)。
-> **客户端指标**：插件自动在 SGLang 自带的 `/metrics` 上暴露 `dfkv_client_*{tp_rank}`（set/get 量、命中、IO 错误、peer 熔断切换、set/get 延迟直方图）。后台轮询线程读 C 客户端快照，间隔由 extra_config `client_stats_poll_s`（默认 10s，`DFKV_CLIENT_STATS_POLL_S` 兜底，`0`=关）控制。全指标见 [METRICS.md](METRICS.md) §3.3。
-
-## 6. 上线顺序 + 冒烟（无需 GPU）
+## 5. 上线顺序 + 冒烟（无需 GPU）
 
 1. （MDS 路径）起 etcd，再起所有 `dfkv_mds` 副本（§2b），确认日志 "listening"。
 2. 所有节点起 `dfkv_server`（§3），确认 PORT + "registered with MDS" 日志。
@@ -226,18 +171,18 @@ sglang serve ... \
 5. 压测（可选）：`DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 dfkv_bench --members ... --size 2752512 --count 8000 --threads 64`。
 6. 在**一个受控 SGLang 副本**上切 `dynamic` 后端，发共享长前缀请求看命中上涨，确认后推广。
 
-## 7. 回滚（秒级）
+## 6. 回滚（秒级）
 - SGLang：`--hicache-storage-backend` 改回原后端（mooncake 等）重启该副本，与 dfkv 解耦。
 - dfkv 节点：`systemctl stop dfkv`；缓存可丢（KV 可重算），彻底清理删 `/mnt/diskX/dfkv`。
 - dfkv MDS：`systemctl stop dfkv_mds`；无状态，etcd 数据可保留也可清除（`etcdctl del /dfkv --prefix`）。
 - 全程不影响 dingo-cache / dingofs / 生产 MDS / 对象存储。
 
-## 8. 监控 / 边界
+## 7. 监控 / 边界
 **完整指标/CLI 参考见 [METRICS.md](METRICS.md)。** 要点：
 - **Prometheus 抓取**（opt-in）：`dfkv_server`/`dfkv_mds` 加 `--metrics-port <p>` → `GET /metrics`、`/healthz`。`--id/--group` 成为 `{node,group}` 标签（不设=无标签，向后兼容）。**缺省不开端口 → 行为与旧版一致、对数据面零影响**。Prometheus 直接抓每节点 `:<p>/metrics`。
   - 服务端含：put/hit/miss、bytes、淘汰、错误分型、`open_connections`、per-disk、**采样延迟直方图 `dfkv_op_latency_seconds{op}`**、RDMA 完成/错误/活跃连接。
   - MDS 含：register/keepalive/list/lease/etcd-error + members gauge。
-  - 客户端（SGLang 插件 `/metrics`）：`dfkv_client_*{tp_rank}`，见 §5 / METRICS.md §3.3。
+  - 客户端（SGLang 插件 `/metrics`）：`dfkv_client_*{tp_rank}`，见 [hicache/DEPLOY.md](hicache/DEPLOY.md) / METRICS.md §3.3。
 - **集群/环视图**（CLI，无需开端口）：
   - `dfkvctl ring --mds <eps> --group <g>` — 成员表 + 一致性哈希环每节点 vnode 占比。
   - `dfkvctl stat --all --mds <eps> --group <g>` — 逐节点指标 + 集群聚合（容量/对象/命中率）。
@@ -245,32 +190,3 @@ sglang serve ... \
 - SGLang `--enable-cache-report` 的 HiCache storage hit/miss、TTFT。
 - 生产只读：不改现网组件；dfkv 端口（含 `/metrics`）仅内网开放、无鉴权勿暴露公网。
 - 线协议带 1B 版本号，混版本部署会被 server 拒（不静默错读）；升级时整集群同版本。**指标均为新增、不改 wire，v1.3.0 节点与 v1.4.0 客户端互通。**
-
-## 9. 引擎与特性边界（HiCache 侧）
-
-dfkv 现在同时服务三种引擎：**SGLang HiCache**（本 runbook）、**LMCache**（`docs/lmcache/`）、
-**vLLM 直连**（`docs/vllm/DEPLOY.md`）。后续给 vLLM 连接器加的几个特性**并不适用于 HiCache 侧**，
-不是漏配，是数据形状不匹配——HiCache 维持常规路径即可：
-
-- **scatter-gather（SG，合并 key）— HiCache 不用。** SG 把"一个 chunk 的多个层段"合成一个多-SGE
-  RDMA key，是为 vLLM 连接器的变长 chunk × 多层段做的。HiCache MLA **每页就是一个打包 latent 对象
-  （~2.74 MiB）**，本来一页一 key、无碎段可合，SG 在此无收益。（仅 MHA 的 `_k`/`_v` 对或未来多池
-  HiCache v2 才理论上有边际收益，且需改插件代码、非开关。）
-- **io_uring async GET（`DFKV_SERVER_URING`）— HiCache 不要开。** 实测单盘上对吞吐 **flat/无收益**
-  （瓶颈是盘不是读提交），默认关。HiCache 单盘场景开它纯属白费。
-- **`DFKV_RDMA_DEPTH` — 保持默认 1**（见 §5：实测对 PUT/GET 吞吐都 flat）。
-- HiCache 真正需要的硬化与可观测性（RDMA 空闲回收、CLOCK 持久指针、MDS 硬化、Prometheus 指标）
-  **已在 v1.5.2 内**，无需额外动作。
-
-### vLLM 实例与 HiCache 实例（即便同一模型）能否共用同一个池？
-
-- **共用同一套 dfkv 集群 / 同一个哈希环：可以。** 环只负责把 key 路由到节点；两种引擎指同一 `members`
-  即可共用存储池与容量（共享 LRU）。
-- **但二者不会复用彼此的 KV（同模型也不行）。** SGLang HiCache 与 vLLM 连接器用**完全不同的 key 方案**
-  （前缀/哈希/`@sg` 后缀/tp_rank 处理都不同）**和不同的 KV 字节布局**（MLA 单页打包对象 vs 连接器的
-  逐组分段）。同一模型、同一段 token，两边算出的 **key 不同、字节也不兼容**——只是共存于同一池、
-  keyspace 互不相交，谈不上跨引擎前缀命中。
-- **推荐：给两者不同的命名空间隔离 keyspace**（vLLM 侧 `model_hash` / `served-model-name` 与 HiCache 侧
-  取不同值）。这样即使理论上撞到同名 key，也因命名空间不同而不会发生"同 key 不同字节"的静默错读
-  （dfkv 值头只守 `payload_len` 字节大小，大小相同而布局不同会读成脏数据）。结论：**共享节点与容量、
-  隔离 keyspace**。

--- a/docs/hicache/DEPLOY.md
+++ b/docs/hicache/DEPLOY.md
@@ -1,0 +1,137 @@
+# dfkv SGLang HiCache 对接 — 配置指南
+
+> 前提：先按 [docs/DEPLOY.md](../DEPLOY.md) 部署好 dfkv 集群(server + MDS)。本文只讲 SGLang HiCache 如何对接 dfkv 作 L3。
+
+把 `libdfkv.so` + `python/dfkv_hicache.py` 放到 pod 可访问路径，免 fork、`dynamic` 侧载。
+前提：GLM-5.1 = MLA（每页 KV ≈ 2.74 MiB 单对象、跨 TP 复制、仅 tp_rank0 写）。
+
+---
+
+## 1. 环境注入
+
+启动 `sglang serve` 前注入环境：
+```bash
+export PYTHONPATH=/userdata/dfkv:$PYTHONPATH
+export DFKV_LIB=/userdata/dfkv/libdfkv.so
+export DFKV_RDMA=1                       # 启用 RDMA 数据面（否则 TCP）
+export DFKV_REQUIRE_RDMA=1               # 可选：禁止悄悄 TCP fallback
+# 数据面设备；多轨用逗号列表（标准节点 8×400G）
+export DFKV_RDMA_DEV=ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7
+export DFKV_RDMA_NUMA=1                   # 可选：多 NUMA 大机按线程 NUMA 选本地轨（见下）
+export DFKV_RDMA_MAX_PAYLOAD_BYTES=67108864  # 可选：单 chunk payload 上限，默认 64MiB
+# 可选: DFKV_RDMA_DEPTH (单连接 pipeline, K 个请求在途; 仅网络延迟隐藏、对吞吐 flat——见下注; 默认 1 即可)
+```
+> ⚠️ **hd04 当前只有 `ib7s400p0,ib7s400p1` 两轨 up**，但标准训练计算网节点是 8×400G，应列全 8 轨。
+
+> ⚠️ **depth 是延迟隐藏、不是吞吐旋钮(2026-06 实测更正)**：server 单连接 serve loop 串行处理,
+> 实测 **PUT 与 GET 的吞吐对 depth 都是 flat**(1≈8≈16≈32)。早先"depth>1 抬高写带宽"的说法不成立。
+> 写/读吞吐的真正杠杆是 **`batch_concurrency`(多连接跨节点 fan-out,客户端默认 8)** 与**少而大的 key**;
+> depth 只在网络延迟受限的链路上有意义,**默认 1 即可**,见 [../datapath-perf-notes.md](../datapath-perf-notes.md)。
+> (机制仍在:extra_config `"rdma_depth":K` 会在 dfkv_open 前自动设 DFKV_RDMA_DEPTH,且 client depth ≤ server depth;但一般无需设。)
+
+> **多轨 NUMA 选轨**（v1.2.0 起）：设 extra_config `"rdma_numa":1`（或 env `DFKV_RDMA_NUMA=1`）+ 多轨 `DFKV_RDMA_DEV`，**C++ 客户端在建连时按调用线程的 NUMA 节点自动选本地轨**（无本地轨→轮转全轨）。SGLang/vLLM 两端通吃，无需各自改，仅在新建连接触发（热路径零开销）。
+> - ⚠️ **旧 `"rail_affinity"` 已废弃为 no-op**（v1.2.0）：它按 `tp_rank` 收窄，但 DP-attention 下每 rank `tp_rank=0`→塌缩到单轨。配了只打 stderr 告警、不再生效；改用上面的 `rdma_numa`。
+
+---
+
+## 2. SGLang 启动 + 后端配置
+
+**方案 A — MDS 动态发现（推荐）**：配置 `mds_endpoints` + `mds_group`；插件内部调用
+`dfkv_start_mds_discovery` 自动轮询 MDS，epoch 变化时重建环，无需重启。
+```bash
+sglang serve ... \
+  --enable-hierarchical-cache --hicache-write-policy write_through \
+  --hicache-mem-layout page_first_direct --hicache-io-backend direct \
+  --hicache-storage-prefetch-policy timeout \
+  --hicache-size <字节> \
+  --hicache-storage-backend dynamic \
+  --hicache-storage-backend-extra-config '{
+    "backend_name":"dfkv","module_path":"dfkv_hicache","class_name":"DfkvHiCache",
+    "interface_v1":1,
+    "mds_endpoints":"10.0.0.1:9400,10.0.0.2:9400",
+    "mds_group":"default",
+    "model_hash": 81, "page_size":64, "dtype_tag":1178092852,
+    "layer_num":78, "head_num":1, "head_dim":576 }'
+```
+
+**方案 B — 静态成员表（遗留）**：无 MDS 时配置 `members` 字段，节点增减需重启 SGLang。
+```bash
+sglang serve ... \
+  --enable-hierarchical-cache --hicache-write-policy write_through \
+  --hicache-mem-layout page_first_direct --hicache-io-backend direct \
+  --hicache-storage-prefetch-policy timeout \
+  --hicache-size <字节> \
+  --hicache-storage-backend dynamic \
+  --hicache-storage-backend-extra-config '{
+    "backend_name":"dfkv","module_path":"dfkv_hicache","class_name":"DfkvHiCache",
+    "interface_v1":1,
+    "members":"n57=192.168.1.57:28001,n58=192.168.1.58:28001",
+    "model_hash": 81, "page_size":64, "dtype_tag":1178092852,
+    "layer_num":78, "head_num":1, "head_dim":576 }'
+```
+
+### HiCache 关键 flag
+
+| flag | 推荐 | 说明 |
+|---|---|---|
+| `--hicache-storage-backend dynamic` | 必填 | 侧载 dfkv 插件，免 fork SGLang |
+| `--hicache-io-backend direct` | `direct` | O_DIRECT 零拷贝读写路径 |
+| `--hicache-mem-layout page_first_direct` | `page_first_direct` | 配合 direct 后端的内存布局 |
+| `--hicache-write-policy write_through` | `write_through` | 写穿，L3 与 L1/L2 同步 |
+| `--hicache-storage-prefetch-policy timeout` | `timeout` | prefetch 用 timeout 策略（best_effort 之外更安全的杠杆） |
+| `--hicache-size <字节>` | 按 L2-L1 容量 | L3 prefetch 容量；⚠️ 须满足 L2>L1 硬约束，prefetch 容量比建议 0.8 |
+
+> **`interface_v1:1` 是必填项**，插件 `__init__` 强校验：缺失即 `raise ValueError` 启动失败。原因——对 `dynamic` 后端，SGLang 仅在 `interface_v1` 为真时才走零拷贝 `batch_set_v1/get_v1`；否则退回 generic `set/get` 路径，而 dfkv 的 generic `get/batch_get` 是未实现的桩，会导致**写成功、L3 读静默失败**（线上踩过：launch 脚本漏配此项，14GB 写入但 prefetch 全部 miss）。
+> `interface_v1:1` 触发零拷贝 `batch_set_v1/get_v1` —— GET payload 经 RDMA 散射**直落 HiCache 宿主页**（client 端零拷贝），server 端 O_DIRECT 直读入已注册 direct buffer 并 scatter-send（server 端无 payload memcpy），两端零拷贝。
+> MLA 下插件自动单对象、无 rank 后缀、`backup_skip`（仅 tp_rank0 写）。decode 共享前缀配同 members。
+> 多池模型（Mamba/SWA/DeepSeek-V4）用 v2 PoolTransfer 接口（插件已实现）。
+> 排查命中率/慢操作：可开启 access log（`access_log`/`access_log_path` 或 `DFKV_ACCESS_LOG_*`），见 [../access_log.md](../access_log.md)。
+> **客户端指标**：插件自动在 SGLang 自带的 `/metrics` 上暴露 `dfkv_client_*{tp_rank}`（set/get 量、命中、IO 错误、peer 熔断切换、set/get 延迟直方图）。后台轮询线程读 C 客户端快照，间隔由 extra_config `client_stats_poll_s`（默认 10s，`DFKV_CLIENT_STATS_POLL_S` 兜底，`0`=关）控制。全指标见 [../METRICS.md](../METRICS.md) §3.3。
+
+---
+
+## 3. 验证
+
+在**一个受控 SGLang 副本**上切 `dynamic` 后端，发共享长前缀请求看命中上涨，确认后推广：
+- SGLang `--enable-cache-report` 的 HiCache storage hit/miss、TTFT。
+- server 侧 `dfkvctl stat --all --mds <eps> --group <g>` 或 `/metrics` 看 get 命中、写入量（见 [../DEPLOY.md](../DEPLOY.md) §监控）。
+- 回滚：`--hicache-storage-backend` 改回原后端（mooncake 等）重启该副本，与 dfkv 解耦。
+
+---
+
+## 4. 引擎与特性边界（HiCache 侧）
+
+dfkv 现在同时服务三种引擎：**SGLang HiCache**（本文）、**LMCache**（`docs/lmcache/`）、
+**vLLM 直连**（`docs/vllm/DEPLOY.md`）。后续给 vLLM 连接器加的几个特性**并不适用于 HiCache 侧**，
+不是漏配，是数据形状不匹配——HiCache 维持常规路径即可：
+
+- **scatter-gather（SG，合并 key）— HiCache 不用。** SG 把"一个 chunk 的多个层段"合成一个多-SGE
+  RDMA key，是为 vLLM 连接器的变长 chunk × 多层段做的。HiCache MLA **每页就是一个打包 latent 对象
+  （~2.74 MiB）**，本来一页一 key、无碎段可合，SG 在此无收益。（仅 MHA 的 `_k`/`_v` 对或未来多池
+  HiCache v2 才理论上有边际收益，且需改插件代码、非开关。）
+- **io_uring async GET（`DFKV_SERVER_URING`）— HiCache 不要开。** 实测单盘上对吞吐 **flat/无收益**
+  （瓶颈是盘不是读提交），默认关。HiCache 单盘场景开它纯属白费。
+- **`DFKV_RDMA_DEPTH` — 保持默认 1**（见 §1：实测对 PUT/GET 吞吐都 flat）。
+- HiCache 真正需要的硬化与可观测性（RDMA 空闲回收、CLOCK 持久指针、MDS 硬化、Prometheus 指标）
+  **已在 v1.5.2 内**，无需额外动作。
+
+### vLLM 实例与 HiCache 实例（即便同一模型）能否共用同一个池？
+
+- **共用同一套 dfkv 集群 / 同一个哈希环：可以。** 环只负责把 key 路由到节点；两种引擎指同一 `members`
+  即可共用存储池与容量（共享 LRU）。
+- **但二者不会复用彼此的 KV（同模型也不行）。** SGLang HiCache 与 vLLM 连接器用**完全不同的 key 方案**
+  （前缀/哈希/`@sg` 后缀/tp_rank 处理都不同）**和不同的 KV 字节布局**（MLA 单页打包对象 vs 连接器的
+  逐组分段）。同一模型、同一段 token，两边算出的 **key 不同、字节也不兼容**——只是共存于同一池、
+  keyspace 互不相交，谈不上跨引擎前缀命中。
+- **推荐：给两者不同的命名空间隔离 keyspace**（vLLM 侧 `model_hash` / `served-model-name` 与 HiCache 侧
+  取不同值）。这样即使理论上撞到同名 key，也因命名空间不同而不会发生"同 key 不同字节"的静默错读
+  （dfkv 值头只守 `payload_len` 字节大小，大小相同而布局不同会读成脏数据）。结论：**共享节点与容量、
+  隔离 keyspace**。
+
+---
+
+## 相关文档
+- [../DEPLOY.md](../DEPLOY.md) — dfkv 集群(server + MDS)标准部署
+- [../access_log.md](../access_log.md) — 逐操作访问日志
+- [../METRICS.md](../METRICS.md) — Prometheus 观测
+- [../datapath-perf-notes.md](../datapath-perf-notes.md) — RDMA 数据面性能笔记(depth-flat、coalescing 等)

--- a/docs/lmcache/DEPLOY.md
+++ b/docs/lmcache/DEPLOY.md
@@ -1,7 +1,7 @@
 # dfkv LMCache connector — 使用指南
 
 把 vLLM 的 KV cache 通过 LMCache 卸载到 **dfkv** 集群，实现跨请求/跨实例的前缀缓存复用。
-本文按步骤说明怎么从零搭起来：**编译 → 起缓存集群 → 装 connector → 改 lmcache.yaml → 起 vLLM → 验证**。
+本文按步骤说明：**装 connector → 改 lmcache.yaml → 起 vLLM → 验证**。
 
 设计与实现细节见 [DESIGN.md](DESIGN.md) / [IMPLEMENTATION.md](IMPLEMENTATION.md)。
 
@@ -9,81 +9,39 @@
 
 ## 0. 角色与前置条件
 
-两类机器：
+> **前提：先按 [docs/DEPLOY.md](../DEPLOY.md) 部署好 dfkv 集群(server + MDS)。**
+
+推理节点要求：
 
 | 角色 | 跑什么 | 要求 |
 |---|---|---|
-| **推理节点** | vLLM + LMCache + dfkv connector | GPU；已装 vLLM、LMCache (≥0.4.5)；编译需 cmake≥3.20、gcc/g++ |
-| **缓存节点**（≥1 台）| `dfkv_server` | 有数据盘（如 NVMe）；编译需 cmake、gcc/g++；走 RDMA 还需 `libibverbs-dev` |
+| **推理节点** | vLLM + LMCache + dfkv connector | GPU；已装 vLLM、LMCache (≥0.4.5)；connector 是纯 Python 包(ctypes 调 `libdfkv.so`) |
 
 网络要求：
 - 推理节点必须能 TCP 连到每台缓存节点的 dfkv 端口。
-- 若用 RDMA，推理节点与缓存节点要在**同一 IB/RoCE 网络**（否则用 TCP，见第 4 步）。
+- 若用 RDMA，推理节点与缓存节点要在**同一 IB/RoCE 网络**（否则用 TCP，见第 2 步）。
 
 下文用占位符，请替换成你的实际值：
 - `<CACHE1_IP>` `<CACHE2_IP>` … 缓存节点 IP
-- `<DFKV_SRC>` dfkv 源码目录、`<LIBDFKV>` 编译出的 `libdfkv.so` 路径
+- `<DFKV_SRC>` dfkv 源码目录、`<LIBDFKV>` 部署好的 `libdfkv.so` 路径
 
 ---
 
-## 第 1 步：编译 dfkv
-
-推理节点和缓存节点都要编译（同一份源码，产物不同）。
-
-```bash
-git clone -b feat/lmcache_connector https://github.com/dingodb/dfkv.git
-cd dfkv
-# RDMA 版（推荐，自动带 TCP 回退）；只要 TCP 就把 ON 改成 OFF
-cmake -S . -B build-rdma -DDFKV_WITH_RDMA=ON -DDFKV_BUILD_TESTS=OFF
-cmake --build build-rdma -j"$(nproc)" --target dfkv dfkv_server
-```
-
-产物：
-- `build-rdma/libdfkv.so` —— **推理节点** connector 通过 ctypes 加载的库。
-- `build-rdma/dfkv_server` —— **缓存节点** 的缓存服务进程。
-
-> 访问 github 需要代理时：`ALL_PROXY=socks5://<proxy_ip:port> git clone ...`。
-
----
-
-## 第 2 步：在每台缓存节点启动 dfkv_server
-
-每台缓存节点起一个 `dfkv_server`，指定数据盘目录、端口和容量：
-
-```bash
-# TCP + RDMA 都监听（RDMA 设备名用本机的，如 mlx5_0 / ib0；查 `ls /sys/class/infiniband`）
-dfkv_server \
-  --dir /data/disk0/dfkv,/data/disk1/dfkv \   # 逗号分隔多块盘
-  --port 18800 \                              # TCP 端口
-  --rdma-port 18801 \                         # RDMA 端口（不要 RDMA 就去掉这两行）
-  --rdma-dev mlx5_0 \
-  --cap 214748364800                          # 该节点总容量（字节），按盘量设
-```
-
-启动成功会打印 `PORT 18800` 并常驻。**记下每台节点的 `<IP>:<端口>`**，第 4 步要用：
-- 走 TCP → 用 `--port`（如 `<CACHE1_IP>:18800`）
-- 走 RDMA → 用 `--rdma-port`（如 `<CACHE1_IP>:18801`）
-
-> 生产环境想让客户端自动发现节点增减，可改用 MDS 发现模式（`dfkv_mds` + etcd + `dfkv_server --mds ...`），
-> 见根目录 [../DEPLOY.md](../DEPLOY.md)；本指南用更简单的**静态成员**模式。
-
----
-
-## 第 3 步：在推理节点安装 connector
+## 第 1 步：在推理节点安装 connector
 
 装到 vLLM 所在的 Python 环境（venv/conda）里：
 
 ```bash
 source /path/to/your/vllm-venv/bin/activate
 pip install <DFKV_SRC>/integration/lmcache       # 纯 Python wheel，不编译
-export DFKV_LIB=<DFKV_SRC>/build-rdma/libdfkv.so  # 指向第 1 步编出的库
+export DFKV_LIB=<LIBDFKV>                          # 指向部署好的 libdfkv.so
 ```
 
 `dfkv-connector` 是纯 Python 包（通过 ctypes 调用 `libdfkv.so`），无需匹配 ABI。
 
 ---
 
-## 第 4 步：写 LMCache 配置 `lmcache.yaml`
+## 第 2 步：写 LMCache 配置 `lmcache.yaml`
 
 新建一个 LMCache 配置文件，启用 dfkv 插件。**TCP 版**（最简单，先跑通用这个）：
 
@@ -98,10 +56,10 @@ extra_config:
   # 静态成员：列出每台缓存节点的 name=ip:TCP端口，逗号分隔；末尾 /<group> 任意填
   remote_storage_plugin.dfkv.url:         dfkv://c1=<CACHE1_IP>:18800,c2=<CACHE2_IP>:18800/g1
   remote_storage_plugin.dfkv.membership:  static
-  remote_storage_plugin.dfkv.lib:         <DFKV_SRC>/build-rdma/libdfkv.so
+  remote_storage_plugin.dfkv.lib:         <LIBDFKV>
 ```
 
-**RDMA 版**：只改两点 —— URL 用 **RDMA 端口（18801）**，并在第 5 步给 vLLM 进程加 `export DFKV_RDMA=1`：
+**RDMA 版**：只改两点 —— URL 用 **RDMA 端口（18801）**，并在第 3 步给 vLLM 进程加 `export DFKV_RDMA=1`：
 
 ```yaml
   remote_storage_plugin.dfkv.url:         dfkv://c1=<CACHE1_IP>:18801,c2=<CACHE2_IP>:18801/g1
@@ -109,17 +67,27 @@ extra_config:
 
 > 跨网卡（推理节点与缓存节点的 RDMA 设备名不同，如 a100 是 `ib6s200p0`、缓存节点是 `mlx5_0`）时，
 > **不要**在推理节点设 `DFKV_RDMA_DEV`：客户端会用本机第一个设备、并让服务端用它自己的 `--rdma-dev`。
+> 同轨同网卡且要多轨时，`DFKV_RDMA_DEV` 用逗号列表列全部口（标准节点 8×400G：
+> `ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7`；hd04 当前仅 p0,p1 up）。
+
+> **生产推荐 MDS 动态发现**（取代静态成员，节点增减自动生效）：把 `membership` 改为 `mds`、
+> `url` 的 endpoint 改成 dfkv_mds 层的 `ip:port` 列表（组名走 URL 末尾 `/<group>`），
+> 可选 `remote_storage_plugin.dfkv.mds_poll_ms`（默认 3000）。MDS 层如何部署见 [../DEPLOY.md](../DEPLOY.md) §4。
+> ```yaml
+>   remote_storage_plugin.dfkv.membership: mds
+>   remote_storage_plugin.dfkv.url:        dfkv://192.168.0.8:28150,192.168.0.9:28150,192.168.0.10:28150/glm
+> ```
 
 ---
 
-## 第 5 步：启动 vLLM
+## 第 3 步：启动 vLLM
 
 让 vLLM 用 LMCache 连接器，并指向上面的 yaml：
 
 ```bash
 export LMCACHE_USE_EXPERIMENTAL=True
 export LMCACHE_CONFIG_FILE=/path/to/lmcache.yaml
-export DFKV_LIB=<DFKV_SRC>/build-rdma/libdfkv.so
+export DFKV_LIB=<LIBDFKV>
 # 只有走 RDMA 才加这一行（TCP 不要加）：
 export DFKV_RDMA=1
 
@@ -131,7 +99,7 @@ vllm serve <model_path> \
 
 ---
 
-## 第 6 步：验证
+## 第 4 步：验证
 
 1. **连接器已加载**（vLLM 启动日志里应有，且没有回退到 blackhole）：
    ```

--- a/docs/vllm/DEPLOY.md
+++ b/docs/vllm/DEPLOY.md
@@ -20,57 +20,23 @@
 
 > dfkv 与 vLLM 可同机(GPU 节点既跑 server 又跑 vLLM,池化本机 NVMe),也可分离。
 
----
-
-## 第 1 步:编译 dfkv(带 RDMA)
-
-```bash
-cmake -S . -B build -DDFKV_WITH_RDMA=ON          # 数据面 400G 必须开;可选 -DDFKV_WITH_URING=ON
-cmake --build build -j
-ldd build/dfkv_server | grep ibverbs              # 确认链接了 RDMA 库
-# 产物:build/dfkv_server  build/dfkv_mds  build/libdfkv.so
-```
-
-`libdfkv.so` 是连接器唯一的原生依赖,拷到推理节点即可(或挂载共享盘)。
+> **前提:先按 [docs/DEPLOY.md](../DEPLOY.md) 部署好 dfkv 集群(server + MDS);把 libdfkv.so
+> 拷到推理节点;`pip install -e integration/vllm` 装 dfkv_vllm 包。**
+> ⚠️ **`members` 端口必须是 server 的 `--rdma-port`(RDMA QP bootstrap),不是 `--port`。**
 
 ---
 
-## 第 2 步:启动 dfkv 存储集群
+## 第 1 步:启动 vLLM
 
-每台缓存节点起一个 `dfkv_server`。**关键:`--rdma-port` 是 RDMA QP bootstrap 端口,
-连接器的 `members` 必须指向它,而不是 `--port`。** `--advertise` 也用 rdma-port。
-
-```bash
-dfkv_server \
-  --dir /mnt/disk1/dfkv,/mnt/disk2/dfkv,/mnt/disk3/dfkv \   # 多盘逗号分隔,节点内 Ketama
-  --port 28000 --rdma-port 28001 --rdma-dev ib7s400p0 \      # port=TCP bootstrap; rdma-port=RDMA bootstrap; rdma-dev=数据面400G口
-  --cap 6597069766656 \                                      # 总容量(字节),按盘均分,自带 LRU 自限
-  --mds 10.0.0.1:9400,10.0.0.2:9400 --group glm \            # 可选:接 MDS 动态成员(否则连接器用静态 members)
-  --id n1 --advertise 192.168.1.1:28001                      # advertise 端口 = rdma-port
-```
-
-- **容量隔离**:`--cap` 设保守值,确认 `现网用量 + dfkv cap + 预留 < 物理总量`。
-- **MDS(可选)**:多副本无状态 `dfkv_mds --listen 9400 --etcd ...` + 节点 `--mds`;连接器目前用
-  **静态 `members`**,MDS 主要服务 SGLang 侧,vLLM 侧直接列服务端 rdma 地址即可。
-- 观测:加 `--metrics-port 28110` 开 Prometheus `/metrics`(off 时无监听,见 `docs/METRICS.md`)。
-
----
-
-## 第 3 步:在推理节点安装 connector
-
-```bash
-pip install -e integration/vllm        # 提供 dfkv_vllm 包(纯 Python)
-# libdfkv.so 路径通过 extra_config.lib 或 env DFKV_LIB 指定
-```
-
----
-
-## 第 4 步:启动 vLLM
+**推荐(生产):MDS 动态发现** —— 配 `mds_endpoints` + `mds_group`,连接器内部调
+`dfkv_start_mds_discovery` 自动轮询 MDS、epoch 变化时重建环,节点增减无需重启 vLLM。
+连接器要求 **`mds_endpoints` 或 `members` 二选一**,设了 `mds_endpoints` 即优先走 MDS。
 
 ```bash
 PYTHONHASHSEED=0 \                       # ★ 必设,见下方说明,否则跨进程/重启不命中
-DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 \    # 选 RDMA 传输 + 数据面轨
-DFKV_LIB=/opt/dfkv/libdfkv.so \
+DFKV_RDMA=1 \
+DFKV_RDMA_DEV=ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7 \
+DFKV_LIB=/opt/dfkv/libdfkv.so \          # 数据面 8×400G 多轨(逗号列表);单口节点列单个
 vllm serve <model> \
   --tensor-parallel-size 2 --data-parallel-size 4 \
   --kv-transfer-config '{
@@ -78,11 +44,25 @@ vllm serve <model> \
     "kv_connector_module_path": "dfkv_vllm.connector",
     "kv_role": "kv_both",
     "kv_connector_extra_config": {
-      "members": "n1=192.168.1.1:28001,n2=192.168.1.2:28001",
+      "mds_endpoints": "192.168.0.8:28150,192.168.0.9:28150,192.168.0.10:28150",
+      "mds_group": "glm",
       "model_hash": "1234567890",
       "batch_concurrency": "8"
     }
   }'
+```
+
+> ⚠️ **`DFKV_RDMA_DEV` 默认列全 8 轨**:一台 8×400G 节点把 8 个口都列上(逗号分隔)。
+> hd04 当前只有 `ib7s400p0,ib7s400p1` 两轨 up,但标准节点有 8 轨——按本机实际 up 的口列。
+
+**备选(单节点 / 简单部署):静态成员表** —— 无 MDS 时改用 `members`,节点增减需重启 vLLM:
+
+```bash
+    "kv_connector_extra_config": {
+      "members": "n1=192.168.1.1:28001,n2=192.168.1.2:28001",   # 端口=server --rdma-port
+      "model_hash": "1234567890",
+      "batch_concurrency": "8"
+    }
 ```
 
 > **`PYTHONHASHSEED=0` 是头号坑。** dfkv key 的 chunk_hash 源自 vLLM 的 block hash,
@@ -92,7 +72,7 @@ vllm serve <model> \
 
 ---
 
-## 第 5 步:验证
+## 第 2 步:验证
 
 1. **首轮(cold)**:发一个长 prompt,记 TTFT。
 2. **重启 vLLM**(或换一个 DP 实例)后**发同一 prompt**:若连接器工作,vLLM 跳过 prefill
@@ -100,8 +80,8 @@ vllm serve <model> \
    **输出与 cold 逐字一致**。
 3. server 侧 `dfkvctl stat --all` 或 `/metrics` 看 get 命中、写入量。
 
-不命中排查顺序:`PYTHONHASHSEED` → `members` 端口是否 rdma-port → `nvidia-peermem` →
-`model_hash`/几何是否一致(见下)。
+不命中排查顺序:`PYTHONHASHSEED` → MDS 可达(或静态 `members` 端口是否 rdma-port) →
+`nvidia-peermem` → `model_hash`/几何是否一致(见下)。
 
 ---
 
@@ -112,7 +92,7 @@ vllm serve <model> \
 | env | 默认 | 推荐 | 说明 |
 |---|---|---|---|
 | `DFKV_RDMA` | 未设=TCP | `1` | 选 RDMA 传输;未设则 TCP 回退 |
-| `DFKV_RDMA_DEV` | — | 本机 400G 口名(`ib7s400p0`) | RDMA 轨,逗号列表=多轨;`DFKV_RDMA=1` 时必填 |
+| `DFKV_RDMA_DEV` | — | 本机所有 400G 口名,逗号列表(标准节点 8 轨 `ib7s400p0,...,p7`) | RDMA 轨,逗号列表=多轨;`DFKV_RDMA=1` 时必填(hd04 当前仅 p0,p1 up,标准节点 8 轨) |
 | **`PYTHONHASHSEED`** | 未设 | **`0`(全 rank/实例一致)** | 跨进程/跨重启 key 确定性,**不设=不命中** |
 | `DFKV_RDMA_DEPTH` | `1` | **保持 1** | 每连接在途请求数;延迟隐藏、**非吞吐旋钮**(GET/PUT 都 depth-flat,server 单连接串行) |
 | `DFKV_RDMA_NUMA` | `0` | 多 NUMA 大机可设 `1` | 绑 buffer/线程到轨的 NUMA 节点 + 选 NUMA-local 轨 |
@@ -120,9 +100,14 @@ vllm serve <model> \
 
 ### B. `kv_connector_extra_config`
 
+> 成员发现:连接器要求 **`mds_endpoints` 或 `members` 二选一**;设了 `mds_endpoints` 即优先走 MDS,生产推荐 MDS。
+
 | key | 默认 | 推荐 | 说明 |
 |---|---|---|---|
-| `members` | 必填 | `n=ip:rdma-port,...` | **端口必须是 server 的 `--rdma-port`**,不是 `--port` |
+| `mds_endpoints` | — | `ip:port,...`(dfkv_mds 层,如 `192.168.0.8:28150,...`) | **生产首选**;设了即走 MDS 动态发现,省略 `members` |
+| `mds_group` | `default` | `glm` 等 | MDS 成员组名,与 `dfkv_server --group` 一致 |
+| `mds_poll_ms` | `3000` | 默认即可 | MDS 轮询间隔(ms),epoch 变化时重建环 |
+| `members` | static fallback(用 mds_endpoints 时省略) | `n=ip:rdma-port,...` | **端口必须是 server 的 `--rdma-port`**,不是 `--port` |
 | `model_hash` | `0` | 每模型一个固定 uint64 | key 命名空间;共享需几何一致(见下) |
 | `lib` | env 兜底 | `libdfkv.so` 绝对路径 | |
 | `batch_concurrency` | `8` | **大池可调高到≈节点数** | 跨节点 fan-out,**真正的吞吐杠杆**(depth 是平的) |
@@ -130,15 +115,9 @@ vllm serve <model> \
 | `enable_cross_layers_blocks` | `False` | 默认 False | 仅当引擎分页布局层内交错时开 |
 | `lookup_rpc_port` | ipc 自动 | 一般不设 | rank0 前缀查询 RPC,仅 socket 名冲突时设 |
 
-### C. dfkv_server 关键 flag
-
-| flag | 推荐 | 说明 |
-|---|---|---|
-| `--dir` | 多块 NVMe 逗号分隔 | 节点内 Ketama 分散 |
-| `--port` / `--rdma-port` | 错开两个端口 | TCP bootstrap / RDMA bootstrap |
-| `--rdma-dev` | 数据面 400G 口名 | |
-| `--cap` | 保守值(留现网余量) | LRU 自限 |
-| `--mds`/`--group`/`--id`/`--advertise` | 接 MDS 时配 | advertise 端口=rdma-port |
+> dfkv 集群侧 flag(`--dir`/`--port`/`--rdma-port`/`--mds`/`--group`/`--advertise` 等)见
+> [docs/DEPLOY.md](../DEPLOY.md);**连接器侧只需记住 `members` 端口 = server 的 `--rdma-port`、
+> `mds_group` = server 的 `--group`**。
 
 ---
 

--- a/integration/vllm/src/dfkv_vllm/_cabi.py
+++ b/integration/vllm/src/dfkv_vllm/_cabi.py
@@ -43,6 +43,12 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_open.restype = c_void_p
     lib.dfkv_open.argtypes = [c_char_p, c_uint64] + [c_uint32] * 8
 
+    # int = dfkv_start_mds_discovery(c, mds_endpoints, group, poll_ms)
+    # Background MDS-based membership discovery (production path): the ring is
+    # built/refreshed from the MDS tier instead of a static --members list.
+    lib.dfkv_start_mds_discovery.restype = c_int
+    lib.dfkv_start_mds_discovery.argtypes = [c_void_p, c_char_p, c_char_p, c_int]
+
     # GPUDirect MR registration (ibv_reg_mr on a host OR device pointer).
     lib.dfkv_register_memory.restype = c_int
     lib.dfkv_register_memory.argtypes = [c_void_p, c_void_p, c_uint64]

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -36,23 +36,44 @@ class DfkvDeviceClient:
 
     def __init__(
         self,
-        members: str,
-        model_hash: int,
+        members: str = "",
+        model_hash: int = 0,
         lib_path: Optional[str] = None,
         batch_concurrency: int = 8,
         geometry: Sequence[int] = _GEOMETRY_ZEROS,
+        mds_endpoints: str = "",
+        mds_group: str = "default",
+        mds_poll_ms: int = 3000,
     ):
         if len(geometry) != 8:
             raise ValueError("geometry must have exactly 8 fields")
+        if not members and not mds_endpoints:
+            raise ValueError(
+                "DfkvDeviceClient needs 'mds_endpoints' (MDS discovery) or "
+                "'members' (static list)"
+            )
         self._lib = load_lib(lib_path)
+        # MDS path opens with an empty/seed member list and lets discovery build
+        # the ring; the static path opens directly with the given members.
         self._h = self._lib.dfkv_open(
             members.encode(),
             c_uint64(model_hash & 0xFFFFFFFFFFFFFFFF),
             *(c_uint32(int(g) & 0xFFFFFFFF) for g in geometry),
         )
         if not self._h:
-            raise RuntimeError(f"dfkv_open failed (members={members!r})")
+            raise RuntimeError(
+                f"dfkv_open failed (members={members!r}, mds={mds_endpoints!r})"
+            )
         self._lib.dfkv_set_batch_concurrency(self._h, c_uint64(batch_concurrency))
+        if mds_endpoints:
+            rc = self._lib.dfkv_start_mds_discovery(
+                self._h, mds_endpoints.encode(), mds_group.encode(), int(mds_poll_ms)
+            )
+            if rc != 0:
+                raise RuntimeError(
+                    f"dfkv_start_mds_discovery failed (rc={rc}, "
+                    f"mds={mds_endpoints!r}, group={mds_group!r})"
+                )
 
     @property
     def transport_mode(self) -> str:

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -727,8 +727,13 @@ class DfkvStoreWorker:
         # client. dfkv selects its own RNIC via the DFKV_RDMA_DEV env and is
         # configured entirely through kv_connector_extra_config.
         extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+        # Membership: prefer MDS discovery (production) when mds_endpoints is set;
+        # else fall back to a static members list. The client requires one of them.
         self.client = DfkvDeviceClient(
-            members=extra["members"],
+            members=extra.get("members", ""),
+            mds_endpoints=extra.get("mds_endpoints", ""),
+            mds_group=extra.get("mds_group", "default"),
+            mds_poll_ms=int(extra.get("mds_poll_ms", 3000)),
             model_hash=int(extra.get("model_hash", 0)),
             lib_path=extra.get("lib"),
             batch_concurrency=int(extra.get("batch_concurrency", 8)),


### PR DESCRIPTION
Two related changes from a production review of the hd04 deployment.

## 1. vLLM connector: MDS-based membership discovery (code)
The connector only supported a static `members` list; production uses the MDS tier (like the SGLang HiCache plugin and the LMCache connector already do). Wired `dfkv_start_mds_discovery` into the connector:
- `_cabi.py`: declare `dfkv_start_mds_discovery(c, mds_endpoints, group, poll_ms)`.
- `dfkv_client.py`: `DfkvDeviceClient` gains `mds_endpoints`/`mds_group`/`mds_poll_ms`; opens then starts background MDS discovery; requires `mds_endpoints` **or** `members`.
- `worker.py`: read the MDS keys from `kv_connector_extra_config`, prefer MDS when set.
Backward-compatible (existing members-only configs keep working).

## 2. Deploy docs restructure
Principle: **one** detailed dfkv **cluster-deploy** doc, and per-engine docs that only cover **config/connect/use** (not how to deploy dfkv).
- `docs/DEPLOY.md` → the single dfkv cluster-deploy doc (build/etcd/MDS/server/systemd/verify/rollback/monitoring); moved out the SGLang-接入 and engine-boundary sections.
- `docs/hicache/DEPLOY.md` (**new**, parallel to `docs/vllm/`) → SGLang HiCache connect/config only.
- `docs/vllm/DEPLOY.md` → dropped cluster-start steps; **MDS is now the primary path**, static members the fallback; `DFKV_RDMA_DEV` lists all 8 rails; server-flag table replaced by a pointer.
- `docs/lmcache/DEPLOY.md` → dropped cluster-start steps; added the production MDS note.
- `README` → docs/ layout + per-engine pointers.

Verified: `py_compile` clean; the MDS keys match the connector code; no per-engine doc still contains dfkv build/cluster-start steps.