### PR TITLE
ci: package vLLM/LMCache connectors into release tarball

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,10 @@ jobs:
              build-static/dfkv_smoke build-static/dfkvctl "$PKG/bin/"
           cp build-static/libdfkv.so "$PKG/lib/"
           cp python/dfkv_hicache.py python/dfkv_access_log.py python/dfkv_metrics.py "$PKG/python/"
+          # vLLM / LMCache 连接器（源码 Python 包，随 release 一起发，便于免源码直接 pip install 对接）
+          mkdir -p "$PKG/integration"
+          cp -r integration/vllm integration/lmcache "$PKG/integration/"
+          find "$PKG/integration" -type d \( -name '__pycache__' -o -name '*.egg-info' -o -name '.pytest_cache' \) -prune -exec rm -rf {} + 2>/dev/null || true
           cp README.md VERSION LICENSE "$PKG/"
           tar czf "${PKG}.tar.gz" "$PKG"
           sha256sum "${PKG}.tar.gz"


### PR DESCRIPTION
release tarball 此前只含 SGLang HiCache 的 3 个 py + libdfkv.so，缺 `integration/vllm`(DfkvStoreConnector) 与 `integration/lmcache`(LMCache 适配器)，vLLM 对接被迫另取源码。本 PR 在打包步骤加入 `integration/{vllm,lmcache}`（剔除 __pycache__/.egg-info/.pytest_cache），使 release 自带三种引擎对接所需的全部客户端文件。

注：v1.6.3 release 资产已手工重打包含连接器并 clobber 上传，本 PR 让后续版本自动包含。