### PR TITLE
ci: drop azure-cli/microsoft apt source by content, not filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,14 @@ jobs:
       - name: Install build & test deps
         run: |
           # Drop preinstalled third-party apt sources (google-chrome, microsoft):
-          # their mirrors intermittently fail `apt-get update` with a size mismatch
-          # ("File has unexpected size ... Mirror sync in progress"), which has
-          # nothing to do with our deps (all from the Ubuntu archive).
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list
+          # their mirrors intermittently break `apt-get update` (size mismatch
+          # "Mirror sync in progress", or 403/"no longer signed" on the azure-cli
+          # repo), which has nothing to do with our deps (all from the Ubuntu
+          # archive). Match by content, not filename: the offending source lives
+          # in different files across runner images (microsoft-prod.list,
+          # azure-cli.list, *.sources, ...), so a fixed rm list misses some.
+          sudo grep -rlE 'packages\.microsoft\.com|dl\.google\.com' \
+            /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++ clang python3 python3-numpy git ca-certificates
@@ -59,11 +62,14 @@ jobs:
       - name: Install deps
         run: |
           # Drop preinstalled third-party apt sources (google-chrome, microsoft):
-          # their mirrors intermittently fail `apt-get update` with a size mismatch
-          # ("File has unexpected size ... Mirror sync in progress"), which has
-          # nothing to do with our deps (all from the Ubuntu archive).
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list
+          # their mirrors intermittently break `apt-get update` (size mismatch
+          # "Mirror sync in progress", or 403/"no longer signed" on the azure-cli
+          # repo), which has nothing to do with our deps (all from the Ubuntu
+          # archive). Match by content, not filename: the offending source lives
+          # in different files across runner images (microsoft-prod.list,
+          # azure-cli.list, *.sources, ...), so a fixed rm list misses some.
+          sudo grep -rlE 'packages\.microsoft\.com|dl\.google\.com' \
+            /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends cmake ninja-build g++ git ca-certificates
       - name: Build with TSan
@@ -84,11 +90,14 @@ jobs:
       - name: Install deps incl. RDMA dev
         run: |
           # Drop preinstalled third-party apt sources (google-chrome, microsoft):
-          # their mirrors intermittently fail `apt-get update` with a size mismatch
-          # ("File has unexpected size ... Mirror sync in progress"), which has
-          # nothing to do with our deps (all from the Ubuntu archive).
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list
+          # their mirrors intermittently break `apt-get update` (size mismatch
+          # "Mirror sync in progress", or 403/"no longer signed" on the azure-cli
+          # repo), which has nothing to do with our deps (all from the Ubuntu
+          # archive). Match by content, not filename: the offending source lives
+          # in different files across runner images (microsoft-prod.list,
+          # azure-cli.list, *.sources, ...), so a fixed rm list misses some.
+          sudo grep -rlE 'packages\.microsoft\.com|dl\.google\.com' \
+            /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++ git ca-certificates libibverbs-dev
@@ -108,11 +117,14 @@ jobs:
       - name: Install deps incl. RDMA dev + tools
         run: |
           # Drop preinstalled third-party apt sources (google-chrome, microsoft):
-          # their mirrors intermittently fail `apt-get update` with a size mismatch
-          # ("File has unexpected size ... Mirror sync in progress"), which has
-          # nothing to do with our deps (all from the Ubuntu archive).
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list
+          # their mirrors intermittently break `apt-get update` (size mismatch
+          # "Mirror sync in progress", or 403/"no longer signed" on the azure-cli
+          # repo), which has nothing to do with our deps (all from the Ubuntu
+          # archive). Match by content, not filename: the offending source lives
+          # in different files across runner images (microsoft-prod.list,
+          # azure-cli.list, *.sources, ...), so a fixed rm list misses some.
+          sudo grep -rlE 'packages\.microsoft\.com|dl\.google\.com' \
+            /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++ git ca-certificates \


### PR DESCRIPTION
## Problem

The latest `main` CI run failed: the **RDMA datapath (Soft-RoCE loopback + TSan)** job died at `apt-get update` with exit code 100:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: The repository 'https://packages.microsoft.com/repos/azure-cli noble InRelease' is no longer signed.
```

This is a **runner-environment issue, not a code regression** — the same commit passed on its PR branch 40 min earlier, and 4 of 5 jobs in the failing run passed. `apt-get update` exits non-zero if *any* configured source fails to fetch, so an unrelated Microsoft mirror hiccup breaks our build.

The existing cleanup only `rm`'d `microsoft-prod.list`, but the azure-cli source lives in a **separate file** on the noble runner image, so it slipped through.

## Fix

Remove offending third-party sources by **content** (`packages.microsoft.com` / `dl.google.com`) across all of `sources.list.d/`, regardless of filename:

```bash
sudo grep -rlE 'packages\.microsoft\.com|dl\.google\.com' \
  /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
```

Applied to all four runner-based jobs. The `portable-static` job runs in an `ubuntu:22.04` container with no third-party sources and is unaffected.