### PR TITLE
fix(vllm): save-dedup must probe @sg0 keys, not bare keys

### DIFF
--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -291,10 +291,18 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if not keys:
                 return
 
-            # Check which blocks already exist (dedup)
+            # Check which blocks already exist (dedup). Blocks are stored under
+            # scatter-gather keys "<key>@sg{n}" (see _group_segments_sg), so we
+            # must probe the first SG group as the block-present proxy -- the
+            # SAME proxy the lookup path uses (find_longest_cache_hit). Probing
+            # the bare "<key>" never matches a stored "<key>@sg0", so without the
+            # suffix this dedup is a silent no-op: every block gets re-PUT on
+            # every request, even when identical KV is already cached.
             save_exists_start = time.perf_counter()
             try:
-                exists_states = self.client.batch_exist(keys)
+                exists_states = self.client.batch_exist(
+                    [f"{k}@sg0" for k in keys]
+                )
             except Exception:
                 self._record_operation(
                     "save_exists",


### PR DESCRIPTION
## Bug

The `DfkvStoreConnector` save path stores each block under scatter-gather keys `<key>@sg{n}` (`_group_segments_sg` → `batch_put_sg`), and the **lookup** path correctly probes `<key>@sg0` as the block-present proxy (`find_longest_cache_hit`, worker.py:1117, with an explanatory comment).

But the **SAVE-side dedup** check probed the *bare* key (worker.py:297):

```python
exists_states = self.client.batch_exist(keys)   # keys carry no @sg suffix
```

A bare `<key>` can never match a stored `<key>@sg0`, so `batch_exist` always returns `present=0` → `missing_indices` is always the full set → **every block is re-PUT on every request, even when identical KV is already cached.** The dedup is a silent no-op.

## Evidence (production: DeepSeek-V4-Flash, dfkv L3)

From the connector access log over a 10-min `vllm bench serve` window:

| probe | keys/batch | result |
|-------|-----------|--------|
| save-dedup (bare key) | 1121 | `present=0/1121` on **every** call (726×), never a single hit |
| lookup (`@sg0`) | 4485 | `present=4485/4485` full hit on reuse (271×) |
| load (`batch_get_auto_sg`) | 5265 | `hits=5265/5265`, 3.5 GB read back (555×) |

`batch_put_sg` keeps running at full volume (~880 MB/batch) during replay runs that the lookup reports as 100% cached — i.e. redundant re-writes. (The `1121 ≈ 4485 / put_step(4)` ratio is just the per-rank `put_step` striding of the same block set.)

## Fix

Probe `<key>@sg0`, matching the on-wire SAVE/LOAD key and the lookup path. `missing_indices` still indexes the bare `keys` list, so downstream key/segment formation is unchanged.

**Correctness was never affected** (loads already use the correct `@sg0` keys, hence cache reuse works); this removes redundant RDMA writes, server-side disk re-writes, and LRU churn on the save path.

## Testing

The vLLM connector has no CI-runnable harness (existing `integration/vllm/tests` need a GPU + a live `dfkv_server`; CI only packages the connector into the release tarball). Verified by the production access-log evidence above and by direct symmetry with the already-correct lookup probe.