### PR TITLE
feat(lmcache): MP-server L2 adapter (DfkvL2Adapter) for LMCacheMPConnector

### DIFF
--- a/docs/lmcache/DESIGN.md
+++ b/docs/lmcache/DESIGN.md
@@ -147,7 +147,10 @@ cache miss 重算）。
 - **geometry 稳定性** —— 所有字段确定性推导。
 - **大 chunk 传输** —— dfkv 无 4 MiB cap，但部署前应用真实 `full_chunk_size_bytes` 冒烟一次，
   确认 wire frame 不会拒绝大 value。
-- **无 L2 adapter 路径** —— dingofs 的 L2 adapter 绑定原生 eventfd 模型，dfkv 没有，故初版只支持
-  `remote_storage_plugin` 路径。
+- **L2 adapter 路径** —— ⚠️【2026-06-29 更新】初版只支持 `remote_storage_plugin`（in-process）路径，
+  因 dingofs 的 L2 adapter 绑定原生 eventfd 模型。**现已补齐 MP-server L2 adapter**（`l2_adapter.py`,
+  `DfkvL2Adapter`）：用后台 asyncio loop + 三 eventfd 把 dfkv 同步 ctypes 客户端桥接到 LMCache 的
+  `L2AdapterInterface`，经内置 `plugin` L2 adapter 加载（`--l2-adapter`）。GLM-5.2 上实测 store→重启→
+  从 dfkv 回载、prefill 跳过。这是 `LMCacheMPConnector`（多 KV-group 模型，如 GLM-5.x DSA）的唯一可用路径。
 - **无 remove / 枚举** —— dfkv 无此 RPC，`list()` 返回 `[]`。
 - **RDMA 可达性** —— a100↔jg29/jg31 需在同一 IB 网络，否则回退 TCP。

--- a/docs/lmcache/IMPLEMENTATION.md
+++ b/docs/lmcache/IMPLEMENTATION.md
@@ -40,7 +40,11 @@ integration/lmcache/
 | `native_client.py` | ctypes 加载 `libdfkv.so`，异步封装 batch_set/get/exists | **重写**（核心） |
 | `remote_connector.py` | `RemoteConnector` 全部接口 | 移植改名；删 cap；接 reshape；改名环境变量 |
 
-`l2_adapter.py` / `l2_factory.py` 初版**丢弃**（依赖 dfkv 没有的原生 eventfd 模型）。
+`l2_adapter.py`：⚠️【2026-06-29】初版丢弃（dingofs 版依赖原生 eventfd）；**现已重新实现** `DfkvL2Adapter`
+——纯 Python，后台 asyncio loop 跑 `DfkvNativeClient` 的 batch_set/get/exists 协程，三个 `create_event_notifier`
+（store/lookup/load）+ done-callback 桥接到 LMCache `L2AdapterInterface`；`ObjectKey`→`model_name@kv_rank@group@hash[@salt]`；
+经 LMCache 内置 `plugin` L2 adapter（`--l2-adapter {"type":"plugin",...}`）加载，给 `LMCacheMPConnector`（多 KV-group 模型）用。
+单测 `tests/test_l2_adapter.py`（fake client）+ GLM-5.2 真机 store/重启/回载已验证。
 
 ---
 

--- a/integration/lmcache/README.md
+++ b/integration/lmcache/README.md
@@ -53,6 +53,45 @@ extra_config:
 The library is found via (highest first) `remote_storage_plugin.dfkv.lib` →
 env `DFKV_LIB` → `$DFKV_BUILD/libdfkv.so`.
 
+## Configure LMCache (MP-server mode — L2 adapter)
+
+LMCache's multiprocess server (`lmcache server` + `LMCacheMPConnector` on the
+vLLM side, the path used by models that split the KV cache into multiple groups
+such as **GLM-5.1/5.2 DSA** and **DeepSeek-V4-Flash**) drives its remote tier
+through `L2AdapterInterface`, **not** the in-process `remote_storage_plugins`
+mechanism above. `dfkv_connector.l2_adapter.DfkvL2Adapter` implements that
+interface and is loaded through LMCache's built-in `plugin` L2 adapter:
+
+```bash
+# 1) Start the MP server with dfkv as the remote (L2) tier:
+lmcache server --port 6555 --max-workers 8 --l1-size-gb 80 \
+  --eviction-policy LRU --chunk-size 256 \
+  --l2-adapter '{"type":"plugin",
+    "module_path":"dfkv_connector.l2_adapter",
+    "class_name":"DfkvL2Adapter",
+    "config_class_name":"DfkvL2AdapterConfig",
+    "adapter_params":{
+      "url":"dfkv://<mds_ip:port,...>/<group>",
+      "membership":"mds",
+      "lib":"/path/to/libdfkv.so",
+      "model_name":"<deployment-name>"}}'
+
+# 2) Point vLLM at the MP server (NOTE: --no-enable-prefix-caching routes all
+#    KV reuse through LMCache):
+vllm serve <model> --tensor-parallel-size 8 --no-enable-prefix-caching \
+  --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both",
+    "kv_connector_extra_config":{"lmcache.mp.port":6555}}'
+```
+
+`adapter_params` keys: `url` (required, same grammar as in-process),
+`membership` (`mds`|`static`), `lib` (else `DFKV_LIB`), `model_name`
+(isolation namespace → stable dfkv `model_hash`), `mds_poll_ms` (3000),
+`page_size` (0 = geometry guard off), `num_workers` (8), `max_capacity_gb`
+(0 = dfkv manages its own capacity; >0 enables aggregate L2 eviction). The
+server's pinned L1 arena is auto-registered for RDMA zero-copy when LMCache
+passes an `l1_memory_desc`. Validated on GLM-5.2 (vLLM 0.23.0 + LMCache 0.4.7):
+store → restart (L1 wiped) → reload from dfkv with prefill skipped.
+
 ## Environment variables
 
 | Variable | Default | Meaning |
@@ -66,6 +105,13 @@ env `DFKV_LIB` → `$DFKV_BUILD/libdfkv.so`.
 
 ## Limitations
 
-- No L2-adapter path (the dingofs L2 adapter was bound to the native eventfd
-  model dfkv doesn't have). Only the `remote_storage_plugin` path is supported.
-- No `remove` / enumeration (`list()` returns `[]`) — dfkv has no such RPC.
+- Two integration paths, pick by LMCache mode: the in-process
+  `remote_storage_plugin` path (`adapter.py`, `RemoteConnector`) for the legacy
+  in-process connector, and the **MP-server L2-adapter path** (`l2_adapter.py`,
+  `DfkvL2Adapter`) for `LMCacheMPConnector`. The L2 adapter bridges dfkv's
+  synchronous ctypes client to LMCache's eventfd model with a background asyncio
+  loop (dfkv has no native eventfd, so no pybind/`NativeConnectorL2Adapter`
+  path is used).
+- No `remove` / enumeration (`list()` returns `[]`) — dfkv has no such RPC. L2
+  eviction (`max_capacity_gb > 0`) reports usage but cannot delete (dfkv manages
+  its own capacity).

--- a/integration/lmcache/src/dfkv_connector/l2_adapter.py
+++ b/integration/lmcache/src/dfkv_connector/l2_adapter.py
@@ -1,0 +1,518 @@
+# SPDX-License-Identifier: Apache-2.0
+"""dfkv L2 adapter for the LMCache **multiprocess (MP) server**.
+
+LMCache's MP server (``lmcache server`` + ``LMCacheMPConnector`` on the vLLM
+side) drives its remote tier through ``L2AdapterInterface`` — a non-blocking,
+eventfd-signalled store/lookup/load contract — instead of the in-process
+``RemoteConnector`` plugin mechanism used by :mod:`dfkv_connector.remote_connector`.
+The two interfaces are not interchangeable: the in-process ``remote_storage_plugins``
+config is silently ignored by the MP server, so dfkv could not be an MP L2 tier
+until this adapter existed.
+
+This module bridges the gap **without any native (pybind/eventfd) code**: it
+reuses the existing ctypes client (:class:`dfkv_connector.native_client.DfkvNativeClient`,
+which already does RDMA Put/Get over ``libdfkv.so`` and fans blocking calls out to a
+thread pool) and adapts it to the L2 eventfd model with:
+
+* three distinct cross-platform event notifiers (store / lookup / load);
+* a background asyncio loop thread that runs the client's ``batch_*`` coroutines;
+* a done-callback per submitted task that records the result and ``notify()``-s
+  the matching event fd — exactly the completion shape the MP store / prefetch
+  controllers poll for.
+
+Design notes:
+* **No allocation.** Unlike the in-process connector, the MP controllers own the
+  ``MemoryObj`` buffers for both store (read-from) and load (write-into); the
+  adapter only borrows their ``byte_array`` memoryviews for the duration of a task.
+* **RDMA zero-copy.** When the factory passes an ``l1_memory_desc`` (the server's
+  pinned L1 arena), the whole arena is registered once so Put/Get into any slice
+  skips per-op MR registration. No-op on TCP transport.
+* **Locking is a no-op.** dfkv is a remote KV store with no L1-eviction concept,
+  so lookup "locks" / unlocks are tracked only as a client-side refcount (kept for
+  interface symmetry; nothing can evict a remote object out from under a loader).
+* **Isolation.** ``ObjectKey`` is serialized to a model-namespaced string
+  (``model_name@kv_rank@object_group_id@chunk_hash[@cache_salt]``); on top of that
+  the dfkv geometry header carries a stable ``model_hash`` derived from the
+  configured ``model_name`` so two deployments sharing a ring stay isolated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import threading
+from concurrent.futures import Future as _CFuture
+from typing import TYPE_CHECKING, List, Optional
+
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
+from lmcache.v1.distributed.l2_adapters.config import L2AdapterConfigBase
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
+
+from .config import parse_dfkv_url
+from .native_client import DfkvNativeClient
+
+if TYPE_CHECKING:
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+
+logger = init_logger(__name__)
+
+# Key field separator — same convention as fs / native-connector L2 adapters.
+# ObjectKey forbids ``@`` in model_name and cache_salt, so this is unambiguous.
+_KEY_SEP = "@"
+
+_FLAG_IS_MLA = 0x1
+
+
+def _object_key_to_string(key: ObjectKey) -> str:
+    """Serialize an ObjectKey to a stable, model-namespaced dfkv key string.
+
+    Format (matches the native-connector L2 adapter so behavior is familiar)::
+
+        <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>[@<cache_salt>]
+
+    Deterministic across processes/restarts so a cache written before a restart
+    is found afterwards.
+    """
+    base = (
+        f"{key.model_name}{_KEY_SEP}{key.kv_rank:08x}"
+        f"{_KEY_SEP}{key.object_group_id:x}{_KEY_SEP}{key.chunk_hash.hex()}"
+    )
+    if key.cache_salt:
+        return f"{base}{_KEY_SEP}{key.cache_salt}"
+    return base
+
+
+def _stable_model_hash(model_name: str) -> int:
+    """Deterministic 64-bit hash of the model name (NOT Python's salted hash).
+
+    Goes into the dfkv geometry header and must be stable across process
+    restarts so a cache written before a restart is still readable.
+    """
+    digest = hashlib.blake2b((model_name or "").encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "little")
+
+
+# ----------------------------------------------------------------------------
+# Config
+# ----------------------------------------------------------------------------
+
+
+class DfkvL2AdapterConfig(L2AdapterConfigBase):
+    """Config for the dfkv L2 adapter (loaded via the ``plugin`` L2 adapter).
+
+    Example ``--l2-adapter`` JSON::
+
+        {"type": "plugin",
+         "module_path": "dfkv_connector.l2_adapter",
+         "class_name": "DfkvL2Adapter",
+         "config_class_name": "DfkvL2AdapterConfig",
+         "adapter_params": {
+             "url": "dfkv://127.0.0.1:28150/glm",
+             "membership": "mds",
+             "lib": "/dfkv/lib/libdfkv.so",
+             "model_name": "glm-5.2"
+         }}
+
+    Fields (all under ``adapter_params``):
+      - url (str, required): ``dfkv://<endpoint>/<group>``. For ``mds``
+        membership the host part is a comma-separated MDS ip:port list; for
+        ``static`` it is a literal member string.
+      - membership (str): ``"mds"`` (default) or ``"static"``.
+      - lib (str): path to ``libdfkv.so`` (else env ``DFKV_LIB`` /
+        ``$DFKV_BUILD/libdfkv.so``).
+      - model_name (str): isolation namespace → stable dfkv ``model_hash``.
+      - mds_poll_ms (int): MDS ring re-discovery interval (default 3000).
+      - page_size (int): dfkv geometry page-size guard (default 0 = no guard).
+      - num_workers (int): client I/O parallelism (default 8).
+      - max_capacity_gb (float): if > 0, enables aggregate usage reporting /
+        global eviction; default 0 (dfkv manages its own capacity).
+    """
+
+    def __init__(
+        self,
+        url: str,
+        membership: str = "mds",
+        lib: Optional[str] = None,
+        model_name: str = "",
+        mds_poll_ms: int = 3000,
+        page_size: int = 0,
+        num_workers: int = 8,
+        max_capacity_gb: float = 0.0,
+    ) -> None:
+        self.url = url
+        self.membership = membership
+        self.lib = lib
+        self.model_name = model_name
+        self.mds_poll_ms = mds_poll_ms
+        self.page_size = page_size
+        self.num_workers = num_workers
+        self.max_capacity_gb = max_capacity_gb
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DfkvL2AdapterConfig":
+        url = d.get("url")
+        if not isinstance(url, str) or not url:
+            raise ValueError("dfkv L2 adapter: 'url' must be a non-empty string")
+
+        membership = d.get("membership", "mds")
+        if membership not in ("mds", "static"):
+            raise ValueError("dfkv L2 adapter: 'membership' must be 'mds' or 'static'")
+
+        lib = d.get("lib")
+        if lib is not None and not isinstance(lib, str):
+            raise ValueError("dfkv L2 adapter: 'lib' must be a string")
+
+        model_name = d.get("model_name", "")
+        if not isinstance(model_name, str):
+            raise ValueError("dfkv L2 adapter: 'model_name' must be a string")
+
+        mds_poll_ms = d.get("mds_poll_ms", 3000)
+        if not isinstance(mds_poll_ms, int) or mds_poll_ms <= 0:
+            raise ValueError("dfkv L2 adapter: 'mds_poll_ms' must be a positive int")
+
+        page_size = d.get("page_size", 0)
+        if not isinstance(page_size, int) or page_size < 0:
+            raise ValueError("dfkv L2 adapter: 'page_size' must be a non-negative int")
+
+        num_workers = d.get("num_workers", 8)
+        if isinstance(num_workers, bool) or not isinstance(num_workers, int) \
+                or num_workers <= 0:
+            raise ValueError("dfkv L2 adapter: 'num_workers' must be a positive int")
+
+        max_capacity_gb = d.get("max_capacity_gb", 0.0)
+        if not isinstance(max_capacity_gb, (int, float)) or max_capacity_gb < 0:
+            raise ValueError(
+                "dfkv L2 adapter: 'max_capacity_gb' must be a non-negative number"
+            )
+
+        return cls(
+            url=url,
+            membership=membership,
+            lib=lib,
+            model_name=model_name,
+            mds_poll_ms=mds_poll_ms,
+            page_size=page_size,
+            num_workers=num_workers,
+            max_capacity_gb=float(max_capacity_gb),
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "dfkv L2 adapter config (under adapter_params):\n"
+            "- url (str, required): dfkv://<endpoint>/<group>\n"
+            "- membership (str): 'mds' (default) or 'static'\n"
+            "- lib (str): path to libdfkv.so (else env DFKV_LIB)\n"
+            "- model_name (str): isolation namespace -> stable model_hash\n"
+            "- mds_poll_ms (int): MDS rediscovery interval (default 3000)\n"
+            "- page_size (int): geometry page-size guard (default 0 = off)\n"
+            "- num_workers (int): client I/O parallelism (default 8)\n"
+            "- max_capacity_gb (float): >0 enables aggregate eviction "
+            "(default 0 = dfkv manages capacity)"
+        )
+
+
+# ----------------------------------------------------------------------------
+# Adapter
+# ----------------------------------------------------------------------------
+
+
+class DfkvL2Adapter(L2AdapterInterface):
+    """L2 adapter backed by a dfkv ring (ctypes ``libdfkv.so`` + asyncio bridge)."""
+
+    config_class_name = "DfkvL2AdapterConfig"
+
+    def __init__(
+        self,
+        config: DfkvL2AdapterConfig,
+        l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+    ) -> None:
+        super().__init__(max_capacity_bytes=int(config.max_capacity_gb * (1024**3)))
+        self._config = config
+
+        # 3 distinct event notifiers (the contract requires distinct fds).
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
+
+        # Shared task state (touched by submit calls on controller threads and
+        # by done-callbacks on the loop thread) — guarded by ``_lock``.
+        self._next_task_id: L2TaskId = 0
+        self._completed_stores: dict[L2TaskId, L2StoreResult] = {}
+        self._completed_lookups: dict[L2TaskId, Bitmap] = {}
+        self._completed_loads: dict[L2TaskId, Bitmap] = {}
+        self._locked_keys: dict[ObjectKey, int] = {}
+        # First-store-wins byte accounting (re-store of a known key adds 0).
+        self._key_sizes: dict[ObjectKey, int] = {}
+        self._lock = threading.Lock()
+
+        # Background asyncio loop that runs the client's batch_* coroutines.
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._run_event_loop, daemon=True, name="dfkv-l2-loop"
+        )
+        self._loop_thread.start()
+
+        # Register the server's L1 arena for RDMA zero-copy when available.
+        rdma_pools = []
+        if l1_memory_desc is not None:
+            ptr = int(getattr(l1_memory_desc, "ptr", 0) or 0)
+            size = int(getattr(l1_memory_desc, "size", 0) or 0)
+            if ptr and size:
+                rdma_pools = [(ptr, size)]
+
+        geometry = {
+            "model_hash": _stable_model_hash(config.model_name),
+            "page_size": int(config.page_size),
+            "dtype_tag": 0,
+            "flags": 0,
+            "tp_size": 1,
+            "tp_rank": 0,
+            "layer_num": 0,
+            "head_num": 0,
+            "head_dim": 0,
+        }
+
+        endpoint = parse_dfkv_url(config.url, membership=config.membership)
+        self._client = DfkvNativeClient(
+            raw_endpoint=endpoint.raw_endpoint,
+            group=endpoint.group,
+            membership=endpoint.membership,
+            geometry=geometry,
+            lib_path=config.lib,
+            mds_poll_ms=config.mds_poll_ms,
+            rdma_pools=rdma_pools,
+            loop=self._loop,
+            get_parallelism=config.num_workers,
+        )
+        logger.info(
+            "DfkvL2Adapter ready: endpoint=%s group=%s membership=%s "
+            "model_hash=%d rdma_pools=%d transport=%s",
+            endpoint.raw_endpoint, endpoint.group, endpoint.membership,
+            geometry["model_hash"], len(rdma_pools),
+            getattr(self._client, "transport_mode", "unknown"),
+        )
+
+    # ------------------------------------------------------------------
+    # Event Fd Interface
+    # ------------------------------------------------------------------
+
+    def get_store_event_fd(self) -> int:
+        return self._store_efd.fileno()
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        return self._lookup_efd.fileno()
+
+    def get_load_event_fd(self) -> int:
+        return self._load_efd.fileno()
+
+    # ------------------------------------------------------------------
+    # Store
+    # ------------------------------------------------------------------
+
+    def submit_store_task(
+        self, keys: List[ObjectKey], objects: List[MemoryObj]
+    ) -> L2TaskId:
+        key_strs = [_object_key_to_string(k) for k in keys]
+        views = [obj.byte_array for obj in objects]
+        sizes = [obj.get_size() for obj in objects]
+        with self._lock:
+            task_id = self._next_task_id
+            self._next_task_id += 1
+        fut = asyncio.run_coroutine_threadsafe(
+            self._client.batch_set(key_strs, views), self._loop
+        )
+        # Hold ``objects`` alive in the closure until the store completes — the
+        # memoryviews alias their buffers and the C call must finish reading.
+        fut.add_done_callback(
+            lambda f: self._on_store_done(f, task_id, list(keys), sizes, objects)
+        )
+        return task_id
+
+    def _on_store_done(
+        self,
+        fut: _CFuture,
+        task_id: L2TaskId,
+        keys: List[ObjectKey],
+        sizes: List[int],
+        _objects_keepalive: List[MemoryObj],
+    ) -> None:
+        keys_stored: List[ObjectKey] = []
+        sizes_stored: List[int] = []
+        task_bytes = 0
+        try:
+            ok, per_key = fut.result()
+        except Exception as e:  # pragma: no cover - network/lib failure path
+            logger.warning("dfkv L2 store task %d failed: %s", task_id, e)
+            ok, per_key = False, None
+        if ok:
+            flags = per_key if per_key is not None else [True] * len(keys)
+            for key, size, stored in zip(keys, sizes, flags):
+                if not stored:
+                    continue
+                # First-store wins: a re-store of a known key adds 0 bytes but
+                # still notifies (so LRU can move_to_end); base counters no-op.
+                if key not in self._key_sizes:
+                    self._key_sizes[key] = size
+                    keys_stored.append(key)
+                    sizes_stored.append(size)
+                    task_bytes += size
+                else:
+                    keys_stored.append(key)
+                    sizes_stored.append(0)
+        with self._lock:
+            self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+        if keys_stored:
+            self._notify_keys_stored(keys_stored, sizes_stored)
+        self._store_efd.notify()
+
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
+        with self._lock:
+            completed = self._completed_stores
+            self._completed_stores = {}
+        return completed
+
+    # ------------------------------------------------------------------
+    # Lookup and Lock
+    # ------------------------------------------------------------------
+
+    def submit_lookup_and_lock_task(self, keys: List[ObjectKey]) -> L2TaskId:
+        key_strs = [_object_key_to_string(k) for k in keys]
+        with self._lock:
+            task_id = self._next_task_id
+            self._next_task_id += 1
+        fut = asyncio.run_coroutine_threadsafe(
+            self._client.batch_exists(key_strs), self._loop
+        )
+        fut.add_done_callback(
+            lambda f: self._on_lookup_done(f, task_id, list(keys))
+        )
+        return task_id
+
+    def _on_lookup_done(
+        self, fut: _CFuture, task_id: L2TaskId, keys: List[ObjectKey]
+    ) -> None:
+        n = len(keys)
+        bitmap = Bitmap(n)
+        try:
+            per_key = fut.result()
+        except Exception as e:  # pragma: no cover
+            logger.warning("dfkv L2 lookup task %d failed: %s", task_id, e)
+            per_key = None
+        with self._lock:
+            if per_key is not None:
+                for i, found in enumerate(per_key):
+                    if found:
+                        bitmap.set(i)
+                        self._locked_keys[keys[i]] = self._locked_keys.get(keys[i], 0) + 1
+            self._completed_lookups[task_id] = bitmap
+        self._lookup_efd.notify()
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Optional[Bitmap]:
+        with self._lock:
+            return self._completed_lookups.pop(task_id, None)
+
+    def submit_unlock(self, keys: List[ObjectKey]) -> None:
+        # dfkv objects are remote and never evicted out from under a loader, so
+        # this is purely client-side refcount bookkeeping (kept for symmetry).
+        with self._lock:
+            for key in keys:
+                c = self._locked_keys.get(key)
+                if c is None:
+                    continue
+                if c <= 1:
+                    del self._locked_keys[key]
+                else:
+                    self._locked_keys[key] = c - 1
+
+    # ------------------------------------------------------------------
+    # Load
+    # ------------------------------------------------------------------
+
+    def submit_load_task(
+        self, keys: List[ObjectKey], objects: List[MemoryObj]
+    ) -> L2TaskId:
+        key_strs = [_object_key_to_string(k) for k in keys]
+        views = [obj.byte_array for obj in objects]
+        with self._lock:
+            task_id = self._next_task_id
+            self._next_task_id += 1
+        fut = asyncio.run_coroutine_threadsafe(
+            self._client.batch_get(key_strs, views), self._loop
+        )
+        # Keep ``objects`` alive until the C call finishes writing into them.
+        fut.add_done_callback(
+            lambda f: self._on_load_done(f, task_id, list(keys), objects)
+        )
+        return task_id
+
+    def _on_load_done(
+        self,
+        fut: _CFuture,
+        task_id: L2TaskId,
+        keys: List[ObjectKey],
+        _objects_keepalive: List[MemoryObj],
+    ) -> None:
+        n = len(keys)
+        bitmap = Bitmap(n)
+        accessed: List[ObjectKey] = []
+        try:
+            _ok, per_key, _lengths = fut.result()
+        except Exception as e:  # pragma: no cover
+            logger.warning("dfkv L2 load task %d failed: %s", task_id, e)
+            per_key = None
+        if per_key is not None:
+            for i, loaded in enumerate(per_key):
+                if loaded:
+                    bitmap.set(i)
+                    accessed.append(keys[i])
+        with self._lock:
+            self._completed_loads[task_id] = bitmap
+        if accessed:
+            self._notify_keys_accessed(accessed)
+        self._load_efd.notify()
+
+    def query_load_result(self, task_id: L2TaskId) -> Optional[Bitmap]:
+        with self._lock:
+            return self._completed_loads.pop(task_id, None)
+
+    # ------------------------------------------------------------------
+    # Status / Cleanup
+    # ------------------------------------------------------------------
+
+    def report_status(self) -> dict:
+        return {
+            "is_healthy": self._loop_thread.is_alive(),
+            "type": "DfkvL2Adapter",
+            "transport": getattr(self._client, "transport_mode", "unknown"),
+            "group": self._config.url,
+        }
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:  # pragma: no cover
+            pass
+        if self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        self._loop_thread.join(timeout=5)
+        try:
+            self._loop.close()
+        except Exception:  # pragma: no cover
+            pass
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run_event_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()

--- a/integration/lmcache/tests/test_l2_adapter.py
+++ b/integration/lmcache/tests/test_l2_adapter.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the dfkv LMCache MP-server L2 adapter (DfkvL2Adapter).
+
+These exercise the eventfd / task-id / Bitmap / byte-accounting *bridge* logic
+with an in-memory fake dfkv client, so they need lmcache installed but NO real
+dfkv ring or libdfkv.so. The real-ring end-to-end path is covered by the
+integration test / RUNBOOK.
+
+Run (inside an env with lmcache>=0.4.7):
+    python3 -m pytest integration/lmcache/tests/test_l2_adapter.py -v
+or standalone:
+    python3 integration/lmcache/tests/test_l2_adapter.py
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import sys
+import time
+
+# Make ``import dfkv_connector`` work when run from the repo without install.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "src")
+)
+
+import dfkv_connector.l2_adapter as l2mod  # noqa: E402
+from dfkv_connector.l2_adapter import (  # noqa: E402
+    DfkvL2Adapter,
+    DfkvL2AdapterConfig,
+    _object_key_to_string,
+)
+from lmcache.v1.distributed.api import ObjectKey  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+class _FakeObj:
+    """Minimal MemoryObj stand-in: the adapter only needs byte_array + get_size."""
+
+    def __init__(self, data: bytes):
+        self._buf = bytearray(data)
+
+    @property
+    def byte_array(self) -> memoryview:
+        return memoryview(self._buf)
+
+    def get_size(self) -> int:
+        return len(self._buf)
+
+    def data(self) -> bytes:
+        return bytes(self._buf)
+
+
+class _FakeDfkvClient:
+    """In-memory async stand-in for DfkvNativeClient (key_str -> bytes)."""
+
+    def __init__(self, **kwargs):
+        self.transport_mode = "fake"
+        self.closed = False
+        self._store: dict[str, bytes] = {}
+
+    async def batch_set(self, keys, bufs):
+        for k, b in zip(keys, bufs):
+            self._store[k] = bytes(b)
+        return True, [True] * len(keys)
+
+    async def batch_get(self, keys, bufs):
+        per_key, lengths = [], []
+        for k, b in zip(keys, bufs):
+            data = self._store.get(k)
+            if data is None:
+                per_key.append(False)
+                lengths.append(0)
+            else:
+                n = min(len(data), len(b))
+                b[:n] = data[:n]
+                per_key.append(True)
+                lengths.append(n)
+        return all(per_key) if per_key else True, per_key, lengths
+
+    async def batch_exists(self, keys):
+        return [k in self._store for k in keys]
+
+    def close(self):
+        self.closed = True
+
+
+def _mk_adapter() -> DfkvL2Adapter:
+    l2mod.DfkvNativeClient = _FakeDfkvClient  # type: ignore[assignment]
+    cfg = DfkvL2AdapterConfig.from_dict(
+        {
+            "url": "dfkv://127.0.0.1:28150/glm",
+            "membership": "mds",
+            "model_name": "unit-test",
+        }
+    )
+    return DfkvL2Adapter(cfg)
+
+
+def _key(tag: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=tag.to_bytes(8, "little"),
+        model_name="unit-test",
+        kv_rank=0,
+    )
+
+
+def _wait_for(fn, timeout: float = 5.0):
+    """Poll fn() until it returns a truthy value or timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        v = fn()
+        if v is not None:
+            return v
+        time.sleep(0.01)
+    return None
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+def test_distinct_event_fds():
+    a = _mk_adapter()
+    try:
+        fds = {
+            a.get_store_event_fd(),
+            a.get_lookup_and_lock_event_fd(),
+            a.get_load_event_fd(),
+        }
+        assert len(fds) == 3, f"event fds must be distinct, got {fds}"
+    finally:
+        a.close()
+
+
+def test_object_key_serialization_stable_and_salted():
+    k = ObjectKey(chunk_hash=b"\x01\x02\x03", model_name="m", kv_rank=5)
+    s1 = _object_key_to_string(k)
+    assert s1 == _object_key_to_string(k), "serialization must be deterministic"
+    assert s1.startswith("m@00000005@0@010203")
+    ks = ObjectKey(
+        chunk_hash=b"\x01", model_name="m", kv_rank=0, cache_salt="userA"
+    )
+    assert _object_key_to_string(ks).endswith("@userA")
+
+
+def test_store_then_lookup_then_load_roundtrip():
+    a = _mk_adapter()
+    try:
+        k = _key(1)
+        payload = b"hello-dfkv-kv-cache-payload"
+        store_tid = a.submit_store_task([k], [_FakeObj(payload)])
+        res = _wait_for(lambda: a.pop_completed_store_tasks().get(store_tid))
+        assert res is not None and res.is_successful()
+        assert res.bytes_transferred() == len(payload)
+
+        # lookup hit
+        lk_tid = a.submit_lookup_and_lock_task([k])
+        bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk_tid))
+        assert bm is not None and bm.test(0) and bm.popcount() == 1
+
+        # load writes the stored bytes back into the caller buffer
+        dst = _FakeObj(bytes(len(payload)))
+        ld_tid = a.submit_load_task([k], [dst])
+        bm2 = _wait_for(lambda: a.query_load_result(ld_tid))
+        assert bm2 is not None and bm2.test(0)
+        assert dst.data() == payload, "loaded bytes must match stored payload"
+    finally:
+        a.close()
+
+
+def test_lookup_miss_and_load_miss():
+    a = _mk_adapter()
+    try:
+        miss = _key(999)
+        lk_tid = a.submit_lookup_and_lock_task([miss])
+        bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk_tid))
+        assert bm is not None and bm.popcount() == 0
+
+        ld_tid = a.submit_load_task([miss], [_FakeObj(bytes(8))])
+        bm2 = _wait_for(lambda: a.query_load_result(ld_tid))
+        assert bm2 is not None and bm2.popcount() == 0
+    finally:
+        a.close()
+
+
+def test_batch_partial_hit():
+    a = _mk_adapter()
+    try:
+        k0, k1, k2 = _key(10), _key(11), _key(12)
+        # store only k0 and k2
+        st = a.submit_store_task([k0, k2], [_FakeObj(b"aaaa"), _FakeObj(b"cccc")])
+        _wait_for(lambda: a.pop_completed_store_tasks().get(st))
+
+        lk = a.submit_lookup_and_lock_task([k0, k1, k2])
+        bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk))
+        assert bm is not None
+        assert bm.test(0) and not bm.test(1) and bm.test(2)
+        assert bm.popcount() == 2
+    finally:
+        a.close()
+
+
+def test_store_byte_accounting_first_store_wins():
+    a = _mk_adapter()
+    try:
+        k = _key(20)
+        payload = b"x" * 4096
+        t1 = a.submit_store_task([k], [_FakeObj(payload)])
+        r1 = _wait_for(lambda: a.pop_completed_store_tasks().get(t1))
+        assert r1.bytes_transferred() == 4096
+        # re-store same key -> 0 new bytes (first-store-wins accounting)
+        t2 = a.submit_store_task([k], [_FakeObj(payload)])
+        r2 = _wait_for(lambda: a.pop_completed_store_tasks().get(t2))
+        assert r2.is_successful() and r2.bytes_transferred() == 0
+        usage = a.get_usage()
+        assert usage.total_bytes_used == 4096
+    finally:
+        a.close()
+
+
+def test_unlock_is_safe_noop_without_lock():
+    a = _mk_adapter()
+    try:
+        # unlocking unknown keys must not raise
+        a.submit_unlock([_key(31), _key(32)])
+    finally:
+        a.close()
+
+
+def test_store_event_fd_is_signalled():
+    a = _mk_adapter()
+    try:
+        efd = a.get_store_event_fd()
+        a.submit_store_task([_key(40)], [_FakeObj(b"data")])
+        # the store event fd must become readable on completion
+        r, _, _ = select.select([efd], [], [], 5.0)
+        assert efd in r, "store event fd was not signalled"
+    finally:
+        a.close()
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception as e:
+            failed += 1
+            import traceback
+            print(f"FAIL {fn.__name__}: {e}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)

--- a/integration/lmcache/tests/test_l2_adapter_integration.py
+++ b/integration/lmcache/tests/test_l2_adapter_integration.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real-ring integration test for DfkvL2Adapter (LMCache MP-server L2 adapter).
+
+Drives the adapter's store / lookup-and-lock / load path against a LIVE dfkv ring
+(RDMA or TCP), verifying byte-exact round-trip through libdfkv.so — the same path
+LMCache's MP store/prefetch controllers exercise, minus vLLM/LMCache themselves.
+
+Requires lmcache (for ObjectKey/Bitmap/MemoryObj imports), libdfkv.so, and a
+running dfkv ring. Opt-in via env; skipped otherwise (the C++ CI does not run it,
+matching integration/vllm/tests/test_dfkv_client.py).
+
+Env:
+    DFKV_L2_URL          dfkv://<mds_ip:port,...>/<group>  (required to run)
+    DFKV_L2_MEMBERSHIP   "mds" (default) | "static"
+    DFKV_LIB             path to libdfkv.so
+    DFKV_RDMA=1, DFKV_RDMA_DEV=<dev>   for the RDMA datapath (optional; TCP otherwise)
+
+Run on a node with a ring:
+    DFKV_L2_URL=dfkv://127.0.0.1:28150/glm DFKV_LIB=/dfkv/lib/libdfkv.so \
+    DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 \
+    python3 -m pytest integration/lmcache/tests/test_l2_adapter_integration.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("DFKV_L2_URL"),
+        reason="needs DFKV_L2_URL + a running dfkv ring + libdfkv.so",
+    ),
+]
+
+from dfkv_connector.l2_adapter import (  # noqa: E402
+    DfkvL2Adapter,
+    DfkvL2AdapterConfig,
+)
+from lmcache.v1.distributed.api import ObjectKey  # noqa: E402
+
+
+class _Buf:
+    """Minimal MemoryObj stand-in: the adapter only needs byte_array + get_size.
+
+    The buffer is real; the bytes still traverse the live dfkv datapath.
+    """
+
+    def __init__(self, data: bytes):
+        self._buf = bytearray(data)
+
+    @property
+    def byte_array(self) -> memoryview:
+        return memoryview(self._buf)
+
+    def get_size(self) -> int:
+        return len(self._buf)
+
+    def data(self) -> bytes:
+        return bytes(self._buf)
+
+
+def _mk_adapter() -> DfkvL2Adapter:
+    cfg = DfkvL2AdapterConfig.from_dict(
+        {
+            "url": os.environ["DFKV_L2_URL"],
+            "membership": os.environ.get("DFKV_L2_MEMBERSHIP", "mds"),
+            "lib": os.environ.get("DFKV_LIB"),
+            "model_name": "l2-integration-test",
+        }
+    )
+    return DfkvL2Adapter(cfg)
+
+
+def _key(tag: bytes) -> ObjectKey:
+    return ObjectKey(chunk_hash=tag, model_name="l2-integration-test", kv_rank=0)
+
+
+def _wait_for(fn, timeout: float = 20.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        v = fn()
+        if v is not None:
+            return v
+        time.sleep(0.02)
+    return None
+
+
+def test_real_ring_store_lookup_load_roundtrip():
+    a = _mk_adapter()
+    try:
+        # Unique keys per run so the store always counts fresh and the
+        # pre-store lookup is a clean miss.
+        run = os.urandom(6)
+        k0 = _key(b"k0-" + run)
+        k1 = _key(b"k1-" + run)  # never stored -> miss
+        payload = b"dfkv-L2-adapter real-ring integration payload " * 37  # ~1.7 KiB
+
+        # lookup BEFORE store -> miss
+        lk0 = a.submit_lookup_and_lock_task([k0])
+        bm0 = _wait_for(lambda: a.query_lookup_and_lock_result(lk0))
+        assert bm0 is not None and bm0.popcount() == 0, "key must be absent pre-store"
+
+        # store
+        st = a.submit_store_task([k0], [_Buf(payload)])
+        res = _wait_for(lambda: a.pop_completed_store_tasks().get(st))
+        assert res is not None and res.is_successful(), "store failed on real ring"
+        assert res.bytes_transferred() == len(payload)
+
+        # lookup AFTER store -> hit for k0, miss for k1
+        lk = a.submit_lookup_and_lock_task([k0, k1])
+        bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk))
+        assert bm is not None
+        assert bm.test(0) and not bm.test(1) and bm.popcount() == 1
+
+        # load into a fresh zeroed buffer -> bytes must match what we stored
+        dst = _Buf(bytes(len(payload)))
+        ld = a.submit_load_task([k0], [dst])
+        bm2 = _wait_for(lambda: a.query_load_result(ld))
+        assert bm2 is not None and bm2.test(0), "load missed on real ring"
+        assert dst.data() == payload, "loaded bytes differ from stored payload"
+
+        # transport sanity (rdma when DFKV_RDMA=1 on an IB host, else tcp)
+        status = a.report_status()
+        assert status["is_healthy"]
+    finally:
+        a.close()
+
+
+def test_real_ring_batch_roundtrip():
+    a = _mk_adapter()
+    try:
+        run = os.urandom(6)
+        keys = [_key(f"b{i}-".encode() + run) for i in range(8)]
+        payloads = [bytes([i]) * (512 * (i + 1)) for i in range(8)]
+        st = a.submit_store_task(keys, [_Buf(p) for p in payloads])
+        res = _wait_for(lambda: a.pop_completed_store_tasks().get(st))
+        assert res is not None and res.is_successful()
+        assert res.bytes_transferred() == sum(len(p) for p in payloads)
+
+        dsts = [_Buf(bytes(len(p))) for p in payloads]
+        ld = a.submit_load_task(keys, dsts)
+        bm = _wait_for(lambda: a.query_load_result(ld))
+        assert bm is not None and bm.popcount() == len(keys)
+        for d, p in zip(dsts, payloads):
+            assert d.data() == p
+    finally:
+        a.close()


### PR DESCRIPTION
## What

Adds `dfkv_connector.l2_adapter.DfkvL2Adapter` — an LMCache **MP-server**
`L2AdapterInterface` implementation so a dfkv ring can serve as the remote (L2)
KV tier behind `LMCacheMPConnector`.

## Why

LMCache's multiprocess server (`lmcache server` + `LMCacheMPConnector` on the
vLLM side) drives its remote tier through `L2AdapterInterface` (a non-blocking,
eventfd-signalled store / lookup-and-lock / load contract) — **not** the
in-process `remote_storage_plugins` mechanism that the existing
`DfkvConnectorAdapter` / `RemoteConnector` implements. The MP path silently
ignores `remote_storage_plugins`, so dfkv could not be a remote tier for MP-mode
deployments.

This matters because MP mode is the **only working LMCache path for models that
split the KV cache into multiple groups** — GLM-5.1/5.2 DSA, DeepSeek-V4-Flash.
The in-process `LMCacheConnectorV1` crashes on those (`kv_cache_pointers
could not broadcast (156,) into (78,)` for GLM-5.2's per-layer MLA+sparse split);
`LMCacheMPConnector` is the fix, and now dfkv can back it.

## How

Pure-Python `L2AdapterInterface` — no pybind / native eventfd needed (dfkv has
none, which is why the original L2 path was dropped). It reuses the existing
ctypes `DfkvNativeClient` (RDMA Put/Get over `libdfkv.so`) and bridges it to the
L2 eventfd model:

- three distinct cross-platform event notifiers (store / lookup / load);
- a background asyncio loop running the client's `batch_set/get/exists` coroutines;
- a per-task done-callback that records the result and `notify()`s the matching fd;
- `ObjectKey` → `model_name@kv_rank@object_group_id@chunk_hash[@cache_salt]`;
- server L1 arena auto-registered for RDMA zero-copy when `l1_memory_desc` is passed;
- locking is a client-side no-op (remote objects can't be L1-evicted);
  `max_capacity_gb > 0` opts into aggregate usage reporting.

Loaded through LMCache's built-in `plugin` L2 adapter:

```
lmcache server --port 6555 ... \
  --l2-adapter '{"type":"plugin","module_path":"dfkv_connector.l2_adapter",
    "class_name":"DfkvL2Adapter","config_class_name":"DfkvL2AdapterConfig",
    "adapter_params":{"url":"dfkv://<mds>/<group>","membership":"mds",
      "lib":"/path/to/libdfkv.so","model_name":"<deployment>"}}'
vllm serve <model> --no-enable-prefix-caching \
  --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both",
    "kv_connector_extra_config":{"lmcache.mp.port":6555}}'
```

## Validation

- **Unit** (`integration/lmcache/tests/test_l2_adapter.py`, fake client): 8/8 —
  distinct fds, ObjectKey serialization, store→lookup→load round-trip,
  miss handling, batch partial hit, first-store-wins byte accounting,
  safe unlock, store eventfd signalling. `ruff` clean.
- **Real ring** (GLM-5.2-Int4-Int8Mix, 8×B200, vLLM 0.23.0 + LMCache 0.4.7,
  single-node dfkv ring, RDMA): store wrote 58 chunks (15 028 tok) to dfkv;
  after a full container restart (L1 wiped) the same prompt reloaded **58/58
  keys from L2 (0 L1, 58 L2)**, dfkv `hit_total` +58, vLLM
  **`External prefix cache hit rate: 98.8%`** (prefill skipped), output
  byte-identical.

## Docs

README gains an MP-server section and corrects the "No L2-adapter path"
limitation; `docs/lmcache/{DESIGN,IMPLEMENTATION}.md` updated.

## Notes

Draft — pure addition (new module + tests) plus the existing in-process path is
untouched. No new runtime deps. Opening as draft for review of the eventfd-bridge
approach and the geometry/isolation choices (`model_name` → stable `model_hash`,
geometry guards off by default).