### PR TITLE
feat(remove): remove RPC + LMCache L2 eviction (DfkvL2Adapter.delete)

### DIFF
--- a/integration/lmcache/README.md
+++ b/integration/lmcache/README.md
@@ -112,6 +112,12 @@ store → restart (L1 wiped) → reload from dfkv with prefill skipped.
   synchronous ctypes client to LMCache's eventfd model with a background asyncio
   loop (dfkv has no native eventfd, so no pybind/`NativeConnectorL2Adapter`
   path is used).
-- No `remove` / enumeration (`list()` returns `[]`) — dfkv has no such RPC. L2
-  eviction (`max_capacity_gb > 0`) reports usage but cannot delete (dfkv manages
-  its own capacity).
+- **L2 eviction is supported** (dfkv gained a `remove` RPC): set
+  `max_capacity_gb > 0` on the L2 adapter to enable LMCache's L2EvictionController,
+  which calls `DfkvL2Adapter.delete()` → `dfkv_batch_remove` to drop blocks when
+  the configured capacity is exceeded. The in-process connector's `remove_sync`
+  is likewise backed by `dfkv_remove`. Requires a `libdfkv.so` / `dfkv_server`
+  built with the remove RPC (older libs are detected via `supports_remove()` and
+  the delete path degrades to a logged no-op). Default `max_capacity_gb = 0`
+  leaves capacity management to dfkv's own per-node LRU.
+- No enumeration (`list()` returns `[]`) — dfkv has no listing RPC.

--- a/integration/lmcache/src/dfkv_connector/exists_cache.py
+++ b/integration/lmcache/src/dfkv_connector/exists_cache.py
@@ -44,6 +44,12 @@ class ExistsLRU:
             for key in keys:
                 self._touch_unlocked(key)
 
+    def discard(self, key: str) -> None:
+        """Forget a key (e.g. after remove) so a later has() doesn't report a
+        stale hit. No-op if absent."""
+        with self._lock:
+            self._entries.pop(key, None)
+
     def has(self, key: str) -> bool:
         with self._lock:
             if key not in self._entries:

--- a/integration/lmcache/src/dfkv_connector/l2_adapter.py
+++ b/integration/lmcache/src/dfkv_connector/l2_adapter.py
@@ -249,6 +249,7 @@ class DfkvL2Adapter(L2AdapterInterface):
         self._locked_keys: dict[ObjectKey, int] = {}
         # First-store-wins byte accounting (re-store of a known key adds 0).
         self._key_sizes: dict[ObjectKey, int] = {}
+        self._warned_no_remove = False
         self._lock = threading.Lock()
 
         # Background asyncio loop that runs the client's batch_* coroutines.
@@ -480,6 +481,50 @@ class DfkvL2Adapter(L2AdapterInterface):
     def query_load_result(self, task_id: L2TaskId) -> Optional[Bitmap]:
         with self._lock:
             return self._completed_loads.pop(task_id, None)
+
+    # ------------------------------------------------------------------
+    # Eviction (delete)
+    # ------------------------------------------------------------------
+
+    def delete(self, keys: List[ObjectKey]) -> None:
+        """Drop keys from dfkv (L2 eviction). Synchronous per the L2 controller
+        contract; fires ``_notify_keys_deleted`` so the eviction policy's byte
+        accounting stays in sync. No-op (with a one-time warning) if the loaded
+        libdfkv.so predates the remove RPC. Only meaningful when the adapter was
+        constructed with ``max_capacity_gb > 0`` (otherwise the controller never
+        calls delete — dfkv manages its own capacity)."""
+        if not keys:
+            return
+        if not self._client.supports_remove():
+            if not self._warned_no_remove:
+                self._warned_no_remove = True
+                logger.warning(
+                    "dfkv L2 delete requested but libdfkv.so has no remove RPC; "
+                    "eviction is a no-op. Rebuild dfkv with the remove RPC."
+                )
+            return
+        key_strs = [_object_key_to_string(k) for k in keys]
+        fut = asyncio.run_coroutine_threadsafe(
+            self._client.batch_remove(key_strs), self._loop
+        )
+        try:
+            per_key = fut.result(timeout=30.0)
+        except Exception as e:  # pragma: no cover - network/lib failure path
+            logger.warning("dfkv L2 delete failed for %d keys: %s", len(keys), e)
+            return
+        deleted: List[ObjectKey] = []
+        sizes: List[int] = []
+        with self._lock:
+            for key, ok in zip(keys, per_key):
+                if not ok:
+                    continue
+                # Only account keys we tracked a size for (stored via this adapter).
+                sz = self._key_sizes.pop(key, None)
+                if sz is not None:
+                    deleted.append(key)
+                    sizes.append(sz)
+        if deleted:
+            self._notify_keys_deleted(deleted, sizes)
 
     # ------------------------------------------------------------------
     # Status / Cleanup

--- a/integration/lmcache/src/dfkv_connector/native_client.py
+++ b/integration/lmcache/src/dfkv_connector/native_client.py
@@ -78,6 +78,15 @@ def load_lib(path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_batch_exist.restype = c_int
     lib.dfkv_batch_exist.argtypes = [c_void_p, POINTER(c_char_p), c_int,
                                      POINTER(c_int)]
+    # dfkv_remove / dfkv_batch_remove are additive (>= dfkv with the remove RPC).
+    # Declared unconditionally; guarded at call sites for older libdfkv.so.
+    if hasattr(lib, "dfkv_remove"):
+        lib.dfkv_remove.restype = c_int
+        lib.dfkv_remove.argtypes = [c_void_p, c_char_p]
+    if hasattr(lib, "dfkv_batch_remove"):
+        lib.dfkv_batch_remove.restype = c_int
+        lib.dfkv_batch_remove.argtypes = [c_void_p, POINTER(c_char_p), c_int,
+                                          POINTER(c_int)]
     lib.dfkv_set_members.restype = c_int
     lib.dfkv_set_members.argtypes = [c_void_p, c_char_p]
     lib.dfkv_start_mds_discovery.restype = c_int
@@ -263,6 +272,15 @@ class DfkvNativeClient:
             raise RuntimeError(f"dfkv_batch_exist rc={rc}")
         return [out[i] == 1 for i in range(n)]
 
+    def _batch_remove_blocking(self, keys: List[str]) -> List[bool]:
+        n = len(keys)
+        karr = (c_char_p * n)(*[k.encode() for k in keys])
+        out = (c_int * n)()
+        rc = self._lib.dfkv_batch_remove(self._h, karr, n, out)
+        if rc != 0:
+            raise RuntimeError(f"dfkv_batch_remove rc={rc}")
+        return [out[i] == 1 for i in range(n)]
+
     # ------------------------------------------------------------------
     # public async API (returns the same tuple shapes the connector expects)
     # ------------------------------------------------------------------
@@ -311,11 +329,45 @@ class DfkvNativeClient:
             r.result = f"hits={hits}/{n}"
             return per_key
 
+    def supports_remove(self) -> bool:
+        """True iff the loaded libdfkv.so exposes the remove RPC (additive)."""
+        return hasattr(self._lib, "dfkv_batch_remove")
+
+    async def batch_remove(
+        self, keys: Sequence[str]
+    ) -> List[bool]:
+        """Drop keys from the ring. per_key[i] = the owning node confirmed the op
+        (removed or already absent). Raises if the lib has no remove RPC."""
+        n = len(keys)
+        if not self.supports_remove():
+            raise RuntimeError(
+                "libdfkv.so has no dfkv_batch_remove (rebuild dfkv with the "
+                "remove RPC to enable L2 eviction)"
+            )
+        with _push_metrics.op("remove", num_keys=n), \
+                access_log("native.batch_remove", lambda: f"{n} keys") as r:
+            per_key = await self._loop.run_in_executor(
+                self._executor, self._batch_remove_blocking, list(keys)
+            )
+            ok = sum(1 for b in per_key if b)
+            r.result = f"ok={ok}/{n}"
+            return per_key
+
     def exists_sync(self, key: str) -> bool:
         with access_log("native.exists_sync", lambda: key) as r:
             found = self._lib.dfkv_exist(self._h, key.encode()) == 1
             r.result = "found" if found else "not_found"
             return found
+
+    def remove_sync(self, key: str) -> bool:
+        """Drop one key synchronously. True iff the owning node confirmed the op
+        (removed or already absent). Raises if the lib has no remove RPC."""
+        if not self.supports_remove():
+            raise RuntimeError("libdfkv.so has no dfkv_remove")
+        with access_log("native.remove_sync", lambda: key) as r:
+            ok = self._lib.dfkv_remove(self._h, key.encode()) == 1
+            r.result = "ok" if ok else "fail"
+            return ok
 
     def ping_sync(self) -> None:
         """Cheap liveness check — connectivity is established at construction

--- a/integration/lmcache/src/dfkv_connector/remote_connector.py
+++ b/integration/lmcache/src/dfkv_connector/remote_connector.py
@@ -561,8 +561,21 @@ class DfkvConnector(RemoteConnector):
     def remove_sync(self, key: CacheEngineKey) -> bool:
         key_str = cache_engine_key_to_dfkv_str(key)
         with access_log("remove_sync", lambda: key_str) as r:
-            r.result = "FAIL NotImplementedError"
-            raise NotImplementedError("dfkv connector has no remove path yet")
+            if not self._client.supports_remove():
+                r.result = "FAIL no remove RPC"
+                raise NotImplementedError(
+                    "libdfkv.so has no remove RPC (rebuild dfkv with it)"
+                )
+            try:
+                ok = self._client.remove_sync(key_str)
+            except Exception as e:
+                logger.warning("remove_sync failed for %s: %s", key_str, e)
+                r.result = f"error: {e}"
+                return False
+            if ok:
+                self._exists_lru.discard(key_str)
+            r.result = "ok" if ok else "fail"
+            return ok
 
     def support_batched_contains(self) -> bool:
         return False

--- a/integration/lmcache/tests/test_l2_adapter.py
+++ b/integration/lmcache/tests/test_l2_adapter.py
@@ -85,6 +85,19 @@ class _FakeDfkvClient:
     async def batch_exists(self, keys):
         return [k in self._store for k in keys]
 
+    def supports_remove(self) -> bool:
+        return True
+
+    async def batch_remove(self, keys):
+        out = []
+        for k in keys:
+            out.append(self._store.pop(k, None) is not None or True)
+        return out
+
+    def remove_sync(self, key) -> bool:
+        self._store.pop(key, None)
+        return True
+
     def close(self):
         self.closed = True
 
@@ -241,6 +254,38 @@ def test_store_event_fd_is_signalled():
         # the store event fd must become readable on completion
         r, _, _ = select.select([efd], [], [], 5.0)
         assert efd in r, "store event fd was not signalled"
+    finally:
+        a.close()
+
+
+def test_delete_removes_and_updates_byte_accounting():
+    a = _mk_adapter()
+    try:
+        k = _key(70)
+        payload = b"y" * 2048
+        st = a.submit_store_task([k], [_FakeObj(payload)])
+        _wait_for(lambda: a.pop_completed_store_tasks().get(st))
+        assert a.get_usage().total_bytes_used == 2048
+
+        # delete is synchronous; it removes from the backend and decrements the
+        # base-class byte accounting via _notify_keys_deleted.
+        a.delete([k])
+        assert a.get_usage().total_bytes_used == 0
+
+        # gone from the backend -> lookup miss
+        lk = a.submit_lookup_and_lock_task([k])
+        bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk))
+        assert bm is not None and bm.popcount() == 0
+    finally:
+        a.close()
+
+
+def test_delete_empty_and_unknown_key_safe():
+    a = _mk_adapter()
+    try:
+        a.delete([])            # no-op
+        a.delete([_key(71)])    # never stored -> no accounting change, no raise
+        assert a.get_usage().total_bytes_used == 0
     finally:
         a.close()
 

--- a/integration/lmcache/tests/test_l2_adapter_integration.py
+++ b/integration/lmcache/tests/test_l2_adapter_integration.py
@@ -133,6 +133,43 @@ def test_real_ring_store_lookup_load_roundtrip():
         a.close()
 
 
+def test_real_ring_remove_and_eviction_roundtrip():
+    a = _mk_adapter()
+    try:
+        if not a._client.supports_remove():
+            pytest.skip("libdfkv.so has no remove RPC (rebuild dfkv with it)")
+        run = os.urandom(6)
+        k = _key(b"rm-" + run)
+        payload = b"dfkv remove + L2 eviction round-trip payload " * 20
+
+        st = a.submit_store_task([k], [_Buf(payload)])
+        res = _wait_for(lambda: a.pop_completed_store_tasks().get(st))
+        assert res is not None and res.is_successful()
+        assert a.get_usage().total_bytes_used == len(payload)
+
+        # present before delete
+        lk = a.submit_lookup_and_lock_task([k])
+        bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk))
+        assert bm is not None and bm.test(0)
+
+        # delete via the L2 eviction path (real dfkv_remove over the wire)
+        a.delete([k])
+        assert a.get_usage().total_bytes_used == 0  # accounting reclaimed
+
+        # gone after delete
+        lk2 = a.submit_lookup_and_lock_task([k])
+        bm2 = _wait_for(lambda: a.query_lookup_and_lock_result(lk2))
+        assert bm2 is not None and bm2.popcount() == 0
+
+        # a load now misses (nothing to bring back)
+        dst = _Buf(bytes(len(payload)))
+        ld = a.submit_load_task([k], [dst])
+        bm3 = _wait_for(lambda: a.query_load_result(ld))
+        assert bm3 is not None and bm3.popcount() == 0
+    finally:
+        a.close()
+
+
 def test_real_ring_batch_roundtrip():
     a = _mk_adapter()
     try:

--- a/src/dfkv_c_api.cc
+++ b/src/dfkv_c_api.cc
@@ -81,6 +81,11 @@ int dfkv_exist(dfkv_client_t c, const char* key) {
   return static_cast<KVClient*>(c)->Exist(key) ? 1 : 0;
 }
 
+int dfkv_remove(dfkv_client_t c, const char* key) {
+  if (!c || !key) return 0;
+  return static_cast<KVClient*>(c)->Remove(key) ? 1 : 0;
+}
+
 int dfkv_register_memory(dfkv_client_t c, const void* base, uint64_t size) {
   if (!c) return -1;
   static_cast<KVClient*>(c)->RegisterMemory(const_cast<void*>(base),
@@ -152,6 +157,16 @@ int dfkv_batch_exist(dfkv_client_t c, const char** keys, int n, int* out_exist) 
   for (int i = 0; i < n; ++i) ks[i] = keys[i] ? std::string(keys[i]) : std::string();
   auto r = static_cast<KVClient*>(c)->BatchExist(ks);
   for (int i = 0; i < n; ++i) out_exist[i] = (keys[i] && r[i]) ? 1 : 0;
+  return 0;
+}
+
+int dfkv_batch_remove(dfkv_client_t c, const char** keys, int n, int* out_ok) {
+  if (!c || n < 0) return -1;
+  if (n > 0 && (!keys || !out_ok)) return -1;
+  std::vector<std::string> ks(n);
+  for (int i = 0; i < n; ++i) ks[i] = keys[i] ? std::string(keys[i]) : std::string();
+  auto r = static_cast<KVClient*>(c)->BatchRemove(ks);
+  for (int i = 0; i < n; ++i) out_ok[i] = (keys[i] && r[i]) ? 1 : 0;
   return 0;
 }
 

--- a/src/dfkv_c_api.h
+++ b/src/dfkv_c_api.h
@@ -30,6 +30,9 @@ int dfkv_get(dfkv_client_t c, const char* key, void* ptr, uint64_t n);        //
 int dfkv_get_auto(dfkv_client_t c, const char* key, void* ptr, uint64_t cap,
                   uint64_t* out_len);
 int dfkv_exist(dfkv_client_t c, const char* key);                            // 1/0
+// Drop a key from the cache (LMCache L2 eviction). Returns 1 if the owning node
+// confirmed the op (block removed OR already absent), 0 on route/health/IO error.
+int dfkv_remove(dfkv_client_t c, const char* key);                           // 1/0
 // Register a large host memory region (e.g. the whole SGLang host KV pool) so
 // put/get into any buffer inside it never do a per-op RDMA MR registration — the
 // region is registered once per connection. No-op on the TCP transport. Call once
@@ -65,6 +68,10 @@ int dfkv_batch_get_auto(dfkv_client_t c, const char** keys, void** ptrs,
                         const uint64_t* caps, int n, int* out_hit,
                         uint64_t* out_len);
 int dfkv_batch_exist(dfkv_client_t c, const char** keys, int n, int* out_exist);
+// Batch remove. out_ok[i] = 1 iff the owning node confirmed key[i]'s removal
+// (removed or already absent), 0 on failure. Returns 0 on call success, -1 on
+// bad args.
+int dfkv_batch_remove(dfkv_client_t c, const char** keys, int n, int* out_ok);
 
 // Scatter-gather batch put: each of the n keys gathers num_bufs[i] non-contiguous
 // source buffers (ptrs[i][0..num_bufs[i]-1], sizes[i][...]) into one stored blob

--- a/src/disk_cache_group.cc
+++ b/src/disk_cache_group.cc
@@ -29,6 +29,12 @@ Status DiskCacheGroup::Cache(const BlockKey& key, const void* data, size_t len) 
   return d->Cache(key, data, len);
 }
 
+Status DiskCacheGroup::Remove(const BlockKey& key) {
+  KVStore* d = Route(key);
+  if (d == nullptr) return Status::kInvalid;
+  return d->Remove(key);
+}
+
 Status DiskCacheGroup::CacheDirect(const BlockKey& key, char* data, size_t len,
                                    size_t cap) {
   KVStore* d = Route(key);

--- a/src/disk_cache_group.h
+++ b/src/disk_cache_group.h
@@ -41,6 +41,10 @@ class DiskCacheGroup {
                          size_t io_cap, KVStore::RangePrep* out);
   bool IsCached(const BlockKey& key) const;
 
+  // Drop a cached block from its owning disk (routes like IsCached). kOk if
+  // removed, kNotFound if absent. Backs the LMCache L2 eviction path.
+  Status Remove(const BlockKey& key);
+
   uint64_t UsedBytes() const;   // summed across disks
   size_t Count() const;         // summed across disks
   size_t DiskCount() const { return disks_.size(); }

--- a/src/kv_client.cc
+++ b/src/kv_client.cc
@@ -332,6 +332,18 @@ bool KVClient::Exist(const std::string& key) {
   return st == Status::kOk && e;
 }
 
+bool KVClient::Remove(const std::string& key) {
+  std::string node = Route(key);
+  if (node.empty()) return false;
+  uint64_t now = NowMs();
+  if (!health_.Healthy(node, now)) return false;
+  Status st = t_->Remove(node, ToBlockKey(key));
+  if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
+  health_.MarkGood(node);
+  // kNotFound is a success for the caller: the goal (key not present) holds.
+  return st == Status::kOk || st == Status::kNotFound;
+}
+
 std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
   const size_t N = items.size();
   std::vector<char> ok(N, 0);  // char (not vector<bool>) for thread-safe writes
@@ -515,6 +527,43 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
     for (size_t m = 0; m < idx.size(); ++m) e[idx[m]] = (m < ex.size() && ex[m]) ? 1 : 0;
   });
   return std::vector<bool>(e.begin(), e.end());
+}
+
+std::vector<bool> KVClient::BatchRemove(const std::vector<std::string>& keys) {
+  const size_t N = keys.size();
+  std::vector<char> ok(N, 0);
+  if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
+    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
+      ok[i] = Remove(keys[i]) ? 1 : 0;
+    });
+    return std::vector<bool>(ok.begin(), ok.end());
+  }
+  // RDMA: group by node and RemoveMany per node (sequential within a node since
+  // eviction is off the hot path; nodes still fan out in parallel).
+  std::map<std::string, std::vector<size_t>> by_node;
+  for (size_t i = 0; i < N; ++i) {
+    std::string node = Route(keys[i]);
+    if (node.empty()) continue;
+    by_node[node].push_back(i);
+  }
+  std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
+  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+    const std::string& node = groups[g].first;
+    uint64_t now = NowMs();
+    if (!health_.Healthy(node, now)) return;
+    const std::vector<size_t>& idx = groups[g].second;
+    std::vector<BlockKey> bkeys;
+    bkeys.reserve(idx.size());
+    for (size_t k : idx) bkeys.push_back(ToBlockKey(keys[k]));
+    std::vector<Status> sts = t_->RemoveMany(node, bkeys);
+    bool resp = false, ioerr = false;
+    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    for (size_t m = 0; m < idx.size(); ++m)
+      ok[idx[m]] = (m < sts.size() &&
+                    (sts[m] == Status::kOk || sts[m] == Status::kNotFound)) ? 1 : 0;
+  });
+  return std::vector<bool>(ok.begin(), ok.end());
 }
 
 std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {

--- a/src/kv_client.h
+++ b/src/kv_client.h
@@ -71,6 +71,9 @@ class KVClient {
   // it to read back variable-size (unfull) chunks.
   bool GetAuto(const std::string& key, void* out, size_t cap, size_t* out_len);
   bool Exist(const std::string& key);
+  // Drop a key from its owning node. true iff the node confirmed the op (the
+  // block was removed OR was already absent); false on route/health/IO failure.
+  bool Remove(const std::string& key);
 
   // Batched, concurrently fanned out across owning nodes. Per-item results.
   std::vector<bool> BatchPut(const std::vector<KvPutItem>& items);
@@ -84,6 +87,9 @@ class KVClient {
   std::vector<bool> BatchGetAuto(const std::vector<KvGetItem>& items,
                                  std::vector<size_t>* out_lens);
   std::vector<bool> BatchExist(const std::vector<std::string>& keys);
+  // Batched remove, fanned out across owning nodes (grouped per node). Per-item
+  // result like BatchExist: true iff the owning node confirmed the op.
+  std::vector<bool> BatchRemove(const std::vector<std::string>& keys);
 
   // Scatter-gather batch put: each key gathers its N source segments into one
   // stored blob (sum of sizes). Mirrors BatchPut (consistent-hash routing per key,

--- a/src/kv_node_server.cc
+++ b/src/kv_node_server.cc
@@ -140,6 +140,8 @@ std::string KvNodeServer::MetricsText() const {
   metric("dfkv_cache_miss_total", "counter", "Range (GET) ops that missed", m_cache_miss());
   metric("dfkv_exist_hit_total", "counter", "Exist checks that hit", m_exist_hit());
   metric("dfkv_exist_miss_total", "counter", "Exist checks that missed", m_exist_miss());
+  metric("dfkv_remove_ok_total", "counter", "Remove ops that dropped a block", m_remove_ok());
+  metric("dfkv_remove_miss_total", "counter", "Remove ops for an absent block", m_remove_miss());
   metric("dfkv_bytes_written_total", "counter", "Payload bytes written",
          bytes_written_.load(std::memory_order_relaxed));
   metric("dfkv_bytes_read_total", "counter", "Payload bytes read",
@@ -251,6 +253,11 @@ Status KvNodeServer::ProcessRequest(uint8_t op_raw, uint64_t id, uint32_t index,
     case WireOp::kExist:
       if (group_.IsCached(key)) { st = Status::kOk; exist_hit_.fetch_add(1, std::memory_order_relaxed); }
       else { st = Status::kNotFound; exist_miss_.fetch_add(1, std::memory_order_relaxed); }
+      break;
+    case WireOp::kRemove:
+      st = group_.Remove(key);
+      if (st == Status::kOk) remove_ok_.fetch_add(1, std::memory_order_relaxed);
+      else if (st == Status::kNotFound) remove_miss_.fetch_add(1, std::memory_order_relaxed);
       break;
     case WireOp::kStats:
       *out_data = MetricsText();

--- a/src/kv_node_server.h
+++ b/src/kv_node_server.h
@@ -52,6 +52,8 @@ class KvNodeServer {
   size_t m_cache_miss() const { return cache_miss_.load(std::memory_order_relaxed); }
   size_t m_exist_hit() const { return exist_hit_.load(std::memory_order_relaxed); }
   size_t m_exist_miss() const { return exist_miss_.load(std::memory_order_relaxed); }
+  size_t m_remove_ok() const { return remove_ok_.load(std::memory_order_relaxed); }
+  size_t m_remove_miss() const { return remove_miss_.load(std::memory_order_relaxed); }
   std::string MetricsText() const;  // Prometheus text format
 
   // Transport-agnostic request processing (shared by the TCP handler and, when
@@ -96,6 +98,7 @@ class KvNodeServer {
   void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
   std::atomic<size_t> cache_put_{0}, cache_hit_{0}, cache_miss_{0};
   std::atomic<size_t> exist_hit_{0}, exist_miss_{0};
+  std::atomic<size_t> remove_ok_{0}, remove_miss_{0};
   std::atomic<size_t> bytes_written_{0}, bytes_read_{0};
   // depth metrics: errors by op, live connections, sampled op latency
   std::atomic<size_t> put_io_err_{0}, get_io_err_{0}, invalid_ops_{0};

--- a/src/kv_store.cc
+++ b/src/kv_store.cc
@@ -328,6 +328,29 @@ Status KVStore::Cache(const BlockKey& key, const void* data, size_t len) {
   return Status::kOk;
 }
 
+Status KVStore::Remove(const BlockKey& key) {
+  const std::string fname = key.Filename();
+  Shard& sh = ShardFor(fname);
+  std::lock_guard<std::shared_mutex> wl(sh.mu);  // exclusive
+  auto it = sh.index.find(fname);
+  if (it == sh.index.end()) return Status::kNotFound;
+  std::error_code ec;
+  fs::remove(it->second.path, ec);  // best-effort unlink (index is the source of truth)
+  sh.used_bytes -= it->second.size;
+  // Drop it from the CLOCK ring; if the hand points at the victim, advance the
+  // hand off it first so the persistent eviction cursor stays valid (same
+  // discipline as EvictLocked).
+  for (auto rit = sh.ring.begin(); rit != sh.ring.end(); ++rit) {
+    if (*rit == fname) {
+      if (sh.hand == rit) sh.hand = HandNext(sh.ring, rit);
+      sh.ring.erase(rit);
+      break;
+    }
+  }
+  sh.index.erase(it);
+  return Status::kOk;
+}
+
 Status KVStore::CacheDirect(const BlockKey& key, char* data, size_t len,
                             size_t cap) {
   if (data == nullptr && len != 0) return Status::kInvalid;

--- a/src/kv_store.h
+++ b/src/kv_store.h
@@ -87,6 +87,13 @@ class KVStore {
 
   bool IsCached(const BlockKey& key) const;
 
+  // Explicitly drop a cached block: deletes the file, removes it from the
+  // shard index + CLOCK ring, and reclaims its bytes (exclusive shard lock).
+  // kOk if removed, kNotFound if absent. Used by the LMCache L2 eviction path
+  // (dfkv_remove / DfkvL2Adapter.delete); distinct from capacity eviction so
+  // it does NOT touch the eviction counters.
+  Status Remove(const BlockKey& key);
+
   uint64_t UsedBytes() const;
   size_t Count() const;
   uint64_t Evictions() const { return evictions_.load(std::memory_order_relaxed); }

--- a/src/rdma_transport.cc
+++ b/src/rdma_transport.cc
@@ -283,6 +283,11 @@ Status RdmaTransport::Exist(const std::string& node, const BlockKey& key, bool* 
   return st;
 }
 
+Status RdmaTransport::Remove(const std::string& node, const BlockKey& key) {
+  // Key-only request, Status-only response (same framing as kExist).
+  return RoundTrip(node, WireOp::kRemove, key, 0, 0, nullptr, 0, nullptr);
+}
+
 Status RdmaTransport::Members(const std::string& node, std::string* out) {
   return RoundTrip(node, WireOp::kMembers, BlockKey{}, 0, 0, nullptr, 0, out);
 }

--- a/src/rdma_transport.h
+++ b/src/rdma_transport.h
@@ -38,6 +38,7 @@ class RdmaTransport : public Transport {
                uint64_t length, std::string* out) override;
   Status Exist(const std::string& node, const BlockKey& key,
                bool* exist) override;
+  Status Remove(const std::string& node, const BlockKey& key) override;
   Status Members(const std::string& node, std::string* out) override;
 
   void RegisterMemory(void* base, size_t size) override;

--- a/src/tcp_transport.cc
+++ b/src/tcp_transport.cc
@@ -116,4 +116,11 @@ Status TcpTransport::Exist(const std::string& node, const BlockKey& key,
   return st;
 }
 
+Status TcpTransport::Remove(const std::string& node, const BlockKey& key) {
+  // kRemove is a key-only request (no payload), Status-only response: kOk when a
+  // block was dropped, kNotFound when it was already absent (both fine for the
+  // caller), kIOError on a transport failure.
+  return RoundTrip(node, WireOp::kRemove, key, 0, 0, nullptr, 0, nullptr);
+}
+
 }  // namespace dfkv

--- a/src/tcp_transport.h
+++ b/src/tcp_transport.h
@@ -24,6 +24,7 @@ class TcpTransport : public Transport {
                uint64_t length, std::string* out) override;
   Status Exist(const std::string& node, const BlockKey& key,
                bool* exist) override;
+  Status Remove(const std::string& node, const BlockKey& key) override;
 
   // Fetch a node's Prometheus-format metrics text (not part of Transport iface).
   Status Stats(const std::string& node, std::string* out);

--- a/src/transport.h
+++ b/src/transport.h
@@ -60,10 +60,28 @@ class Transport {
   virtual Status Exist(const std::string& node, const BlockKey& key,
                        bool* exist) = 0;
 
+  // Explicitly drop a block on its owning node (LMCache L2 eviction). Default:
+  // not supported; TcpTransport/RdmaTransport override it with a kRemove round
+  // trip. kOk = removed, kNotFound = absent, kIOError = transport failure.
+  virtual Status Remove(const std::string& node, const BlockKey& key) {
+    (void)node; (void)key; return Status::kInvalid;
+  }
+
   // Query a node's advertised cluster member list (for discovery). Default: not
   // supported; TCP/RDMA override it. *out = "name=ip:port,name=ip:port,...".
   virtual Status Members(const std::string& node, std::string* out) {
     (void)node; (void)out; return Status::kInvalid;
+  }
+
+  // Batch remove for one node. Default = sequential loop over Remove (eviction
+  // is off the hot path, so neither transport bothers to pipeline it). Returns
+  // the per-key Status for caller-side health accounting.
+  virtual std::vector<Status> RemoveMany(const std::string& node,
+                                         const std::vector<BlockKey>& keys) {
+    std::vector<Status> r;
+    r.reserve(keys.size());
+    for (const auto& k : keys) r.push_back(Remove(node, k));
+    return r;
   }
 
   // Transport-level Prometheus metrics (e.g. RDMA per-rail connections, MR

--- a/src/wire.h
+++ b/src/wire.h
@@ -21,7 +21,7 @@ namespace dfkv {
 // reuses the existing request framing; variable content rides the payload/data blob.
 enum class WireOp : uint8_t {
   kCache = 1, kRange = 2, kExist = 3, kStats = 4, kMembers = 5,
-  kRegister = 6, kHeartbeat = 7, kListMembers = 8
+  kRegister = 6, kHeartbeat = 7, kListMembers = 8, kRemove = 9
 };
 
 constexpr uint8_t kProtoVersion = 1;

--- a/tests/kv_client_test.cc
+++ b/tests/kv_client_test.cc
@@ -68,6 +68,40 @@ TEST_F(KVClientTest, PutGetExistRoundTripWithImmediateVisibility) {
   EXPECT_EQ(out, v);
 }
 
+TEST_F(KVClientTest, RemoveRoundTripThenMiss) {
+  nodes_.push_back(StartNode("r1"));
+  KVClient c({{ "a", nodes_[0]->addr }}, SelfHdr());
+  std::string v(1500, 'r');
+  ASSERT_TRUE(c.Put("glm-5.1/rm_k", v.data(), v.size()));
+  ASSERT_TRUE(c.Exist("glm-5.1/rm_k"));
+  EXPECT_TRUE(c.Remove("glm-5.1/rm_k"));       // dropped
+  EXPECT_FALSE(c.Exist("glm-5.1/rm_k"));       // gone now
+  std::string out(v.size(), '\0');
+  EXPECT_FALSE(c.Get("glm-5.1/rm_k", &out[0], out.size()));  // miss
+  // Removing an absent key still "succeeds" (node confirmed: not present).
+  EXPECT_TRUE(c.Remove("glm-5.1/rm_k"));
+}
+
+TEST_F(KVClientTest, BatchRemoveFansOutAcrossNodes) {
+  nodes_.push_back(StartNode("b1"));
+  nodes_.push_back(StartNode("b2"));
+  std::vector<std::pair<std::string, std::string>> members = {
+      {"b1", nodes_[0]->addr}, {"b2", nodes_[1]->addr}};
+  KVClient c(members, SelfHdr());
+  std::vector<std::string> keys;
+  std::string v(256, 'z');
+  for (int i = 0; i < 12; ++i) {
+    std::string k = "glm-5.1/bk_" + std::to_string(i);
+    keys.push_back(k);
+    ASSERT_TRUE(c.Put(k, v.data(), v.size()));
+  }
+  for (const auto& k : keys) ASSERT_TRUE(c.Exist(k));
+  std::vector<bool> r = c.BatchRemove(keys);
+  ASSERT_EQ(r.size(), keys.size());
+  for (bool ok : r) EXPECT_TRUE(ok);
+  for (const auto& k : keys) EXPECT_FALSE(c.Exist(k));
+}
+
 TEST_F(KVClientTest, RefreshMembersDiscoversClusterFromSeed) {
   nodes_.push_back(StartNode("disc1"));
   nodes_.push_back(StartNode("disc2"));

--- a/tests/kv_store_test.cc
+++ b/tests/kv_store_test.cc
@@ -243,3 +243,49 @@ TEST_F(KVStoreTest, ConcurrentShardedReadWrite) {
     EXPECT_EQ(hits.load(), N * 8);
   }
 }
+
+TEST_F(KVStoreTest, RemoveDropsBlockReclaimsBytesAndIsIdempotent) {
+  KVStore s(Opts());
+  BlockKey k{555, 0, 1};
+  std::string v = "remove-me-payload-bytes";
+  ASSERT_EQ(s.Cache(k, v.data(), v.size()), Status::kOk);
+  ASSERT_TRUE(s.IsCached(k));
+  ASSERT_EQ(s.UsedBytes(), v.size());
+
+  EXPECT_EQ(s.Remove(k), Status::kOk);
+  EXPECT_FALSE(s.IsCached(k));
+  EXPECT_EQ(s.UsedBytes(), 0u);
+  EXPECT_EQ(s.Count(), 0u);
+
+  // Removing an absent key is a clean kNotFound (idempotent re-remove too).
+  EXPECT_EQ(s.Remove(k), Status::kNotFound);
+  EXPECT_EQ(s.Remove(BlockKey{556, 0, 1}), Status::kNotFound);
+
+  // Eviction counters are untouched by an explicit Remove (distinct from
+  // capacity eviction).
+  EXPECT_EQ(s.Evictions(), 0u);
+
+  // The key is re-cacheable after removal (file path freed, index slot reusable).
+  ASSERT_EQ(s.Cache(k, v.data(), v.size()), Status::kOk);
+  EXPECT_TRUE(s.IsCached(k));
+  EXPECT_EQ(s.UsedBytes(), v.size());
+}
+
+TEST_F(KVStoreTest, RemoveKeepsClockHandValidUnderManyKeys) {
+  // shards=1 forces all keys into one CLOCK ring so Remove must keep the
+  // persistent eviction hand valid; interleave removes with caches and verify
+  // the store stays consistent (no crash / stale index).
+  KVStore s(Opts(1ull << 30, 1));
+  std::string v(64, 'x');
+  for (uint64_t i = 0; i < 64; ++i)
+    ASSERT_EQ(s.Cache(BlockKey{i, 0, 1}, v.data(), v.size()), Status::kOk);
+  ASSERT_EQ(s.Count(), 64u);
+  for (uint64_t i = 0; i < 64; i += 2)  // remove every other key
+    EXPECT_EQ(s.Remove(BlockKey{i, 0, 1}), Status::kOk);
+  EXPECT_EQ(s.Count(), 32u);
+  for (uint64_t i = 0; i < 64; ++i)
+    EXPECT_EQ(s.IsCached(BlockKey{i, 0, 1}), (i % 2 == 1));
+  // The survivors are still readable and a fresh cache still evicts correctly.
+  std::string out;
+  EXPECT_EQ(s.Range(BlockKey{1, 0, 1}, 0, 64, &out), Status::kOk);
+}


### PR DESCRIPTION
## What

Adds a `remove` RPC to dfkv (C++ core + C ABI) and wires it into the LMCache
integration so the **MP-server L2 tier can actually evict** (`DfkvL2Adapter.delete`)
and the in-process connector's `remove_sync` works.

## Why

PR #62 added the MP-server L2 adapter (`DfkvL2Adapter`), but its eviction path
(`delete`) was a base no-op and the in-process `DfkvConnector.remove_sync` raised
`NotImplementedError` — because **dfkv had no remove RPC**. So LMCache's
`L2EvictionController` (enabled with `max_capacity_gb > 0`) could not drop blocks
from dfkv when over capacity. This closes that gap end to end.

## How

C++ core mirrors the existing key-only `exist` path (a `kRemove` frame + a
`Status` response, no payload):

- `wire.h`: `WireOp::kRemove`
- `KVStore::Remove` — exclusive shard lock; unlink the file, drop the index +
  CLOCK-ring entry (advancing the persistent eviction hand off the victim first),
  reclaim `used_bytes`; `kOk`/`kNotFound`. Does **not** touch the eviction
  counters (explicit remove ≠ capacity eviction).
- `DiskCacheGroup::Remove` — routes to the owning disk (like `IsCached`)
- `KvNodeServer`: `kRemove` case + `dfkv_remove_ok/miss` Prometheus counters
- `Transport::Remove` (+ default sequential `RemoveMany`; eviction is off the hot
  path); `TcpTransport`/`RdmaTransport` implement it via a `kRemove` round trip
- `KVClient::Remove` / `BatchRemove` (per-node fan-out, mirrors `Exist`/`BatchExist`)
- C ABI: `dfkv_remove` / `dfkv_batch_remove`

Python (`integration/lmcache`):

- `native_client`: ctypes decls (guarded for older libs via `supports_remove()`),
  async `batch_remove`, sync `remove_sync`
- `DfkvL2Adapter.delete()`: synchronous `batch_remove` + `_notify_keys_deleted`
  (keeps the eviction policy's byte accounting in sync); logged no-op if the lib
  predates the RPC. Active only when `max_capacity_gb > 0`.
- `DfkvConnector.remove_sync()`: backed by `dfkv_remove`; invalidates the ExistsLRU
- `ExistsLRU.discard()`

## Validation

- **C++ gtest (local ctest 180/180):** `KVStore` remove (reclaim + idempotent +
  CLOCK-hand validity under many keys); `KVClient` `RemoveRoundTrip` +
  `BatchRemove` fan-out (TCP loopback, real server + client).
- **Python unit (fake client) 10/10:** L2 `delete` + byte accounting + safe
  empty/unknown-key.
- **Real-lib integration 3/3:** built `libdfkv.so` + `dfkv_server` **with** the
  remove RPC (TCP throwaway ring), then store → `DfkvL2Adapter.delete()` → real
  `dfkv_remove` over the wire → lookup miss + `get_usage()` reclaimed.

## Docs

README L2-eviction section + corrected the "cannot delete" limitation. Pure
addition; the existing put/get/exist/store paths are untouched.