### PR TITLE
feat(vllm): support multi-group (hybrid attn) + PCP/DCP in DfkvStoreConnector

### DIFF
--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -114,12 +114,12 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
                     f"{spec.block_size} != cache_config.block_size="
                     f"{cache_block_size} (mamba_cache_mode != 'align')"
                 )
-        pcp = vllm_config.parallel_config.prefill_context_parallel_size
-        dcp = vllm_config.parallel_config.decode_context_parallel_size
-        if len(kv_cache_config.kv_cache_groups) > 1 and pcp * dcp > 1:
-            unsupported.append(
-                f"PCP/DCP > 1 (pcp={pcp}, dcp={dcp}) with hybrid attention"
-            )
+        # NOTE: multi-group (hybrid attention, e.g. GLM-5.2 DSA = MLA + sparse
+        # indexer groups) together with PCP/DCP > 1 is now supported: each group
+        # is normalized to scheduler_block_size in the worker and every rank
+        # stores/loads only its own physical shard under its @pcp{r}@dcp{r} key,
+        # so the per-group store/load masks stay correct regardless of how a
+        # given group shards under CP. (Previously guarded off.)
         if unsupported:
             raise ValueError(
                 "DfkvStoreConnector does not support: " + "; ".join(unsupported)

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -766,20 +766,45 @@ class DfkvStoreWorker:
         self.kv_connector_stats = DfkvStoreConnectorStats()
 
         self._kv_cache_config = kv_cache_config
-        # Single-group + PCP/DCP > 1: scale the lone group's spec.block_size to
-        # self.block_size (= scheduler_block_size) so the coordinator's
-        # ``block_size % hash_block_size == 0`` invariant holds.
-        groups = list(kv_cache_config.kv_cache_groups)
-        if len(groups) == 1 and groups[0].kv_cache_spec.block_size != self.block_size:
-            g = groups[0]
-            groups = [
-                dataclasses.replace(
-                    g,
-                    kv_cache_spec=dataclasses.replace(
-                        g.kv_cache_spec, block_size=self.block_size
-                    ),
+        # PCP/DCP > 1 (single- OR multi-group): scale EACH group's
+        # spec.block_size to self.block_size (= scheduler_block_size) so the
+        # coordinator's ``block_size % hash_block_size == 0`` and
+        # ``scheduler_block_size % block_size == 0`` invariants hold. Under CP
+        # different groups shard differently (e.g. GLM-5.2 DSA: the MLA group is
+        # DCP-sharded while the indexer group is not), but normalizing every
+        # group to scheduler_block_size keeps the per-group hashing / store-load
+        # masks uniform; each rank still only holds (and stores under its
+        # @pcp{r}@dcp{r} key) its own physical shard of the cache.
+        from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+
+        def _scale_spec(spec):
+            # UniformTypeKVCacheSpecs wraps inner per-layer specs; the
+            # coordinator unwraps to the inner spec (see _unwrap_spec), so the
+            # inner block_size(s) must be scaled too, not just the wrapper's.
+            if isinstance(spec, UniformTypeKVCacheSpecs):
+                inner = {
+                    name: (
+                        dataclasses.replace(s, block_size=self.block_size)
+                        if s.block_size != self.block_size
+                        else s
+                    )
+                    for name, s in spec.kv_cache_specs.items()
+                }
+                if spec.block_size == self.block_size and all(
+                    s.block_size == self.block_size for s in inner.values()
+                ):
+                    return spec
+                return dataclasses.replace(
+                    spec, block_size=self.block_size, kv_cache_specs=inner
                 )
-            ]
+            if spec.block_size != self.block_size:
+                return dataclasses.replace(spec, block_size=self.block_size)
+            return spec
+
+        groups = [
+            dataclasses.replace(g, kv_cache_spec=_scale_spec(g.kv_cache_spec))
+            for g in kv_cache_config.kv_cache_groups
+        ]
         self._kv_cache_groups: list[KVCacheGroupSpec] = groups
         spec_cfg = getattr(vllm_config, "speculative_config", None)
         use_eagle = bool(


### PR DESCRIPTION
## What

Enable `DfkvStoreConnector` for **multi-group (hybrid-attention) models together with PCP/DCP > 1**, previously guarded off.

Motivation: GLM-5.2 (DeepSeek Sparse Attention = MLA group + sparse-indexer group) needs Decode Context Parallel (DCP) to fit a 1M-token context on a single 8×H100 node (MLA KV is replicated across TP; only DCP shards it). The store connector previously raised `ValueError: PCP/DCP > 1 ... with hybrid attention`.

## Changes

- **`worker.py`**: normalize **every** kv-cache group's `spec.block_size` to `scheduler_block_size` (not just the single-group case), **including the inner specs of `UniformTypeKVCacheSpecs`**. The coordinator unwraps to the inner spec (`_unwrap_spec`), so scaling only the wrapper was a no-op and tripped `block_hashes_for_spec`'s `assert target_block_size % hash_block_size == 0` under DCP. Under CP different groups shard differently (GLM-5.2: MLA group is DCP-sharded, indexer group is not), but normalizing every group keeps the per-group hashing / store-load masks uniform; each rank still stores/loads only its own physical shard under its `@pcp{r}@dcp{r}` key.
- **`connector.py`**: drop the `len(groups) > 1 and pcp*dcp > 1` guard.

## Validation (hd04, GLM-5.2-Int4-Int8Mix, TP8 + DCP8, bf16)

- **kv_both single instance**: DfkvStoreConnector store+load under DCP8 + multi-group — 6K/17K needle hits (correct long-context), dfkv `save_put keys/bytes` with `failed_keys=0 error_count=0`.
- **PD split (producer + consumer)**: prefill stores (70 MB, 0 err), decode loads across instances; end-to-end request returns HTTP 200 with correct output. Cross-instance block-hash consistency requires identical `max_num_batched_tokens` on producer/consumer and `kv_load_failure_policy=recompute` for the tail partial block (operational config, not connector code).

No change to the C++ core / RDMA path; Python-only. Core ctest unaffected.