### PR TITLE
fix(vllm): correct put_step over-dedup under DCP (MLA sharded, not replicated)

### DIFF
--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -721,6 +721,19 @@ class DfkvStoreWorker:
             self.head_or_tp_rank = self.tp_rank
             self.put_step = 1
 
+        # DCP shards the (otherwise TP-replicated) MLA KV across dcp ranks, so
+        # each rank holds a UNIQUE shard (separated by the @dcp{r} key field),
+        # not a replica. put_step is a dedup stride that assumes replication:
+        # only 1/put_step of the identical-across-TP keys are stored. Under DCP
+        # that assumption is wrong -- the stride would drop ~(1 - 1/put_step) of
+        # each rank's own unique shard, so cross-instance (PD) consumers miss
+        # most of the KV (observed ~7% hit at TP8/DCP8, i.e. ~1/8). Shrink the
+        # stride by dcp_size so every rank stores its full shard. head_or_tp_rank
+        # is left unchanged: @dcp{r} already separates the shards, and both P and
+        # D derive it identically, so the keyspace stays consistent.
+        if self.dcp_size > 1 and self.put_step > 1:
+            self.put_step = max(1, self.put_step // self.dcp_size)
+
         self.metadata = KeyMetadata(
             model_name=model_config.model.rstrip("/").split("/")[-1],
             tp_rank=self.head_or_tp_rank,


### PR DESCRIPTION
Follow-up to #69. Fixes the ~7% cross-instance (PD) dfkv hit rate under DCP.

## Root cause
`put_step = tp_size // num_kv_head` is a store-dedup stride that assumes MLA KV is **replicated** across TP ranks (each rank stores only `keys[r::put_step]`, sharing the `tp_rank:0` namespace). Under **DCP** the MLA KV is **sharded** across dcp ranks — each rank holds a UNIQUE shard (separated by the `@dcp{r}` key field), not a replica. The stride then drops ~`(1 - 1/put_step)` of each rank's OWN shard, so PD consumers miss most of the KV.

## Fix
Shrink `put_step` by `dcp_size` so every rank stores its full shard. `head_or_tp_rank` is unchanged — `@dcp{r}` already separates shards and P/D derive the keyspace identically.

## Validation (hd04, GLM-5.2-Int4-Int8Mix, TP8+DCP8, DfkvStoreConnector PD)
- prefill `save_put_total_keys` 66 → 720 (full shards, no store hang)
- decode `External prefix cache hit rate` **7.1% → 46.6%** (== the no-DCP baseline)
- fresh 6K PD request **>260s → 38s**; recompute fallback ⇒ 0 fatal failures

Python-only; C++ core / ctest unaffected.