### PR TITLE
fix(mds): re-put the member key on the heartbeat fast path (multi-MDS lease drift)

### DIFF
--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -112,7 +112,21 @@ Status MdsServer::Upsert(const std::string& group, const MemberInfo& m) {
     auto it = leases_.find(key);
     if (it != leases_.end()) { existing = it->second; have = true; }
   }
-  if (have && etcd_.LeaseKeepAlive(existing)) return Status::kOk;  // fast path: refresh
+  // Fast path: refresh the lease AND re-write the key under it. The Put is
+  // load-bearing, not redundant: with several MDS instances behind a rotating
+  // registrar, a slow path on ANOTHER MDS re-attaches the key to that MDS's
+  // lease. From then on a value-less keepalive here would refresh a lease that
+  // no longer holds the key, while the key's actual lease only gets refreshed
+  // once per full rotation (N_mds * heartbeat) — at 3 MDS * 10s hb that equals
+  // the 30s TTL, so the member can expire out of etcd while every heartbeat
+  // still returns kOk. Re-putting under our own live lease restores the
+  // invariant "any MDS that answers a heartbeat guarantees the key survives".
+  // It also propagates MemberInfo changes (ip/weight after a reconfigure)
+  // that the old refresh silently dropped. Cost: one small etcd write per
+  // heartbeat; the epoch is a content hash, so unchanged values don't make
+  // clients rebuild their ring.
+  if (have && etcd_.LeaseKeepAlive(existing) && etcd_.Put(key, val, existing))
+    return Status::kOk;
   // Slow path: (re)grant a lease and (re)write the member key. A same-key race
   // here (two heartbeats both missing the lease) can briefly orphan one lease,
   // which expires on its own via the TTL; same-key heartbeats are serial in

--- a/test/mds/mds_server_test.cc
+++ b/test/mds/mds_server_test.cc
@@ -74,3 +74,37 @@ TEST(MdsServer, ListEmptyGroupOkEmpty) {
   EXPECT_TRUE(got.empty());
   mds.Stop();
 }
+
+TEST(MdsServer, HeartbeatRewritesMemberValueUnderOwnLease) {
+  // Regression for the multi-MDS lease-drift bug: the fast path used to only
+  // LeaseKeepAlive and never re-Put the key, so (a) a MemberInfo change within
+  // the TTL was silently dropped, and (b) with several rotating MDS instances
+  // the key stayed attached to another MDS's decaying lease while every
+  // heartbeat still returned kOk. Both reduce to the same observable pinned
+  // here: a heartbeat must re-write the key's current value.
+  const char* ep = EtcdEp();
+  if (!ep) GTEST_SKIP() << "set DFKV_TEST_ETCD=host:port";
+  MdsServer mds(ep);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+  int port = mds.port();
+  std::string group = "itest-reput-" + std::to_string(port);
+
+  MemberInfo m{"n1", "10.1.1.1", 28000, 1};
+  Status st; std::string data;
+  ASSERT_TRUE(DoReq(port, WireOp::kRegister, EncodeMemberReq(group, m), &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+
+  m.ip = "10.9.9.9";  // node reconfigured within the TTL
+  m.weight = 7;
+  ASSERT_TRUE(DoReq(port, WireOp::kHeartbeat, EncodeMemberReq(group, m), &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+
+  ASSERT_TRUE(DoReq(port, WireOp::kListMembers, group, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  std::vector<MemberInfo> got; uint64_t epoch = 0;
+  ASSERT_TRUE(DecodeMembers(data.data(), data.size(), &got, &epoch));
+  ASSERT_EQ(got.size(), 1u);
+  EXPECT_EQ(got[0].ip, "10.9.9.9");
+  EXPECT_EQ(got[0].weight, 7u);
+  mds.Stop();
+}


### PR DESCRIPTION
## Problem (P0, membership correctness)

The heartbeat fast path only does `LeaseKeepAlive` and never re-writes the member key. With several MDS instances behind a rotating registrar this breaks an implicit invariant: the MDS answering a heartbeat is not necessarily the owner of the key's lease.

Sequence (3 MDS, hb=10s, TTL=30s):
1. hb→MDS1: no lease known → grant L1 + Put(key@L1)
2. hb→MDS2: no lease known → grant L2 + **Put re-attaches key to L2**
3. hb→MDS3: grant L3 + **key re-attached to L3**
4. hb→MDS1: keepalive(L1) succeeds → returns kOk, **but L1 no longer holds the key**

The key's actual lease is only refreshed once per full rotation = N_mds × hb = **30s = exactly the TTL**, so any single missed/slow beat expires the member out of etcd — every client rebuilds its ring (~1/N keyspace flash-miss, twice) — while the server sees green heartbeats throughout. Production fingerprint: rings show **N_servers × N_mds** long-lived leases instead of N_servers.

Side effect of the same bug: a MemberInfo change (ip/weight) within the TTL is silently dropped (register goes through the same fast path).

## Fix
Fast path = keepalive **and** re-Put the key under our own live lease; fall to the slow path if either fails. Restores the invariant "any MDS that answers a heartbeat guarantees the key survives", and propagates MemberInfo changes. Cost: one small etcd write per heartbeat (~N_nodes/hb_s writes/s cluster-wide); the epoch is a content hash, so unchanged values don't disturb clients.

## Test
- New `MdsServer.HeartbeatRewritesMemberValueUnderOwnLease` pins the observable (heartbeat must re-write current value). Verified it **fails on the old code** and passes with the fix (real etcd via `DFKV_TEST_ETCD`).
- Full local suite: **181/181 ctest green** incl. real-etcd integration tests.