### PR TITLE
fix(net): bounded connect uses poll, not select (FD_SETSIZE overflow in host processes)

### DIFF
--- a/src/utils/net_util.h
+++ b/src/utils/net_util.h
@@ -9,7 +9,7 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -82,9 +82,15 @@ inline int Dial(const std::string& addr, int connect_ms = 0, int io_ms = 0) {
     int rc = ::connect(fd, reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
     if (rc != 0) {
       if (errno != EINPROGRESS) { ::close(fd); return -1; }
-      fd_set wf; FD_ZERO(&wf); FD_SET(fd, &wf);
-      timeval tv{connect_ms / 1000, (connect_ms % 1000) * 1000};
-      if (::select(fd + 1, nullptr, &wf, nullptr, &tv) <= 0) { ::close(fd); return -1; }
+      // poll, not select: this header is linked into inference-engine hosts
+      // that routinely hold thousands of fds, so a fresh socket's fd number
+      // can exceed FD_SETSIZE (1024) — FD_SET would then write past the
+      // fd_set (stack corruption in the host process, not just a failed
+      // connect). poll has no fd-number limit.
+      pollfd pf{fd, POLLOUT, 0};
+      int pr;
+      do { pr = ::poll(&pf, 1, connect_ms); } while (pr < 0 && errno == EINTR);
+      if (pr <= 0) { ::close(fd); return -1; }
       int err = 0; socklen_t el = sizeof(err);
       ::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &el);
       if (err != 0) { ::close(fd); return -1; }

--- a/test/utils/net_util_test.cc
+++ b/test/utils/net_util_test.cc
@@ -1,0 +1,75 @@
+#include "utils/net_util.h"
+
+#include <gtest/gtest.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+using namespace dfkv;  // NOLINT
+
+namespace {
+
+// Loopback listener on an ephemeral port; returns {listen_fd, port}.
+std::pair<int, int> Listen() {
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  EXPECT_GE(fd, 0);
+  sockaddr_in sa{};
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  sa.sin_port = 0;
+  EXPECT_EQ(::bind(fd, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)), 0);
+  EXPECT_EQ(::listen(fd, 16), 0);
+  socklen_t sl = sizeof(sa);
+  EXPECT_EQ(::getsockname(fd, reinterpret_cast<sockaddr*>(&sa), &sl), 0);
+  return {fd, ntohs(sa.sin_port)};
+}
+
+}  // namespace
+
+TEST(NetDial, ConnectsWithTimeout) {
+  auto [lfd, port] = Listen();
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 1000, 1000);
+  EXPECT_GE(fd, 0);
+  if (fd >= 0) ::close(fd);
+  ::close(lfd);
+}
+
+TEST(NetDial, TimedConnectWorksWithFdAboveFdSetsize) {
+  // Regression: the bounded-connect path used select()/FD_SET, which writes
+  // past the fd_set when the socket's fd number is >= FD_SETSIZE (1024) —
+  // stack corruption inside whatever host process links libdfkv (inference
+  // engines routinely hold thousands of fds). Occupy the low fd space so the
+  // dialed socket's fd lands above FD_SETSIZE, then exercise the timed path.
+  rlimit rl{};
+  ASSERT_EQ(::getrlimit(RLIMIT_NOFILE, &rl), 0);
+  if (rl.rlim_cur < 1100) {
+    rl.rlim_cur = std::min<rlim_t>(4096, rl.rlim_max);
+    if (::setrlimit(RLIMIT_NOFILE, &rl) != 0 || rl.rlim_cur < 1100)
+      GTEST_SKIP() << "cannot raise RLIMIT_NOFILE above 1100";
+  }
+
+  auto [lfd, port] = Listen();
+  std::vector<int> hold;
+  hold.reserve(1200);
+  int dev_null = ::open("/dev/null", O_RDONLY);
+  ASSERT_GE(dev_null, 0);
+  hold.push_back(dev_null);
+  while (hold.size() < 1100) {
+    int d = ::dup(dev_null);
+    ASSERT_GE(d, 0) << "dup failed at " << hold.size();
+    hold.push_back(d);
+  }
+
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 1000, 1000);
+  EXPECT_GE(fd, 1024) << "test precondition: fd should land above FD_SETSIZE";
+  EXPECT_GE(fd, 0) << "timed connect must work for fd >= FD_SETSIZE";
+  if (fd >= 0) ::close(fd);
+
+  for (int d : hold) ::close(d);
+  ::close(lfd);
+}


### PR DESCRIPTION
## Problem (P1, host-process memory safety)

`net::Dial`'s timed-connect path used `select()`/`FD_SET`. `FD_SET` writes past the `fd_set` when the fd number is **>= FD_SETSIZE (1024)** — undefined behavior (stack corruption), not just a failed connect.

This matters because the header is linked into **inference-engine host processes** (SGLang/vLLM via libdfkv's `MdsMemberPoller`/`MdsRegistrar`/TCP transport). Those processes routinely hold thousands of fds, so a fresh socket landing above 1024 is the normal case there — the corruption target is the inference engine itself.

## Fix
`poll()` (no fd-number limit), EINTR retried. Only call site of select in the tree.

## Test
New `test/utils/net_util_test.cc`: occupies the low fd space (1100 dups) so the dialed socket's fd lands above FD_SETSIZE, then exercises the timed-connect path end-to-end against a loopback listener. Full local suite 182/182 green (incl. real-etcd tests).