### PR TITLE
fix(vllm): fence preempted requests' in-flight saves before the next forward (cache poison)

### DIFF
--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -258,8 +258,14 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self.connector_worker.register_cross_layers_kv_caches(kv_cache)
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
-        # No-op: loads are issued in get_finished() for compute overlap.
-        pass
+        # Loads are issued in get_finished() for compute overlap; this hook
+        # only runs the preemption fence, which must happen BEFORE this step's
+        # forward pass can overwrite a preempted request's freed (and possibly
+        # re-allocated) blocks while an in-flight save still reads them.
+        assert self.connector_worker is not None
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, DfkvStoreConnectorMetadata)
+        self.connector_worker.start_load_kv(metadata)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         # No layerwise support - no-op

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -224,6 +224,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.kv_role = kv_role
         self.stored_requests: defaultdict[str, int] = defaultdict(int)
         self.enable_kv_event = enable_kv_event
+        # Which request _handle_request is executing right now. Published under
+        # done_task_lock together with the dequeue gate below, so a request is
+        # either dropped at the gate or visibly in flight to
+        # wait_for_inflight_put() -- never invisibly both.
+        self._active_req_id: str | None = None
+        self._active_cv = threading.Condition(self.done_task_lock)
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -239,6 +245,23 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
 
+    def wait_for_inflight_put(self, req_id: str, timeout_s: float = 30.0) -> bool:
+        """Block until no store for ``req_id`` is currently executing.
+
+        Queued-but-not-started entries are handled by
+        delete_finished_stored_request() + the dequeue gate (they get dropped
+        before any GPU read); the one entry the thread may already be
+        executing cannot be cancelled -- it holds an RDMA read against the
+        request's GPU blocks -- so the preemption path must wait it out
+        before those blocks can be handed to another request. Returns False
+        on timeout (put ops are client-side bounded, so this only happens if
+        the store path is badly wedged).
+        """
+        with self._active_cv:
+            return self._active_cv.wait_for(
+                lambda: self._active_req_id != req_id, timeout_s
+            )
+
     def _handle_request(self, req_meta: ReqMeta):
         # Cache hits are always a multiple of ``lcm_block_size`` tokens, which
         # is also ``store_mask``'s precondition.
@@ -248,7 +271,17 @@ class KVCacheStoreSendingThread(KVTransferThread):
         req_id = req_meta.req_id
         current_event = req_meta.current_event
 
-        if req_id not in self.stored_requests:
+        # Publish the active request and take the dequeue gate under ONE lock
+        # acquisition: a concurrent preemption fence either deletes the counter
+        # first (we drop the entry here) or sees _active_req_id == req_id and
+        # waits for the finally below. No window where the put runs invisibly.
+        with self.done_task_lock:
+            self._active_req_id = req_id
+            gate_ok = req_id in self.stored_requests
+        if not gate_ok:
+            with self._active_cv:
+                self._active_req_id = None
+                self._active_cv.notify_all()
             self.request_queue.task_done()
             return
 
@@ -426,6 +459,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if self.enable_kv_event and stored_events:
                 self.update_kv_event(stored_events)
         finally:
+            with self._active_cv:
+                self._active_req_id = None
+                self._active_cv.notify_all()
             self.dec_stored_request(req_id)
             self.request_queue.task_done()
 
@@ -980,8 +1016,39 @@ class DfkvStoreWorker:
         self,
         metadata: DfkvStoreConnectorMetadata,
     ):
-        """No-op: loads are issued in get_finished() for overlap."""
-        pass
+        """Pre-forward hook: fence preempted requests' in-flight saves.
+
+        Loads/stores are issued in get_finished() for overlap; the ONLY work
+        here is the preemption fence, and it must be here. The scheduler
+        frees a preempted request's GPU blocks with no connector hook
+        (request_finished()'s delay-free covers only the normal finish path)
+        and can hand them to another request scheduled in this very step.
+        This hook runs before this step's forward pass writes into those
+        blocks, so it is the last point where the race can still be closed:
+        drop the queued-not-started saves, then wait out the one save the
+        send thread may currently be executing (an uncancellable RDMA read
+        of the request's old blocks). Without the fence that read races the
+        new request's prefill writes and stores mixed bytes under a
+        content-addressed key -- and the save path's exists-dedup then
+        prevents the correct bytes from ever replacing them (persistent
+        cache poison, spread across instances by PD reuse).
+        """
+        if self.kv_send_thread is None or not metadata.preempted_req_ids:
+            return
+        # Drop queued entries first (the dequeue gate re-checks per entry),
+        # then join whichever entry is already executing.
+        for req_id in metadata.preempted_req_ids:
+            self.kv_send_thread.delete_finished_stored_request(req_id)
+        for req_id in metadata.preempted_req_ids:
+            wait_start = time.perf_counter()
+            if not self.kv_send_thread.wait_for_inflight_put(req_id):
+                logger.error(
+                    "preemption fence timed out waiting for in-flight save "
+                    "of request %s (%.1fs); its old GPU blocks may be read "
+                    "while reused -- possible poisoned store keys",
+                    req_id,
+                    time.perf_counter() - wait_start,
+                )
 
     def wait_for_save(
         self,

--- a/integration/vllm/tests/test_preempt_fence.py
+++ b/integration/vllm/tests/test_preempt_fence.py
@@ -1,0 +1,117 @@
+"""Preemption-fence unit tests for KVCacheStoreSendingThread.
+
+No GPU or dfkv server needed, but importing dfkv_vllm.worker pulls in vllm
+(and torch), so the whole module self-skips where vllm is absent -- same
+convention as the other tests in this directory.
+
+Run: python3 -m unittest test_preempt_fence  (from this directory, with
+dfkv_vllm on PYTHONPATH, e.g. pip install -e integration/vllm)
+"""
+
+import threading
+import types
+import unittest
+
+try:
+    from dfkv_vllm.worker import KVCacheStoreSendingThread
+
+    HAVE_VLLM = True
+except ImportError:  # pragma: no cover - vllm not installed
+    HAVE_VLLM = False
+
+
+def _req_meta(req_id: str) -> "types.SimpleNamespace":
+    # The fields _handle_request touches before it bails out on empty
+    # token_databases (masks come from coord.store_mask; the db loop is empty).
+    return types.SimpleNamespace(
+        req_id=req_id,
+        token_len_chunk=32,
+        block_ids=(),
+        block_hashes=[],
+        current_event=None,
+        token_ids=None,
+    )
+
+
+@unittest.skipUnless(HAVE_VLLM, "requires vllm (dfkv_vllm.worker imports it)")
+class PreemptFenceTest(unittest.TestCase):
+    def _mk_thread(self, coord) -> "KVCacheStoreSendingThread":
+        ready = threading.Event()
+        t = KVCacheStoreSendingThread(
+            client=None,  # never reached: empty token_databases => no keys
+            coord=coord,
+            token_databases=[],
+            block_size=16,
+            tp_rank=0,
+            put_step=1,
+            kv_role="kv_producer",
+            ready_event=ready,
+        )
+        t.start()
+        self.assertTrue(ready.wait(5))
+        return t
+
+    def test_wait_blocks_while_put_executes_and_returns_after(self):
+        # A store that is already executing cannot be cancelled: the fence
+        # must report it in flight until it completes, then release.
+        entered = threading.Event()
+        release = threading.Event()
+
+        class Coord:
+            lcm_block_size = 16
+
+            def store_mask(self, token_len):
+                entered.set()
+                release.wait(10)
+                return []
+
+        t = self._mk_thread(Coord())
+        t.add_stored_request("r1")
+        t.add_request(_req_meta("r1"))
+        self.assertTrue(entered.wait(5), "store should be executing")
+
+        # Preemption path: drop queued entries, then join the executing one.
+        t.delete_finished_stored_request("r1")
+        self.assertFalse(
+            t.wait_for_inflight_put("r1", timeout_s=0.3),
+            "fence must NOT pass while the store still reads the blocks",
+        )
+        release.set()
+        self.assertTrue(
+            t.wait_for_inflight_put("r1", timeout_s=5),
+            "fence must release once the store completed",
+        )
+
+    def test_deleted_request_is_dropped_at_the_dequeue_gate(self):
+        # Entries still queued when the request is preempted must be dropped
+        # before any work (store_mask is the first touch inside the body).
+        calls: list[int] = []
+
+        class Coord:
+            lcm_block_size = 16
+
+            def store_mask(self, token_len):
+                calls.append(token_len)
+                return []
+
+        t = self._mk_thread(Coord())
+        t.add_stored_request("r2")
+        t.delete_finished_stored_request("r2")  # preempt before dequeue
+        t.add_request(_req_meta("r2"))
+        t.request_queue.join()  # waits for task_done of the dropped entry
+        self.assertEqual(calls, [], "dropped entry must never start a store")
+        self.assertTrue(t.wait_for_inflight_put("r2", timeout_s=1))
+
+    def test_fence_is_noop_for_unknown_request(self):
+        class Coord:
+            lcm_block_size = 16
+
+            def store_mask(self, token_len):
+                return []
+
+        t = self._mk_thread(Coord())
+        self.assertTrue(t.wait_for_inflight_put("never-seen", timeout_s=1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem (P0, persistent cache poison)

Preemption frees a request's GPU blocks with **no connector hook** (`request_finished()`'s delay-free covers only the normal finish path), and the scheduler can hand those blocks to another request scheduled **in the same step**. Meanwhile the send thread may still be executing an uncancellable store for the preempted request — an RDMA read of those very blocks.

Sequence:
1. step N-1 `get_finished()`: save for request R enqueued (reads R's GPU blocks async)
2. step N scheduling: R preempted → blocks freed → re-allocated to request Q
3. step N forward: Q's prefill **writes** the blocks while R's save still **reads** them
4. mixed bytes are stored under R's content-addressed key

Worst-case: the save path's exists-dedup afterwards prevents the *correct* bytes from ever replacing them (**persistent** poison), and PD reuse spreads it across instances. Preemption happens exactly when the block pool is tightest and reuse is fastest, so the window (a put is ms–tens of ms) is real.

The existing handling in `get_finished()` only deleted the bookkeeping counter — and `get_finished()` runs **after** the forward pass, when the overwrite has already happened.

## Fix
- `KVCacheStoreSendingThread` publishes the request it is currently executing (under the same lock as the dequeue gate → an entry is either dropped at the gate or visibly in flight, never invisibly both) and gains `wait_for_inflight_put(req_id)`.
- `start_load_kv` (until now a no-op) runs the **preemption fence pre-forward** — the last point where the race can still be closed: drop queued-not-started saves for `meta.preempted_req_ids`, then join the executing one. Bounded (30s; put ops are client-side bounded), logs an error on timeout instead of blocking the engine.
- `get_finished()` keeps its deletion as a defensive no-op.

No behavior change outside the preemption path; the fence is a no-op when `preempted_req_ids` is empty (the common case — one dict check per step).

## Tests
`integration/vllm/tests/test_preempt_fence.py` (no GPU/server needed; self-skips without vllm, same convention as this directory's other tests): fence blocks while a store executes and releases after; preempted queued entries are dropped at the gate before any work; unknown request is a no-op. `py_compile` clean; C++ suite untouched.