### PR TITLE
feat(vllm): fail fast when block hashes are not deterministic across processes (silent 0% hit)

### DIFF
--- a/integration/vllm/src/dfkv_vllm/_determinism.py
+++ b/integration/vllm/src/dfkv_vllm/_determinism.py
@@ -1,0 +1,44 @@
+"""Fail-fast guard: dfkv store keys require cross-process block hashes.
+
+Kept free of vllm/torch imports (duck-typed on cache_config) so it can be
+unit-tested anywhere; both the scheduler- and worker-side components call it
+at construction time.
+"""
+
+import os
+
+
+def ensure_deterministic_block_hashing(cache_config) -> None:
+    """Raise unless vLLM's prefix-cache block hashes survive a process change.
+
+    dfkv keys embed ``request.block_hashes`` verbatim. With the default
+    ``builtin`` hash algorithm Python randomizes ``hash()`` per process unless
+    ``PYTHONHASHSEED`` is pinned, so the keys computed by a restarted engine --
+    or by the decode instance of a PD pair -- never match the stored ones.
+    The failure mode is the worst kind: **silent zero hit rate while puts keep
+    landing** (P keeps writing, D never loads, storage fills with unreachable
+    keys). This bit production before and was hand-fixed with
+    ``PYTHONHASHSEED=0``; guard it structurally instead of by folklore.
+
+    Accepted as deterministic:
+    - a sha256-family ``prefix_caching_hash_algo`` (content-defined,
+      process-independent), or
+    - ``PYTHONHASHSEED`` pinned to a fixed value in the environment. It must
+      be the SAME value on every engine sharing the store (both PD sides,
+      every restart); that cross-instance agreement is the operator's part,
+      this guard can only see its own process.
+    """
+    algo = str(getattr(cache_config, "prefix_caching_hash_algo", "builtin"))
+    if "sha256" in algo.lower():
+        return
+    seed = os.environ.get("PYTHONHASHSEED", "")
+    if seed and seed.lower() != "random":
+        return
+    raise RuntimeError(
+        "DfkvStoreConnector: vLLM block hashes are not deterministic across "
+        f"processes (prefix_caching_hash_algo={algo!r} and PYTHONHASHSEED is "
+        "not pinned). Cross-restart and PD cross-instance lookups would "
+        "silently never hit while stores keep writing. Fix: set the SAME "
+        "fixed PYTHONHASHSEED on every engine sharing this store (e.g. "
+        "PYTHONHASHSEED=0), or use --prefix-caching-hash-algo sha256."
+    )

--- a/integration/vllm/src/dfkv_vllm/scheduler.py
+++ b/integration/vllm/src/dfkv_vllm/scheduler.py
@@ -19,6 +19,7 @@ from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request
 
+from ._determinism import ensure_deterministic_block_hashing
 from .data import (
     LoadSpec,
     DfkvStoreConnectorMetadata,
@@ -55,6 +56,9 @@ class DfkvStoreScheduler:
         kv_cache_config: KVCacheConfig,
     ):
         assert vllm_config.kv_transfer_config is not None
+        # Store keys embed block_hashes: refuse to start with process-local
+        # hashing (silent 0% cross-instance/cross-restart hit rate otherwise).
+        ensure_deterministic_block_hashing(vllm_config.cache_config)
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "load_async", True

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -47,6 +47,7 @@ from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 
 # dfkv: get_dp_engine_index replaces mooncake_utils.get_mooncake_dp_engine_index;
 # dfkv handles its own RDMA bootstrap so the transfer-engine helpers are dropped.
+from ._determinism import ensure_deterministic_block_hashing
 from .coordinator import (
     ExternalCachedBlockPool,
     DfkvStoreCoordinator,
@@ -691,6 +692,9 @@ class DfkvStoreWorker:
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
 
         assert vllm_config.kv_transfer_config is not None
+        # Store keys embed block_hashes: refuse to start with process-local
+        # hashing (silent 0% cross-instance/cross-restart hit rate otherwise).
+        ensure_deterministic_block_hashing(vllm_config.cache_config)
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "load_async", True

--- a/integration/vllm/tests/test_determinism_guard.py
+++ b/integration/vllm/tests/test_determinism_guard.py
@@ -1,0 +1,80 @@
+"""Unit tests for the block-hash determinism guard.
+
+``_determinism.py`` has no vllm/torch imports, so unlike this directory's
+other tests these run anywhere: the module is loaded by file path to avoid
+importing the (vllm-dependent) package __init__.
+
+Run: python3 -m unittest test_determinism_guard  (from this directory)
+"""
+
+import importlib.util
+import os
+import pathlib
+import types
+import unittest
+
+_MOD_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "src"
+    / "dfkv_vllm"
+    / "_determinism.py"
+)
+_spec = importlib.util.spec_from_file_location("dfkv_determinism", _MOD_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+ensure_deterministic_block_hashing = _mod.ensure_deterministic_block_hashing
+
+
+def _cfg(algo):
+    return types.SimpleNamespace(prefix_caching_hash_algo=algo)
+
+
+class DeterminismGuardTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("PYTHONHASHSEED")
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("PYTHONHASHSEED", None)
+        else:
+            os.environ["PYTHONHASHSEED"] = self._saved
+
+    def test_builtin_without_seed_raises(self):
+        os.environ.pop("PYTHONHASHSEED", None)
+        with self.assertRaisesRegex(RuntimeError, "PYTHONHASHSEED"):
+            ensure_deterministic_block_hashing(_cfg("builtin"))
+
+    def test_builtin_with_seed_random_raises(self):
+        os.environ["PYTHONHASHSEED"] = "random"
+        with self.assertRaises(RuntimeError):
+            ensure_deterministic_block_hashing(_cfg("builtin"))
+
+    def test_builtin_with_pinned_seed_passes(self):
+        os.environ["PYTHONHASHSEED"] = "0"
+        ensure_deterministic_block_hashing(_cfg("builtin"))
+        os.environ["PYTHONHASHSEED"] = "42"
+        ensure_deterministic_block_hashing(_cfg("builtin"))
+
+    def test_sha256_family_passes_without_seed(self):
+        os.environ.pop("PYTHONHASHSEED", None)
+        ensure_deterministic_block_hashing(_cfg("sha256"))
+        ensure_deterministic_block_hashing(_cfg("sha256_cbor_64bit"))
+
+    def test_enum_like_algo_value_passes(self):
+        # vLLM may hand an enum whose str() embeds the name.
+        os.environ.pop("PYTHONHASHSEED", None)
+
+        class Algo:
+            def __str__(self):
+                return "HashAlgo.SHA256"
+
+        ensure_deterministic_block_hashing(_cfg(Algo()))
+
+    def test_missing_attr_defaults_to_builtin(self):
+        os.environ.pop("PYTHONHASHSEED", None)
+        with self.assertRaises(RuntimeError):
+            ensure_deterministic_block_hashing(types.SimpleNamespace())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem (P1, silent total cache miss)

dfkv store keys embed `request.block_hashes` verbatim. With vLLM's default `builtin` prefix-cache hash, Python randomizes `hash()` per process unless `PYTHONHASHSEED` is pinned — so keys computed by a restarted engine, or by the decode instance of a PD pair, never match the stored ones. Failure mode is the worst kind: **silent 0% hit rate while puts keep landing** (P keeps writing, D never loads, storage fills with unreachable keys). This bit production before and was hand-fixed with `PYTHONHASHSEED=0`; the connector never enforced it — deployment folklore instead of a structural guard.

## Fix
New `_determinism.py` (no vllm/torch imports, duck-typed → unit-testable anywhere), called from **both** the scheduler- and worker-side components at construction:
- accept a sha256-family `prefix_caching_hash_algo` (content-defined, process-independent), or
- accept a pinned `PYTHONHASHSEED` (must be the SAME value on every engine sharing the store — both PD sides, every restart; that cross-instance agreement stays on the operator, the guard can only see its own process),
- otherwise **raise at startup** with the exact fix in the message.

## Tests
`test_determinism_guard.py` — builtin/unset raises, `PYTHONHASHSEED=random` raises, pinned seeds pass, sha256 family passes, enum-like algo values, missing-attr default. **Runs without vllm** (module loaded by file path), verified locally 6/6 green. `py_compile` clean on all touched files.