### PR TITLE
fix(wire): bound declared frame lengths on every socket (16 GiB OOM DoS)

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "cache/kv_node_server.h"
+#include "utils/wire_limits.h"
 #include "utils/log.h"
 #include "mds/mds_registrar.h"
 #include "utils/metrics_http.h"
@@ -85,6 +86,9 @@ int main(int argc, char** argv) {
   if (dirs.empty()) dirs.push_back(dir);
 
   KvNodeServer srv(dirs, cap);
+  // TCP request frames share the RDMA path's resolved max-value bound (OOM-DoS
+  // guard; see utils/wire_limits.h).
+  srv.set_max_request_payload(dfkv::wire_limits::MaxRequestPayload());
   // Identity for Prometheus labels: reuse the MDS --id/--group when present.
   if (!node_id.empty() || group != "default") srv.set_identity(node_id, group);
   if (srv.Start(port) != Status::kOk) {

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "utils/net_util.h"
+#include "utils/wire_limits.h"
 #include "utils/prom_escape.h"
 #include "transport/transport.h"
 
@@ -360,11 +361,17 @@ void KvNodeServer::RangeDirectComplete(bool ok, size_t bytes_read) {
 
 // Keep-alive: serve requests on this connection until the peer closes it.
 void KvNodeServer::Handle(int fd) {
+  // Bound the declared payload_len BEFORE the allocation below: without this
+  // a forged 42-byte prefix is a 16 GiB allocation. Same bound as the RDMA
+  // path (utils/wire_limits.h).
+  const uint64_t max_payload = max_request_payload_
+                                   ? max_request_payload_
+                                   : wire_limits::MaxRequestPayload();
   while (running_) {
     char prefix[kReqPrefix];
     if (!net::ReadAll(fd, prefix, kReqPrefix)) return;  // peer closed / error
     ReqFields rq;
-    if (!DecodeReq(prefix, &rq)) return;  // bad protocol version => drop
+    if (!DecodeReq(prefix, &rq, max_payload)) return;  // bad version / oversize => drop
     std::vector<char> payload(rq.payload_len);
     if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
 

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -39,6 +39,12 @@ class KvNodeServer {
   void set_identity(const std::string& id, const std::string& group) {
     node_id_ = id; node_group_ = group;
   }
+  // Upper bound for a request frame's declared payload_len. The TCP handler
+  // allocates payload_len BEFORE reading the payload bytes, so without a real
+  // bound a 42-byte forged prefix triggers a 16 GiB allocation (one-frame OOM
+  // DoS). Defaults to value-header + the env-resolved max value size — the
+  // SAME bound the RDMA server enforces (utils/wire_limits.h).
+  void set_max_request_payload(uint64_t n) { max_request_payload_ = n; }
   int port() const { return port_; }
   size_t Count() const { return group_.Count(); }
   uint64_t UsedBytes() const { return group_.UsedBytes(); }
@@ -106,6 +112,7 @@ class KvNodeServer {
   Sampler lat_sampler_{64};        // 1-in-64 latency sampling (near-zero hot-path cost)
   LatencyHist get_lat_, put_lat_;  // server-side op latency (sampled)
   std::string members_;  // advertised cluster membership (kMembers)
+  uint64_t max_request_payload_ = 0;  // 0 = resolve default lazily (see .cc)
   std::string node_id_, node_group_;       // identity for Prometheus labels (optional)
   std::chrono::steady_clock::time_point start_time_ = std::chrono::steady_clock::now();
 

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -17,6 +17,7 @@
 
 #include "utils/net_util.h"     // ReadAll / WriteAll / Get*/Put*
 #include "utils/numa_util.h"    // pin serve thread to the device's NUMA node
+#include "utils/wire_limits.h"  // ResolveMaxPayload (shared with the TCP path)
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
 #include "transport/transport.h"    // kReqPrefix, kRespPrefix
 #include "cache/uring_reader.h" // io_uring async-GET path (DFKV_WITH_URING only)
@@ -25,32 +26,13 @@
 namespace dfkv {
 
 namespace {
-size_t EnvBytes(const char* name, size_t dflt) {
-  const char* v = std::getenv(name);
-  if (!v || !*v) return dflt;
-  errno = 0;
-  char* end = nullptr;
-  unsigned long long x = std::strtoull(v, &end, 10);
-  if (errno != 0 || end == v || x == 0) return dflt;
-  constexpr unsigned long long kMaxSge =
-      static_cast<unsigned long long>(std::numeric_limits<uint32_t>::max() -
-                                      ValueHeader::kSize - 2 * rdma::kDirectIoAlign);
-  if (x > kMaxSge) x = kMaxSge;
-  return static_cast<size_t>(x);
-}
-
-size_t ResolveMaxPayload(size_t configured) {
-  size_t n = configured ? configured : (64u << 20);
-  n = EnvBytes("DFKV_RDMA_MAX_PAYLOAD_BYTES", n);
-  n = EnvBytes("DFKV_RDMA_MAX_MSG_BYTES", n);
-  // Clamp the constructor-supplied value too (EnvBytes only clamps the env paths):
-  // dbuf/SGE length is uint32, so payload must stay under uint32 - header - 2*align
-  // or the registered length silently overflows/truncates -> corruption.
-  constexpr size_t kMaxSge = static_cast<size_t>(
-      std::numeric_limits<uint32_t>::max() - ValueHeader::kSize - 2 * rdma::kDirectIoAlign);
-  if (n > kMaxSge) n = kMaxSge;
-  return n;
-}
+// EnvBytes/ResolveMaxPayload live in utils/wire_limits.h so the TCP request
+// path (kv_node_server) bounds its frames with the SAME resolved max value
+// this RDMA server enforces (wire_limits::kIoAlign == rdma::kDirectIoAlign;
+// static_assert below keeps that true).
+static_assert(wire_limits::kIoAlign == rdma::kDirectIoAlign,
+              "wire_limits must mirror the RDMA direct-IO alignment");
+using wire_limits::ResolveMaxPayload;
 
 size_t ControlCapFor(size_t max_payload) {
   constexpr size_t kDefaultControlCap = 8u << 20;

--- a/src/mds/mds_member_poller.cc
+++ b/src/mds/mds_member_poller.cc
@@ -7,6 +7,7 @@
 
 #include "common/status.h"
 #include "utils/net_util.h"
+#include "utils/wire_limits.h"
 #include "transport/wire.h"
 
 namespace dfkv {
@@ -42,7 +43,7 @@ bool MdsMemberPoller::Query(std::vector<MemberInfo>* out, uint64_t* epoch) {
     char rp[kRespPrefix];
     Status st = Status::kInvalid;
     uint64_t dlen = 0;
-    ok = net::ReadAll(fd, rp, kRespPrefix) && DecodeResp(rp, &st, &dlen) &&
+    ok = net::ReadAll(fd, rp, kRespPrefix) && DecodeResp(rp, &st, &dlen, wire_limits::kMdsMaxRespData) &&
          st == Status::kOk;
     if (ok) { data.resize(dlen); ok = (dlen == 0) || net::ReadAll(fd, &data[0], dlen); }
   }

--- a/src/mds/mds_registrar.cc
+++ b/src/mds/mds_registrar.cc
@@ -9,6 +9,7 @@
 #include "common/status.h"
 #include "mds/mds_proto.h"
 #include "utils/net_util.h"
+#include "utils/wire_limits.h"
 #include "transport/wire.h"
 
 namespace dfkv {
@@ -45,7 +46,7 @@ bool MdsRegistrar::SendOnce(uint8_t op) {
     char rp[kRespPrefix];
     Status st = Status::kInvalid;
     uint64_t dlen = 0;
-    ok = net::ReadAll(fd, rp, kRespPrefix) && DecodeResp(rp, &st, &dlen) &&
+    ok = net::ReadAll(fd, rp, kRespPrefix) && DecodeResp(rp, &st, &dlen, wire_limits::kMdsMaxRespData) &&
          st == Status::kOk;
     if (ok && dlen) {
       std::vector<char> d(dlen);

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -7,6 +7,7 @@
 
 #include "mds/mds_proto.h"
 #include "utils/net_util.h"
+#include "utils/wire_limits.h"
 #include "transport/wire.h"
 
 namespace dfkv {
@@ -168,7 +169,9 @@ void MdsServer::Handle(int fd) {
     char prefix[kReqPrefix];
     if (!net::ReadAll(fd, prefix, kReqPrefix)) return;
     ReqFields rq;
-    if (!DecodeReq(prefix, &rq)) return;
+    // MDS frames carry a group name + one MemberInfo (<1 KiB); cap the
+    // declared length so a forged prefix can't trigger a giant allocation.
+    if (!DecodeReq(prefix, &rq, wire_limits::kMdsMaxReqPayload)) return;
     std::vector<char> payload(rq.payload_len);
     if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
 

--- a/src/transport/tcp_transport.cc
+++ b/src/transport/tcp_transport.cc
@@ -1,5 +1,7 @@
 #include "transport/tcp_transport.h"
 
+#include "utils/wire_limits.h"
+
 #include <unistd.h>
 
 #include <string>
@@ -16,7 +18,7 @@ constexpr size_t kMaxIdlePerNode = 16;  // cap pooled idle conns per node
 // server's response status (which may itself be NotFound etc.).
 bool OneShot(int fd, WireOp op, const BlockKey& k, uint64_t offset,
              uint64_t length, const void* payload, uint64_t payload_len,
-             Status* st, std::string* out) {
+             Status* st, std::string* out, uint64_t max_data) {
   char prefix[kReqPrefix];
   EncodeReq(prefix, op, k, offset, length, payload_len);
   if (!net::WriteAll(fd, prefix, kReqPrefix)) return false;
@@ -25,7 +27,10 @@ bool OneShot(int fd, WireOp op, const BlockKey& k, uint64_t offset,
   char rp[kRespPrefix];
   if (!net::ReadAll(fd, rp, kRespPrefix)) return false;
   uint64_t dlen = 0;
-  if (!DecodeResp(rp, st, &dlen)) return false;  // bad protocol version
+  // max_data caps the server-declared response length BEFORE the allocation
+  // below (the caller knows what it asked for; a corrupt/hostile peer must
+  // not be able to declare a 16 GiB body).
+  if (!DecodeResp(rp, st, &dlen, max_data)) return false;  // bad version / oversize
   if (dlen) {
     std::string data(dlen, '\0');
     if (!net::ReadAll(fd, &data[0], dlen)) return false;
@@ -71,7 +76,8 @@ void TcpTransport::Release(const std::string& node, int fd) {
 Status TcpTransport::RoundTrip(const std::string& node, WireOp op,
                               const BlockKey& k, uint64_t offset,
                               uint64_t length, const void* payload,
-                              uint64_t payload_len, std::string* out) {
+                              uint64_t payload_len, std::string* out,
+                              uint64_t max_data) {
   // Up to 2 attempts: a stale pooled connection is dropped and re-dialed once.
   for (int attempt = 0; attempt < 2; ++attempt) {
     bool from_pool = false;
@@ -79,7 +85,8 @@ Status TcpTransport::RoundTrip(const std::string& node, WireOp op,
     if (fd < 0) return Status::kIOError;  // dial failed
 
     Status st = Status::kIOError;
-    if (OneShot(fd, op, k, offset, length, payload, payload_len, &st, out)) {
+    if (OneShot(fd, op, k, offset, length, payload, payload_len, &st, out,
+                max_data)) {
       Release(node, fd);  // healthy -> back to pool
       return st;
     }
@@ -92,25 +99,31 @@ Status TcpTransport::RoundTrip(const std::string& node, WireOp op,
 
 Status TcpTransport::Cache(const std::string& node, const BlockKey& key,
                            const void* data, size_t len) {
-  return RoundTrip(node, WireOp::kCache, key, 0, 0, data, len, nullptr);
+  return RoundTrip(node, WireOp::kCache, key, 0, 0, data, len, nullptr,
+                   wire_limits::kStatusMaxRespData);
 }
 
 Status TcpTransport::Range(const std::string& node, const BlockKey& key,
                            uint64_t offset, uint64_t length, std::string* out) {
-  return RoundTrip(node, WireOp::kRange, key, offset, length, nullptr, 0, out);
+  // A Range reply carries at most the requested byte count.
+  return RoundTrip(node, WireOp::kRange, key, offset, length, nullptr, 0, out,
+                   length);
 }
 
 Status TcpTransport::Stats(const std::string& node, std::string* out) {
-  return RoundTrip(node, WireOp::kStats, BlockKey{}, 0, 0, nullptr, 0, out);
+  return RoundTrip(node, WireOp::kStats, BlockKey{}, 0, 0, nullptr, 0, out,
+                   wire_limits::kTextMaxRespData);
 }
 
 Status TcpTransport::Members(const std::string& node, std::string* out) {
-  return RoundTrip(node, WireOp::kMembers, BlockKey{}, 0, 0, nullptr, 0, out);
+  return RoundTrip(node, WireOp::kMembers, BlockKey{}, 0, 0, nullptr, 0, out,
+                   wire_limits::kTextMaxRespData);
 }
 
 Status TcpTransport::Exist(const std::string& node, const BlockKey& key,
                            bool* exist) {
-  Status st = RoundTrip(node, WireOp::kExist, key, 0, 0, nullptr, 0, nullptr);
+  Status st = RoundTrip(node, WireOp::kExist, key, 0, 0, nullptr, 0, nullptr,
+                        wire_limits::kStatusMaxRespData);
   if (st == Status::kOk) { *exist = true; return Status::kOk; }
   if (st == Status::kNotFound) { *exist = false; return Status::kOk; }
   return st;
@@ -120,7 +133,8 @@ Status TcpTransport::Remove(const std::string& node, const BlockKey& key) {
   // kRemove is a key-only request (no payload), Status-only response: kOk when a
   // block was dropped, kNotFound when it was already absent (both fine for the
   // caller), kIOError on a transport failure.
-  return RoundTrip(node, WireOp::kRemove, key, 0, 0, nullptr, 0, nullptr);
+  return RoundTrip(node, WireOp::kRemove, key, 0, 0, nullptr, 0, nullptr,
+                   wire_limits::kStatusMaxRespData);
 }
 
 }  // namespace dfkv

--- a/src/transport/tcp_transport.h
+++ b/src/transport/tcp_transport.h
@@ -38,7 +38,8 @@ class TcpTransport : public Transport {
  private:
   Status RoundTrip(const std::string& node, WireOp op, const BlockKey& key,
                    uint64_t offset, uint64_t length, const void* payload,
-                   uint64_t payload_len, std::string* out);
+                   uint64_t payload_len, std::string* out,
+                   uint64_t max_data);
   int Acquire(const std::string& node, bool* from_pool);
   void Release(const std::string& node, int fd);
 

--- a/src/utils/wire_limits.h
+++ b/src/utils/wire_limits.h
@@ -1,0 +1,77 @@
+/* Shared wire payload limits. Every socket that reads a length prefix MUST
+ * pass a real bound into DecodeReq/DecodeResp instead of the 16 GiB
+ * kMaxFrameLen default: the servers allocate payload_len BEFORE reading the
+ * payload bytes, so an unbounded declared length is a one-frame OOM DoS.
+ *
+ * ResolveMaxPayload is the single source of the server's max VALUE size (env
+ * overridable), previously private to rdma_server.cc; the TCP request path
+ * and the RDMA path must agree on it or a value accepted by one transport
+ * would be rejected by the other. */
+#ifndef DFKV_WIRE_LIMITS_H_
+#define DFKV_WIRE_LIMITS_H_
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+
+#include "common/value_header.h"
+
+namespace dfkv {
+namespace wire_limits {
+
+// O_DIRECT / registered-buffer alignment (mirrors rdma::kDirectIoAlign; kept
+// as a plain constant here so this header stays free of RDMA-gated includes).
+constexpr size_t kIoAlign = 4096;
+
+// dbuf/SGE length is uint32, so a payload must stay under
+// uint32max - header - 2*align or registered lengths silently overflow.
+constexpr size_t kPayloadHardCap = static_cast<size_t>(
+    std::numeric_limits<uint32_t>::max() - ValueHeader::kSize - 2 * kIoAlign);
+
+inline size_t EnvBytes(const char* name, size_t dflt) {
+  const char* v = std::getenv(name);
+  if (!v || !*v) return dflt;
+  errno = 0;
+  char* end = nullptr;
+  unsigned long long x = std::strtoull(v, &end, 10);
+  if (errno != 0 || end == v || x == 0) return dflt;
+  if (x > kPayloadHardCap) x = kPayloadHardCap;
+  return static_cast<size_t>(x);
+}
+
+// The server's max value payload: configured (0 = 64 MiB default), then the
+// env overrides (DFKV_RDMA_MAX_PAYLOAD_BYTES / DFKV_RDMA_MAX_MSG_BYTES, in
+// that order), clamped to the uint32 hard cap. Same math the RDMA server
+// applies; a PUT larger than this is rejected on every transport.
+inline size_t ResolveMaxPayload(size_t configured) {
+  size_t n = configured ? configured : (64u << 20);
+  n = EnvBytes("DFKV_RDMA_MAX_PAYLOAD_BYTES", n);
+  n = EnvBytes("DFKV_RDMA_MAX_MSG_BYTES", n);
+  if (n > kPayloadHardCap) n = kPayloadHardCap;
+  return n;
+}
+
+// Bound for a full PUT request frame's payload (value header + value bytes).
+inline uint64_t MaxRequestPayload(size_t configured_max_value = 0) {
+  return static_cast<uint64_t>(ValueHeader::kSize) +
+         static_cast<uint64_t>(ResolveMaxPayload(configured_max_value));
+}
+
+// MDS request frames carry a group name + one MemberInfo (well under 1 KiB);
+// list responses carry the member table (a few KiB for a 62-node ring). The
+// caps leave two orders of magnitude of headroom.
+constexpr uint64_t kMdsMaxReqPayload = 1u << 20;   // 1 MiB
+constexpr uint64_t kMdsMaxRespData = 1u << 24;     // 16 MiB
+
+// Stats/Members text responses on the data-path TCP port.
+constexpr uint64_t kTextMaxRespData = 1u << 24;    // 16 MiB
+// Status-only responses (Cache/Exist/Remove) carry no data; allow a tiny
+// slack instead of 0 so a future short diagnostic string can't break us.
+constexpr uint64_t kStatusMaxRespData = 4096;
+
+}  // namespace wire_limits
+}  // namespace dfkv
+
+#endif  // DFKV_WIRE_LIMITS_H_

--- a/test/transport/frame_caps_test.cc
+++ b/test/transport/frame_caps_test.cc
@@ -1,0 +1,161 @@
+// Frame-cap regressions: every socket that reads a declared length must bound
+// it BEFORE allocating (utils/wire_limits.h). A forged prefix declaring a
+// huge payload/body must drop the connection promptly -- not allocate.
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <string>
+#include <thread>
+
+#include "cache/kv_node_server.h"
+#include "mds/mds_server.h"
+#include "mds/mds_member_poller.h"
+#include "transport/tcp_transport.h"
+#include "transport/wire.h"
+#include "utils/net_util.h"
+
+using namespace dfkv;  // NOLINT
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint64_t kHuge = 1ull << 33;  // 8 GiB: legal under the old 16 GiB default
+
+// Sends a request prefix declaring `payload_len` bytes (without sending them)
+// and returns true iff the server closed the connection promptly (recv == 0
+// within the socket timeout) -- the post-fix behavior. Pre-fix the server
+// would allocate and then block waiting for the payload.
+bool ServerDropsOversizeFrame(int port, uint64_t payload_len) {
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 2000, 2000);
+  if (fd < 0) return false;
+  char prefix[kReqPrefix];
+  EncodeReq(prefix, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, payload_len);
+  if (!net::WriteAll(fd, prefix, kReqPrefix)) { ::close(fd); return false; }
+  char c;
+  ssize_t r = ::recv(fd, &c, 1, 0);  // 0 = orderly close, <0 = timeout/err
+  ::close(fd);
+  return r == 0;
+}
+
+// One-shot fake server: accepts a single connection, consumes the request
+// prefix (+payload), replies with a response prefix declaring `resp_dlen`
+// body bytes, then closes without sending a body.
+class FakeDlenServer {
+ public:
+  explicit FakeDlenServer(uint64_t resp_dlen) : dlen_(resp_dlen) {
+    lfd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    ::bind(lfd_, reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
+    ::listen(lfd_, 4);
+    socklen_t sl = sizeof(sa);
+    ::getsockname(lfd_, reinterpret_cast<sockaddr*>(&sa), &sl);
+    port_ = ntohs(sa.sin_port);
+    th_ = std::thread([this] {
+      for (;;) {
+        int fd = ::accept(lfd_, nullptr, nullptr);
+        if (fd < 0) return;  // listener closed
+        char prefix[kReqPrefix];
+        if (net::ReadAll(fd, prefix, kReqPrefix)) {
+          ReqFields rq;
+          if (DecodeReq(prefix, &rq) && rq.payload_len) {
+            std::string sink(rq.payload_len, '\0');
+            net::ReadAll(fd, &sink[0], rq.payload_len);
+          }
+          char rp[kRespPrefix];
+          EncodeResp(rp, Status::kOk, dlen_);
+          net::WriteAll(fd, rp, kRespPrefix);
+        }
+        ::close(fd);
+      }
+    });
+  }
+  ~FakeDlenServer() {
+    ::shutdown(lfd_, SHUT_RDWR);
+    ::close(lfd_);
+    if (th_.joinable()) th_.join();
+  }
+  int port() const { return port_; }
+
+ private:
+  uint64_t dlen_;
+  int lfd_ = -1, port_ = 0;
+  std::thread th_;
+};
+
+}  // namespace
+
+TEST(FrameCaps, KvNodeServerDropsOversizeRequestAndStaysAlive) {
+  fs::path dir = fs::temp_directory_path() / "dfkv_framecap_node";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  KvNodeServer srv(dir.string(), 1ull << 30);
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+
+  EXPECT_TRUE(ServerDropsOversizeFrame(srv.port(), kHuge));
+
+  // Server must still serve a well-formed request afterwards.
+  TcpTransport t;
+  std::string node = "127.0.0.1:" + std::to_string(srv.port());
+  std::string blob(1024, 'x');
+  EXPECT_EQ(t.Cache(node, BlockKey{7, 0, 1}, blob.data(), blob.size()),
+            Status::kOk);
+  bool exist = false;
+  EXPECT_EQ(t.Exist(node, BlockKey{7, 0, 1}, &exist), Status::kOk);
+  EXPECT_TRUE(exist);
+  srv.Stop();
+  fs::remove_all(dir);
+}
+
+TEST(FrameCaps, MdsServerDropsOversizeRequestAndStaysAlive) {
+  // etcd is never contacted: the oversize frame is dropped at decode, and the
+  // liveness probe below only needs the server to answer (kIOError from the
+  // unreachable etcd endpoint is an ANSWER -- the connection survives).
+  MdsServer mds("127.0.0.1:9");  // discard port: connection refused fast
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+
+  EXPECT_TRUE(ServerDropsOversizeFrame(mds.port(), 2ull << 20));  // > 1 MiB cap
+
+  int fd = net::Dial("127.0.0.1:" + std::to_string(mds.port()), 2000, 5000);
+  ASSERT_GE(fd, 0);
+  std::string group = "g";
+  char prefix[kReqPrefix];
+  EncodeReq(prefix, WireOp::kListMembers, BlockKey{}, 0, 0, group.size());
+  ASSERT_TRUE(net::WriteAll(fd, prefix, kReqPrefix));
+  ASSERT_TRUE(net::WriteAll(fd, group.data(), group.size()));
+  char rp[kRespPrefix];
+  EXPECT_TRUE(net::ReadAll(fd, rp, kRespPrefix)) << "server must still answer";
+  ::close(fd);
+  mds.Stop();
+}
+
+TEST(FrameCaps, ClientRejectsOversizeStatusResponse) {
+  FakeDlenServer fake(kHuge);
+  TcpTransport t;
+  std::string node = "127.0.0.1:" + std::to_string(fake.port());
+  bool exist = false;
+  // Status-only op: a peer declaring an 8 GiB body is a protocol violation.
+  EXPECT_EQ(t.Exist(node, BlockKey{1, 0, 1}, &exist), Status::kIOError);
+}
+
+TEST(FrameCaps, ClientRejectsRangeResponseLargerThanAsked) {
+  FakeDlenServer fake(4096 + 1000);  // more than the request asks for
+  TcpTransport t;
+  std::string node = "127.0.0.1:" + std::to_string(fake.port());
+  std::string out;
+  EXPECT_EQ(t.Range(node, BlockKey{1, 0, 1}, 0, 4096, &out), Status::kIOError);
+}
+
+TEST(FrameCaps, PollerRejectsOversizeMemberList) {
+  FakeDlenServer fake(kHuge);
+  std::atomic<int> changes{0};
+  MdsMemberPoller poller({"127.0.0.1:" + std::to_string(fake.port())}, "g",
+                         [&](const std::vector<MemberInfo>&) { ++changes; });
+  EXPECT_FALSE(poller.PollOnce());  // oversize dlen must fail the poll...
+  EXPECT_EQ(changes.load(), 0);     // ...and never reach the on_change callback
+}


### PR DESCRIPTION
## Problem (P1, remote OOM DoS)

`DecodeReq`/`DecodeResp` default to a 16 GiB `kMaxFrameLen`, and the servers allocate the declared length **before** reading the bytes. A 42-byte forged prefix declaring a huge `payload_len`/`data_len` is a one-frame OOM. Every TCP/MDS read path was affected (the RDMA path already passed a real bound — used here as the template).

## Fix
Bound every call site with a real limit:
- **kv_node_server** TCP handler → value-header + the resolved max value (the SAME limit the RDMA server enforces). Factored `EnvBytes`/`ResolveMaxPayload` out of `rdma_server.cc` into `utils/wire_limits.h` (with a `static_assert` tying the alignment constant to `rdma::kDirectIoAlign`) so both transports agree; `server_main` sets it explicitly for parity.
- **mds_server** → 1 MiB request cap (frames are a group name + one MemberInfo).
- **mds_member_poller / mds_registrar** → 16 MiB response cap.
- **tcp_transport** `OneShot`/`RoundTrip` → caller passes `max_data`: Range bounds to the requested length, Stats/Members to 16 MiB, status-only ops (Cache/Exist/Remove) to 4 KiB.

No behavior change for legal traffic (limits sit orders of magnitude above real frames).

## Tests
`test/transport/frame_caps_test.cc`: oversize request frame is dropped and the KvNodeServer/MdsServer stay alive and keep serving; client rejects an oversize status/Range response; a poller rejects an oversize member list (never reaching `on_change`). Local: default **188/188**, RDMA+URING **210/210** (incl. real etcd).