### PR TITLE
fix(mds): validate group/id charset to block key-subtree injection

### DIFF
--- a/src/common/membership.h
+++ b/src/common/membership.h
@@ -26,6 +26,22 @@ struct MemberInfo {
   }
 };
 
+// A group or member id is embedded verbatim into the etcd key
+//   /dfkv/v1/groups/<group>/members/<id>
+// so a '/' (or an empty/overlong token) lets a registration escape its own
+// key subtree -- e.g. group "a/members/ghost" injects a phantom member into
+// group "a"'s RangePrefix, and any reachable client can point a real node id
+// at an attacker IP. Restrict both to a conservative, path-safe alphabet.
+inline bool IsValidGroupOrId(const std::string& s) {
+  if (s.empty() || s.size() > 128) return false;
+  for (unsigned char c : s) {
+    const bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                    (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-';
+    if (!ok) return false;
+  }
+  return true;
+}
+
 // Magic tag marking the OPTIONAL tcp_port extension appended after the member list.
 // Old encodings carry no trailing bytes, so this tag is unambiguous when present.
 constexpr uint32_t kMemberExtTcpPort = 0x54435031u;  // "TCP1"

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -5,6 +5,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include "common/membership.h"
 #include "mds/mds_proto.h"
 #include "utils/net_util.h"
 #include "utils/wire_limits.h"
@@ -99,6 +100,9 @@ void MdsServer::AcceptLoop() {
 }
 
 Status MdsServer::Upsert(const std::string& group, const MemberInfo& m) {
+  // Reject before the id/group reach the etcd key: an unrestricted token can
+  // contain '/' and escape its own key subtree (phantom-member injection).
+  if (!IsValidGroupOrId(group) || !IsValidGroupOrId(m.id)) return Status::kInvalid;
   std::string key = MemberKey(group, m.id);
   std::string val = EncodeMembers({m}, 0);
   // Look up this member's known lease under the lock, then do the BLOCKING etcd
@@ -145,6 +149,9 @@ Status MdsServer::Upsert(const std::string& group, const MemberInfo& m) {
 
 Status MdsServer::ListMembers(const std::string& group, std::string* out) {
   metrics_.list_requests.fetch_add(1, std::memory_order_relaxed);
+  // A malformed group would build a RangePrefix straddling other groups'
+  // subtrees; reject it the same way Upsert does.
+  if (!IsValidGroupOrId(group)) return Status::kInvalid;
   std::string prefix = "/dfkv/v1/groups/" + group + "/members/";
   auto r = etcd_.RangePrefix(prefix);
   if (!r) { metrics_.etcd_errors.fetch_add(1, std::memory_order_relaxed); return Status::kIOError; }

--- a/test/common/membership_test.cc
+++ b/test/common/membership_test.cc
@@ -82,3 +82,23 @@ TEST(MembersEpoch, NoFieldBoundaryCollision) {
   std::vector<MemberInfo> y = {{"a", "bc", 0, 0}};
   EXPECT_NE(MembersEpoch(x), MembersEpoch(y));
 }
+
+TEST(Membership, ValidGroupOrIdAlphabet) {
+  // Accepted: the tokens real deployments use.
+  EXPECT_TRUE(IsValidGroupOrId("glm"));
+  EXPECT_TRUE(IsValidGroupOrId("glm-a"));
+  EXPECT_TRUE(IsValidGroupOrId("gpu2-0045"));
+  EXPECT_TRUE(IsValidGroupOrId("itest-grp-12345"));
+  EXPECT_TRUE(IsValidGroupOrId("a.b_c-1"));
+  EXPECT_TRUE(IsValidGroupOrId(std::string(128, 'a')));  // max length
+
+  // Rejected: empty, overlong, and anything that could escape the key subtree.
+  EXPECT_FALSE(IsValidGroupOrId(""));
+  EXPECT_FALSE(IsValidGroupOrId(std::string(129, 'a')));
+  EXPECT_FALSE(IsValidGroupOrId("a/members/ghost"));  // path traversal
+  EXPECT_FALSE(IsValidGroupOrId("a/b"));
+  EXPECT_FALSE(IsValidGroupOrId("a b"));   // space
+  EXPECT_FALSE(IsValidGroupOrId("a\tb"));
+  EXPECT_FALSE(IsValidGroupOrId("a:b"));
+  EXPECT_FALSE(IsValidGroupOrId(std::string("a\0b", 3)));  // embedded NUL
+}

--- a/test/mds/mds_server_test.cc
+++ b/test/mds/mds_server_test.cc
@@ -108,3 +108,37 @@ TEST(MdsServer, HeartbeatRewritesMemberValueUnderOwnLease) {
   EXPECT_EQ(got[0].weight, 7u);
   mds.Stop();
 }
+
+TEST(MdsServer, RejectsPathTraversalGroupAndId) {
+  const char* ep = EtcdEp();
+  if (!ep) GTEST_SKIP() << "set DFKV_TEST_ETCD=host:port";
+  MdsServer mds(ep);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+  int port = mds.port();
+  Status st; std::string data;
+
+  // A group containing "/members/" would land the key inside group "victim".
+  std::string victim = "victim-" + std::to_string(port);
+  MemberInfo ghost{"ghost", "6.6.6.6", 28000, 1};
+  std::string evil_group = victim + "/members/x/members";
+  ASSERT_TRUE(DoReq(port, WireOp::kRegister, EncodeMemberReq(evil_group, ghost),
+                    &st, &data));
+  EXPECT_EQ(st, Status::kInvalid) << "path-traversal group must be rejected";
+
+  // An id with a slash is equally dangerous.
+  MemberInfo m{"a/members/x", "1.1.1.1", 28000, 1};
+  ASSERT_TRUE(DoReq(port, WireOp::kRegister, EncodeMemberReq(victim, m), &st, &data));
+  EXPECT_EQ(st, Status::kInvalid) << "path-traversal id must be rejected";
+
+  // The victim group must contain no injected phantom member.
+  ASSERT_TRUE(DoReq(port, WireOp::kListMembers, victim, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  std::vector<MemberInfo> got; uint64_t epoch = 0;
+  ASSERT_TRUE(DecodeMembers(data.data(), data.size(), &got, &epoch));
+  EXPECT_TRUE(got.empty()) << "no phantom member should have been injected";
+
+  // A malformed group on ListMembers is rejected outright.
+  ASSERT_TRUE(DoReq(port, WireOp::kListMembers, "a/b", &st, &data));
+  EXPECT_EQ(st, Status::kInvalid);
+  mds.Stop();
+}


### PR DESCRIPTION
## Problem (P1, membership integrity / access)

A group or member id is embedded verbatim into the etcd key `/dfkv/v1/groups/<group>/members/<id>`. An unrestricted token can contain `/` and escape its own subtree: registering group `a/members/x/members` injects a **phantom member into group `a`**, and any client that can reach the MDS port can point a real node id at an attacker IP (traffic hijack / cache poisoning).

## Fix
`IsValidGroupOrId` (common/membership.h): non-empty, ≤128 chars, `[A-Za-z0-9._-]` only. `Upsert` and `ListMembers` reject with `kInvalid` before the token reaches the key. Every real token (glm, glm-a, gpu2-0045, itest-grp-*) is within the alphabet — no compatibility impact.

## Tests
- Charset unit tests (membership_test.cc): accepts real tokens; rejects `/`, space, tab, `:`, embedded NUL, empty, and >128 chars.
- Real-etcd regression (mds_server_test): a path-traversal register returns kInvalid and the victim group stays empty (no phantom member) — **fails on the old code**.
- Local: default **190/190**, RDMA+URING **212/212** green.