### PR TITLE
fix(client): exponential peer-health backoff + off-datapath probe recovery

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -151,7 +151,13 @@ void KVClient::ProbeLoop() {
                        std::chrono::steady_clock::now() - t0).count();
       // Only record real round trips; a transport IO error (e.g. connect refused)
       // is fast and would skew latency, and is already counted by PeerHealth.
-      if (st != Status::kIOError) peer_lat_.Observe(a, sec);
+      // A non-IO reply also means the peer is reachable: clear its data-path
+      // cooldown here (off the data path) so recovery never depends on a data
+      // request re-dialing a peer that is still inside its backed-off cooldown.
+      if (st != Status::kIOError) {
+        peer_lat_.Observe(a, sec);
+        health_.MarkProbeAlive(a);
+      }
     }
     std::unique_lock<std::mutex> lk(probe_mu_);
     probe_cv_.wait_for(lk, std::chrono::milliseconds(probe_interval_ms_),
@@ -241,8 +247,12 @@ bool KVClient::Put(const std::string& key, const void* value, size_t n) {
     if (n) std::memcpy(buf.data() + ValueHeader::kSize, value, n);
     st = t_->Cache(node, bk, buf.data(), buf.size());
   }
-  if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
-  health_.MarkGood(node);
+  // Fresh clock: `now` was taken before a round trip that can burn the whole
+  // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
+  if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
+  // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
+  // client-side/oversize outcomes that must not clear a peer's cooldown.
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
   return st == Status::kOk;
 }
 
@@ -275,8 +285,12 @@ bool KVClient::Get(const std::string& key, void* out, size_t n) {
   // TCP (non-pipelined): response into a string, then copy to out.
   std::string raw;
   Status st = t_->Range(node, bk, 0, ValueHeader::kSize + n, &raw);
-  if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
-  health_.MarkGood(node);
+  // Fresh clock: `now` was taken before a round trip that can burn the whole
+  // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
+  if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
+  // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
+  // client-side/oversize outcomes that must not clear a peer's cooldown.
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
   if (st != Status::kOk) return false;
   if (raw.size() < ValueHeader::kSize) return false;
 
@@ -298,8 +312,12 @@ bool KVClient::GetAuto(const std::string& key, std::string* out, size_t max_byte
   if (!health_.Healthy(node, now)) return false;
   std::string raw;
   Status st = t_->Range(node, ToBlockKey(key), 0, ValueHeader::kSize + max_bytes, &raw);
-  if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
-  health_.MarkGood(node);
+  // Fresh clock: `now` was taken before a round trip that can burn the whole
+  // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
+  if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
+  // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
+  // client-side/oversize outcomes that must not clear a peer's cooldown.
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
   if (st != Status::kOk) return false;
   if (raw.size() < ValueHeader::kSize) return false;
   ValueHeader h;
@@ -319,8 +337,12 @@ bool KVClient::GetAuto(const std::string& key, void* out, size_t cap, size_t* ou
   // Read [header | up-to-cap payload]; the header tells us the true payload_len.
   std::string raw;
   Status st = t_->Range(node, ToBlockKey(key), 0, ValueHeader::kSize + cap, &raw);
-  if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
-  health_.MarkGood(node);
+  // Fresh clock: `now` was taken before a round trip that can burn the whole
+  // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
+  if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
+  // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
+  // client-side/oversize outcomes that must not clear a peer's cooldown.
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
   if (st != Status::kOk) return false;
   if (raw.size() < ValueHeader::kSize) return false;
   ValueHeader h;
@@ -340,8 +362,12 @@ bool KVClient::Exist(const std::string& key) {
   if (!health_.Healthy(node, now)) return false;
   bool e = false;
   Status st = t_->Exist(node, ToBlockKey(key), &e);
-  if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
-  health_.MarkGood(node);
+  // Fresh clock: `now` was taken before a round trip that can burn the whole
+  // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
+  if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
+  // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
+  // client-side/oversize outcomes that must not clear a peer's cooldown.
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
   return st == Status::kOk && e;
 }
 
@@ -351,8 +377,12 @@ bool KVClient::Remove(const std::string& key) {
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
   Status st = t_->Remove(node, ToBlockKey(key));
-  if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
-  health_.MarkGood(node);
+  // Fresh clock: `now` was taken before a round trip that can burn the whole
+  // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
+  if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
+  // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
+  // client-side/oversize outcomes that must not clear a peer's cooldown.
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
   // kNotFound is a success for the caller: the goal (key not present) holds.
   return st == Status::kOk || st == Status::kNotFound;
 }
@@ -394,8 +424,13 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
     std::vector<Status> sts = t_->CacheFrom(node, srcs);
     for (size_t m = 0; m < idx.size(); ++m) ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
     bool resp = false, ioerr = false;
-    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    // kInvalid (oversize/per-item guard) is neither: it must not clear the
+    // peer cooldown (resp) nor trip MarkBad (ioerr).
+    for (Status s : sts) {
+      if (s == Status::kIOError) ioerr = true;
+      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
   });
   // RDMA path records the batch once (TCP path above is counted per-key by Put()).
   uint64_t bytes = 0;
@@ -440,8 +475,13 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
     std::vector<std::string> hdrs;
     std::vector<Status> sts = t_->RangeInto(node, keys, dsts, ValueHeader::kSize, &hdrs);
     bool resp = false, ioerr = false;
-    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    // kInvalid (oversize/per-item guard) is neither: it must not clear the
+    // peer cooldown (resp) nor trip MarkBad (ioerr).
+    for (Status s : sts) {
+      if (s == Status::kIOError) ioerr = true;
+      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) {
       if (sts[m] != Status::kOk || hdrs[m].size() < ValueHeader::kSize) continue;
       ValueHeader h;
@@ -497,8 +537,13 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
     std::vector<std::string> hdrs;
     std::vector<Status> sts = t_->RangeInto(node, keys, dsts, ValueHeader::kSize, &hdrs);
     bool resp = false, ioerr = false;
-    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    // kInvalid (oversize/per-item guard) is neither: it must not clear the
+    // peer cooldown (resp) nor trip MarkBad (ioerr).
+    for (Status s : sts) {
+      if (s == Status::kIOError) ioerr = true;
+      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) {
       if (sts[m] != Status::kOk || hdrs[m].size() < ValueHeader::kSize) continue;
       ValueHeader h;
@@ -546,8 +591,13 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
     std::vector<char> ex;
     std::vector<Status> sts = t_->ExistMany(node, bkeys, &ex);
     bool resp = false, ioerr = false;
-    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    // kInvalid (oversize/per-item guard) is neither: it must not clear the
+    // peer cooldown (resp) nor trip MarkBad (ioerr).
+    for (Status s : sts) {
+      if (s == Status::kIOError) ioerr = true;
+      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) e[idx[m]] = (m < ex.size() && ex[m]) ? 1 : 0;
   });
   return RecordBatch(OpMetrics::kExist, t0, e, 0);
@@ -581,8 +631,13 @@ std::vector<bool> KVClient::BatchRemove(const std::vector<std::string>& keys) {
     for (size_t k : idx) bkeys.push_back(ToBlockKey(keys[k]));
     std::vector<Status> sts = t_->RemoveMany(node, bkeys);
     bool resp = false, ioerr = false;
-    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    // kInvalid (oversize/per-item guard) is neither: it must not clear the
+    // peer cooldown (resp) nor trip MarkBad (ioerr).
+    for (Status s : sts) {
+      if (s == Status::kIOError) ioerr = true;
+      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m)
       ok[idx[m]] = (m < sts.size() &&
                     (sts[m] == Status::kOk || sts[m] == Status::kNotFound)) ? 1 : 0;
@@ -643,8 +698,13 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     std::vector<Status> sts = t_->CacheFromMulti(node, srcs);
     for (size_t m = 0; m < idx.size(); ++m) ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
     bool resp = false, ioerr = false;
-    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    // kInvalid (oversize/per-item guard) is neither: it must not clear the
+    // peer cooldown (resp) nor trip MarkBad (ioerr).
+    for (Status s : sts) {
+      if (s == Status::kIOError) ioerr = true;
+      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
   });
   uint64_t bytes = 0;
   for (size_t i = 0; i < N; ++i) if (ok[i]) for (size_t s : items[i].sizes) bytes += s;
@@ -702,8 +762,13 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
     std::vector<Status> sts =
         t_->RangeIntoMulti(node, keys, dsts, ValueHeader::kSize, &hdrs, &tlens);
     bool resp = false, ioerr = false;
-    for (Status s : sts) { if (s == Status::kIOError) ioerr = true; else resp = true; }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, now);
+    // kInvalid (oversize/per-item guard) is neither: it must not clear the
+    // peer cooldown (resp) nor trip MarkBad (ioerr).
+    for (Status s : sts) {
+      if (s == Status::kIOError) ioerr = true;
+      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    }
+    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) {
       size_t cap = groups[g].first.second;
       if (sts[m] != Status::kOk || hdrs[m].size() < ValueHeader::kSize) continue;

--- a/src/client/peer_health.h
+++ b/src/client/peer_health.h
@@ -22,7 +22,14 @@ namespace dfkv {
 // here at no extra hot-path cost (the mutex is already taken on these calls).
 class PeerHealth {
  public:
-  explicit PeerHealth(uint64_t cooldown_ms = 2000) : cooldown_ms_(cooldown_ms) {}
+  // base_cooldown_ms doubles per consecutive failure up to max_cooldown_ms. A
+  // FIXED cooldown shorter than the connect timeout (2s < 3s) meant a dead peer
+  // was re-dialed on the data path every base period, stalling each batch on a
+  // full connect timeout indefinitely; exponential backoff caps that cost at
+  // one connect per max_cooldown once a peer is persistently down.
+  explicit PeerHealth(uint64_t base_cooldown_ms = 2000,
+                      uint64_t max_cooldown_ms = 30000)
+      : base_cooldown_ms_(base_cooldown_ms), max_cooldown_ms_(max_cooldown_ms) {}
 
   bool Healthy(const std::string& peer, uint64_t now_ms) const {
     std::lock_guard<std::mutex> lk(mu_);
@@ -36,7 +43,12 @@ class PeerHealth {
     std::lock_guard<std::mutex> lk(mu_);
     auto it = until_.find(peer);
     bool was_ok = it == until_.end() || it->second <= now_ms;
-    until_[peer] = now_ms + cooldown_ms_;
+    // Exponential backoff: base << (fails-1), capped at max_cooldown.
+    uint32_t fails = ++fail_streak_[peer];
+    unsigned shift = fails > 31 ? 31u : (fails - 1);
+    uint64_t cd = base_cooldown_ms_ << shift;
+    if (cd > max_cooldown_ms_ || cd < base_cooldown_ms_ /*overflow*/) cd = max_cooldown_ms_;
+    until_[peer] = now_ms + cd;
     errors_.fetch_add(1, std::memory_order_relaxed);
     if (was_ok) marked_bad_.fetch_add(1, std::memory_order_relaxed);  // healthy->bad edge
     // Bound per-peer cardinality: only track a new peer while under the cap, so a
@@ -44,10 +56,20 @@ class PeerHealth {
     // map (and its scrape series) without bound. Aggregate errors_ still counts.
     if (peer_errors_.size() < kMaxPeers || peer_errors_.count(peer)) peer_errors_[peer]++;
   }
+  // Data-path success: clears the cooldown and the backoff streak. Bumps the
+  // served counter (an op completed), so it is NOT for probe-driven recovery.
   void MarkGood(const std::string& peer) {
     std::lock_guard<std::mutex> lk(mu_);
     served_.fetch_add(1, std::memory_order_relaxed);
-    if (until_.erase(peer)) recovered_.fetch_add(1, std::memory_order_relaxed);  // bad->good edge
+    ClearLocked(peer);
+  }
+  // Probe-driven recovery (off the data path): the background prober reached
+  // the peer, so clear its cooldown/streak WITHOUT counting a served op. This
+  // is what lets recovery happen without the data path ever having to re-dial a
+  // dead peer inside its (now backed-off) cooldown.
+  void MarkProbeAlive(const std::string& peer) {
+    std::lock_guard<std::mutex> lk(mu_);
+    ClearLocked(peer);
   }
 
   // Prometheus client-side metrics text. Aggregates + per-peer error counts.
@@ -92,10 +114,18 @@ class PeerHealth {
   uint64_t recovered() const { return recovered_.load(std::memory_order_relaxed); }
 
  private:
+  // Clear a peer's cooldown + backoff streak (recovery). Caller holds mu_.
+  void ClearLocked(const std::string& peer) {
+    fail_streak_.erase(peer);
+    if (until_.erase(peer)) recovered_.fetch_add(1, std::memory_order_relaxed);  // bad->good edge
+  }
+
   static constexpr size_t kMaxPeers = 4096;  // per-peer error-map cardinality cap
   mutable std::mutex mu_;
-  uint64_t cooldown_ms_;
+  uint64_t base_cooldown_ms_;
+  uint64_t max_cooldown_ms_;
   std::unordered_map<std::string, uint64_t> until_;        // peer -> unhealthy-until (ms)
+  std::unordered_map<std::string, uint32_t> fail_streak_;  // peer -> consecutive failures
   std::unordered_map<std::string, uint64_t> peer_errors_;  // peer -> cumulative IO errors
   mutable std::atomic<uint64_t> checks_{0}, unhealthy_skips_{0}, errors_{0},
       marked_bad_{0}, served_{0}, recovered_{0};

--- a/test/client/peer_health_test.cc
+++ b/test/client/peer_health_test.cc
@@ -29,3 +29,39 @@ TEST(PeerHealth, PeersAreIndependent) {
   EXPECT_FALSE(h.Healthy("a", 1500));
   EXPECT_TRUE(h.Healthy("b", 1500));
 }
+
+TEST(PeerHealth, CooldownBacksOffExponentiallyAndCapsAtMax) {
+  PeerHealth h(/*base_cooldown_ms=*/100, /*max_cooldown_ms=*/800);
+  // 1st failure -> 100ms cooldown: unhealthy at now, healthy at now+100.
+  h.MarkBad("p", 1000);
+  EXPECT_FALSE(h.Healthy("p", 1050));
+  EXPECT_TRUE(h.Healthy("p", 1100));
+  // Consecutive failures double the cooldown: 200, 400, 800, then capped at 800.
+  h.MarkBad("p", 2000); EXPECT_FALSE(h.Healthy("p", 2199)); EXPECT_TRUE(h.Healthy("p", 2200));
+  h.MarkBad("p", 3000); EXPECT_FALSE(h.Healthy("p", 3399)); EXPECT_TRUE(h.Healthy("p", 3400));
+  h.MarkBad("p", 4000); EXPECT_FALSE(h.Healthy("p", 4799)); EXPECT_TRUE(h.Healthy("p", 4800));
+  h.MarkBad("p", 5000); EXPECT_FALSE(h.Healthy("p", 5799)); EXPECT_TRUE(h.Healthy("p", 5800));  // capped
+}
+
+TEST(PeerHealth, MarkGoodResetsBackoffStreak) {
+  PeerHealth h(/*base=*/100, /*max=*/10000);
+  h.MarkBad("p", 0); h.MarkBad("p", 0); h.MarkBad("p", 0);  // streak -> 400ms
+  h.MarkGood("p");                                          // reset
+  h.MarkBad("p", 1000);                                     // back to base 100ms
+  EXPECT_FALSE(h.Healthy("p", 1099));
+  EXPECT_TRUE(h.Healthy("p", 1100));
+}
+
+TEST(PeerHealth, MarkProbeAliveRecoversWithoutCountingServed) {
+  PeerHealth h(/*base=*/1000, /*max=*/30000);
+  h.MarkBad("p", 0);
+  EXPECT_FALSE(h.Healthy("p", 500));
+  uint64_t served_before = h.served();
+  h.MarkProbeAlive("p");                       // off-data-path recovery
+  EXPECT_TRUE(h.Healthy("p", 500));            // cooldown cleared
+  EXPECT_EQ(h.served(), served_before);        // served counter untouched
+  EXPECT_EQ(h.recovered(), 1u);                // bad->good edge counted
+  // And the streak was reset: next failure starts at base again.
+  h.MarkBad("p", 1000);
+  EXPECT_TRUE(h.Healthy("p", 2000));
+}


### PR DESCRIPTION
## Problem (P1, tail latency on single node failure)

A dead peer cost **every batch a full connect timeout, indefinitely**: the fixed 2s cooldown was shorter than the 3s connect timeout, so the data path re-dialed the peer every ~2s and each batch's `RunParallel` join waited on that 3s connect. One down node in a 62-node ring → persistent global batch jitter. Three linked defects:

- **Fixed cooldown < connect timeout.** Now exponential: base 2s doubling per consecutive failure, capped at 30s — at most one connect per 30s for a persistently-down peer.
- **Recovery lived only on the data path.** `ProbeLoop` measured latency but never fed health, so a data request had to re-dial the dead peer to notice recovery. It now calls a new `MarkProbeAlive()` (clears cooldown + streak, off the data path, no served-op count).
- **kInvalid + stale clock.** A `kInvalid` reply (oversize / per-item guard — peer untouched) used to `MarkGood` and clear the cooldown; health now reacts only to `kIOError` (bad) and `kOk`/`kNotFound` (good). `MarkBad` now takes a fresh `NowMs()` instead of a timestamp that could be a full io_timeout stale.

`MarkGood` resets the streak. Single-op (6 sites) and batch (7 sites) paths updated.

## Tests
`peer_health_test`: backoff doubles and caps; `MarkGood` resets the streak; `MarkProbeAlive` recovers without bumping `served` and resets the streak. Local: default **193/193**, RDMA+URING **215/215**.