### PR TITLE
fix(cache): reclaim orphan .tmp files at startup instead of leaking them

### DIFF
--- a/src/cache/kv_store.cc
+++ b/src/cache/kv_store.cc
@@ -226,16 +226,31 @@ KVStore::Shard& KVStore::ShardFor(const std::string& fname) const {
 void KVStore::RebuildIndex() {  // constructor-time, single-threaded: no locks
   std::error_code ec;
   if (!fs::exists(opt_.cache_dir, ec)) return;
+  // A crash between WriteFileDirect and the atomic rename (every rolling upgrade
+  // kills a process mid-flight) leaves an orphan ".tmp": it is never indexed,
+  // never counted toward capacity, and thus never evicted -- a permanent disk
+  // leak that accumulates across restarts. Delete them on startup instead of
+  // just skipping. A published block's name is purely digits ("id_index_size")
+  // and never contains '.', so ".tmp" can only be an orphan -- no false delete.
+  std::vector<fs::path> orphans;
   for (auto it = fs::recursive_directory_iterator(opt_.cache_dir, ec);
        !ec && it != fs::recursive_directory_iterator(); it.increment(ec)) {
     if (!it->is_regular_file(ec)) continue;
     std::string fname = it->path().filename().string();
-    if (fname.size() >= 4 && fname.substr(fname.size() - 4) == ".tmp") continue;
+    if (fname.size() >= 4 && fname.substr(fname.size() - 4) == ".tmp") {
+      orphans.push_back(it->path());
+      continue;
+    }
     uint64_t sz = static_cast<uint64_t>(fs::file_size(it->path(), ec));
     Shard& sh = ShardFor(fname);
     sh.ring.push_front(fname);
     sh.index.try_emplace(fname, it->path().string(), sz);
     sh.used_bytes += sz;
+  }
+  // Reclaim outside the iteration so removal can't perturb the directory walk.
+  for (const auto& p : orphans) {
+    std::error_code rc;
+    if (fs::remove(p, rc)) tmp_reclaimed_.fetch_add(1, std::memory_order_relaxed);
   }
 }
 

--- a/src/cache/kv_store.h
+++ b/src/cache/kv_store.h
@@ -95,6 +95,10 @@ class KVStore {
   size_t Count() const;
   uint64_t Evictions() const { return evictions_.load(std::memory_order_relaxed); }
   uint64_t EvictedBytes() const { return evicted_bytes_.load(std::memory_order_relaxed); }
+  // Orphan ".tmp" files removed at construction (crash-between-write-and-rename
+  // leaks). Diagnostic: a persistently non-zero value across restarts points at
+  // frequent mid-write kills.
+  uint64_t TmpReclaimed() const { return tmp_reclaimed_.load(std::memory_order_relaxed); }
   const std::string& Dir() const { return opt_.cache_dir; }
 
  private:
@@ -127,6 +131,7 @@ class KVStore {
   std::atomic<uint64_t> tmp_seq_{0};  // unique suffix for concurrent lock-free writes
   // Eviction counters (relaxed): incremented in EvictLocked across shards.
   std::atomic<uint64_t> evictions_{0}, evicted_bytes_{0};
+  std::atomic<uint64_t> tmp_reclaimed_{0};  // orphan .tmp removed at startup
 };
 
 }  // namespace dfkv

--- a/test/cache/kv_store_test.cc
+++ b/test/cache/kv_store_test.cc
@@ -1,4 +1,5 @@
 // TDD R3 — KVStore: the cache-node local store (disk + LRU + cache-only/no-S3).
+#include <fstream>
 #include "cache/kv_store.h"
 
 #include <gtest/gtest.h>
@@ -288,4 +289,38 @@ TEST_F(KVStoreTest, RemoveKeepsClockHandValidUnderManyKeys) {
   // The survivors are still readable and a fresh cache still evicts correctly.
   std::string out;
   EXPECT_EQ(s.Range(BlockKey{1, 0, 1}, 0, 64, &out), Status::kOk);
+}
+
+TEST_F(KVStoreTest, RebuildIndexReclaimsOrphanTmpAndKeepsPublishedBlocks) {
+  BlockKey k{555, 0, 1};
+  std::string v = "durable-value-0123456789";
+  {
+    KVStore s(Opts());
+    ASSERT_EQ(s.Cache(k, v.data(), v.size()), Status::kOk);
+  }
+  // Simulate a crash between WriteFileDirect and rename: drop orphan ".tmp"
+  // files alongside the published block (nested like the real StoreKey layout).
+  std::error_code ec;
+  fs::path bucket = dir_ / "blocks" / "0" / "0";
+  fs::create_directories(bucket, ec);
+  size_t before = 0;
+  for (auto& e : fs::recursive_directory_iterator(dir_)) (void)e, ++before;
+  std::ofstream(bucket / "999_0_1.7.tmp") << "half-written-aligned-garbage";
+  std::ofstream(dir_ / "888_0_1.3.tmp") << "another-orphan";
+
+  KVStore s2(Opts());
+  EXPECT_EQ(s2.TmpReclaimed(), 2u);
+  EXPECT_TRUE(s2.IsCached(k)) << "published block must survive tmp cleanup";
+  std::string out;
+  ASSERT_EQ(s2.Range(k, 0, v.size(), &out), Status::kOk);
+  EXPECT_EQ(out, v);
+  // No ".tmp" files remain on disk.
+  size_t tmps = 0;
+  for (auto& e : fs::recursive_directory_iterator(dir_)) {
+    std::string n = e.path().filename().string();
+    if (n.size() >= 4 && n.substr(n.size() - 4) == ".tmp") ++tmps;
+  }
+  EXPECT_EQ(tmps, 0u);
+  // Orphan bytes were never counted toward capacity.
+  (void)before;
 }


### PR DESCRIPTION
## Problem (P1, permanent disk leak)

A crash between `WriteFileDirect` and the atomic rename — which every rolling upgrade causes by killing a process mid-write — leaves an orphan `.tmp`. `RebuildIndex` *skipped* it, so it was never indexed, never counted toward capacity, and never evicted: a permanent leak of MB-sized files that accumulates across restarts (and quietly eats into the disk headroom the ENOSPC path depends on).

## Fix
`RebuildIndex` now removes `.tmp` files (collected during the walk, deleted afterward so removal can't perturb the directory iteration). A published block's name is pure digits (`id_index_size`) and never contains `.`, so `.tmp` can only be an orphan — no false delete. Adds `TmpReclaimed()` for observability.

## Test
`kv_store_test`: a reopened store with orphan `.tmp` files alongside a published block reclaims exactly the orphans (`TmpReclaimed()==2`, none left on disk) while the published block still reads back. Local: default **197/197**, RDMA+URING **219/219**.