### PR TITLE
fix(cache): self-heal on ENOSPC via force-evict + one retry

### DIFF
--- a/src/cache/kv_store.cc
+++ b/src/cache/kv_store.cc
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
@@ -79,9 +80,11 @@ class AlignedBuf {
 // Writes [data, data+len) to `path` via O_DIRECT: fallocate the (aligned) space,
 // write an aligned superset from a bounce buffer, then ftruncate to the exact
 // `len`. Returns true on success. The caller owns tmp-file cleanup on failure.
-bool WriteFileDirect(const std::string& path, const void* data, size_t len) {
+bool WriteFileDirect(const std::string& path, const void* data, size_t len,
+                     int* out_errno) {
+  if (out_errno) *out_errno = 0;  // 0 unless a syscall below fails (see ENOSPC path)
   Fd fd(::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_DIRECT, 0644));
-  if (!fd.valid()) return false;
+  if (!fd.valid()) { if (out_errno) *out_errno = errno; return false; }
   if (len == 0) return true;  // empty file already created + truncated by O_TRUNC
 
   uint64_t alen64 = 0;
@@ -93,6 +96,7 @@ bool WriteFileDirect(const std::string& path, const void* data, size_t len) {
   // so tolerate "unsupported"; treat other errors (e.g. ENOSPC) as fatal.
   if (::fallocate(fd.get(), 0, 0, static_cast<off_t>(alen)) != 0 &&
       errno != EOPNOTSUPP && errno != ENOSYS && errno != EINVAL) {
+    if (out_errno) *out_errno = errno;
     return false;
   }
 
@@ -105,14 +109,17 @@ bool WriteFileDirect(const std::string& path, const void* data, size_t len) {
   while (done < alen) {
     ssize_t w = ::pwrite(fd.get(), buf.data() + done, alen - done,
                          static_cast<off_t>(done));
-    if (w < 0) { if (errno == EINTR) continue; return false; }
+    if (w < 0) { if (errno == EINTR) continue; if (out_errno) *out_errno = errno; return false; }
     if (w == 0) return false;  // not expected for a regular file
     done += static_cast<size_t>(w);
     // A sub-block resume offset would make the next O_DIRECT pwrite EINVAL.
     if (done < alen && (done % kDioAlign) != 0) return false;
   }
 
-  if (::ftruncate(fd.get(), static_cast<off_t>(len)) != 0) return false;  // exact size
+  if (::ftruncate(fd.get(), static_cast<off_t>(len)) != 0) {  // exact size
+    if (out_errno) *out_errno = errno;
+    return false;
+  }
   return true;
 }
 
@@ -301,6 +308,38 @@ void KVStore::EvictLocked(Shard& sh) {
   }
 }
 
+// Reclaim at least `target` bytes from this shard regardless of the capacity
+// watermark, for the ENOSPC self-heal path: the disk filled before the logical
+// capacity did (tmp/FS-metadata overhead, a shared-disk tenant), so a normal
+// capacity-triggered eviction never fires and every PUT would fail forever.
+// Same CLOCK mechanics as EvictLocked; bounded by a full ring sweep so it
+// terminates even if `target` exceeds what the shard holds. Exclusive lock held.
+void KVStore::ForceEvictLocked(Shard& sh, uint64_t target) {
+  uint64_t freed = 0;
+  size_t swept = 0;
+  const size_t budget = 3 * sh.ring.size() + 4;  // bounded sweep (progress guarantee)
+  while (freed < target && sh.ring.size() > 1 && swept++ < budget) {
+    if (sh.hand == sh.ring.end()) sh.hand = std::prev(sh.ring.end());
+    auto cur = sh.hand;
+    auto it = sh.index.find(*cur);
+    if (it == sh.index.end()) {
+      sh.hand = HandNext(sh.ring, cur);
+      sh.ring.erase(cur);
+      continue;
+    }
+    // Under real pressure we don't grant second chances (we need bytes now).
+    sh.hand = HandNext(sh.ring, cur);
+    std::error_code ec;
+    fs::remove(it->second.path, ec);
+    sh.used_bytes -= it->second.size;
+    freed += it->second.size;
+    evictions_.fetch_add(1, std::memory_order_relaxed);
+    evicted_bytes_.fetch_add(it->second.size, std::memory_order_relaxed);
+    sh.ring.erase(cur);
+    sh.index.erase(it);
+  }
+}
+
 Status KVStore::Cache(const BlockKey& key, const void* data, size_t len) {
   if (data == nullptr && len != 0) return Status::kInvalid;
   const std::string fname = key.Filename();
@@ -315,11 +354,29 @@ Status KVStore::Cache(const BlockKey& key, const void* data, size_t len) {
   fs::path full = fs::path(opt_.cache_dir) / key.StoreKey();
   std::error_code ec;
   fs::create_directories(full.parent_path(), ec);
-  fs::path tmp = full;
-  tmp += "." + std::to_string(tmp_seq_.fetch_add(1, std::memory_order_relaxed)) + ".tmp";
-  if (!WriteFileDirect(tmp.string(), data, len)) {
+  auto write_tmp = [&](fs::path* tmp, int* werr) -> bool {
+    *tmp = full;
+    *tmp += "." + std::to_string(tmp_seq_.fetch_add(1, std::memory_order_relaxed)) + ".tmp";
+    return write_fn_override_
+               ? write_fn_override_(tmp->string(), data, len, werr)
+               : WriteFileDirect(tmp->string(), data, len, werr);
+  };
+  fs::path tmp;
+  int werr = 0;
+  if (!write_tmp(&tmp, &werr)) {
     fs::remove(tmp, ec);
-    return Status::kIOError;
+    // ENOSPC self-heal: the disk filled before logical capacity did (tmp/FS
+    // overhead / shared-disk tenant), so capacity-triggered eviction never
+    // fires and PUTs would fail forever. Force-evict this shard and retry once.
+    if (werr == ENOSPC) {
+      { std::lock_guard<std::shared_mutex> wl(sh.mu);
+        ForceEvictLocked(sh, std::max<uint64_t>(2 * len, 64ull << 20)); }
+      werr = 0;
+      if (!write_tmp(&tmp, &werr)) { fs::remove(tmp, ec); return Status::kIOError; }
+      enospc_evictions_.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      return Status::kIOError;
+    }
   }
   std::lock_guard<std::shared_mutex> wl(sh.mu);  // exclusive
   if (sh.index.count(fname)) { fs::remove(tmp, ec); return Status::kOk; }  // lost the race; keep first

--- a/src/cache/kv_store.h
+++ b/src/cache/kv_store.h
@@ -16,6 +16,7 @@
 #define DFKV_KV_STORE_H_
 
 #include <atomic>
+#include <functional>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -99,7 +100,16 @@ class KVStore {
   // leaks). Diagnostic: a persistently non-zero value across restarts points at
   // frequent mid-write kills.
   uint64_t TmpReclaimed() const { return tmp_reclaimed_.load(std::memory_order_relaxed); }
+  // PUTs that hit a real ENOSPC, force-evicted, and retried successfully.
+  uint64_t EnospcEvictions() const { return enospc_evictions_.load(std::memory_order_relaxed); }
   const std::string& Dir() const { return opt_.cache_dir; }
+
+  // Test-only: override the disk write for the Cache() path so a test can
+  // inject a transient ENOSPC (returning false with *out_errno=ENOSPC once,
+  // then succeeding) and exercise the force-evict + retry self-heal.
+  using WriteFn = std::function<bool(const std::string& path, const void* data,
+                                     size_t len, int* out_errno)>;
+  void SetWriteFnForTest(WriteFn fn) { write_fn_override_ = std::move(fn); }
 
  private:
   struct Entry {
@@ -124,6 +134,7 @@ class KVStore {
 
   Shard& ShardFor(const std::string& fname) const;
   void EvictLocked(Shard& sh);  // CLOCK second-chance; exclusive lock held
+  void ForceEvictLocked(Shard& sh, uint64_t target);  // ENOSPC self-heal; excl. lock
   void RebuildIndex();
 
   Options opt_;
@@ -131,7 +142,9 @@ class KVStore {
   std::atomic<uint64_t> tmp_seq_{0};  // unique suffix for concurrent lock-free writes
   // Eviction counters (relaxed): incremented in EvictLocked across shards.
   std::atomic<uint64_t> evictions_{0}, evicted_bytes_{0};
-  std::atomic<uint64_t> tmp_reclaimed_{0};  // orphan .tmp removed at startup
+  std::atomic<uint64_t> tmp_reclaimed_{0};   // orphan .tmp removed at startup
+  std::atomic<uint64_t> enospc_evictions_{0};  // ENOSPC force-evict + retry succeeded
+  WriteFn write_fn_override_;                // test-only Cache() write injection
 };
 
 }  // namespace dfkv

--- a/test/cache/kv_store_test.cc
+++ b/test/cache/kv_store_test.cc
@@ -1,4 +1,5 @@
 // TDD R3 — KVStore: the cache-node local store (disk + LRU + cache-only/no-S3).
+#include <cerrno>
 #include <fstream>
 #include "cache/kv_store.h"
 
@@ -323,4 +324,50 @@ TEST_F(KVStoreTest, RebuildIndexReclaimsOrphanTmpAndKeepsPublishedBlocks) {
   EXPECT_EQ(tmps, 0u);
   // Orphan bytes were never counted toward capacity.
   (void)before;
+}
+
+TEST_F(KVStoreTest, EnospcTriggersForceEvictAndRetrySucceeds) {
+  // Fill the store with several evictable blocks, then inject a single ENOSPC
+  // on the next write. The store must force-evict and retry, landing the block.
+  KVStore s(Opts(/*cap=*/1ull << 30));
+  for (int i = 0; i < 8; ++i) {
+    std::string v(4096, 'a' + i);
+    ASSERT_EQ(s.Cache(BlockKey{static_cast<uint64_t>(1000 + i), 0, 1},
+                      v.data(), v.size()), Status::kOk);
+  }
+  ASSERT_GE(s.Count(), 8u);
+
+  int calls = 0;
+  s.SetWriteFnForTest([&](const std::string& path, const void* data, size_t len,
+                          int* werr) -> bool {
+    if (++calls == 1) { if (werr) *werr = ENOSPC; return false; }  // first write: disk full
+    // Retry: write for real so the block actually lands + reads back.
+    std::ofstream(path, std::ios::binary).write(static_cast<const char*>(data),
+                                                static_cast<std::streamsize>(len));
+    return true;
+  });
+
+  std::string v(4096, 'Z');
+  BlockKey nk{2000, 0, 1};
+  EXPECT_EQ(s.Cache(nk, v.data(), v.size()), Status::kOk);
+  EXPECT_EQ(calls, 2) << "must retry exactly once after the injected ENOSPC";
+  EXPECT_EQ(s.EnospcEvictions(), 1u);
+  EXPECT_GT(s.Evictions(), 0u) << "force-evict must have reclaimed at least one block";
+  EXPECT_TRUE(s.IsCached(nk));
+}
+
+TEST_F(KVStoreTest, PersistentEnospcReturnsIoErrorWithoutInfiniteLoop) {
+  KVStore s(Opts());
+  for (int i = 0; i < 4; ++i) {
+    std::string v(4096, 'a' + i);
+    ASSERT_EQ(s.Cache(BlockKey{static_cast<uint64_t>(3000 + i), 0, 1},
+                      v.data(), v.size()), Status::kOk);
+  }
+  s.SetWriteFnForTest([&](const std::string&, const void*, size_t, int* werr) -> bool {
+    if (werr) *werr = ENOSPC;  // always full: retry can't succeed
+    return false;
+  });
+  std::string v(4096, 'Q');
+  EXPECT_EQ(s.Cache(BlockKey{4000, 0, 1}, v.data(), v.size()), Status::kIOError);
+  EXPECT_EQ(s.EnospcEvictions(), 0u);  // retry did not succeed -> not counted
 }


### PR DESCRIPTION
## Problem (P1, permanent write dead-end)

Eviction only fires when `used_bytes > capacity`. If the **physical** disk fills before the **logical** capacity does — tmp/FS-metadata overhead, a shared-disk tenant, leaked orphans — the store dead-ends: every write returns `kIOError` forever, capacity-eviction never triggers, and only manual intervention recovers it.

## Fix
`Cache()` inspects the write's errno: on `ENOSPC` it force-evicts the target shard (`ForceEvictLocked` reclaims `max(2*len, 64 MiB)` regardless of the watermark, no second chances, bounded sweep for termination) and retries the write **once**. `WriteFileDirect` propagates the failing errno via a new out-param. Adds `EnospcEvictions()`.

## Tests
`kv_store_test` (via a test-only write hook, no real full disk): an injected one-shot ENOSPC force-evicts and the block lands + reads back (retry runs exactly once, `EnospcEvictions()==1`, `Evictions()>0`); a persistent ENOSPC returns `kIOError` without looping and is not counted. Local: default **199/199**, RDMA+URING **221/221**.

Note: `WriteFileDirectAligned` (CacheDirect / RDMA PUT) is intentionally deferred to the slab-engine rework; this covers the TCP `Cache()` path and the shared force-evict mechanism.