### PR TITLE
fix(dfkvctl): fail over across MDS endpoints instead of only trying one

### DIFF
--- a/src/tools/dfkvctl_main.cc
+++ b/src/tools/dfkvctl_main.cc
@@ -47,7 +47,11 @@ static bool QueryMembers(const std::string& mds, const std::string& group,
   MdsMemberPoller poller(eps, group,
                          [&](const std::vector<MemberInfo>& ms) { *out = ms; got = true; },
                          1000, 2000);
-  poller.PollOnce();
+  // Try up to one full round of the endpoint list: PollOnce picks a single MDS
+  // per call and MarkFailed's backoff steers the next Pick to a different one,
+  // so a dead first endpoint no longer fails the whole command while other MDS
+  // instances are healthy (RUNBOOK uses `dfkvctl ring` to verify upgrades).
+  for (size_t i = 0; i < eps.size() && !got; ++i) poller.PollOnce();
   return got;
 }
 

--- a/test/mds/mds_member_poller_test.cc
+++ b/test/mds/mds_member_poller_test.cc
@@ -186,3 +186,21 @@ TEST(MdsMemberPoller, FirstViewEmptyIsAdopted) {
   EXPECT_EQ(fires, 1);
   EXPECT_EQ(poller.empty_view_rejected(), 0u);
 }
+
+TEST(MdsMemberPoller, FailsOverPastDeadEndpointAcrossPolls) {
+  // Mirrors dfkvctl's QueryMembers: a dead first endpoint must not fail the
+  // query while a healthy MDS is listed. One PollOnce picks one endpoint;
+  // MarkFailed's backoff steers the next Pick to the live one, so a loop of
+  // eps.size() PollOnce calls succeeds.
+  ScriptedMds live({2});                       // healthy MDS, 2 members
+  const std::string dead = "127.0.0.1:9";      // discard port: connect refused fast
+  std::vector<std::string> eps = {dead, live.ep()};
+  std::vector<MemberInfo> got;
+  MdsMemberPoller poller(eps, "g",
+      [&](const std::vector<MemberInfo>& ms) { got = ms; });
+
+  bool ok = false;
+  for (size_t i = 0; i < eps.size() && !ok; ++i) ok = poller.PollOnce();
+  EXPECT_TRUE(ok);
+  EXPECT_EQ(got.size(), 2u) << "failover to the live MDS must return its members";
+}


### PR DESCRIPTION
## Problem (P1, upgrade-validation usability)

`QueryMembers` called `PollOnce` once, which picks a single MDS endpoint. If the first listed endpoint was down, `dfkvctl ring` / `stat --all` reported `MDS query failed` even when other MDS instances were healthy. The RUNBOOK uses these commands to verify rolling upgrades, so one down MDS blocked validation.

## Fix
Loop `PollOnce` up to `eps.size()` times: each call picks one endpoint and `MdsEndpoints::MarkFailed`'s backoff steers the next `Pick` to a different one, so a dead first endpoint no longer fails the command.

## Test
`mds_member_poller_test` (hermetic, scripted in-process MDS): a poller over `[dead, live]` returns the live MDS's members within `eps.size()` PollOnce calls — the exact failover mechanism QueryMembers relies on. Local: default **200/200**, RDMA+URING **222/222**.