### PR TITLE
fix(cli): strict arg parsing + MDS etcd startup probe + /healthz reflects etcd

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -12,6 +12,7 @@
 #include <memory>
 #include <vector>
 
+#include "utils/args.h"
 #include "cache/kv_node_server.h"
 #include "utils/wire_limits.h"
 #include "utils/log.h"
@@ -53,24 +54,33 @@ int main(int argc, char** argv) {
       dfkv::Version());
     return help ? 0 : 1;
   }
-  std::string dir = "/tmp/dfkv_node";
-  std::string rdma_dev, mds, group = "default", node_id, advertise, metrics_bind;
-  int weight = 1;
-  int port = 0, rdma_port = -1, metrics_port = -1;
-  unsigned long long cap = 1ull << 30;
-  for (int i = 1; i + 1 < argc; i += 2) {
-    if (!std::strcmp(argv[i], "--dir")) dir = argv[i + 1];
-    else if (!std::strcmp(argv[i], "--port")) port = std::atoi(argv[i + 1]);
-    else if (!std::strcmp(argv[i], "--cap")) cap = std::strtoull(argv[i + 1], nullptr, 10);
-    else if (!std::strcmp(argv[i], "--rdma-port")) rdma_port = std::atoi(argv[i + 1]);
-    else if (!std::strcmp(argv[i], "--rdma-dev")) rdma_dev = argv[i + 1];
-    else if (!std::strcmp(argv[i], "--mds")) mds = argv[i + 1];
-    else if (!std::strcmp(argv[i], "--group")) group = argv[i + 1];
-    else if (!std::strcmp(argv[i], "--id")) node_id = argv[i + 1];
-    else if (!std::strcmp(argv[i], "--advertise")) advertise = argv[i + 1];
-    else if (!std::strcmp(argv[i], "--weight")) weight = std::atoi(argv[i + 1]);
-    else if (!std::strcmp(argv[i], "--metrics-port")) metrics_port = std::atoi(argv[i + 1]);
-    else if (!std::strcmp(argv[i], "--metrics-bind")) metrics_bind = argv[i + 1];
+  dfkv::Args args(argc, argv,
+                  {"--dir", "--port", "--cap", "--rdma-port", "--rdma-dev",
+                   "--mds", "--group", "--id", "--advertise", "--weight",
+                   "--metrics-port", "--metrics-bind"});
+  std::string dir = args.Get("--dir", "/tmp/dfkv_node");
+  std::string rdma_dev = args.Get("--rdma-dev", "");
+  std::string mds = args.Get("--mds", "");
+  std::string group = args.Get("--group", "default");
+  std::string node_id = args.Get("--id", "");
+  std::string advertise = args.Get("--advertise", "");
+  std::string metrics_bind = args.Get("--metrics-bind", "");
+  int weight = args.GetInt("--weight", 1);
+  int port = args.GetInt("--port", 0);
+  int rdma_port = args.GetInt("--rdma-port", -1);
+  int metrics_port = args.GetInt("--metrics-port", -1);
+  unsigned long long cap = args.GetU64("--cap", 1ull << 30);
+  if (!args.ok()) {
+    std::fprintf(stderr, "dfkv_server: %s\n(run with --help for usage)\n",
+                 args.error().c_str());
+    return 2;
+  }
+  // A mistyped --advertise (no ':') used to wrap rfind(':')+1 into a garbage
+  // port; reject it up front rather than register an unreachable address.
+  if (!advertise.empty() && !dfkv::IsValidHostPort(advertise)) {
+    std::fprintf(stderr, "dfkv_server: --advertise must be host:port (1..65535), "
+                 "got '%s'\n", advertise.c_str());
+    return 2;
   }
   (void)rdma_port;
   std::signal(SIGINT, OnSig);

--- a/src/mds/dfkv_mds_main.cc
+++ b/src/mds/dfkv_mds_main.cc
@@ -6,6 +6,8 @@
 #include <memory>
 #include <string>
 
+#include <chrono>
+#include "utils/args.h"
 #include "mds/mds_server.h"
 #include "utils/metrics_http.h"
 #include "common/version.h"
@@ -32,13 +34,16 @@ int main(int argc, char** argv) {
       dfkv::Version());
     return help ? 0 : 1;
   }
-  std::string etcd = "127.0.0.1:2379", metrics_bind;
-  int port = 0, metrics_port = -1;
-  for (int i = 1; i + 1 < argc; i += 2) {
-    if (!std::strcmp(argv[i], "--etcd")) etcd = argv[i + 1];
-    else if (!std::strcmp(argv[i], "--listen")) port = std::atoi(argv[i + 1]);
-    else if (!std::strcmp(argv[i], "--metrics-port")) metrics_port = std::atoi(argv[i + 1]);
-    else if (!std::strcmp(argv[i], "--metrics-bind")) metrics_bind = argv[i + 1];
+  dfkv::Args args(argc, argv,
+                  {"--etcd", "--listen", "--metrics-port", "--metrics-bind"});
+  std::string etcd = args.Get("--etcd", "127.0.0.1:2379");
+  std::string metrics_bind = args.Get("--metrics-bind", "");
+  int port = args.GetInt("--listen", 0);
+  int metrics_port = args.GetInt("--metrics-port", -1);
+  if (!args.ok()) {
+    std::fprintf(stderr, "dfkv_mds: %s\n(run with --help for usage)\n",
+                 args.error().c_str());
+    return 2;
   }
   dfkv::MdsServer srv(etcd);
   std::signal(SIGINT, OnSig);
@@ -47,12 +52,40 @@ int main(int argc, char** argv) {
     std::fprintf(stderr, "dfkv_mds: failed to listen on %d\n", port);
     return 1;
   }
+  // Fail loud on a bad --etcd: probe until etcd answers within a window, else
+  // exit non-zero so the supervisor restarts (and the misconfig is visible)
+  // instead of running "up" while every registration silently fails. Window is
+  // env-tunable (tests use a short one); default 30 s.
+  {
+    int probe_ms = 30000;
+    if (const char* e = std::getenv("DFKV_MDS_ETCD_PROBE_MS")) {
+      int v = std::atoi(e);
+      if (v >= 0) probe_ms = v;
+    }
+    bool up = false;
+    auto t0 = std::chrono::steady_clock::now();
+    for (;;) {
+      if (srv.ProbeEtcd()) { up = true; break; }
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - t0).count() >= probe_ms) break;
+      struct timespec ts{0, 200 * 1000 * 1000}; nanosleep(&ts, nullptr);
+    }
+    if (!up) {
+      std::fprintf(stderr,
+                   "dfkv_mds: etcd unreachable at '%s' after %dms — check --etcd "
+                   "(host:port, NO http:// scheme)\n", etcd.c_str(), probe_ms);
+      srv.Stop();
+      return 1;
+    }
+  }
   std::printf("dfkv_mds listening on %d, etcd=%s\n", srv.port(), etcd.c_str());
   std::fflush(stdout);
   // Optional Prometheus /metrics on a dedicated port/thread. Absent => no listener.
   std::unique_ptr<dfkv::MetricsHttpServer> mhttp;
   if (metrics_port >= 0) {
     mhttp = std::make_unique<dfkv::MetricsHttpServer>([&srv] { return srv.MetricsText(); });
+    // /healthz reflects live etcd reachability (503 when a probe fails).
+    mhttp->set_health_check([&srv] { return srv.ProbeEtcd(); });
     if (mhttp->Start(metrics_port, metrics_bind) == dfkv::Status::kOk)
       std::printf("dfkv_mds /metrics on port %d\n", mhttp->port());
     std::fflush(stdout);

--- a/src/mds/mds_server.h
+++ b/src/mds/mds_server.h
@@ -33,6 +33,12 @@ class MdsServer {
   std::string MetricsText() const { return metrics_.Render(); }
   size_t live_conn_count();  // handler threads not yet reaped (test/diagnostic)
 
+  // One read against etcd (a bounded RangePrefix on a probe key). Returns true
+  // iff etcd answered. Used at startup to fail loud on a misconfigured --etcd
+  // (a wrong endpoint/scheme otherwise runs "healthy" while every registration
+  // silently fails), and by /healthz to reflect etcd reachability.
+  bool ProbeEtcd() { return etcd_.RangePrefix("/dfkv/v1/_healthz_probe/").has_value(); }
+
   static constexpr int kTtlSeconds = 30;
 
  private:

--- a/src/tools/dfkvctl_main.cc
+++ b/src/tools/dfkvctl_main.cc
@@ -10,6 +10,7 @@
  *     override (e.g. for older servers that predate tcp_port registration).
  * Geometry flags (must match the writer for get to hit): --model_hash --page_size
  *   --dtype_tag --layer_num --head_num --head_dim --mla 0|1 --tp_size --tp_rank */
+#include <cstdlib>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -139,8 +140,10 @@ int main(int argc, char** argv) {
   std::vector<std::string> pos;
   for (int i = 1; i < argc; ++i) {
     std::string a = argv[i];
-    auto nv = [&](uint64_t* d) { if (i + 1 < argc) *d = std::stoull(argv[++i]); };
-    auto nv32 = [&](uint32_t* d) { if (i + 1 < argc) *d = (uint32_t)std::stoul(argv[++i]); };
+    // strtoull/strtoul (not stoull/stoul): the std:: variants THROW on a
+    // non-numeric arg, terminating the tool; strto* return 0 instead.
+    auto nv = [&](uint64_t* d) { if (i + 1 < argc) *d = std::strtoull(argv[++i], nullptr, 0); };
+    auto nv32 = [&](uint32_t* d) { if (i + 1 < argc) *d = (uint32_t)std::strtoul(argv[++i], nullptr, 0); };
     if (a == "--members" && i + 1 < argc) members = argv[++i];
     else if (a == "--mds" && i + 1 < argc) mds = argv[++i];
     else if (a == "--group" && i + 1 < argc) group = argv[++i];

--- a/src/utils/args.h
+++ b/src/utils/args.h
@@ -1,0 +1,116 @@
+/* Strict CLI argument parser for the daemons/tools. Replaces the ad-hoc
+ * `for (i=1; i+1<argc; i+=2)` loops, which silently ignored unknown flags
+ * (a typo'd --capp fell back to the 1 GiB default -> eviction storm), desynced
+ * on a valueless flag (eating the next flag as its value), and used atoi/strtoull
+ * that accept trailing garbage (--cap 5TiB parsed as 5). Every parse error here
+ * is fatal-by-design: the caller prints usage and exit(2), so a misconfigured
+ * unit fails loudly at startup instead of running with silent wrong values.
+ *
+ * Header-only, no deps, unit-tested directly (see test/utils/args_test.cc). */
+#ifndef DFKV_ARGS_H_
+#define DFKV_ARGS_H_
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+namespace dfkv {
+
+class Args {
+ public:
+  // valued = flags that consume the next token ("--port" -> "8080");
+  // boolean = flags that stand alone ("--foo"). A leading token that is neither
+  // (and starts with '-') is an unknown-flag error; --version/-V/--help/-h are
+  // always accepted (the caller handles them before constructing Args, but
+  // tolerating them here keeps parsing order-independent).
+  Args(int argc, char** argv, std::set<std::string> valued,
+       std::set<std::string> boolean = {})
+      : valued_(std::move(valued)), boolean_(std::move(boolean)) {
+    static const std::set<std::string> kAlways = {"--version", "-V", "--help", "-h"};
+    for (int i = 1; i < argc; ++i) {
+      std::string tok = argv[i];
+      if (kAlways.count(tok)) { flags_.insert(tok); continue; }
+      if (tok.rfind("--", 0) != 0) {
+        Fail("unexpected argument: " + tok);
+        return;
+      }
+      if (boolean_.count(tok)) { flags_.insert(tok); continue; }
+      if (valued_.count(tok)) {
+        if (i + 1 >= argc) { Fail("missing value for " + tok); return; }
+        values_[tok] = argv[++i];
+        continue;
+      }
+      Fail("unknown flag: " + tok);
+      return;
+    }
+  }
+
+  bool ok() const { return ok_; }
+  const std::string& error() const { return error_; }
+
+  bool Has(const std::string& flag) const {
+    return flags_.count(flag) || values_.count(flag);
+  }
+  std::string Get(const std::string& flag, const std::string& dflt) const {
+    auto it = values_.find(flag);
+    return it == values_.end() ? dflt : it->second;
+  }
+
+  // Typed getters. On a present-but-malformed value they set the parser to
+  // not-ok (so the caller's single `if (!args.ok())` catches it) and return dflt.
+  int GetInt(const std::string& flag, int dflt) {
+    auto it = values_.find(flag);
+    if (it == values_.end()) return dflt;
+    errno = 0;
+    char* end = nullptr;
+    long v = std::strtol(it->second.c_str(), &end, 10);
+    if (errno != 0 || end == it->second.c_str() || *end != '\0') {
+      Fail("invalid integer for " + flag + ": '" + it->second + "'");
+      return dflt;
+    }
+    return static_cast<int>(v);
+  }
+  uint64_t GetU64(const std::string& flag, uint64_t dflt) {
+    auto it = values_.find(flag);
+    if (it == values_.end()) return dflt;
+    errno = 0;
+    char* end = nullptr;
+    unsigned long long v = std::strtoull(it->second.c_str(), &end, 10);
+    if (errno != 0 || end == it->second.c_str() || *end != '\0') {
+      Fail("invalid number for " + flag + " (expects bytes, decimal): '" +
+           it->second + "'");
+      return dflt;
+    }
+    return static_cast<uint64_t>(v);
+  }
+
+ private:
+  void Fail(const std::string& msg) {
+    if (ok_) { ok_ = false; error_ = msg; }  // keep the first error
+  }
+  std::set<std::string> valued_, boolean_;
+  std::unordered_map<std::string, std::string> values_;
+  std::set<std::string> flags_;
+  bool ok_ = true;
+  std::string error_;
+};
+
+// "host:port" validity: exactly one ':' with a non-empty host and a port in
+// 1..65535 and no trailing garbage. Used to reject a mis-typed --advertise
+// (whose rfind(':')==npos used to wrap to a garbage port).
+inline bool IsValidHostPort(const std::string& s) {
+  auto pos = s.rfind(':');
+  if (pos == std::string::npos || pos == 0 || pos + 1 >= s.size()) return false;
+  const std::string port = s.substr(pos + 1);
+  errno = 0;
+  char* end = nullptr;
+  long p = std::strtol(port.c_str(), &end, 10);
+  return errno == 0 && *end == '\0' && p >= 1 && p <= 65535;
+}
+
+}  // namespace dfkv
+
+#endif  // DFKV_ARGS_H_

--- a/src/utils/metrics_http.cc
+++ b/src/utils/metrics_http.cc
@@ -124,7 +124,12 @@ void MetricsHttpServer::Handle(int fd) {
   if (path == "/metrics") {
     out = Resp("200 OK", "text/plain; version=0.0.4", render_ ? render_() : "");
   } else if (path == "/healthz") {
-    out = Resp("200 OK", "text/plain", "ok\n");
+    // A registered predicate (e.g. MDS etcd reachability) gates the status; with
+    // none set, keep the always-healthy 200 the endpoint had before.
+    if (!health_ || health_())
+      out = Resp("200 OK", "text/plain", "ok\n");
+    else
+      out = Resp("503 Service Unavailable", "text/plain", "unavailable\n");
   } else {
     out = Resp("404 Not Found", "text/plain", "not found\n");
   }

--- a/src/utils/metrics_http.h
+++ b/src/utils/metrics_http.h
@@ -29,6 +29,11 @@ class MetricsHttpServer {
       : render_(std::move(render)) {}
   ~MetricsHttpServer();
 
+  // Optional /healthz predicate. When set and it returns false, /healthz
+  // answers 503 (e.g. MDS reporting etcd unreachable) instead of a blanket
+  // 200 "ok"; unset keeps the always-200 behavior. Called on the HTTP thread.
+  void set_health_check(std::function<bool()> fn) { health_ = std::move(fn); }
+
   // port 0 => ephemeral (query with port()). bind_addr empty => all interfaces
   // (back-compat); pass e.g. "127.0.0.1" to restrict /metrics to loopback.
   Status Start(int port, const std::string& bind_addr = "");
@@ -53,6 +58,7 @@ class MetricsHttpServer {
   };
 
   std::function<std::string()> render_;
+  std::function<bool()> health_;  // optional /healthz predicate (null => always ok)
   int listen_fd_ = -1;
   int port_ = 0;
   std::atomic<bool> running_{false};

--- a/test/mds/mds_server_test.cc
+++ b/test/mds/mds_server_test.cc
@@ -142,3 +142,15 @@ TEST(MdsServer, RejectsPathTraversalGroupAndId) {
   EXPECT_EQ(st, Status::kInvalid);
   mds.Stop();
 }
+
+TEST(MdsServer, ProbeEtcdReflectsReachability) {
+  // Dead endpoint: probe must fail fast (used at startup to exit non-zero on a
+  // misconfigured --etcd instead of running "up" with silent write failures).
+  { MdsServer dead("127.0.0.1:9", /*timeout_ms=*/500);
+    EXPECT_FALSE(dead.ProbeEtcd()); }
+
+  const char* ep = EtcdEp();
+  if (!ep) GTEST_SKIP() << "set DFKV_TEST_ETCD for the reachable case";
+  MdsServer live(ep);
+  EXPECT_TRUE(live.ProbeEtcd());
+}

--- a/test/tool_smoke.sh
+++ b/test/tool_smoke.sh
@@ -27,3 +27,21 @@ got=$("$BUILD/dfkvctl" --members "n=127.0.0.1:$P" get k)
 "$BUILD/dfkvctl" --members "n=127.0.0.1:$P" exist k | grep -q true
 "$BUILD/dfkvctl" stat "127.0.0.1:$P" | grep -q dfkv_cache_put_total
 echo "tool_smoke OK (port $P)"
+
+# Strict arg parsing: an unknown flag / bad number / bad --advertise must fail
+# fast (exit 2), not run with silent defaults. (`set -e` is on, so guard the
+# expected-nonzero calls.)
+rc=0; "$BUILD/dfkv_server" --dir "$D" --capp 5 --port 0 >/dev/null 2>&1 || rc=$?
+[ "$rc" = 2 ] || { echo "dfkv_server unknown flag: expected exit 2, got $rc"; exit 1; }
+rc=0; "$BUILD/dfkv_server" --dir "$D" --cap 5TiB --port 0 >/dev/null 2>&1 || rc=$?
+[ "$rc" = 2 ] || { echo "dfkv_server bad --cap: expected exit 2, got $rc"; exit 1; }
+rc=0; "$BUILD/dfkv_server" --dir "$D" --advertise no-colon --port 0 >/dev/null 2>&1 || rc=$?
+[ "$rc" = 2 ] || { echo "dfkv_server bad --advertise: expected exit 2, got $rc"; exit 1; }
+echo "strict-args smoke OK"
+
+# MDS must fail loud (exit 1) when etcd is unreachable, within the probe window,
+# instead of running "healthy" while every registration silently fails.
+rc=0; DFKV_MDS_ETCD_PROBE_MS=500 "$BUILD/dfkv_mds" --listen 0 --etcd 127.0.0.1:9 \
+  >/dev/null 2>&1 || rc=$?
+[ "$rc" = 1 ] || { echo "dfkv_mds bad etcd: expected exit 1, got $rc"; exit 1; }
+echo "mds etcd-probe smoke OK"

--- a/test/utils/args_test.cc
+++ b/test/utils/args_test.cc
@@ -1,0 +1,94 @@
+#include "utils/args.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace dfkv;  // NOLINT
+
+namespace {
+// Build an argv from string literals for Args (which takes char**).
+struct Argv {
+  std::vector<std::string> store;
+  std::vector<char*> ptrs;
+  explicit Argv(std::vector<std::string> a) : store(std::move(a)) {
+    for (auto& s : store) ptrs.push_back(s.data());
+  }
+  int argc() const { return static_cast<int>(ptrs.size()); }
+  char** argv() { return ptrs.data(); }
+};
+}  // namespace
+
+TEST(Args, ParsesKnownValuedAndBooleanFlags) {
+  Argv a({"prog", "--port", "8080", "--verbose", "--dir", "/x"});
+  Args args(a.argc(), a.argv(), {"--port", "--dir"}, {"--verbose"});
+  ASSERT_TRUE(args.ok()) << args.error();
+  EXPECT_EQ(args.GetInt("--port", 0), 8080);
+  EXPECT_EQ(args.Get("--dir", ""), "/x");
+  EXPECT_TRUE(args.Has("--verbose"));
+  EXPECT_FALSE(args.Has("--nope"));
+}
+
+TEST(Args, UnknownFlagFails) {
+  Argv a({"prog", "--capp", "5"});
+  Args args(a.argc(), a.argv(), {"--cap"});
+  EXPECT_FALSE(args.ok());
+  EXPECT_NE(args.error().find("--capp"), std::string::npos);
+}
+
+TEST(Args, MissingValueFails) {
+  Argv a({"prog", "--port"});
+  Args args(a.argc(), a.argv(), {"--port"});
+  EXPECT_FALSE(args.ok());
+  EXPECT_NE(args.error().find("missing value"), std::string::npos);
+}
+
+TEST(Args, ValuelessFlagDoesNotEatNextFlag) {
+  // The old i+=2 loop would swallow "--port" as --verbose's value. Here
+  // --verbose stands alone and --port keeps its own value.
+  Argv a({"prog", "--verbose", "--port", "9"});
+  Args args(a.argc(), a.argv(), {"--port"}, {"--verbose"});
+  ASSERT_TRUE(args.ok()) << args.error();
+  EXPECT_TRUE(args.Has("--verbose"));
+  EXPECT_EQ(args.GetInt("--port", 0), 9);
+}
+
+TEST(Args, TrailingGarbageInNumberFails) {
+  Argv a({"prog", "--cap", "5TiB"});
+  Args args(a.argc(), a.argv(), {"--cap"});
+  uint64_t cap = args.GetU64("--cap", 1);
+  EXPECT_FALSE(args.ok());
+  EXPECT_EQ(cap, 1u);  // returns the default on error
+  EXPECT_NE(args.error().find("--cap"), std::string::npos);
+}
+
+TEST(Args, ValidNumbersParse) {
+  Argv a({"prog", "--cap", "5368709120"});  // 5 GiB in bytes
+  Args args(a.argc(), a.argv(), {"--cap"});
+  EXPECT_EQ(args.GetU64("--cap", 0), 5368709120ull);
+  EXPECT_TRUE(args.ok());
+}
+
+TEST(Args, NonFlagTokenFails) {
+  Argv a({"prog", "stray"});
+  Args args(a.argc(), a.argv(), {"--port"});
+  EXPECT_FALSE(args.ok());
+}
+
+TEST(Args, VersionHelpAlwaysAccepted) {
+  Argv a({"prog", "--version"});
+  Args args(a.argc(), a.argv(), {"--port"});
+  EXPECT_TRUE(args.ok());
+  EXPECT_TRUE(args.Has("--version"));
+}
+
+TEST(HostPort, ValidatesAdvertise) {
+  EXPECT_TRUE(IsValidHostPort("192.168.1.5:28100"));
+  EXPECT_TRUE(IsValidHostPort("host:1"));
+  EXPECT_TRUE(IsValidHostPort("h:65535"));
+  EXPECT_FALSE(IsValidHostPort("no-colon"));
+  EXPECT_FALSE(IsValidHostPort(":28100"));       // empty host
+  EXPECT_FALSE(IsValidHostPort("host:"));        // empty port
+  EXPECT_FALSE(IsValidHostPort("host:0"));       // port 0
+  EXPECT_FALSE(IsValidHostPort("host:70000"));   // out of range
+  EXPECT_FALSE(IsValidHostPort("host:80x"));     // trailing garbage
+}

--- a/test/utils/metrics_http_test.cc
+++ b/test/utils/metrics_http_test.cc
@@ -90,3 +90,22 @@ TEST(MetricsHttp, StopIsIdempotent) {
   srv.Stop();
   srv.Stop();  // must not crash / hang
 }
+
+TEST(MetricsHttp, HealthCheckPredicateGates503) {
+  std::atomic<bool> healthy{true};
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  srv.set_health_check([&] { return healthy.load(); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int port = srv.port();
+
+  std::string ok = HttpGet(port, "/healthz");
+  EXPECT_NE(ok.find("200"), std::string::npos) << ok;
+  EXPECT_NE(ok.find("ok"), std::string::npos) << ok;
+
+  healthy.store(false);
+  std::string bad = HttpGet(port, "/healthz");
+  EXPECT_NE(bad.find("503"), std::string::npos) << bad;
+  EXPECT_NE(bad.find("unavailable"), std::string::npos) << bad;
+
+  srv.Stop();
+}


### PR DESCRIPTION
## Problem (P2, silent misconfiguration -> production incidents)

The daemons parsed args with an ad-hoc `for (i=1; i+1<argc; i+=2)` loop that:
- **silently ignored unknown flags** — a typo'd `--capp` fell back to the 1 GiB default → eviction storm on a 5 TiB node;
- **desynced on a valueless flag** — it ate the next flag as its value;
- used `atoi`/`strtoull` that **accept trailing garbage** — `--cap 5TiB` parsed as 5 bytes.

And a misconfigured `--etcd` (e.g. a stray `http://` scheme — a real past incident) let the MDS run "up" while every registration silently failed; `/healthz` returned a blanket 200 regardless.

## Fix
- **`utils/args.h`** — strict, header-only, unit-tested parser. Unknown flag / missing value / trailing chars in a number → not-ok; both daemons print the error and `exit(2)`. `IsValidHostPort` rejects a mistyped `--advertise`.
- **`dfkv_mds`** — probe etcd at startup (bounded RangePrefix) until it answers within `DFKV_MDS_ETCD_PROBE_MS` (default 30 s) or `exit(1)`, so the supervisor restarts and the misconfig is visible.
- **`/healthz`** — `MetricsHttpServer` gains an optional health predicate; the MDS wires it to live etcd reachability → 503 when etcd is unreachable.
- **`dfkvctl`** — `strtoull`/`strtoul` instead of `std::stoull`/`stoul` (which threw → terminated the tool on a non-numeric arg).

Fail-fast on misconfig is an intentional behavior change (a unit with a typo'd flag now refuses to start).

## Tests
`args_test` (9 cases), `metrics_http_test` health-predicate 200↔503, `mds_server_test` `ProbeEtcd` reachable-vs-dead, and `tool_smoke.sh` E2E: `dfkv_server` exits 2 on `--capp`/`--cap 5TiB`/bad `--advertise`, `dfkv_mds` exits 1 on unreachable etcd. Local: default **211/211**, RDMA+URING **233/233**.