### PR TITLE
fix(client): route single GetAuto through zero-copy RangeInto on RDMA

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -310,8 +310,34 @@ bool KVClient::GetAuto(const std::string& key, std::string* out, size_t max_byte
   if (node.empty()) return false;
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
+  BlockKey bk = ToBlockKey(key);
+
+  if (t_->pipelined()) {
+    // Zero-copy via RangeInto (a 1-element batch), matching Get(): the payload
+    // scatters straight into `out`'s buffer. This also lifts the limit from the
+    // single-Range control_cap (8 MiB) to the batch max_payload (64 MiB) — a
+    // value in (8 MiB, 64 MiB] used to "miss on single read, hit on batch read".
+    out->resize(max_bytes);
+    std::vector<BlockKey> keys{bk};
+    std::vector<RangeDst> dsts{RangeDst{max_bytes ? &(*out)[0] : nullptr, max_bytes}};
+    std::vector<std::string> hdrs;
+    Status st = t_->RangeInto(node, keys, dsts, ValueHeader::kSize, &hdrs)[0];
+    if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); out->clear(); return false; }
+    if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+    if (st != Status::kOk || hdrs[0].size() < ValueHeader::kSize) { out->clear(); return false; }
+    ValueHeader h;
+    if (!ValueHeader::Parse(hdrs[0].data(), hdrs[0].size(), &h) ||
+        !HeaderMatches(self_hdr_, h) || h.payload_len > max_bytes) {
+      out->clear();
+      return false;
+    }
+    out->resize(h.payload_len);  // trim the receive buffer to the true stored length
+    return true;
+  }
+
+  // TCP (non-pipelined): response into a string, then copy out.
   std::string raw;
-  Status st = t_->Range(node, ToBlockKey(key), 0, ValueHeader::kSize + max_bytes, &raw);
+  Status st = t_->Range(node, bk, 0, ValueHeader::kSize + max_bytes, &raw);
   // Fresh clock: `now` was taken before a round trip that can burn the whole
   // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
@@ -334,9 +360,30 @@ bool KVClient::GetAuto(const std::string& key, void* out, size_t cap, size_t* ou
   if (node.empty()) return false;
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
-  // Read [header | up-to-cap payload]; the header tells us the true payload_len.
+  BlockKey bk = ToBlockKey(key);
+
+  if (t_->pipelined()) {
+    // Zero-copy: the payload scatters straight into the caller's buffer and the
+    // header (true payload_len) comes back separately. Lifts the 8 MiB
+    // single-Range cap to the 64 MiB batch max_payload, like Get()/GetAuto(str).
+    std::vector<BlockKey> keys{bk};
+    std::vector<RangeDst> dsts{RangeDst{cap ? out : nullptr, cap}};
+    std::vector<std::string> hdrs;
+    Status st = t_->RangeInto(node, keys, dsts, ValueHeader::kSize, &hdrs)[0];
+    if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
+    if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+    if (st != Status::kOk || hdrs[0].size() < ValueHeader::kSize) return false;
+    ValueHeader h;
+    if (!ValueHeader::Parse(hdrs[0].data(), hdrs[0].size(), &h)) return false;
+    if (!HeaderMatches(self_hdr_, h)) return false;        // geometry drift => miss
+    if (h.payload_len > cap) return false;                 // won't fit caller buffer
+    if (out_len) *out_len = h.payload_len;
+    return true;
+  }
+
+  // TCP: read [header | up-to-cap payload]; the header tells us the true payload_len.
   std::string raw;
-  Status st = t_->Range(node, ToBlockKey(key), 0, ValueHeader::kSize + cap, &raw);
+  Status st = t_->Range(node, bk, 0, ValueHeader::kSize + cap, &raw);
   // Fresh clock: `now` was taken before a round trip that can burn the whole
   // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }

--- a/test/client/get_auto_pipelined_test.cc
+++ b/test/client/get_auto_pipelined_test.cc
@@ -1,0 +1,149 @@
+// GetAuto over a PIPELINED (RDMA-like) transport must use the zero-copy
+// RangeInto path, not the single-Range path (which on RDMA is capped at the
+// 8 MiB control_cap and does a double copy). A fake pipelined transport lets
+// us assert the routing hermetically; the real zero-copy bytes are covered by
+// rdma_loopback_test.
+#include "client/kv_client.h"
+#include "transport/transport.h"
+#include "common/value_header.h"
+#include "client/key_map.h"
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace dfkv;  // NOLINT
+
+namespace {
+ValueHeader Hdr(uint64_t payload_len) {
+  ValueHeader h = ValueHeader::Make(0x51ULL, 64, 0x46384534u, ValueHeader::kFlagIsMla,
+                                    8, 0, 78, 1, 576);
+  h.payload_len = payload_len;
+  return h;
+}
+
+// Pipelined transport that serves stored blobs only through RangeInto and counts
+// each entry point, so a test can prove GetAuto never falls back to Range here.
+struct FakePipelinedTransport : Transport {
+  std::map<std::string, std::string> blobs;  // key.Filename() -> payload
+  std::string dead;
+  int range_calls = 0, rangeinto_calls = 0;
+
+  bool pipelined() const override { return true; }
+
+  Status Range(const std::string&, const BlockKey&, uint64_t, uint64_t,
+               std::string*) override {
+    ++range_calls;  // must stay 0 on the pipelined GetAuto path
+    return Status::kIOError;
+  }
+  Status Cache(const std::string&, const BlockKey&, const void*, size_t) override {
+    return Status::kOk;
+  }
+  Status Exist(const std::string&, const BlockKey&, bool* e) override {
+    *e = false;
+    return Status::kOk;
+  }
+  std::vector<Status> RangeInto(const std::string& node,
+                                const std::vector<BlockKey>& keys,
+                                const std::vector<RangeDst>& dsts,
+                                size_t header_size,
+                                std::vector<std::string>* hdrs) override {
+    ++rangeinto_calls;
+    hdrs->assign(keys.size(), std::string());
+    std::vector<Status> r(keys.size(), Status::kNotFound);
+    for (size_t i = 0; i < keys.size(); ++i) {
+      if (node == dead) { r[i] = Status::kIOError; continue; }
+      auto it = blobs.find(keys[i].Filename());
+      if (it == blobs.end()) { r[i] = Status::kNotFound; continue; }
+      const std::string& payload = it->second;
+      // Header carries the TRUE stored length; payload scatters up to dsts[i].n.
+      ValueHeader h = Hdr(payload.size());
+      std::string hb(header_size, '\0');
+      h.Serialize(&hb[0]);
+      (*hdrs)[i] = hb;
+      size_t n = std::min(payload.size(), dsts[i].n);
+      if (n && dsts[i].payload) std::memcpy(dsts[i].payload, payload.data(), n);
+      r[i] = Status::kOk;
+    }
+    return r;
+  }
+};
+
+KVClient MakeClient(FakePipelinedTransport* t) {
+  return KVClient({{"n", "10.0.0.1:1"}},
+                  ValueHeader::Make(0x51ULL, 64, 0x46384534u, ValueHeader::kFlagIsMla,
+                                    8, 0, 78, 1, 576),
+                  t);
+}
+}  // namespace
+
+TEST(GetAutoPipelined, VoidBufferUsesRangeIntoNotRange) {
+  FakePipelinedTransport t;
+  KVClient c = MakeClient(&t);
+  std::string v(1234, 'p');
+  t.blobs[ToBlockKey("kv").Filename()] = v;
+
+  std::vector<char> buf(4096);
+  size_t got = 0;
+  ASSERT_TRUE(c.GetAuto("kv", buf.data(), buf.size(), &got));
+  EXPECT_EQ(got, 1234u);
+  EXPECT_EQ(std::memcmp(buf.data(), v.data(), 1234), 0);
+  EXPECT_EQ(t.rangeinto_calls, 1);
+  EXPECT_EQ(t.range_calls, 0) << "pipelined GetAuto must not fall back to Range";
+}
+
+TEST(GetAutoPipelined, StringOverloadTrimsToTrueLength) {
+  FakePipelinedTransport t;
+  KVClient c = MakeClient(&t);
+  std::string v(777, 'q');
+  t.blobs[ToBlockKey("ks").Filename()] = v;
+
+  std::string out;
+  ASSERT_TRUE(c.GetAuto("ks", &out, 8192));
+  EXPECT_EQ(out.size(), 777u);
+  EXPECT_EQ(out, v);
+  EXPECT_EQ(t.rangeinto_calls, 1);
+  EXPECT_EQ(t.range_calls, 0);
+}
+
+TEST(GetAutoPipelined, ValueLargerThanEightMiBIsServed) {
+  // The exact regression: a value above the single-Range control_cap (8 MiB)
+  // used to miss on GetAuto but hit on batch read. Through RangeInto it serves.
+  FakePipelinedTransport t;
+  KVClient c = MakeClient(&t);
+  const size_t big = (10u << 20);  // 10 MiB > 8 MiB control_cap
+  std::string v(big, 'B');
+  t.blobs[ToBlockKey("kbig").Filename()] = v;
+
+  std::string out;
+  ASSERT_TRUE(c.GetAuto("kbig", &out, 16u << 20));
+  EXPECT_EQ(out.size(), big);
+  EXPECT_EQ(out.front(), 'B');
+  EXPECT_EQ(out.back(), 'B');
+  EXPECT_EQ(t.range_calls, 0);
+}
+
+TEST(GetAutoPipelined, CapSmallerThanPayloadIsMiss) {
+  FakePipelinedTransport t;
+  KVClient c = MakeClient(&t);
+  t.blobs[ToBlockKey("kbig2").Filename()] = std::string(5000, 'z');
+
+  std::vector<char> buf(1024);
+  size_t got = 0;
+  EXPECT_FALSE(c.GetAuto("kbig2", buf.data(), buf.size(), &got));
+  std::string s;
+  EXPECT_FALSE(c.GetAuto("kbig2", &s, 1024));
+  EXPECT_TRUE(s.empty());
+}
+
+TEST(GetAutoPipelined, MissReturnsFalse) {
+  FakePipelinedTransport t;
+  KVClient c = MakeClient(&t);
+  std::vector<char> buf(64);
+  size_t got = 0;
+  EXPECT_FALSE(c.GetAuto("absent", buf.data(), buf.size(), &got));
+  std::string s;
+  EXPECT_FALSE(c.GetAuto("absent", &s, 64));
+}


### PR DESCRIPTION
## Problem (P1, behavior inconsistency + double copy)

Both `GetAuto` overloads called `t_->Range` directly. On the RDMA transport that path is capped at the **8 MiB `control_cap`** and does an `rbuf -> string -> memcpy` double copy, while the batch path (`RangeInto`) is zero-copy and bounded by the **64 MiB `max_payload`**. So a value in (8 MiB, 64 MiB] would *miss on a single `GetAuto` but hit on a batch read* — an inconsistency the LMCache single-read path can trip — and every `GetAuto` paid two extra copies.

## Fix
In pipelined (RDMA) mode both overloads now issue a 1-element `RangeInto` — the payload scatters straight into the caller's buffer / the string's buffer (trimmed to the header's true `payload_len`), matching `Get()`. The non-pipelined TCP path is unchanged.

## Tests
`get_auto_pipelined_test` (hermetic fake pipelined transport): both overloads use `RangeInto` not `Range`, trim to the true length, serve a 10 MiB value (the >8 MiB regression), and miss when `cap < payload`. Existing `get_auto_test` (TCP) and `rdma_loopback_test` cover the real transports. Local: default **216/216**, RDMA+URING **238/238**.