### PR TITLE
perf(rdma): register the host KV pool once per device, not per connection

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -225,6 +225,17 @@ std::string RdmaTransport::MetricsText() const {
     s += "dfkv_rdma_client_rail_conns_total{dev=\"" + d + "\"} " +
          std::to_string(rail_conns_[i].load(std::memory_order_relaxed)) + "\n";
   }
+  // Effective pipeline depth (DFKV_RDMA_DEPTH; default 1). Per-connection pinned
+  // control memory is ~2*control_cap*depth, so raising depth trades memory for
+  // per-node request pipelining — surfaced so the value in effect is visible.
+  s += "# HELP dfkv_rdma_client_pipeline_depth Effective RDMA pipeline depth (env DFKV_RDMA_DEPTH)\n";
+  s += "# TYPE dfkv_rdma_client_pipeline_depth gauge\n";
+  s += "dfkv_rdma_client_pipeline_depth " + std::to_string(depth_) + "\n";
+  // Ad-hoc (out-of-pool) user MR registrations; should be 0 (see AdhocUserMrTotal).
+  s += "# HELP dfkv_rdma_client_adhoc_user_mr_total User MRs registered outside any pool region\n";
+  s += "# TYPE dfkv_rdma_client_adhoc_user_mr_total counter\n";
+  s += "dfkv_rdma_client_adhoc_user_mr_total " +
+       std::to_string(rdma::RcEndpoint::AdhocUserMrTotal()) + "\n";
   return s;
 }
 

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <atomic>
 #include <mutex>
 #include <random>
 #include <string>
@@ -28,9 +29,28 @@ namespace {
 // usable by any QP on it). After the first connection opens a device, all others
 // reuse it -- no further ibv_open_device. Keyed by device name (multi-rail rails
 // are distinct devices -> distinct shared entries, which is correct).
-struct SharedDevice { ibv_context* ctx; ibv_pd* pd; long refs; };
+// A pool MR is the big pre-registered host KV region. It belongs to the PD, not
+// to any one connection, so it is registered ONCE per device and shared by all
+// endpoints — previously each new connection re-ran ibv_reg_mr over the whole
+// (tens-to-hundreds-of-GB) region, a registration storm at reconnect time.
+struct SharedPoolMr { uintptr_t base; size_t size; ibv_mr* mr; };
+struct SharedDevice {
+  ibv_context* ctx;
+  ibv_pd* pd;
+  long refs;
+  std::vector<SharedPoolMr> pool_mrs;  // registered once per PD; freed on last ref
+};
 std::mutex g_dev_mu;
 std::unordered_map<std::string, SharedDevice> g_devs;
+
+// Ad-hoc user MRs registered OUTSIDE any pool region (RegisterUser slow path).
+// In correct deployments every datapath buffer is inside a RegisterMemory pool,
+// so this counter should stay 0; a rising value flags a pool-registration gap.
+std::atomic<uint64_t> g_adhoc_user_mr{0};
+// Actual ibv_reg_mr calls for pool regions (once per PD per region). Diagnostic:
+// with the shared registry this is ~= number of distinct (device,region) pairs,
+// NOT number of connections (the pre-fix behavior).
+std::atomic<uint64_t> g_pool_mr_regs{0};
 
 // Get-or-open the shared {ctx, pd} for `dev_name` (nullptr/"" = first device),
 // bumping its refcount. Returns {nullptr,nullptr} on failure (no refcount taken).
@@ -67,6 +87,7 @@ void ReleaseSharedDevice(ibv_context* ctx) {
   for (auto it = g_devs.begin(); it != g_devs.end(); ++it) {
     if (it->second.ctx != ctx) continue;
     if (--it->second.refs == 0) {
+      for (auto& p : it->second.pool_mrs) if (p.mr) ibv_dereg_mr(p.mr);  // shared MRs
       ibv_dealloc_pd(it->second.pd);
       ibv_close_device(it->second.ctx);
       g_devs.erase(it);
@@ -74,7 +95,37 @@ void ReleaseSharedDevice(ibv_context* ctx) {
     return;
   }
 }
+
+// Register `base`/`size` on the device's shared PD exactly once; subsequent
+// callers (other endpoints on the same PD) get the existing MR with no
+// ibv_reg_mr. Returns the (shared, PD-owned) MR, or nullptr on failure. The MR's
+// lkey is valid for any QP on this PD, so callers may cache the pointer locally
+// for lock-free lookup. Only called at connection setup (not the datapath), so
+// taking g_dev_mu here is fine.
+ibv_mr* SharedAddPoolMr(ibv_context* ctx, ibv_pd* pd, void* base, size_t size) {
+  auto b = reinterpret_cast<uintptr_t>(base);
+  std::lock_guard<std::mutex> lk(g_dev_mu);
+  for (auto& d : g_devs) {
+    if (d.second.ctx != ctx) continue;
+    for (const auto& p : d.second.pool_mrs)
+      if (p.base == b && p.size >= size) return p.mr;  // already registered on this PD
+    ibv_mr* mr = ibv_reg_mr(pd, base, size, IBV_ACCESS_LOCAL_WRITE);
+    if (!mr) return nullptr;
+    g_pool_mr_regs.fetch_add(1, std::memory_order_relaxed);  // one actual registration
+    d.second.pool_mrs.push_back(SharedPoolMr{b, size, mr});
+    return mr;
+  }
+  return nullptr;  // device not found (shouldn't happen for a live endpoint)
+}
 }  // namespace
+
+uint64_t RcEndpoint::AdhocUserMrTotal() {
+  return g_adhoc_user_mr.load(std::memory_order_relaxed);
+}
+
+uint64_t RcEndpoint::PoolMrRegistrations() {
+  return g_pool_mr_regs.load(std::memory_order_relaxed);
+}
 
 void SerializeQpInfo(const QpInfo& in, char out[kQpInfoBytes]) {
   std::memset(out, 0, kQpInfoBytes);
@@ -103,7 +154,10 @@ void RcEndpoint::Close() {
   for (auto& [addr, e] : user_mr_) if (e.first) ibv_dereg_mr(e.first);
   user_mr_.clear();
   user_lru_.clear();
-  for (auto& p : pool_mr_) if (p.mr) ibv_dereg_mr(p.mr);
+  // pool_mr_ holds SHARED, PD-owned MRs (SharedAddPoolMr); the SharedDevice
+  // frees them on the last device ref (ReleaseSharedDevice). Just drop the local
+  // lookup cache — do NOT dereg here (that would free an MR other live endpoints
+  // on the same PD still use).
   pool_mr_.clear();
   smr_.clear(); rmr_.clear(); dmr_.clear();
   for (auto* b : sbuf_) delete[] b;
@@ -318,8 +372,12 @@ bool RcEndpoint::PostSend(size_t slot, size_t len) {
 
 bool RcEndpoint::AddPoolMr(void* base, size_t size) {
   auto b = reinterpret_cast<uintptr_t>(base);
-  for (const auto& p : pool_mr_) if (p.base == b) return true;  // already registered
-  ibv_mr* mr = ibv_reg_mr(pd_, base, size, IBV_ACCESS_LOCAL_WRITE);
+  for (const auto& p : pool_mr_) if (p.base == b) return true;  // local cache hit
+  // Register on the shared PD (deduped across all endpoints on this device), then
+  // cache the (shared) MR locally so the datapath RegisterUser lookup stays
+  // lock-free. The MR is owned by the SharedDevice and freed on the last ref, so
+  // this endpoint must NOT dereg it in Close().
+  ibv_mr* mr = SharedAddPoolMr(ctx_, pd_, base, size);
   if (!mr) return false;
   pool_mr_.push_back(PoolMr{b, size, mr});
   return true;
@@ -357,6 +415,7 @@ ibv_mr* RcEndpoint::RegisterUser(void* addr, size_t len) {
   }
   ibv_mr* mr = ibv_reg_mr(pd_, addr, len, IBV_ACCESS_LOCAL_WRITE);
   if (mr) {
+    g_adhoc_user_mr.fetch_add(1, std::memory_order_relaxed);  // out-of-pool: should be 0 in prod
     user_lru_.push_front(key);
     user_mr_[key] = {mr, user_lru_.begin()};
   }

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -96,6 +96,16 @@ class RcEndpoint {
   // is acquired so regions declared at any time land on every connection's PD.
   void EnsurePoolMrs(const std::vector<std::pair<void*, size_t>>& regions);
 
+  // Process-wide count of ad-hoc user MRs registered OUTSIDE any pool region
+  // (RegisterUser slow path). Should stay 0 in correct deployments where every
+  // datapath buffer lives inside a RegisterMemory pool; a rising value flags a
+  // pool-registration gap. Diagnostic; surfaced in the transport MetricsText.
+  static uint64_t AdhocUserMrTotal();
+  // Process-wide count of actual ibv_reg_mr calls for pool regions. With the
+  // shared per-PD registry this counts distinct (device,region) pairs, not
+  // connections (the pre-fix per-connection storm). Diagnostic/test.
+  static uint64_t PoolMrRegistrations();
+
   // Resolve a caller buffer to an MR for zero-copy transfer. Fast path: a buffer
   // inside a registered pool region (AddPoolMr) returns that MR with no syscall.
   // Otherwise it is registered ad-hoc and kept in a small LRU cache (stable repeat

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -322,6 +322,43 @@ TEST(RdmaLoopback, PoolMrSharedAcrossBuffers) {
   EXPECT_NE(c, a);  // outside the pool -> ad-hoc registration
 }
 
+// The host KV pool belongs to the PD, not to a connection: many endpoints on
+// the same device must register it ONCE (the #P1-2 fix), not once per connection
+// (the pre-fix storm — re-running ibv_reg_mr over a tens-of-GB region on every
+// reconnect). Verified via the pool-registration counter delta, and by every
+// endpoint resolving an in-pool buffer to the SAME MR (shared lkey).
+TEST(RdmaLoopback, PoolMrRegisteredOncePerDeviceNotPerConnection) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  // A distinct region per test run so the counter delta is attributable here.
+  std::vector<char> region(512 * 1024);
+  const uint64_t regs0 = rdma::RcEndpoint::PoolMrRegistrations();
+  const uint64_t adhoc0 = rdma::RcEndpoint::AdhocUserMrTotal();
+
+  constexpr int N = 8;
+  std::vector<std::unique_ptr<rdma::RcEndpoint>> eps;
+  ibv_mr* first = nullptr;
+  for (int i = 0; i < N; ++i) {
+    eps.push_back(std::make_unique<rdma::RcEndpoint>());
+    ASSERT_TRUE(eps.back()->Open(nullptr, 64 * 1024, 1)) << "endpoint " << i;
+    ASSERT_TRUE(eps.back()->AddPoolMr(region.data(), region.size()));
+    ibv_mr* m = eps.back()->RegisterUser(region.data() + 4096, 4096);
+    ASSERT_NE(m, nullptr);
+    if (i == 0) first = m;
+    else EXPECT_EQ(m, first) << "all endpoints on one PD share the pool MR";
+  }
+  EXPECT_EQ(rdma::RcEndpoint::PoolMrRegistrations() - regs0, 1u)
+      << N << " endpoints registered the region " << (rdma::RcEndpoint::PoolMrRegistrations() - regs0)
+      << " times; must be exactly once per device";
+  EXPECT_EQ(rdma::RcEndpoint::AdhocUserMrTotal() - adhoc0, 0u)
+      << "in-pool buffers must never take the ad-hoc registration path";
+
+  eps.clear();  // all close; region MR freed when the last device ref drops
+  // A fresh endpoint re-registers the (now-freed) region: counter advances by 1.
+  rdma::RcEndpoint again;
+  ASSERT_TRUE(again.Open(nullptr, 64 * 1024, 1));
+  ASSERT_TRUE(again.AddPoolMr(region.data(), region.size()));
+}
+
 // End-to-end: register the host pool once, then Put from / Get into sub-buffers
 // of it. All transfers hit the pool MR (no per-op registration) and round-trip.
 TEST(RdmaLoopback, RegisterMemoryRoundtrip) {


### PR DESCRIPTION
## Problem (P1, registration storm at reconnect)

`pool_mr_` lived on each `RcEndpoint`, so every new connection re-ran `ibv_reg_mr` over the **entire host KV pool** — tens to hundreds of GB. A single registration walks the region's page tables and can take **seconds**; at reconnect fan-out (`pool_max` 256/node) this is a registration storm exactly when throughput matters most.

## Fix
A pool MR belongs to the PD, and the PD is already shared per device (`SharedDevice`). `SharedAddPoolMr` registers a `(base,size)` **once per PD** and returns the shared MR; later endpoints on the same device get it with no `ibv_reg_mr`. Each endpoint still keeps its local `pool_mr_` vector as a **lock-free lookup cache** for the datapath `RegisterUser` fast path (the shared MR's lkey is valid for any QP on the PD). Lifetime moves to the device: `Close()` drops the local cache without deregistering; `ReleaseSharedDevice` frees the pool MRs on the last device ref.

Also surfaces in `MetricsText`: effective pipeline depth (`DFKV_RDMA_DEPTH`; **default unchanged at 1** — raising it is an ops decision, per-conn pinned memory ≈ `2*control_cap*depth`) and `dfkv_rdma_client_adhoc_user_mr_total` (out-of-pool registrations; should stay 0).

## Test
`rdma_loopback` (Soft-RoCE): 8 endpoints on one device register the same region **exactly once** (`PoolMrRegistrations` delta == 1) and all resolve an in-pool buffer to the **same MR**, with zero ad-hoc registrations; after all close, a fresh endpoint re-registers cleanly. Local: default **217/217**, RDMA+URING **240/240**, `rdma_loopback` **18/18** on rxe0. CI's rdma-loopback+TSan job covers the MR-lifetime change.