### PR TITLE
feat(wire): v2 frame with request seq + server dual-accept (TCP/MDS)

### DIFF
--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -148,6 +148,10 @@ std::string KvNodeServer::MetricsText() const {
   metric("dfkv_bytes_read_total", "counter", "Payload bytes read",
          bytes_read_.load(std::memory_order_relaxed));
   metric("dfkv_accepts_total", "counter", "TCP connections accepted", AcceptCount());
+  metric("dfkv_wire_v1_requests_total", "counter", "TCP requests decoded as wire v1",
+         wire_v1_requests_.load(std::memory_order_relaxed));
+  metric("dfkv_wire_v2_requests_total", "counter", "TCP requests decoded as wire v2",
+         wire_v2_requests_.load(std::memory_order_relaxed));
   metric("dfkv_evictions_total", "counter", "Objects evicted (capacity pressure)",
          group_.Evictions());
   metric("dfkv_evicted_bytes_total", "counter", "Bytes evicted", group_.EvictedBytes());
@@ -368,10 +372,19 @@ void KvNodeServer::Handle(int fd) {
                                    ? max_request_payload_
                                    : wire_limits::MaxRequestPayload();
   while (running_) {
-    char prefix[kReqPrefix];
+    // Dual-accept v1/v2: read the common v1 prefix, then 8 more bytes only when
+    // the version byte marks a v2 frame; reply in the SAME version. A v1 and a
+    // v2 client thus share this server with no flag-day upgrade.
+    char prefix[kReqPrefixV2];
     if (!net::ReadAll(fd, prefix, kReqPrefix)) return;  // peer closed / error
+    if (static_cast<uint8_t>(prefix[0]) == kProtoVersionV2 &&
+        !net::ReadAll(fd, prefix + kReqPrefix, kReqPrefixV2 - kReqPrefix))
+      return;
     ReqFields rq;
-    if (!DecodeReq(prefix, &rq, max_payload)) return;  // bad version / oversize => drop
+    uint8_t ver = DecodeReq(prefix, &rq, max_payload);
+    if (!ver) return;  // bad version / oversize => drop
+    (ver == kProtoVersionV2 ? wire_v2_requests_ : wire_v1_requests_)
+        .fetch_add(1, std::memory_order_relaxed);
     std::vector<char> payload(rq.payload_len);
     if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
 
@@ -379,9 +392,11 @@ void KvNodeServer::Handle(int fd) {
     Status st = ProcessRequest(rq.op, rq.id, rq.index, rq.size, rq.offset,
                                rq.length, payload.data(), rq.payload_len, &data);
 
-    char rp[kRespPrefix];
-    EncodeResp(rp, st, data.size());
-    if (!net::WriteAll(fd, rp, kRespPrefix)) return;
+    char rp[kRespPrefixV2];
+    size_t rlen;
+    if (ver == kProtoVersionV2) { EncodeRespV2(rp, st, data.size(), rq.seq); rlen = kRespPrefixV2; }
+    else { EncodeResp(rp, st, data.size()); rlen = kRespPrefix; }
+    if (!net::WriteAll(fd, rp, rlen)) return;
     if (!data.empty() && !net::WriteAll(fd, data.data(), data.size())) return;
   }
 }

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -60,6 +60,8 @@ class KvNodeServer {
   size_t m_exist_miss() const { return exist_miss_.load(std::memory_order_relaxed); }
   size_t m_remove_ok() const { return remove_ok_.load(std::memory_order_relaxed); }
   size_t m_remove_miss() const { return remove_miss_.load(std::memory_order_relaxed); }
+  size_t m_wire_v1() const { return wire_v1_requests_.load(std::memory_order_relaxed); }
+  size_t m_wire_v2() const { return wire_v2_requests_.load(std::memory_order_relaxed); }
   std::string MetricsText() const;  // Prometheus text format
 
   // Transport-agnostic request processing (shared by the TCP handler and, when
@@ -111,6 +113,7 @@ class KvNodeServer {
   std::atomic<size_t> open_connections_{0};
   Sampler lat_sampler_{64};        // 1-in-64 latency sampling (near-zero hot-path cost)
   LatencyHist get_lat_, put_lat_;  // server-side op latency (sampled)
+  std::atomic<uint64_t> wire_v1_requests_{0}, wire_v2_requests_{0};  // by frame version
   std::string members_;  // advertised cluster membership (kMembers)
   uint64_t max_request_payload_ = 0;  // 0 = resolve default lazily (see .cc)
   std::string node_id_, node_group_;       // identity for Prometheus labels (optional)

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -433,7 +433,10 @@ void RdmaServer::Serve(int boot_fd) {
           completions_.fetch_add(1, std::memory_order_relaxed);  // a request RECV
           size_t r = static_cast<size_t>(wc.wr_id);
           ReqFields rq;
-          if (!DecodeReq(ep.rbuf(r), &rq)) { fail = true; break; }
+          // v1-only for now: the RDMA server's v2 dual-accept (variable prefix +
+          // seq echo) lands with the v2 client (no v2 frames reach here until
+          // then). Reject a non-v1 version cleanly rather than reply v1 to it.
+          if (DecodeReq(ep.rbuf(r), &rq) != kProtoVersion) { fail = true; break; }
           if (free_send.empty()) { fail = true; break; }
           size_t s = free_send.back(); free_send.pop_back();
 
@@ -585,7 +588,7 @@ sync_serve_loop:;
       completions_.fetch_add(1, std::memory_order_relaxed);  // a request RECV
       size_t r = static_cast<size_t>(wc.wr_id);
       ReqFields rq;
-      if (!DecodeReq(ep.rbuf(r), &rq)) { fail = true; break; }  // bad protocol version
+      if (DecodeReq(ep.rbuf(r), &rq) != kProtoVersion) { fail = true; break; }  // v1-only (see above)
       if (free_send.empty()) { fail = true; break; }
       size_t s = free_send.back(); free_send.pop_back();
       Reply reply;

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -173,12 +173,18 @@ Status MdsServer::ListMembers(const std::string& group, std::string* out) {
 
 void MdsServer::Handle(int fd) {
   while (running_) {
-    char prefix[kReqPrefix];
+    // Dual-accept v1/v2 (see wire.h): the version byte is in the common v1
+    // prefix; a v2 frame carries 8 more trailing bytes and gets a v2 reply.
+    char prefix[kReqPrefixV2];
     if (!net::ReadAll(fd, prefix, kReqPrefix)) return;
+    if (static_cast<uint8_t>(prefix[0]) == kProtoVersionV2 &&
+        !net::ReadAll(fd, prefix + kReqPrefix, kReqPrefixV2 - kReqPrefix))
+      return;
     ReqFields rq;
     // MDS frames carry a group name + one MemberInfo (<1 KiB); cap the
     // declared length so a forged prefix can't trigger a giant allocation.
-    if (!DecodeReq(prefix, &rq, wire_limits::kMdsMaxReqPayload)) return;
+    uint8_t ver = DecodeReq(prefix, &rq, wire_limits::kMdsMaxReqPayload);
+    if (!ver) return;
     std::vector<char> payload(rq.payload_len);
     if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
 
@@ -199,9 +205,11 @@ void MdsServer::Handle(int fd) {
       st = ListMembers(group, &data);
     }
 
-    char rp[kRespPrefix];
-    EncodeResp(rp, st, data.size());
-    if (!net::WriteAll(fd, rp, kRespPrefix)) return;
+    char rp[kRespPrefixV2];
+    size_t rlen;
+    if (ver == kProtoVersionV2) { EncodeRespV2(rp, st, data.size(), rq.seq); rlen = kRespPrefixV2; }
+    else { EncodeResp(rp, st, data.size()); rlen = kRespPrefix; }
+    if (!net::WriteAll(fd, rp, rlen)) return;
     if (!data.empty() && !net::WriteAll(fd, data.data(), data.size())) return;
   }
 }

--- a/src/transport/wire.h
+++ b/src/transport/wire.h
@@ -25,6 +25,16 @@ enum class WireOp : uint8_t {
 };
 
 constexpr uint8_t kProtoVersion = 1;
+// Protocol v2 appends an 8-byte request seq (echoed in the response) at the TAIL
+// of each prefix, so a v2 frame is a v1 frame + 8 bytes. The seq lets a client
+// correlate a reply to its request explicitly instead of relying on the servers
+// replying in strict arrival order (a cross-component FIFO assumption that any
+// future out-of-order reply would silently break). Servers DUAL-ACCEPT: they
+// decode either version and reply in the SAME version, so a v1 client and a v2
+// client interoperate with the same server -- rolling upgrades need no flag day
+// (upgrade servers first, then clients). Behavior is otherwise identical; the
+// seq is validated but replies stay in arrival order until a later change.
+constexpr uint8_t kProtoVersionV2 = 2;
 
 // Hard ceiling on a single wire frame's variable payload. Decode rejects any
 // frame whose declared length exceeds this, so a garbage/hostile 64-bit length
@@ -35,9 +45,14 @@ constexpr uint8_t kProtoVersion = 1;
 constexpr uint64_t kMaxFrameLen = 1ull << 34;  // 16 GiB
 
 // Request prefix: ver(1) op(1) id(8) index(4) size(4) offset(8) length(8) payload_len(8)
-constexpr size_t kReqPrefix = 1 + 1 + 8 + 4 + 4 + 8 + 8 + 8;  // = 42
+constexpr size_t kReqPrefix = 1 + 1 + 8 + 4 + 4 + 8 + 8 + 8;  // = 42 (v1)
 // Response prefix: ver(1) status(1) data_len(8)
-constexpr size_t kRespPrefix = 1 + 1 + 8;  // = 10
+constexpr size_t kRespPrefix = 1 + 1 + 8;  // = 10 (v1)
+// v2 = v1 layout + an 8-byte trailing seq. A reader takes the v1 prefix first
+// (the version byte is at [0] of both), and reads the extra 8 bytes only when
+// [0] == kProtoVersionV2.
+constexpr size_t kReqPrefixV2 = kReqPrefix + 8;    // = 50
+constexpr size_t kRespPrefixV2 = kRespPrefix + 8;  // = 18
 
 inline void EncodeReq(char* p, WireOp op, const BlockKey& k, uint64_t offset,
                       uint64_t length, uint64_t payload_len) {
@@ -51,6 +66,15 @@ inline void EncodeReq(char* p, WireOp op, const BlockKey& k, uint64_t offset,
   net::PutU64(p + 34, payload_len);
 }
 
+// v2 request: the v1 layout plus an 8-byte seq at the tail (offset kReqPrefix).
+// Writes kReqPrefixV2 bytes.
+inline void EncodeReqV2(char* p, WireOp op, const BlockKey& k, uint64_t offset,
+                        uint64_t length, uint64_t payload_len, uint64_t seq) {
+  EncodeReq(p, op, k, offset, length, payload_len);
+  p[0] = static_cast<char>(kProtoVersionV2);  // overwrite the version byte
+  net::PutU64(p + kReqPrefix, seq);
+}
+
 struct ReqFields {
   uint8_t op;
   uint64_t id;
@@ -59,15 +83,19 @@ struct ReqFields {
   uint64_t offset;
   uint64_t length;
   uint64_t payload_len;
+  uint64_t seq = 0;  // v2 only (0 for a v1 frame)
 };
 
-// Returns false on a protocol-version mismatch or an oversized declared payload
-// (> max_payload); the caller drops the connection in either case. max_payload
-// defaults to the global frame ceiling, so every caller is guarded even without
-// passing a tighter bound.
-inline bool DecodeReq(const char* p, ReqFields* o,
-                      uint64_t max_payload = kMaxFrameLen) {
-  if (static_cast<uint8_t>(p[0]) != kProtoVersion) return false;
+// Returns the decoded frame version (kProtoVersion or kProtoVersionV2), or 0 on
+// a version mismatch / oversized declared payload (> max_payload) — the caller
+// drops the connection when 0. `if (!DecodeReq(...))` therefore still means "bad
+// frame", and a caller that needs the version keeps the return value.
+// For a v2 frame `p` MUST hold kReqPrefixV2 bytes (the seq is read from
+// p+kReqPrefix); for a v1 frame only kReqPrefix bytes are touched.
+inline uint8_t DecodeReq(const char* p, ReqFields* o,
+                         uint64_t max_payload = kMaxFrameLen) {
+  const uint8_t ver = static_cast<uint8_t>(p[0]);
+  if (ver != kProtoVersion && ver != kProtoVersionV2) return 0;
   o->op = static_cast<uint8_t>(p[1]);
   o->id = net::GetU64(p + 2);
   o->index = net::GetU32(p + 10);
@@ -75,8 +103,9 @@ inline bool DecodeReq(const char* p, ReqFields* o,
   o->offset = net::GetU64(p + 18);
   o->length = net::GetU64(p + 26);
   o->payload_len = net::GetU64(p + 34);
-  if (o->payload_len > max_payload) return false;  // reject oversized frame
-  return true;
+  o->seq = (ver == kProtoVersionV2) ? net::GetU64(p + kReqPrefix) : 0;
+  if (o->payload_len > max_payload) return 0;  // reject oversized frame
+  return ver;
 }
 
 inline void EncodeResp(char* p, Status st, uint64_t data_len) {
@@ -85,13 +114,25 @@ inline void EncodeResp(char* p, Status st, uint64_t data_len) {
   net::PutU64(p + 2, data_len);
 }
 
-inline bool DecodeResp(const char* p, Status* st, uint64_t* data_len,
-                       uint64_t max_data = kMaxFrameLen) {
-  if (static_cast<uint8_t>(p[0]) != kProtoVersion) return false;
+// v2 response: v1 layout plus an 8-byte echoed seq. Writes kRespPrefixV2 bytes.
+inline void EncodeRespV2(char* p, Status st, uint64_t data_len, uint64_t seq) {
+  EncodeResp(p, st, data_len);
+  p[0] = static_cast<char>(kProtoVersionV2);
+  net::PutU64(p + kRespPrefix, seq);
+}
+
+// Returns the response frame version (1 or 2), or 0 on version mismatch /
+// oversize. For a v2 frame `p` must hold kRespPrefixV2 bytes. `seq` (nullable)
+// receives the echoed seq (0 for a v1 frame).
+inline uint8_t DecodeResp(const char* p, Status* st, uint64_t* data_len,
+                          uint64_t max_data = kMaxFrameLen, uint64_t* seq = nullptr) {
+  const uint8_t ver = static_cast<uint8_t>(p[0]);
+  if (ver != kProtoVersion && ver != kProtoVersionV2) return 0;
   *st = static_cast<Status>(static_cast<uint8_t>(p[1]));
   *data_len = net::GetU64(p + 2);
-  if (*data_len > max_data) return false;  // reject oversized frame
-  return true;
+  if (seq) *seq = (ver == kProtoVersionV2) ? net::GetU64(p + kRespPrefix) : 0;
+  if (*data_len > max_data) return 0;  // reject oversized frame
+  return ver;
 }
 
 }  // namespace dfkv

--- a/test/transport/wire_test.cc
+++ b/test/transport/wire_test.cc
@@ -36,7 +36,7 @@ TEST(Wire, RespRoundTrip) {
 TEST(Wire, ReqRejectsBadVersion) {
   char buf[kReqPrefix];
   EncodeReq(buf, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, 0);
-  buf[0] = static_cast<char>(kProtoVersion + 1);  // version skew
+  buf[0] = static_cast<char>(kProtoVersionV2 + 1);  // unknown version (>v2)
   ReqFields rq;
   EXPECT_FALSE(DecodeReq(buf, &rq));
 }
@@ -44,7 +44,7 @@ TEST(Wire, ReqRejectsBadVersion) {
 TEST(Wire, RespRejectsBadVersion) {
   char buf[kRespPrefix];
   EncodeResp(buf, Status::kOk, 0);
-  buf[0] = static_cast<char>(kProtoVersion + 1);
+  buf[0] = static_cast<char>(kProtoVersionV2 + 1);  // unknown version (>v2)
   Status st = Status::kInvalid;
   uint64_t dlen = 0;
   EXPECT_FALSE(DecodeResp(buf, &st, &dlen));
@@ -84,4 +84,52 @@ TEST(Wire, RespRejectsOversizedData) {
   EXPECT_FALSE(DecodeResp(buf, &st, &dlen));
   EXPECT_TRUE(DecodeResp(buf, &st, &dlen, kMaxFrameLen + 1));
   EXPECT_EQ(dlen, kMaxFrameLen + 1);
+}
+
+TEST(Wire, ReqV2RoundTripCarriesSeq) {
+  char buf[kReqPrefixV2];
+  BlockKey k{0x1122334455667788ull, 0xAABBCCDD, 0x12345678};
+  EncodeReqV2(buf, WireOp::kRange, k, 4096, 8192, 65536, 0xDEADBEEFCAFEull);
+  ReqFields rq;
+  EXPECT_EQ(DecodeReq(buf, &rq), kProtoVersionV2);
+  EXPECT_EQ(rq.op, static_cast<uint8_t>(WireOp::kRange));
+  EXPECT_EQ(rq.id, k.id);
+  EXPECT_EQ(rq.payload_len, 65536u);
+  EXPECT_EQ(rq.seq, 0xDEADBEEFCAFEull);
+}
+
+TEST(Wire, ReqV1DecodesWithZeroSeqAndVersionOne) {
+  char buf[kReqPrefix];
+  EncodeReq(buf, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, 0);
+  ReqFields rq;
+  EXPECT_EQ(DecodeReq(buf, &rq), kProtoVersion);
+  EXPECT_EQ(rq.seq, 0u) << "a v1 frame has no seq";
+}
+
+TEST(Wire, RespV2RoundTripEchoesSeq) {
+  char buf[kRespPrefixV2];
+  EncodeRespV2(buf, Status::kOk, 1u << 20, 0x0102030405060708ull);
+  Status st = Status::kInvalid;
+  uint64_t dlen = 0, seq = 0;
+  EXPECT_EQ(DecodeResp(buf, &st, &dlen, kMaxFrameLen, &seq), kProtoVersionV2);
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(dlen, 1u << 20);
+  EXPECT_EQ(seq, 0x0102030405060708ull);
+}
+
+TEST(Wire, RespV1DecodesWithVersionOneAndZeroSeq) {
+  char buf[kRespPrefix];
+  EncodeResp(buf, Status::kNotFound, 0);
+  Status st = Status::kInvalid;
+  uint64_t dlen = 0, seq = 0xff;
+  EXPECT_EQ(DecodeResp(buf, &st, &dlen, kMaxFrameLen, &seq), kProtoVersion);
+  EXPECT_EQ(st, Status::kNotFound);
+  EXPECT_EQ(seq, 0u);
+}
+
+TEST(Wire, V2OversizePayloadStillRejected) {
+  char buf[kReqPrefixV2];
+  EncodeReqV2(buf, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, kMaxFrameLen + 1, 7);
+  ReqFields rq;
+  EXPECT_EQ(DecodeReq(buf, &rq), 0u);  // oversize -> rejected even for v2
 }

--- a/test/transport/wire_v2_server_test.cc
+++ b/test/transport/wire_v2_server_test.cc
@@ -1,0 +1,112 @@
+// Server dual-accept (wire v2): a KvNodeServer and an MdsServer must decode both
+// v1 and v2 request frames and reply in the SAME version (echoing the v2 seq),
+// so a v1 and a v2 client share one server with no flag-day upgrade.
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "cache/kv_node_server.h"
+#include "mds/mds_server.h"
+#include "transport/wire.h"
+#include "utils/net_util.h"
+
+using namespace dfkv;  // NOLINT
+namespace fs = std::filesystem;
+
+namespace {
+
+// Send a raw request frame (v1 or v2 per `seq_or_v1`) and read the reply prefix;
+// returns the reply version, and fills status / data_len / echoed seq.
+uint8_t RoundTripRaw(int port, WireOp op, const BlockKey& k, uint64_t offset,
+                     uint64_t length, const std::string& payload, bool v2,
+                     uint64_t req_seq, Status* st, uint64_t* dlen, uint64_t* seq_out,
+                     std::string* data_out) {
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 2000, 2000);
+  if (fd < 0) return 0;
+  char pre[kReqPrefixV2];
+  size_t plen;
+  if (v2) { EncodeReqV2(pre, op, k, offset, length, payload.size(), req_seq); plen = kReqPrefixV2; }
+  else { EncodeReq(pre, op, k, offset, length, payload.size()); plen = kReqPrefix; }
+  if (!net::WriteAll(fd, pre, plen) ||
+      (!payload.empty() && !net::WriteAll(fd, payload.data(), payload.size()))) {
+    ::close(fd); return 0;
+  }
+  char rp[kRespPrefixV2];
+  if (!net::ReadAll(fd, rp, kRespPrefix)) { ::close(fd); return 0; }
+  if (static_cast<uint8_t>(rp[0]) == kProtoVersionV2 &&
+      !net::ReadAll(fd, rp + kRespPrefix, kRespPrefixV2 - kRespPrefix)) { ::close(fd); return 0; }
+  uint8_t ver = DecodeResp(rp, st, dlen, kMaxFrameLen, seq_out);
+  if (ver && *dlen && data_out) { data_out->resize(*dlen); net::ReadAll(fd, &(*data_out)[0], *dlen); }
+  ::close(fd);
+  return ver;
+}
+
+const char* EtcdEp() { return std::getenv("DFKV_TEST_ETCD"); }
+
+}  // namespace
+
+TEST(WireV2Server, KvNodeServerRepliesInRequestVersion) {
+  fs::path dir = fs::temp_directory_path() / "dfkv_wirev2_node";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  KvNodeServer srv(dir.string(), 1ull << 30);
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int port = srv.port();
+
+  std::string val = "wire-v2-value";
+  BlockKey k{0x777, 0, 1};
+  Status st; uint64_t dlen = 0, seq = 0; std::string data;
+
+  // v2 PUT then v2 GET: reply is v2 and echoes the request seq.
+  EXPECT_EQ(RoundTripRaw(port, WireOp::kCache, k, 0, 0, val, /*v2=*/true, 0x1234,
+                         &st, &dlen, &seq, &data), kProtoVersionV2);
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(seq, 0x1234u) << "v2 reply must echo the request seq";
+
+  EXPECT_EQ(RoundTripRaw(port, WireOp::kRange, k, 0, val.size(), "", /*v2=*/true,
+                         0x9999, &st, &dlen, &seq, &data), kProtoVersionV2);
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(seq, 0x9999u);
+  EXPECT_EQ(data, val);
+
+  // v1 GET on the same server: reply is v1 (10-byte prefix, no seq).
+  EXPECT_EQ(RoundTripRaw(port, WireOp::kRange, k, 0, val.size(), "", /*v2=*/false,
+                         0, &st, &dlen, &seq, &data), kProtoVersion);
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(data, val);
+
+  EXPECT_EQ(srv.m_wire_v2(), 2u);  // the two v2 requests
+  EXPECT_GE(srv.m_wire_v1(), 1u);  // the v1 request (+ any Start-time noise: none)
+  srv.Stop();
+  fs::remove_all(dir);
+}
+
+TEST(WireV2Server, MdsServerRepliesInRequestVersion) {
+  const char* ep = EtcdEp();
+  if (!ep) GTEST_SKIP() << "set DFKV_TEST_ETCD";
+  MdsServer mds(ep);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+  int port = mds.port();
+  std::string group = "wirev2-" + std::to_string(port);
+
+  Status st; uint64_t dlen = 0, seq = 0; std::string data;
+  // v2 kListMembers (empty group is a clean kOk empty list) echoes the seq.
+  uint8_t ver = RoundTripRaw(port, WireOp::kListMembers, BlockKey{}, 0, 0, group,
+                             /*v2=*/true, 0x5150, &st, &dlen, &seq, &data);
+  EXPECT_EQ(ver, kProtoVersionV2);
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(seq, 0x5150u);
+
+  // v1 on the same MDS still works and replies v1.
+  ver = RoundTripRaw(port, WireOp::kListMembers, BlockKey{}, 0, 0, group,
+                     /*v2=*/false, 0, &st, &dlen, &seq, &data);
+  EXPECT_EQ(ver, kProtoVersion);
+  EXPECT_EQ(st, Status::kOk);
+  mds.Stop();
+}


### PR DESCRIPTION
## What

Adds wire protocol **v2**: each prefix gains an 8-byte trailing **seq** (request seq, echoed in the response) so a client can correlate a reply to its request explicitly — instead of relying on servers replying in strict arrival order, a cross-component FIFO assumption any future out-of-order reply would silently break. A v2 frame is a v1 frame + 8 bytes (version byte at [0] of both), so a reader takes the v1 prefix and reads the extra 8 bytes only when the version marks v2.

Servers **dual-accept**: `KvNodeServer` (TCP) and `MdsServer` decode either version and reply in the **same** version (echoing the v2 seq) → a v1 and a v2 client share one server, so rolling upgrades need **no flag day** (upgrade servers first, then clients). `DecodeReq`/`DecodeResp` now return the decoded version (0 = bad); every existing "bad frame" check still works. Per-version counters `dfkv_wire_v{1,2}_requests_total` confirm migration.

## Scope
Server dual-accept for the **TCP** paths. The **RDMA server stays v1-only** for now (explicit reject of non-v1, so it can never reply v1 to a v2 request) — its variable-prefix dual-accept lands with the **v2 client** that exercises it end-to-end (next PR, B2-2). No production impact: the client is still v1, so no v2 frames reach any server yet.

## Tests
- `wire_test`: v2 req/resp round-trips (seq echo), v1 zero-seq, oversize still rejected, unknown-version rejected. (The old bad-version tests set version = v1+1, now valid v2 — fixed to use >v2.)
- `wire_v2_server_test`: drives raw v1 and v2 frames at a live `KvNodeServer` and `MdsServer`, asserting the reply version matches, the seq is echoed, and per-version counters advance.
- Local: default **224/224**, RDMA+URING **247/247**, `rdma_loopback` **18/18** (v1 path intact).
