### PR TITLE
fix(client): 96-bit block-key identity (fill index with MD5[8..12))

### DIFF
--- a/src/client/key_map.h
+++ b/src/client/key_map.h
@@ -1,6 +1,19 @@
 /* key_map: SGLang page-hash string -> deterministic BlockKey.
  * F1 fix: BlockKey.size is a FIXED constant (never payload length) so Put/Get/
- * Exist build identical Filename() and route to the same node. */
+ * Exist build identical Filename() and route to the same node.
+ *
+ * Block identity is 96 bits: id = MD5[0..8) (LE u64), index = MD5[8..12) (LE
+ * u32). The 64-bit id alone gave a birthday-collision probability of a few
+ * percent at the ~1e9 lifetime-write scale of a 5 TiB x N-node ring -- and a
+ * collision is NOT a miss but a SILENT cross-key read (the geometry header only
+ * checks model/page/dtype/layer, so two same-model pages that collide pass
+ * validation and one KV block is served under the other's key). Extending
+ * identity into the (previously always-0) index field -- which Filename()/
+ * StoreKey()/operator== already incorporate -- cuts collision probability by
+ * 2^32 with no wire or storage-path change. id stays byte-identical to the old
+ * Md5_64, so routing (a separate Md5_32 hash) is unaffected; only the on-disk
+ * key changes, so a mixed old/new fleet cross-misses once (clean cache warm-up,
+ * never corruption). */
 #ifndef DFKV_KEY_MAP_H_
 #define DFKV_KEY_MAP_H_
 
@@ -16,7 +29,13 @@ namespace dfkv {
 inline constexpr uint32_t kKvFixedSize = 1;
 
 inline BlockKey ToBlockKey(const std::string& key) {
-  return BlockKey{Md5_64(key), 0u, kKvFixedSize};
+  uint8_t d[16];
+  Md5(key.data(), key.size(), d);  // one hash; split into id + index
+  uint64_t id = 0;
+  for (int i = 0; i < 8; ++i) id |= uint64_t(d[i]) << (8 * i);         // bytes 0..7 (== Md5_64)
+  uint32_t index = uint32_t(d[8]) | (uint32_t(d[9]) << 8) |
+                   (uint32_t(d[10]) << 16) | (uint32_t(d[11]) << 24);   // bytes 8..11
+  return BlockKey{id, index, kKvFixedSize};
 }
 
 }  // namespace dfkv

--- a/test/client/key_map_test.cc
+++ b/test/client/key_map_test.cc
@@ -3,6 +3,7 @@
 // identity key (Filename) and route identically. Payload length must NOT enter
 // BlockKey.size.
 #include "client/key_map.h"
+#include "utils/md5.h"
 
 #include <gtest/gtest.h>
 
@@ -18,13 +19,42 @@ TEST(KeyMap, DeterministicSameKeySameId) {
 }
 
 TEST(KeyMap, SizeIsFixedConstantRegardlessOfCaller) {
-  // F1 regression: identity size is constant; never the payload length.
+  // F1 regression: identity size is constant; never the payload length. The
+  // index now carries MD5[8..12) identity bits (was always 0), so Put/Get/Exist
+  // still agree because they all derive it deterministically from the same key.
   BlockKey a = ToBlockKey("k1");
   BlockKey b = ToBlockKey("k1");
   EXPECT_EQ(a.size, kKvFixedSize);
   EXPECT_EQ(b.size, kKvFixedSize);
-  EXPECT_EQ(a.index, 0u);
+  EXPECT_EQ(a.index, b.index);            // deterministic
   EXPECT_EQ(a.Filename(), b.Filename());  // Put/Get/Exist must agree
+}
+
+TEST(KeyMap, IdUnchangedFromMd5_64ButIndexNowCarriesIdentity) {
+  // id must stay byte-identical to the old Md5_64 so ring routing is unaffected;
+  // index is the newly-added identity (MD5 bytes 8..11, little-endian).
+  const std::string key = "glm-5.2/page_777_k";
+  BlockKey k = ToBlockKey(key);
+  EXPECT_EQ(k.id, dfkv::Md5_64(key)) << "id must equal the legacy 64-bit hash";
+  uint8_t d[16];
+  dfkv::Md5(key.data(), key.size(), d);
+  uint32_t want_index = uint32_t(d[8]) | (uint32_t(d[9]) << 8) |
+                        (uint32_t(d[10]) << 16) | (uint32_t(d[11]) << 24);
+  EXPECT_EQ(k.index, want_index);
+}
+
+TEST(KeyMap, IndexParticipatesInIdentity96Bit) {
+  // Distinct keys differ in the full 96-bit identity (id,index); index actually
+  // carries hash bits (non-zero for essentially every key).
+  std::set<std::pair<uint64_t, uint32_t>> ids;
+  size_t nonzero_index = 0;
+  for (int i = 0; i < 50000; ++i) {
+    BlockKey k = ToBlockKey("glm-5.2/pg_" + std::to_string(i) + "_k");
+    ids.insert({k.id, k.index});
+    if (k.index != 0) ++nonzero_index;
+  }
+  EXPECT_EQ(ids.size(), 50000u);
+  EXPECT_GT(nonzero_index, 49900u) << "index must actually carry hash bits";
 }
 
 TEST(KeyMap, DifferentKeysGiveDifferentIdsNoCollisionInSample) {


### PR DESCRIPTION
## Problem (P0, silent cross-key read)

Block identity was only the **64-bit** id (`Md5_64`), with the `BlockKey.index` field hard-wired to 0. At the ~1e9 lifetime-write scale of a 5 TiB × N ring the birthday-collision probability is a **few percent** — and a collision is **not a clean miss but a silent cross-key read**: the geometry header only checks model/page/dtype/layer, so two same-model pages that collide pass validation and one KV block is served under the other's key (attention reads corrupted state, no error, no metric).

## Fix
`ToBlockKey` computes the full 16-byte MD5 once and derives **id from bytes 0..7** (byte-identical to the old `Md5_64`) and **index from bytes 8..11**. `Filename()`/`StoreKey()`/`operator==` already incorporate `index`, so identity widens to **96 bits** with **no wire or storage-path change** and collision probability drops by **2^32**. `id` is unchanged → ring routing (a separate `Md5_32` hash) is unaffected; only the on-disk key changes, so a mixed old/new fleet cross-misses once (clean cache warm-up, never corruption) — roll fleet-wide in one window.

## Tests
`key_map_test`: `id` equals the legacy `Md5_64` while `index` carries the exact `MD5[8..12)` bytes (golden); Put/Get derive the same `(id,index)` deterministically; 50k distinct keys → 50k distinct `(id,index)` pairs, `index` non-zero for essentially all (identity actually widened). The old `index == 0` assertion is updated. Local: default **229/229**, RDMA+URING **252/252**.
