### PR TITLE
feat(cache): SlabAllocator -- media-agnostic slot lifecycle manager

### DIFF
--- a/src/cache/slab_allocator.cc
+++ b/src/cache/slab_allocator.cc
@@ -1,0 +1,249 @@
+#include "cache/slab_allocator.h"
+
+#include <algorithm>
+
+namespace dfkv {
+
+namespace {
+uint64_t AlignUp(uint64_t x, uint64_t a) {
+  return a <= 1 ? x : ((x + (a - 1)) / a) * a;
+}
+}  // namespace
+
+SlabAllocator::SlabAllocator(Options opt) : opt_(opt) {
+  if (opt_.align == 0) opt_.align = 1;
+  if (opt_.num_extents == 0) opt_.num_extents = 1;
+  extents_.assign(opt_.num_extents, ExtentMeta{});  // all kUnbound (in pool)
+}
+
+size_t SlabAllocator::ClassForLen(size_t aligned_len) {
+  // Smallest existing class whose slot fits with bounded waste; else new class.
+  size_t best = classes_.size();
+  uint32_t best_size = 0;
+  for (size_t i = 0; i < classes_.size(); ++i) {
+    uint32_t ss = classes_[i]->slot_size;
+    if (ss < aligned_len) continue;
+    if (static_cast<double>(ss - aligned_len) > opt_.max_waste * ss) continue;
+    if (best == classes_.size() || ss < best_size) { best = i; best_size = ss; }
+  }
+  if (best != classes_.size()) return best;
+  auto c = std::make_unique<Class>();
+  c->slot_size = static_cast<uint32_t>(aligned_len);
+  c->slots_per_extent = static_cast<uint32_t>(opt_.extent_bytes / c->slot_size);
+  classes_.push_back(std::move(c));
+  return classes_.size() - 1;
+}
+
+bool SlabAllocator::BindFreeExtent(size_t cls) {
+  for (uint32_t e = 0; e < extents_.size(); ++e) {
+    if (extents_[e].cls != kUnbound) continue;
+    Class& C = *classes_[cls];
+    const uint32_t total = C.slots_per_extent;
+    if (total == 0) return false;  // slot larger than an extent (guarded in Put)
+    extents_[e].cls = static_cast<int>(cls);
+    extents_[e].total_slots = total;
+    extents_[e].free_slots = total;
+    extents_[e].pinned = 0;
+    C.free_slots.reserve(C.free_slots.size() + total);
+    for (uint32_t s = 0; s < total; ++s) C.free_slots.push_back(Slot{e, s});
+    return true;
+  }
+  return false;
+}
+
+void SlabAllocator::FreeSlotLocked(const std::string& key, Entry& e) {
+  const uint32_t cls = e.ref.cls, ext = e.ref.extent, slot = e.ref.slot;
+  Class& C = *classes_[cls];
+  if (C.hand != C.ring.end() && C.hand == e.ring_it) C.hand = std::next(C.hand);
+  C.ring.erase(e.ring_it);
+  C.free_slots.push_back(Slot{ext, slot});
+  extents_[ext].free_slots++;
+  if (e.refs > 0 && extents_[ext].pinned > 0) extents_[ext].pinned--;
+  used_bytes_ -= e.ref.slot_size;
+  index_.erase(key);
+}
+
+bool SlabAllocator::EvictOneFrom(size_t cls, std::vector<std::string>* evicted) {
+  Class& C = *classes_[cls];
+  if (C.ring.empty()) return false;
+  // CLOCK second-chance sweep, bounded to ~2 cycles; skip pinned entries. A
+  // referenced entry is cleared and given a second chance; the first unreferenced
+  // unpinned entry is evicted. If the bound is hit with no unreferenced victim,
+  // evict the first unpinned entry regardless of its bit (forward progress).
+  const size_t limit = 2 * C.ring.size() + 2;
+  std::list<std::string>::iterator fallback = C.ring.end();
+  for (size_t steps = 0; steps < limit; ++steps) {
+    if (C.hand == C.ring.end()) C.hand = C.ring.begin();
+    if (C.ring.empty()) break;
+    auto cur = C.hand;
+    auto it = index_.find(*cur);
+    if (it == index_.end()) { C.hand = std::next(cur); C.ring.erase(cur); continue; }
+    Entry& e = it->second;
+    if (e.refs > 0) { C.hand = std::next(cur); continue; }  // pinned: skip
+    if (fallback == C.ring.end()) fallback = cur;           // first unpinned seen
+    if (e.referenced) { e.referenced = false; C.hand = std::next(cur); continue; }
+    // unpinned + unreferenced -> evict.
+    std::string victim = *cur;
+    FreeSlotLocked(victim, e);
+    evicted->push_back(std::move(victim));
+    evictions_++;
+    return true;
+  }
+  if (fallback != C.ring.end()) {  // bound hit: force-evict an unpinned entry
+    std::string victim = *fallback;
+    auto it = index_.find(victim);
+    if (it != index_.end()) {
+      FreeSlotLocked(victim, it->second);
+      evicted->push_back(std::move(victim));
+      evictions_++;
+      return true;
+    }
+  }
+  return false;  // every entry in this class is pinned
+}
+
+bool SlabAllocator::StealExtentFor(size_t cls, std::vector<std::string>* evicted) {
+  // Cold path: the target class has no slot and the pool is empty. Reclaim an
+  // entirely-unpinned extent bound to ANOTHER class, evict its residents, unbind
+  // it, and re-bind to the target class. Prefer the emptiest such extent.
+  int best = -1;
+  uint32_t best_free = 0;
+  for (uint32_t e = 0; e < extents_.size(); ++e) {
+    const ExtentMeta& m = extents_[e];
+    if (m.cls == kUnbound || m.cls == static_cast<int>(cls)) continue;
+    if (m.pinned != 0) continue;  // can't evict a pinned slot
+    if (best < 0 || m.free_slots > best_free) { best = static_cast<int>(e); best_free = m.free_slots; }
+  }
+  if (best < 0) return false;
+  const uint32_t E = static_cast<uint32_t>(best);
+  const int old_cls = extents_[E].cls;
+  // Evict every resident key living in extent E (scan the index -- steal is rare).
+  std::vector<std::string> victims;
+  for (const auto& kv : index_)
+    if (kv.second.ref.extent == E) victims.push_back(kv.first);
+  for (const auto& v : victims) {
+    auto it = index_.find(v);
+    if (it != index_.end()) { FreeSlotLocked(v, it->second); evicted->push_back(v); evictions_++; }
+  }
+  // Drop E's now-free slots from the old class's free list, then unbind E.
+  auto& oldfree = classes_[old_cls]->free_slots;
+  oldfree.erase(std::remove_if(oldfree.begin(), oldfree.end(),
+                               [E](const Slot& s) { return s.extent == E; }),
+                oldfree.end());
+  extents_[E].cls = kUnbound;
+  extents_[E].total_slots = 0;
+  extents_[E].free_slots = 0;
+  extents_[E].pinned = 0;
+  return BindFreeExtent(cls);  // now picks the freshly-unbound E
+}
+
+bool SlabAllocator::Put(const std::string& key, size_t len, SlotRef* out,
+                        std::vector<std::string>* evicted) {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto existing = index_.find(key);
+  if (existing != index_.end()) {  // idempotent: keep the current slot
+    existing->second.referenced = true;
+    if (out) *out = existing->second.ref;
+    return true;
+  }
+  uint64_t aligned = AlignUp(len, opt_.align);
+  if (aligned == 0) aligned = opt_.align;              // 0-len value -> one min slot
+  if (aligned > opt_.extent_bytes) return false;       // larger than an extent
+
+  const size_t cls = ClassForLen(static_cast<size_t>(aligned));
+  Slot got{0, 0};
+  for (;;) {
+    Class& C = *classes_[cls];
+    if (!C.free_slots.empty()) { got = C.free_slots.back(); C.free_slots.pop_back(); break; }
+    if (BindFreeExtent(cls)) continue;
+    if (EvictOneFrom(cls, evicted)) continue;
+    if (StealExtentFor(cls, evicted)) continue;
+    return false;  // nothing to free: all candidate slots are pinned
+  }
+
+  Entry e;
+  e.ref.cls = static_cast<uint32_t>(cls);
+  e.ref.extent = got.extent;
+  e.ref.slot = got.slot;
+  e.ref.slot_size = classes_[cls]->slot_size;
+  e.ref.offset = static_cast<uint64_t>(got.slot) * classes_[cls]->slot_size;
+  e.refs = 0;
+  e.referenced = false;
+  Class& C = *classes_[cls];
+  C.ring.push_front(key);
+  e.ring_it = C.ring.begin();
+  extents_[got.extent].free_slots--;
+  used_bytes_ += e.ref.slot_size;
+  auto res = index_.emplace(key, std::move(e));
+  if (out) *out = res.first->second.ref;
+  return true;
+}
+
+bool SlabAllocator::Get(const std::string& key, SlotRef* out) {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto it = index_.find(key);
+  if (it == index_.end()) return false;
+  it->second.referenced = true;  // CLOCK second chance
+  if (out) *out = it->second.ref;
+  return true;
+}
+
+bool SlabAllocator::Contains(const std::string& key) const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return index_.find(key) != index_.end();
+}
+
+bool SlabAllocator::Remove(const std::string& key) {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto it = index_.find(key);
+  if (it == index_.end()) return false;
+  FreeSlotLocked(key, it->second);
+  return true;
+}
+
+bool SlabAllocator::Pin(const std::string& key) {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto it = index_.find(key);
+  if (it == index_.end()) return false;
+  if (it->second.refs == 0) extents_[it->second.ref.extent].pinned++;
+  it->second.refs++;
+  return true;
+}
+
+bool SlabAllocator::Unpin(const std::string& key) {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto it = index_.find(key);
+  if (it == index_.end() || it->second.refs == 0) return false;
+  it->second.refs--;
+  if (it->second.refs == 0 && extents_[it->second.ref.extent].pinned > 0)
+    extents_[it->second.ref.extent].pinned--;
+  return true;
+}
+
+size_t SlabAllocator::Count() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return index_.size();
+}
+uint64_t SlabAllocator::UsedBytes() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return used_bytes_;
+}
+uint64_t SlabAllocator::Capacity() const {
+  return static_cast<uint64_t>(opt_.num_extents) * opt_.extent_bytes;
+}
+uint64_t SlabAllocator::Evictions() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return evictions_;
+}
+size_t SlabAllocator::ClassCount() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return classes_.size();
+}
+uint32_t SlabAllocator::BoundExtents() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  uint32_t n = 0;
+  for (const auto& m : extents_) if (m.cls != kUnbound) ++n;
+  return n;
+}
+
+}  // namespace dfkv

--- a/src/cache/slab_allocator.h
+++ b/src/cache/slab_allocator.h
@@ -1,0 +1,136 @@
+/* SlabAllocator — media-agnostic slot lifecycle manager for the slab store.
+ *
+ * It owns the LAYOUT (which extent, which offset) of fixed-size slots, NOT the
+ * bytes: the caller (DiskSlabStore, or the P3 RamTier) maps a returned SlotRef
+ * to its physical medium (an extent file's offset, or a RAM arena offset) and
+ * does the I/O. Keeping this pure-logic makes it hermetically unit-testable and
+ * lets one implementation back both media (dfkv's slab-store rework and the RAM
+ * hot tier share the same size-class + CLOCK + pin machinery).
+ *
+ * Model (memcached-style slab): a fixed pool of equal-size EXTENTS; each extent
+ * is bound on demand to ONE size CLASS and carved into uniform slots. A value of
+ * `len` bytes goes into the smallest class whose slot_size >= align_up(len) with
+ * bounded internal waste (else a new class is created). Reclamation is per-class
+ * CLOCK second-chance; when a needy class has no slots and the pool is empty, an
+ * entirely-unpinned extent is stolen from another class (its slots evicted) and
+ * re-bound. A pinned slot (in-flight RDMA send) is never evicted.
+ *
+ * Concurrency: one mutex. The ops are O(1) in-memory; the slow medium I/O runs
+ * OUTSIDE this class in the caller. (Per-shard striping is a later perf option;
+ * the single lock is correct and TSan-clean.) */
+#ifndef DFKV_SLAB_ALLOCATOR_H_
+#define DFKV_SLAB_ALLOCATOR_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dfkv {
+
+class SlabAllocator {
+ public:
+  // Physical placement of a key's value. `offset` is within extent `extent`.
+  struct SlotRef {
+    uint32_t cls = 0;         // size-class index (diagnostic)
+    uint32_t extent = 0;      // extent index [0, num_extents)
+    uint32_t slot = 0;        // slot index within the extent
+    uint32_t slot_size = 0;   // class slot size in bytes (>= requested, aligned)
+    uint64_t offset = 0;      // byte offset within the extent (= slot * slot_size)
+    bool valid() const { return slot_size != 0; }
+  };
+
+  struct Options {
+    uint64_t extent_bytes = (1ull << 30);  // bytes per extent (e.g. 1 GiB)
+    uint32_t num_extents = 8;              // total extents in the pool
+    uint32_t align = 4096;                 // slot-size alignment (O_DIRECT friendly)
+    // Reuse an existing (larger) class instead of creating a new one when the
+    // internal waste (slot_size - aligned_len) stays under this fraction.
+    double max_waste = 0.25;
+  };
+
+  explicit SlabAllocator(Options opt);
+
+  // Reserve a slot for `key` holding `len` bytes.
+  // - Idempotent: if `key` is already resident, *out is its current slot and no
+  //   eviction happens (returns true).
+  // - Under capacity pressure, evicts unpinned slots to make room; the evicted
+  //   keys are appended to `*evicted` (caller drops them from its own index / I/O).
+  // - Returns false only if `len` exceeds one extent, or every candidate slot is
+  //   pinned (no room can be freed). *out is left invalid on false.
+  bool Put(const std::string& key, size_t len, SlotRef* out,
+           std::vector<std::string>* evicted);
+
+  // Look up `key`; on hit sets *out and marks it referenced (CLOCK second chance).
+  bool Get(const std::string& key, SlotRef* out);
+  bool Contains(const std::string& key) const;
+
+  // Drop `key` (frees its slot). true if present. A pinned key is still removed
+  // from the index but its slot is not reused until Unpin brings refs to 0.
+  bool Remove(const std::string& key);
+
+  // Pin/unpin a resident key: a pinned slot is never chosen for eviction (used
+  // while an RDMA send reads the slot). Balanced calls; Pin on an absent key is
+  // a no-op returning false.
+  bool Pin(const std::string& key);
+  bool Unpin(const std::string& key);
+
+  // stats (diagnostic)
+  size_t Count() const;
+  uint64_t UsedBytes() const;       // sum of slot_size over resident keys
+  uint64_t Capacity() const;        // num_extents * extent_bytes
+  uint64_t Evictions() const;
+  size_t ClassCount() const;
+  uint32_t BoundExtents() const;    // extents currently carved to a class
+
+ private:
+  static constexpr int kUnbound = -1;
+
+  struct Slot { uint32_t extent; uint32_t slot; };
+  struct Entry {
+    SlotRef ref;
+    uint32_t refs = 0;                       // pin count
+    bool referenced = false;                 // CLOCK bit
+    std::list<std::string>::iterator ring_it;  // this key's node in its class ring
+  };
+  struct Class {
+    uint32_t slot_size = 0;
+    uint32_t slots_per_extent = 0;
+    std::vector<Slot> free_slots;              // available slots (stack)
+    std::list<std::string> ring;               // CLOCK ring of resident keys
+    std::list<std::string>::iterator hand;     // persistent eviction cursor
+    Class() : hand(ring.end()) {}
+  };
+  struct ExtentMeta {
+    int cls = kUnbound;      // class index bound to, or kUnbound (in pool)
+    uint32_t free_slots = 0; // free slots (== total when fully empty)
+    uint32_t total_slots = 0;
+    uint32_t pinned = 0;     // resident pinned slots in this extent (steal guard)
+  };
+
+  size_t ClassForLen(size_t aligned_len);  // returns class index (creates if needed)
+  bool BindFreeExtent(size_t cls);         // bind a pool extent to cls; false if none
+  bool EvictOneFrom(size_t cls, std::vector<std::string>* evicted);  // CLOCK evict 1
+  bool StealExtentFor(size_t cls, std::vector<std::string>* evicted); // rebind a full extent
+  void FreeSlotLocked(const std::string& key, Entry& e);  // internal removal
+
+  Options opt_;
+  mutable std::mutex mu_;
+  // unique_ptr so a Class (holding a std::list ring + a persistent CLOCK `hand`
+  // iterator, with per-key ring_it iterators stored in index_) NEVER moves when
+  // the vector grows -- a moved std::list leaves those iterators dangling
+  // (same reason KVStore boxes its Shards).
+  std::vector<std::unique_ptr<Class>> classes_;
+  std::vector<ExtentMeta> extents_;
+  std::unordered_map<std::string, Entry> index_;
+  uint64_t used_bytes_ = 0;
+  uint64_t evictions_ = 0;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_SLAB_ALLOCATOR_H_

--- a/test/cache/slab_allocator_test.cc
+++ b/test/cache/slab_allocator_test.cc
@@ -1,0 +1,192 @@
+// SlabAllocator: media-agnostic slot lifecycle. Pure logic, hermetic tests.
+// Covers: alloc/get/remove, idempotent put, size-class reuse vs new, per-class
+// CLOCK eviction, extent binding + cross-class steal, pin-blocks-eviction, byte
+// accounting, oversize rejection, and a concurrent (TSan) stress.
+#include "cache/slab_allocator.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+using dfkv::SlabAllocator;
+using SlotRef = SlabAllocator::SlotRef;
+
+namespace {
+SlabAllocator::Options Opts(uint64_t extent_bytes, uint32_t num_extents,
+                            uint32_t align = 4096, double waste = 0.25) {
+  SlabAllocator::Options o;
+  o.extent_bytes = extent_bytes;
+  o.num_extents = num_extents;
+  o.align = align;
+  o.max_waste = waste;
+  return o;
+}
+}  // namespace
+
+TEST(SlabAllocator, PutGetRemoveRoundTrip) {
+  SlabAllocator a(Opts(64 * 1024, 4));
+  std::vector<std::string> ev;
+  SlotRef r;
+  ASSERT_TRUE(a.Put("k", 4096, &r, &ev));
+  EXPECT_TRUE(r.valid());
+  EXPECT_EQ(r.slot_size, 4096u);
+  EXPECT_EQ(r.offset, static_cast<uint64_t>(r.slot) * r.slot_size);
+  EXPECT_TRUE(ev.empty());
+  EXPECT_EQ(a.Count(), 1u);
+  EXPECT_EQ(a.UsedBytes(), 4096u);
+
+  SlotRef g;
+  ASSERT_TRUE(a.Get("k", &g));
+  EXPECT_EQ(g.extent, r.extent);
+  EXPECT_EQ(g.slot, r.slot);
+  EXPECT_FALSE(a.Get("absent", &g));
+
+  EXPECT_TRUE(a.Remove("k"));
+  EXPECT_FALSE(a.Contains("k"));
+  EXPECT_EQ(a.Count(), 0u);
+  EXPECT_EQ(a.UsedBytes(), 0u);
+  EXPECT_FALSE(a.Remove("k"));  // idempotent
+}
+
+TEST(SlabAllocator, PutIsIdempotentKeepsSameSlot) {
+  SlabAllocator a(Opts(64 * 1024, 4));
+  std::vector<std::string> ev;
+  SlotRef r1, r2;
+  ASSERT_TRUE(a.Put("k", 4096, &r1, &ev));
+  ASSERT_TRUE(a.Put("k", 4096, &r2, &ev));  // second put: same slot, no evict
+  EXPECT_EQ(r1.extent, r2.extent);
+  EXPECT_EQ(r1.slot, r2.slot);
+  EXPECT_EQ(a.Count(), 1u);
+  EXPECT_TRUE(ev.empty());
+}
+
+TEST(SlabAllocator, SizeClassReuseVsNew) {
+  SlabAllocator a(Opts(1 << 20, 4, /*align=*/4096, /*waste=*/0.25));
+  std::vector<std::string> ev;
+  SlotRef r;
+  ASSERT_TRUE(a.Put("a", 4096, &r, &ev));       // class 4096
+  EXPECT_EQ(a.ClassCount(), 1u);
+  ASSERT_TRUE(a.Put("b", 4000, &r, &ev));       // fits 4096 within 25% waste -> reuse
+  EXPECT_EQ(a.ClassCount(), 1u);
+  EXPECT_EQ(r.slot_size, 4096u);
+  ASSERT_TRUE(a.Put("c", 8192, &r, &ev));       // needs a bigger class -> new
+  EXPECT_EQ(a.ClassCount(), 2u);
+  EXPECT_EQ(r.slot_size, 8192u);
+}
+
+TEST(SlabAllocator, EvictsWithinClassUnderPressure) {
+  // 1 extent of 4 slots (4 * 4096). A 5th 4096 key must evict one.
+  SlabAllocator a(Opts(4 * 4096, 1));
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 4; ++i)
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  EXPECT_EQ(a.Count(), 4u);
+  EXPECT_TRUE(ev.empty());
+  ASSERT_TRUE(a.Put("k4", 4096, &r, &ev));   // full -> evict one
+  EXPECT_EQ(a.Count(), 4u);
+  EXPECT_EQ(ev.size(), 1u);
+  EXPECT_EQ(a.Evictions(), 1u);
+  EXPECT_TRUE(a.Contains("k4"));
+}
+
+TEST(SlabAllocator, GetGivesSecondChanceInClock) {
+  // 4 slots; touch k0 so it survives the first eviction (referenced bit).
+  SlabAllocator a(Opts(4 * 4096, 1));
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 4; ++i)
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  ASSERT_TRUE(a.Get("k0", &r));  // referenced -> should be spared once
+  ASSERT_TRUE(a.Put("k4", 4096, &r, &ev));
+  EXPECT_EQ(ev.size(), 1u);
+  EXPECT_NE(ev[0], "k0") << "a referenced entry gets a second chance";
+  EXPECT_TRUE(a.Contains("k0"));
+}
+
+TEST(SlabAllocator, PinBlocksEviction) {
+  SlabAllocator a(Opts(2 * 4096, 1));  // 2 slots
+  std::vector<std::string> ev;
+  SlotRef r;
+  ASSERT_TRUE(a.Put("pinned", 4096, &r, &ev));
+  ASSERT_TRUE(a.Put("other", 4096, &r, &ev));
+  ASSERT_TRUE(a.Pin("pinned"));
+  ASSERT_TRUE(a.Put("new", 4096, &r, &ev));  // must evict "other", never "pinned"
+  EXPECT_EQ(ev.size(), 1u);
+  EXPECT_EQ(ev[0], "other");
+  EXPECT_TRUE(a.Contains("pinned"));
+
+  // With BOTH slots pinned, a further Put has nothing to evict -> fails.
+  ASSERT_TRUE(a.Pin("new"));
+  ev.clear();
+  EXPECT_FALSE(a.Put("nope", 4096, &r, &ev)) << "all slots pinned -> no room";
+  EXPECT_TRUE(ev.empty());
+  // Unpin frees the path again.
+  ASSERT_TRUE(a.Unpin("new"));
+  EXPECT_TRUE(a.Put("nope", 4096, &r, &ev));
+}
+
+TEST(SlabAllocator, CrossClassStealWhenPoolEmpty) {
+  // 2 extents. Fill both with class-A (4096) keys. Then a class-B (8192) key
+  // with the pool empty must STEAL a fully-unpinned A extent and rebind it.
+  SlabAllocator a(Opts(4 * 4096, 2));  // each extent: 4 A-slots or 2 B-slots
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 8; ++i)  // 8 A-slots = both extents bound to class A
+    ASSERT_TRUE(a.Put("a" + std::to_string(i), 4096, &r, &ev));
+  EXPECT_EQ(a.BoundExtents(), 2u);
+  ev.clear();
+  ASSERT_TRUE(a.Put("b0", 8192, &r, &ev));  // needs class B -> steal an A extent
+  EXPECT_EQ(r.slot_size, 8192u);
+  EXPECT_FALSE(ev.empty()) << "steal evicts the stolen extent's residents";
+  EXPECT_TRUE(a.Contains("b0"));
+  EXPECT_GE(a.ClassCount(), 2u);
+}
+
+TEST(SlabAllocator, OversizeValueRejected) {
+  SlabAllocator a(Opts(4096, 2));  // extent holds one 4096 slot
+  std::vector<std::string> ev;
+  SlotRef r;
+  EXPECT_FALSE(a.Put("big", 4097, &r, &ev)) << "value larger than an extent";
+  EXPECT_TRUE(a.Put("ok", 4096, &r, &ev));
+}
+
+TEST(SlabAllocator, ZeroLenGetsAMinimalSlot) {
+  SlabAllocator a(Opts(64 * 1024, 2));
+  std::vector<std::string> ev;
+  SlotRef r;
+  ASSERT_TRUE(a.Put("z", 0, &r, &ev));  // 0-byte anchor -> one aligned slot
+  EXPECT_EQ(r.slot_size, 4096u);
+  EXPECT_TRUE(a.Contains("z"));
+}
+
+TEST(SlabAllocator, ConcurrentPutGetRemoveIsRaceFree) {
+  // TSan target: many threads hammer distinct + shared keys. Correctness beyond
+  // "no crash / no race" is loose here; the single mutex must serialize cleanly.
+  SlabAllocator a(Opts(256 * 4096, 8));
+  constexpr int T = 8, N = 2000;
+  std::atomic<int> ok_puts{0};
+  std::vector<std::thread> ts;
+  for (int t = 0; t < T; ++t) {
+    ts.emplace_back([&, t] {
+      std::vector<std::string> ev;
+      SlotRef r;
+      for (int i = 0; i < N; ++i) {
+        std::string k = "k" + std::to_string((t * N + i) % 5000);
+        if (a.Put(k, 4096, &r, &ev)) ok_puts.fetch_add(1);
+        a.Get(k, &r);
+        if ((i & 3) == 0) a.Pin(k);
+        if ((i & 3) == 0) a.Unpin(k);
+        if ((i & 7) == 0) a.Remove(k);
+        ev.clear();
+      }
+    });
+  }
+  for (auto& th : ts) th.join();
+  EXPECT_GT(ok_puts.load(), 0);
+  EXPECT_LE(a.UsedBytes(), a.Capacity());  // never over-commit the pool
+}


### PR DESCRIPTION
## What

The first piece of the slab-store rework: a **pure-logic** allocator that owns the **layout** (which extent, which offset) of fixed-size slots but not the bytes — so one implementation backs both the disk slab store (next PRs, B4-6/B4-7) and the P3 RAM hot tier (batch 5). dfkv's workload is the ideal slab case: fixed-size KV blocks, pure cache, fully rebuildable.

## Model (memcached-style slab)
A fixed pool of equal-size **extents**; each extent is bound on demand to **one size class** and carved into uniform slots. A value goes into the smallest class whose slot fits within a bounded internal-waste fraction, else a new class is created. Under pressure:
- **per-class CLOCK** second-chance eviction (skips pinned slots);
- when a needy class has no slot and the pool is empty, an **entirely-unpinned extent is stolen** from another class and re-bound;
- a **pinned** slot (in-flight RDMA send — the P3 send-in-flight gap) is never evicted.

Classes are boxed in `unique_ptr` so a `Class` (holding a `std::list` ring + persistent CLOCK hand, with per-key ring iterators in the index) never moves when the vector grows — a moved `std::list` would dangle those iterators (same reason `KVStore` boxes its `Shard`s; this was caught by a segfault before the fix).

Concurrency: one mutex; ops are O(1) in-memory, the slow medium I/O runs outside this class. Per-shard striping is a later perf option.

## Tests
`slab_allocator_test` (hermetic): put/get/remove round-trip, idempotent put, size-class reuse vs new, per-class CLOCK eviction with `Get` second-chance, pin-blocks-eviction (+ all-pinned → `Put` fails), cross-class extent steal when the pool is empty, oversize rejection, 0-len minimal slot, and a concurrent put/get/remove/pin stress — **clean under ThreadSanitizer**. Local: default **239/239**, RDMA+URING **262/262**.
