### PR TITLE
feat(cache): DiskSlabStore -- extent-file slab store with crash-safe rebuild

### DIFF
--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -1,0 +1,291 @@
+#include "cache/disk_slab_store.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <vector>
+
+#include "utils/net_util.h"  // PutU32/PutU64/GetU32/GetU64 (host-endian codec)
+
+namespace fs = std::filesystem;
+
+namespace dfkv {
+
+namespace {
+// Table-record + meta magics.
+constexpr uint32_t kRecMagic = 0x424C5453u;   // "SLTB"
+constexpr uint32_t kMetaMagic = 0x424C534Du;  // "SLBM"
+constexpr uint32_t kFormatVersion = 1;
+
+// Small CRC32 (IEEE, reflected) over a byte range; enough to catch a torn record.
+uint32_t Crc32(const uint8_t* p, size_t n) {
+  uint32_t crc = 0xFFFFFFFFu;
+  for (size_t i = 0; i < n; ++i) {
+    crc ^= p[i];
+    for (int k = 0; k < 8; ++k) crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+  }
+  return crc ^ 0xFFFFFFFFu;
+}
+
+bool PwriteAll(int fd, const void* buf, size_t n, uint64_t off) {
+  const char* p = static_cast<const char*>(buf);
+  size_t done = 0;
+  while (done < n) {
+    ssize_t w = ::pwrite(fd, p + done, n - done, static_cast<off_t>(off + done));
+    if (w < 0) { if (errno == EINTR) continue; return false; }
+    if (w == 0) return false;
+    done += static_cast<size_t>(w);
+  }
+  return true;
+}
+
+bool PreadAll(int fd, void* buf, size_t n, uint64_t off) {
+  char* p = static_cast<char*>(buf);
+  size_t done = 0;
+  while (done < n) {
+    ssize_t r = ::pread(fd, p + done, n - done, static_cast<off_t>(off + done));
+    if (r < 0) { if (errno == EINTR) continue; return false; }
+    if (r == 0) return false;  // short/EOF
+    done += static_cast<size_t>(r);
+  }
+  return true;
+}
+}  // namespace
+
+DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
+  if (opt_.extent_bytes == 0) opt_.extent_bytes = (1ull << 30);
+  if (opt_.slot_granularity == 0) opt_.slot_granularity = (1ull << 20);
+  if (opt_.capacity_bytes < opt_.extent_bytes) opt_.capacity_bytes = opt_.extent_bytes;
+  num_extents_ = static_cast<uint32_t>(opt_.capacity_bytes / opt_.extent_bytes);
+  if (num_extents_ == 0) num_extents_ = 1;
+  max_slots_per_extent_ =
+      static_cast<uint32_t>(opt_.extent_bytes / opt_.slot_granularity);
+  if (max_slots_per_extent_ == 0) max_slots_per_extent_ = 1;
+
+  SlabAllocator::Options ao;
+  ao.extent_bytes = opt_.extent_bytes;
+  ao.num_extents = num_extents_;
+  ao.align = static_cast<uint32_t>(opt_.slot_granularity);  // slot_size is a granularity multiple
+  ao.max_waste = 0.25;
+  alloc_ = std::make_unique<SlabAllocator>(ao);
+
+  ok_ = OpenOrInit();
+  if (ok_) Rebuild();
+  if (ok) *ok = ok_;
+}
+
+DiskSlabStore::~DiskSlabStore() {
+  for (int fd : extent_fds_) if (fd >= 0) ::close(fd);
+  if (table_fd_ >= 0) ::close(table_fd_);
+}
+
+bool DiskSlabStore::OpenOrInit() {
+  std::error_code ec;
+  fs::create_directories(opt_.dir, ec);
+  fs::create_directories(fs::path(opt_.dir) / "extents", ec);
+  const std::string meta_path = (fs::path(opt_.dir) / "slab_meta").string();
+
+  // Meta = magic, version, extent_bytes, slot_granularity, num_extents. A magic
+  // mismatch = corruption (refuse); a config mismatch = re-init fresh (the old
+  // layout can't be reused). Cache semantics make a fresh start safe.
+  uint8_t meta[64];
+  bool fresh = true;
+  int mfd = ::open(meta_path.c_str(), O_RDONLY);
+  if (mfd >= 0) {
+    if (PreadAll(mfd, meta, sizeof(meta), 0) && net::GetU32(reinterpret_cast<char*>(meta)) == kMetaMagic) {
+      const uint32_t ver = net::GetU32(reinterpret_cast<char*>(meta) + 4);
+      const uint64_t eb = net::GetU64(reinterpret_cast<char*>(meta) + 8);
+      const uint64_t sg = net::GetU64(reinterpret_cast<char*>(meta) + 16);
+      const uint32_t ne = net::GetU32(reinterpret_cast<char*>(meta) + 24);
+      fresh = !(ver == kFormatVersion && eb == opt_.extent_bytes &&
+                sg == opt_.slot_granularity && ne == num_extents_);
+    }
+    ::close(mfd);
+  }
+
+  const std::string tbl_path = (fs::path(opt_.dir) / "slots.tbl").string();
+  const uint64_t tbl_bytes =
+      static_cast<uint64_t>(num_extents_) * max_slots_per_extent_ * kRecBytes;
+
+  if (fresh) {
+    // (Re)write meta, zero the table, and (re)create extent files at full size.
+    std::memset(meta, 0, sizeof(meta));
+    net::PutU32(reinterpret_cast<char*>(meta), kMetaMagic);
+    net::PutU32(reinterpret_cast<char*>(meta) + 4, kFormatVersion);
+    net::PutU64(reinterpret_cast<char*>(meta) + 8, opt_.extent_bytes);
+    net::PutU64(reinterpret_cast<char*>(meta) + 16, opt_.slot_granularity);
+    net::PutU32(reinterpret_cast<char*>(meta) + 24, num_extents_);
+    int wfd = ::open(meta_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (wfd < 0 || !PwriteAll(wfd, meta, sizeof(meta), 0)) { if (wfd >= 0) ::close(wfd); return false; }
+    ::close(wfd);
+    // Truncate the table to size (sparse zeros == all-free records).
+    int tfd = ::open(tbl_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
+    if (tfd < 0 || ::ftruncate(tfd, static_cast<off_t>(tbl_bytes)) != 0) {
+      if (tfd >= 0) ::close(tfd);
+      return false;
+    }
+    table_fd_ = tfd;
+  } else {
+    int tfd = ::open(tbl_path.c_str(), O_RDWR);
+    if (tfd < 0) return false;
+    ::ftruncate(tfd, static_cast<off_t>(tbl_bytes));  // ensure full size (idempotent)
+    table_fd_ = tfd;
+  }
+
+  // Open (create + size) every extent file, keep the fd resident.
+  extent_fds_.assign(num_extents_, -1);
+  for (uint32_t e = 0; e < num_extents_; ++e) {
+    char name[32];
+    std::snprintf(name, sizeof(name), "E%05u", e);
+    const std::string ep = (fs::path(opt_.dir) / "extents" / name).string();
+    int fd = ::open(ep.c_str(), O_RDWR | O_CREAT, 0644);
+    if (fd < 0) return false;
+    off_t sz = ::lseek(fd, 0, SEEK_END);
+    if (sz < static_cast<off_t>(opt_.extent_bytes))
+      ::ftruncate(fd, static_cast<off_t>(opt_.extent_bytes));
+    extent_fds_[e] = fd;
+  }
+  return true;
+}
+
+void DiskSlabStore::Rebuild() {
+  // Scan slots.tbl; each CRC-valid, state==1 record reinstalls its key into the
+  // allocator (Restore) at its recorded slot. A torn/free record is skipped.
+  uint8_t rec[kRecBytes];
+  for (uint32_t e = 0; e < num_extents_; ++e) {
+    for (uint32_t s = 0; s < max_slots_per_extent_; ++s) {
+      if (!PreadAll(table_fd_, rec, kRecBytes, TableOffset(e, s))) return;
+      if (net::GetU32(reinterpret_cast<char*>(rec)) != kRecMagic) continue;
+      const uint32_t crc = net::GetU32(reinterpret_cast<char*>(rec) + 4);
+      if (Crc32(rec + 8, kRecBytes - 8) != crc) continue;  // torn
+      if (rec[8] != 1) continue;                            // not valid
+      const uint32_t slot_size = net::GetU32(reinterpret_cast<char*>(rec) + 12);
+      BlockKey key;
+      key.id = net::GetU64(reinterpret_cast<char*>(rec) + 16);
+      key.index = net::GetU32(reinterpret_cast<char*>(rec) + 24);
+      key.size = net::GetU32(reinterpret_cast<char*>(rec) + 28);
+      const uint32_t payload_len = net::GetU32(reinterpret_cast<char*>(rec) + 32);
+      const std::string fn = key.Filename();
+      if (alloc_->Restore(fn, slot_size, e, s)) {
+        payload_len_[fn] = payload_len;
+        ++table_rebuilt_;
+      }
+    }
+  }
+}
+
+bool DiskSlabStore::WriteRecord(const SlabAllocator::SlotRef& r, const BlockKey& key,
+                                uint32_t payload_len, bool valid) {
+  uint8_t rec[kRecBytes];
+  std::memset(rec, 0, sizeof(rec));
+  net::PutU32(reinterpret_cast<char*>(rec), kRecMagic);
+  rec[8] = valid ? 1 : 0;
+  net::PutU32(reinterpret_cast<char*>(rec) + 12, r.slot_size);
+  net::PutU64(reinterpret_cast<char*>(rec) + 16, key.id);
+  net::PutU32(reinterpret_cast<char*>(rec) + 24, key.index);
+  net::PutU32(reinterpret_cast<char*>(rec) + 28, key.size);
+  net::PutU32(reinterpret_cast<char*>(rec) + 32, payload_len);
+  const uint32_t crc = Crc32(rec + 8, kRecBytes - 8);
+  net::PutU32(reinterpret_cast<char*>(rec) + 4, crc);
+  return PwriteAll(table_fd_, rec, kRecBytes, TableOffset(r.extent, r.slot));
+}
+
+bool DiskSlabStore::WritePayload(const SlabAllocator::SlotRef& r, const void* data,
+                                 size_t len) {
+  if (len == 0) return true;
+  return PwriteAll(extent_fds_[r.extent], data, len, r.offset);
+}
+
+Status DiskSlabStore::Cache(const BlockKey& key, const void* data, size_t len) {
+  if (data == nullptr && len != 0) return Status::kInvalid;
+  if (!ok_) return Status::kIOError;
+  const std::string fn = key.Filename();
+  std::lock_guard<std::mutex> lk(mu_);
+  if (alloc_->Contains(fn)) return Status::kOk;  // idempotent
+
+  SlabAllocator::SlotRef ref;
+  std::vector<std::string> evicted;
+  if (!alloc_->Put(fn, len, &ref, &evicted)) return Status::kIOError;  // too big / all pinned
+  // Drop evicted keys from the runtime payload map. Their table records are left
+  // as-is: a slot's record always reflects its LAST occupant, so this Put's
+  // WriteRecord overwrites the reused slot's record, and any other evicted slot
+  // that isn't reused before a crash simply "resurrects" its (still-valid,
+  // content-addressed) key on restart -- correct cache data, never corruption
+  // (design's resurrectable-remove semantics).
+  for (const auto& ev : evicted) payload_len_.erase(ev);
+  if (!WritePayload(ref, data, len) ||
+      !WriteRecord(ref, key, static_cast<uint32_t>(len), /*valid=*/true)) {
+    alloc_->Remove(fn);  // roll back the reservation on I/O failure
+    return Status::kIOError;
+  }
+  payload_len_[fn] = static_cast<uint32_t>(len);
+  return Status::kOk;
+}
+
+Status DiskSlabStore::Range(const BlockKey& key, uint64_t offset, uint64_t length,
+                            std::string* out) {
+  if (!ok_) return Status::kIOError;
+  const std::string fn = key.Filename();
+  std::lock_guard<std::mutex> lk(mu_);
+  SlabAllocator::SlotRef ref;
+  if (!alloc_->Get(fn, &ref)) return Status::kNotFound;
+  auto it = payload_len_.find(fn);
+  if (it == payload_len_.end()) return Status::kNotFound;
+  const uint32_t plen = it->second;
+  if (offset >= plen) { out->clear(); return Status::kOk; }
+  const uint64_t avail = plen - offset;
+  const uint64_t n = std::min(length ? length : avail, avail);
+  out->resize(static_cast<size_t>(n));
+  if (n && !PreadAll(extent_fds_[ref.extent], &(*out)[0], static_cast<size_t>(n),
+                     ref.offset + offset))
+    return Status::kIOError;
+  return Status::kOk;
+}
+
+Status DiskSlabStore::RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,
+                                char* dst, size_t dst_cap, size_t* out_len) {
+  if (!ok_) return Status::kIOError;
+  const std::string fn = key.Filename();
+  std::lock_guard<std::mutex> lk(mu_);
+  SlabAllocator::SlotRef ref;
+  if (!alloc_->Get(fn, &ref)) return Status::kNotFound;
+  auto it = payload_len_.find(fn);
+  if (it == payload_len_.end()) return Status::kNotFound;
+  const uint32_t plen = it->second;
+  if (offset >= plen) { if (out_len) *out_len = 0; return Status::kOk; }
+  uint64_t n = std::min(length ? length : (plen - offset), static_cast<uint64_t>(plen - offset));
+  if (n > dst_cap) n = dst_cap;
+  if (n && !PreadAll(extent_fds_[ref.extent], dst, static_cast<size_t>(n), ref.offset + offset))
+    return Status::kIOError;
+  if (out_len) *out_len = static_cast<size_t>(n);
+  return Status::kOk;
+}
+
+bool DiskSlabStore::IsCached(const BlockKey& key) const {
+  if (!ok_) return false;
+  std::lock_guard<std::mutex> lk(mu_);
+  return alloc_->Contains(key.Filename());
+}
+
+Status DiskSlabStore::Remove(const BlockKey& key) {
+  if (!ok_) return Status::kIOError;
+  const std::string fn = key.Filename();
+  std::lock_guard<std::mutex> lk(mu_);
+  SlabAllocator::SlotRef ref;
+  if (!alloc_->Get(fn, &ref)) return Status::kNotFound;
+  WriteRecord(ref, key, 0, /*valid=*/false);  // free the durable record first
+  alloc_->Remove(fn);
+  payload_len_.erase(fn);
+  return Status::kOk;
+}
+
+size_t DiskSlabStore::Count() const { return alloc_->Count(); }
+uint64_t DiskSlabStore::UsedBytes() const { return alloc_->UsedBytes(); }
+uint64_t DiskSlabStore::Capacity() const { return alloc_->Capacity(); }
+uint64_t DiskSlabStore::Evictions() const { return alloc_->Evictions(); }
+
+}  // namespace dfkv

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -1,0 +1,95 @@
+/* DiskSlabStore — a disk-backed KV cache node built on SlabAllocator.
+ *
+ * Replaces the "one file per block" KVStore geometry (whose tmp-leak / ENOSPC-
+ * dead-end / unbounded-inode / lock-held-unlink pathologies all stem from that
+ * base) with a fixed pool of pre-allocated EXTENT files carved into slots by the
+ * media-agnostic SlabAllocator. A compact slots.tbl records which key occupies
+ * each slot so the index rebuilds on restart -- keeping cache warmth across a
+ * rolling upgrade without the per-block file churn.
+ *
+ * I/O is buffered (page cache) for simplicity and correctness; extent fds are
+ * kept resident (no open()-per-GET). O_DIRECT is a future flag. Cache semantics:
+ * a miss is a clean NotFound (upper layer recomputes), so a crash that loses the
+ * last few unsynced table records only costs those keys a recompute -- never
+ * corruption (each record is CRC-checked; a torn record reads as free). */
+#ifndef DFKV_DISK_SLAB_STORE_H_
+#define DFKV_DISK_SLAB_STORE_H_
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cache/slab_allocator.h"
+#include "common/kv_types.h"
+#include "common/status.h"
+
+namespace dfkv {
+
+class DiskSlabStore {
+ public:
+  struct Options {
+    std::string dir;
+    uint64_t capacity_bytes = (1ull << 30);
+    uint64_t extent_bytes = (1ull << 30);    // 1 GiB per extent file
+    // Slot-size quantum: every class slot_size is a multiple of this, so the
+    // per-extent slot count (and thus slots.tbl size) is bounded. Real KV blocks
+    // are MiB-scale, so 1 MiB is a fine default; tests use small values.
+    uint64_t slot_granularity = (1ull << 20);
+  };
+
+  // Opens (or creates) the store under Options::dir, pre-allocating extents and
+  // rebuilding the index from slots.tbl. `*ok` (nullable) reports success; on a
+  // fatal open error the store is left empty and every op returns kIOError.
+  explicit DiskSlabStore(Options opt, bool* ok = nullptr);
+  ~DiskSlabStore();
+
+  DiskSlabStore(const DiskSlabStore&) = delete;
+  DiskSlabStore& operator=(const DiskSlabStore&) = delete;
+
+  Status Cache(const BlockKey& key, const void* data, size_t len);
+  Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
+               std::string* out);
+  Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,
+                   char* dst, size_t dst_cap, size_t* out_len);
+  bool IsCached(const BlockKey& key) const;
+  Status Remove(const BlockKey& key);
+
+  size_t Count() const;
+  uint64_t UsedBytes() const;
+  uint64_t Capacity() const;
+  uint64_t Evictions() const;
+  uint64_t TableRebuilt() const { return table_rebuilt_; }  // records restored at open
+
+ private:
+  static constexpr size_t kRecBytes = 64;
+
+  bool OpenOrInit();                 // create/verify meta, extents, table
+  void Rebuild();                    // scan slots.tbl -> allocator + payload map
+  bool WriteRecord(const SlabAllocator::SlotRef& r, const BlockKey& key,
+                   uint32_t payload_len, bool valid);
+  bool WritePayload(const SlabAllocator::SlotRef& r, const void* data, size_t len);
+  uint64_t TableOffset(uint32_t extent, uint32_t slot) const {
+    return static_cast<uint64_t>(extent) * max_slots_per_extent_ * kRecBytes +
+           static_cast<uint64_t>(slot) * kRecBytes;
+  }
+
+  Options opt_;
+  uint32_t num_extents_ = 0;
+  uint32_t max_slots_per_extent_ = 0;
+  std::unique_ptr<SlabAllocator> alloc_;
+  std::vector<int> extent_fds_;      // resident, one per extent
+  int table_fd_ = -1;                // slots.tbl
+  // key.Filename() -> its true payload length (slot_size >= this). Rebuilt on
+  // open from the table; the allocator only tracks slot size.
+  std::unordered_map<std::string, uint32_t> payload_len_;
+  mutable std::mutex mu_;
+  bool ok_ = false;
+  uint64_t table_rebuilt_ = 0;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_DISK_SLAB_STORE_H_

--- a/src/cache/slab_allocator.cc
+++ b/src/cache/slab_allocator.cc
@@ -34,6 +34,55 @@ size_t SlabAllocator::ClassForLen(size_t aligned_len) {
   return classes_.size() - 1;
 }
 
+size_t SlabAllocator::ClassForExactSize(uint32_t slot_size) {
+  for (size_t i = 0; i < classes_.size(); ++i)
+    if (classes_[i]->slot_size == slot_size) return i;
+  auto c = std::make_unique<Class>();
+  c->slot_size = slot_size;
+  c->slots_per_extent = slot_size ? static_cast<uint32_t>(opt_.extent_bytes / slot_size) : 0;
+  classes_.push_back(std::move(c));
+  return classes_.size() - 1;
+}
+
+bool SlabAllocator::Restore(const std::string& key, uint32_t slot_size,
+                            uint32_t extent, uint32_t slot) {
+  std::lock_guard<std::mutex> lk(mu_);
+  if (slot_size == 0 || extent >= extents_.size() || index_.count(key)) return false;
+  const size_t cls = ClassForExactSize(slot_size);
+  Class& C = *classes_[cls];
+  if (C.slots_per_extent == 0 || slot >= C.slots_per_extent) return false;
+  ExtentMeta& m = extents_[extent];
+  if (m.cls == kUnbound) {  // first restored slot on this extent: bind + cut slots
+    m.cls = static_cast<int>(cls);
+    m.total_slots = C.slots_per_extent;
+    m.free_slots = C.slots_per_extent;
+    m.pinned = 0;
+    C.free_slots.reserve(C.free_slots.size() + m.total_slots);
+    for (uint32_t s = 0; s < m.total_slots; ++s) C.free_slots.push_back(Slot{extent, s});
+  } else if (m.cls != static_cast<int>(cls)) {
+    return false;  // persistence inconsistency: two classes on one extent
+  }
+  // Reserve the exact slot: pull it out of the class free stack.
+  auto& fs = C.free_slots;
+  auto it = std::find_if(fs.begin(), fs.end(), [extent, slot](const Slot& s) {
+    return s.extent == extent && s.slot == slot;
+  });
+  if (it == fs.end()) return false;  // already taken (duplicate record)
+  fs.erase(it);
+  Entry e;
+  e.ref.cls = static_cast<uint32_t>(cls);
+  e.ref.extent = extent;
+  e.ref.slot = slot;
+  e.ref.slot_size = slot_size;
+  e.ref.offset = static_cast<uint64_t>(slot) * slot_size;
+  C.ring.push_front(key);
+  e.ring_it = C.ring.begin();
+  m.free_slots--;
+  used_bytes_ += slot_size;
+  index_.emplace(key, std::move(e));
+  return true;
+}
+
 bool SlabAllocator::BindFreeExtent(size_t cls) {
   for (uint32_t e = 0; e < extents_.size(); ++e) {
     if (extents_[e].cls != kUnbound) continue;

--- a/src/cache/slab_allocator.h
+++ b/src/cache/slab_allocator.h
@@ -69,6 +69,15 @@ class SlabAllocator {
   bool Get(const std::string& key, SlotRef* out);
   bool Contains(const std::string& key) const;
 
+  // Crash-recovery only: install a key KNOWN (from persistence) to occupy
+  // (extent, slot) in a class of `slot_size`. Binds the extent to that class if
+  // needed and reserves the exact slot. Must be called before any Put, and the
+  // (extent, slot) triples restored must be internally consistent (one class per
+  // extent). Returns false on an inconsistency (mixed class on an extent, or a
+  // slot out of range) -- the caller then discards that record.
+  bool Restore(const std::string& key, uint32_t slot_size, uint32_t extent,
+               uint32_t slot);
+
   // Drop `key` (frees its slot). true if present. A pinned key is still removed
   // from the index but its slot is not reused until Unpin brings refs to 0.
   bool Remove(const std::string& key);
@@ -113,6 +122,7 @@ class SlabAllocator {
   };
 
   size_t ClassForLen(size_t aligned_len);  // returns class index (creates if needed)
+  size_t ClassForExactSize(uint32_t slot_size);  // find/create a class of exactly slot_size
   bool BindFreeExtent(size_t cls);         // bind a pool extent to cls; false if none
   bool EvictOneFrom(size_t cls, std::vector<std::string>* evicted);  // CLOCK evict 1
   bool StealExtentFor(size_t cls, std::vector<std::string>* evicted); // rebind a full extent

--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -1,0 +1,180 @@
+// DiskSlabStore: extent-file slab store on SlabAllocator + slots.tbl rebuild.
+// Covers: put/get/remove, idempotency, eviction, restart WARMTH (rebuild from
+// slots.tbl), crash safety (a torn table record reads as free / not resurrected),
+// meta mismatch -> clean re-init, oversize rejection.
+#include "cache/disk_slab_store.h"
+
+#include <gtest/gtest.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+using dfkv::BlockKey;
+using dfkv::DiskSlabStore;
+using dfkv::Status;
+namespace fs = std::filesystem;
+
+namespace {
+class DiskSlabTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    dir_ = fs::temp_directory_path() /
+           ("dfkv_slab_" + std::to_string(::testing::UnitTest::GetInstance()
+                                              ->current_test_info()->line()));
+    fs::remove_all(dir_);
+  }
+  void TearDown() override { fs::remove_all(dir_); }
+
+  DiskSlabStore::Options Opts(uint64_t cap, uint64_t extent, uint64_t gran) {
+    DiskSlabStore::Options o;
+    o.dir = dir_.string();
+    o.capacity_bytes = cap;
+    o.extent_bytes = extent;
+    o.slot_granularity = gran;
+    return o;
+  }
+  fs::path dir_;
+};
+BlockKey K(uint64_t id) { return BlockKey{id, 0, 1}; }
+}  // namespace
+
+TEST_F(DiskSlabTest, PutGetRemoveRoundTrip) {
+  bool ok = false;
+  DiskSlabStore s(Opts(1 << 20, 1 << 20, 4096), &ok);
+  ASSERT_TRUE(ok);
+  std::string v = "the-kv-payload-0123456789";
+  ASSERT_EQ(s.Cache(K(1), v.data(), v.size()), Status::kOk);
+  EXPECT_TRUE(s.IsCached(K(1)));
+  EXPECT_EQ(s.Count(), 1u);
+
+  std::string out;
+  ASSERT_EQ(s.Range(K(1), 0, v.size(), &out), Status::kOk);
+  EXPECT_EQ(out, v);
+  // partial range
+  ASSERT_EQ(s.Range(K(1), 4, 5, &out), Status::kOk);
+  EXPECT_EQ(out, v.substr(4, 5));
+  // RangeInto
+  char buf[64];
+  size_t got = 0;
+  ASSERT_EQ(s.RangeInto(K(1), 0, sizeof(buf), buf, sizeof(buf), &got), Status::kOk);
+  EXPECT_EQ(std::string(buf, got), v);
+
+  EXPECT_EQ(s.Range(K(999), 0, 10, &out), Status::kNotFound);
+  EXPECT_EQ(s.Cache(K(1), v.data(), v.size()), Status::kOk);  // idempotent
+  EXPECT_EQ(s.Count(), 1u);
+
+  ASSERT_EQ(s.Remove(K(1)), Status::kOk);
+  EXPECT_FALSE(s.IsCached(K(1)));
+  EXPECT_EQ(s.Remove(K(1)), Status::kNotFound);
+}
+
+TEST_F(DiskSlabTest, EvictsUnderCapacity) {
+  // 1 extent of 4 * 4096 slots. 5 keys -> one eviction.
+  bool ok = false;
+  DiskSlabStore s(Opts(4 * 4096, 4 * 4096, 4096), &ok);
+  ASSERT_TRUE(ok);
+  std::string v(4096, 'e');
+  for (int i = 0; i < 4; ++i) ASSERT_EQ(s.Cache(K(i), v.data(), v.size()), Status::kOk);
+  EXPECT_EQ(s.Count(), 4u);
+  ASSERT_EQ(s.Cache(K(4), v.data(), v.size()), Status::kOk);
+  EXPECT_EQ(s.Count(), 4u);
+  EXPECT_EQ(s.Evictions(), 1u);
+  EXPECT_TRUE(s.IsCached(K(4)));
+}
+
+TEST_F(DiskSlabTest, RestartRebuildsIndexKeepingWarmth) {
+  std::vector<std::string> vals;
+  {
+    bool ok = false;
+    DiskSlabStore s(Opts(1 << 20, 1 << 20, 4096), &ok);
+    ASSERT_TRUE(ok);
+    for (int i = 0; i < 10; ++i) {
+      std::string v = "val-" + std::to_string(i) + std::string(100, 'x');
+      vals.push_back(v);
+      ASSERT_EQ(s.Cache(K(1000 + i), v.data(), v.size()), Status::kOk);
+    }
+    ASSERT_EQ(s.Count(), 10u);
+  }
+  // Reopen the same dir: the index must rebuild from slots.tbl and all values
+  // read back byte-for-byte (warmth preserved across restart).
+  bool ok = false;
+  DiskSlabStore s2(Opts(1 << 20, 1 << 20, 4096), &ok);
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(s2.TableRebuilt(), 10u);
+  EXPECT_EQ(s2.Count(), 10u);
+  for (int i = 0; i < 10; ++i) {
+    std::string out;
+    ASSERT_EQ(s2.Range(K(1000 + i), 0, vals[i].size(), &out), Status::kOk) << i;
+    EXPECT_EQ(out, vals[i]) << i;
+  }
+}
+
+TEST_F(DiskSlabTest, TornTableRecordReadsAsFreeNotResurrected) {
+  {
+    bool ok = false;
+    DiskSlabStore s(Opts(1 << 20, 1 << 20, 4096), &ok);
+    ASSERT_TRUE(ok);
+    std::string v(200, 'z');
+    ASSERT_EQ(s.Cache(K(7), v.data(), v.size()), Status::kOk);
+    ASSERT_EQ(s.Cache(K(8), v.data(), v.size()), Status::kOk);
+  }
+  // Corrupt the BODY of a real (valid) record so its CRC no longer matches -- a
+  // torn write. Records land in high slots (LIFO alloc), so scan for the first
+  // "SLTB" magic, then flip a body byte (offset +12, inside the CRC'd region).
+  const std::string tbl = (dir_ / "slots.tbl").string();
+  int fd = ::open(tbl.c_str(), O_RDWR);
+  ASSERT_GE(fd, 0);
+  off_t fsz = ::lseek(fd, 0, SEEK_END);
+  bool corrupted = false;
+  for (off_t o = 0; o + 64 <= fsz; o += 64) {
+    uint8_t m[4];
+    if (::pread(fd, m, 4, o) != 4) break;
+    // "SLTB" little-endian = 53 54 4C 42
+    if (m[0] == 0x53 && m[1] == 0x54 && m[2] == 0x4C && m[3] == 0x42) {
+      uint8_t byte = 0;
+      ::pread(fd, &byte, 1, o + 12);
+      byte ^= 0xFF;
+      ::pwrite(fd, &byte, 1, o + 12);
+      corrupted = true;
+      break;
+    }
+  }
+  ::close(fd);
+  ASSERT_TRUE(corrupted) << "expected a valid record to corrupt";
+
+  bool ok = false;
+  DiskSlabStore s2(Opts(1 << 20, 1 << 20, 4096), &ok);
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(s2.TableRebuilt(), 1u) << "the torn record must be skipped";
+  EXPECT_EQ(s2.Count(), 1u);
+}
+
+TEST_F(DiskSlabTest, MetaMismatchReinitsFresh) {
+  {
+    bool ok = false;
+    DiskSlabStore s(Opts(1 << 20, 1 << 20, 4096), &ok);
+    ASSERT_TRUE(ok);
+    std::string v(50, 'q');
+    ASSERT_EQ(s.Cache(K(5), v.data(), v.size()), Status::kOk);
+  }
+  // Reopen with a DIFFERENT slot_granularity: the layout can't be reused, so the
+  // store must re-init fresh (empty) rather than mis-read the old table.
+  bool ok = false;
+  DiskSlabStore s2(Opts(1 << 20, 1 << 20, 8192), &ok);
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(s2.Count(), 0u);
+  EXPECT_FALSE(s2.IsCached(K(5)));
+}
+
+TEST_F(DiskSlabTest, OversizeValueRejected) {
+  bool ok = false;
+  DiskSlabStore s(Opts(4096, 4096, 4096), &ok);  // one 4096 slot per extent
+  ASSERT_TRUE(ok);
+  std::string big(4097, 'b');
+  EXPECT_EQ(s.Cache(K(1), big.data(), big.size()), Status::kIOError);
+  std::string okv(4096, 'o');
+  EXPECT_EQ(s.Cache(K(2), okv.data(), okv.size()), Status::kOk);
+}

--- a/test/cache/slab_allocator_test.cc
+++ b/test/cache/slab_allocator_test.cc
@@ -190,3 +190,35 @@ TEST(SlabAllocator, ConcurrentPutGetRemoveIsRaceFree) {
   EXPECT_GT(ok_puts.load(), 0);
   EXPECT_LE(a.UsedBytes(), a.Capacity());  // never over-commit the pool
 }
+
+TEST(SlabAllocator, RestoreInstallsKeyAtKnownSlot) {
+  SlabAllocator a(Opts(4 * 4096, 2));
+  // Restore two keys at known slots (as a rebuild would from persistence).
+  EXPECT_TRUE(a.Restore("ka", 4096, /*extent=*/0, /*slot=*/1));
+  EXPECT_TRUE(a.Restore("kb", 4096, /*extent=*/0, /*slot=*/2));
+  EXPECT_EQ(a.Count(), 2u);
+  EXPECT_EQ(a.UsedBytes(), 2u * 4096u);
+  SlotRef r;
+  ASSERT_TRUE(a.Get("ka", &r));
+  EXPECT_EQ(r.extent, 0u);
+  EXPECT_EQ(r.slot, 1u);
+  EXPECT_EQ(r.offset, 1u * 4096u);
+  // A subsequent Put on the same extent must use a still-free slot, not clobber
+  // the restored ones.
+  std::vector<std::string> ev;
+  ASSERT_TRUE(a.Put("kc", 4096, &r, &ev));
+  EXPECT_TRUE(ev.empty());
+  EXPECT_NE(r.slot, 1u);
+  EXPECT_NE(r.slot, 2u);
+}
+
+TEST(SlabAllocator, RestoreRejectsInconsistentInput) {
+  SlabAllocator a(Opts(4 * 4096, 1));
+  EXPECT_FALSE(a.Restore("bad_extent", 4096, /*extent=*/9, 0));   // extent out of range
+  EXPECT_FALSE(a.Restore("bad_slot", 4096, 0, /*slot=*/99));      // slot out of range
+  EXPECT_TRUE(a.Restore("k", 4096, 0, 0));
+  EXPECT_FALSE(a.Restore("k", 4096, 0, 1));                       // duplicate key
+  EXPECT_FALSE(a.Restore("k2", 4096, 0, 0));                      // slot already taken
+  // A second class on the same extent is a persistence inconsistency.
+  EXPECT_FALSE(a.Restore("k3", 8192, 0, 0));
+}


### PR DESCRIPTION
## What

The disk store built on `SlabAllocator` (B4-5), replacing the **"one file per block"** `KVStore` geometry whose pathologies — tmp leak, ENOSPC dead-end, unbounded inode growth, lock-held unlink, imprecise capacity — all stem from that base. A fixed pool of pre-allocated **extent files** is carved into slots by the allocator; a compact **64-byte-per-slot `slots.tbl`** records which key holds each slot so the index **rebuilds on restart** — keeping cache warmth across a rolling upgrade without per-block file churn.

## Design
- **`slot_granularity`** bounds `slots.tbl` (every class `slot_size` is a multiple of it → slots-per-extent, and the table, are bounded; 1 MiB default → ~320 MB table at 5 TiB, matching the design doc).
- **Buffered I/O** (page cache) for correctness/simplicity; extent fds stay resident (no `open()`-per-GET). O_DIRECT is a future flag.
- **Crash safety** via CRC32 per record: a torn record reads as **free** (its key is a clean miss = recompute, never corruption). Meta magic mismatch is refused; a config (extent/granularity) mismatch re-inits fresh — both safe under cache semantics.
- **Eviction** leaves evicted slots' records as-is: a slot's record always reflects its **last** occupant, so an unreused evicted slot merely "resurrects" its still-valid content-addressed key on restart (the design's resurrectable-remove semantics); `Remove` writes a free record.
- Adds `SlabAllocator::Restore(key, slot_size, extent, slot)` to reinstall a persisted key at a known slot during rebuild.

## Tests
`disk_slab_store_test`: put/get/remove/idempotency, eviction, **restart rebuild preserving warmth** (10 values read back byte-for-byte), a **torn table record skipped** on rebuild (not resurrected), meta/config mismatch re-init, oversize rejection. `slab_allocator_test` gains direct `Restore` cases (known-slot install; rejects out-of-range / duplicate / mixed-class). Both **TSan-clean**. Local: default **245/245**, RDMA+URING **268/268**.

Slab is not wired in yet — B4-7 adds the `StoreEngine` abstraction with `--store-engine=file|slab` (default **file**), so this lands with zero production impact.
