### PR TITLE
feat(cache): StoreEngine abstraction + selectable slab backend (default file)

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
   dfkv::Args args(argc, argv,
                   {"--dir", "--port", "--cap", "--rdma-port", "--rdma-dev",
                    "--mds", "--group", "--id", "--advertise", "--weight",
-                   "--metrics-port", "--metrics-bind"});
+                   "--metrics-port", "--metrics-bind", "--store-engine"});
   std::string dir = args.Get("--dir", "/tmp/dfkv_node");
   std::string rdma_dev = args.Get("--rdma-dev", "");
   std::string mds = args.Get("--mds", "");
@@ -70,6 +70,11 @@ int main(int argc, char** argv) {
   int rdma_port = args.GetInt("--rdma-port", -1);
   int metrics_port = args.GetInt("--metrics-port", -1);
   unsigned long long cap = args.GetU64("--cap", 1ull << 30);
+  // Storage backend: "file" (default) or "slab". Propagated via env so the
+  // DiskCacheGroup (constructed inside KvNodeServer) picks it up; --store-engine
+  // wins over a pre-set DFKV_STORE_ENGINE.
+  std::string store_engine = args.Get("--store-engine", "");
+  if (!store_engine.empty()) ::setenv("DFKV_STORE_ENGINE", store_engine.c_str(), 1);
   if (!args.ok()) {
     std::fprintf(stderr, "dfkv_server: %s\n(run with --help for usage)\n",
                  args.error().c_str());

--- a/src/cache/disk_cache_group.cc
+++ b/src/cache/disk_cache_group.cc
@@ -1,13 +1,31 @@
 #include "cache/disk_cache_group.h"
 
+#include <cstdlib>
+
+#include "cache/disk_slab_store.h"
+
 namespace dfkv {
 
 DiskCacheGroup::DiskCacheGroup(Options opt) {
   size_t n = opt.cache_dirs.empty() ? 1 : opt.cache_dirs.size();
   uint64_t per_disk = opt.capacity_bytes / n;
   if (per_disk == 0) per_disk = opt.capacity_bytes;  // tiny-cap safety
+  std::string engine = opt.engine;
+  if (engine.empty()) {
+    const char* e = std::getenv("DFKV_STORE_ENGINE");
+    engine = (e && *e) ? e : "file";
+  }
+  const bool use_slab = (engine == "slab");
   for (const auto& dir : opt.cache_dirs) {
-    auto store = std::make_unique<KVStore>(KVStore::Options{dir, per_disk});
+    std::unique_ptr<StoreEngine> store;
+    if (use_slab) {
+      DiskSlabStore::Options so;
+      so.dir = dir;
+      so.capacity_bytes = per_disk;
+      store = std::make_unique<DiskSlabStore>(so);
+    } else {
+      store = std::make_unique<KVStore>(KVStore::Options{dir, per_disk});
+    }
     by_id_[dir] = store.get();
     disks_.push_back(std::move(store));
     ring_.AddNode(dir);  // disk id = its dir path
@@ -15,7 +33,7 @@ DiskCacheGroup::DiskCacheGroup(Options opt) {
   ring_.Build();
 }
 
-KVStore* DiskCacheGroup::Route(const BlockKey& key) const {
+StoreEngine* DiskCacheGroup::Route(const BlockKey& key) const {
   if (disks_.size() == 1) return disks_[0].get();
   std::string id;
   if (!ring_.Lookup(key.Filename(), &id)) return nullptr;
@@ -24,27 +42,27 @@ KVStore* DiskCacheGroup::Route(const BlockKey& key) const {
 }
 
 Status DiskCacheGroup::Cache(const BlockKey& key, const void* data, size_t len) {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   if (d == nullptr) return Status::kInvalid;
   return d->Cache(key, data, len);
 }
 
 Status DiskCacheGroup::Remove(const BlockKey& key) {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   if (d == nullptr) return Status::kInvalid;
   return d->Remove(key);
 }
 
 Status DiskCacheGroup::CacheDirect(const BlockKey& key, char* data, size_t len,
                                    size_t cap) {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   if (d == nullptr) return Status::kInvalid;
   return d->CacheDirect(key, data, len, cap);
 }
 
 Status DiskCacheGroup::Range(const BlockKey& key, uint64_t offset,
                              uint64_t length, std::string* out) {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   if (d == nullptr) return Status::kInvalid;
   return d->Range(key, offset, length, out);
 }
@@ -52,7 +70,7 @@ Status DiskCacheGroup::Range(const BlockKey& key, uint64_t offset,
 Status DiskCacheGroup::RangeInto(const BlockKey& key, uint64_t offset,
                                  uint64_t length, char* dst, size_t dst_cap,
                                  size_t* out_len) {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   if (d == nullptr) return Status::kInvalid;
   return d->RangeInto(key, offset, length, dst, dst_cap, out_len);
 }
@@ -60,7 +78,7 @@ Status DiskCacheGroup::RangeInto(const BlockKey& key, uint64_t offset,
 Status DiskCacheGroup::RangeDirect(const BlockKey& key, uint64_t offset,
                                    uint64_t length, char* io_buf, size_t io_cap,
                                    const char** out_data, size_t* out_len) {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   if (d == nullptr) return Status::kInvalid;
   return d->RangeDirect(key, offset, length, io_buf, io_cap, out_data, out_len);
 }
@@ -68,13 +86,13 @@ Status DiskCacheGroup::RangeDirect(const BlockKey& key, uint64_t offset,
 Status DiskCacheGroup::RangeDirectPrep(const BlockKey& key, uint64_t offset,
                                        uint64_t length, size_t io_cap,
                                        KVStore::RangePrep* out) {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   if (d == nullptr) return Status::kInvalid;
   return d->RangeDirectPrep(key, offset, length, io_cap, out);
 }
 
 bool DiskCacheGroup::IsCached(const BlockKey& key) const {
-  KVStore* d = Route(key);
+  StoreEngine* d = Route(key);
   return d != nullptr && d->IsCached(key);
 }
 

--- a/src/cache/disk_cache_group.h
+++ b/src/cache/disk_cache_group.h
@@ -14,6 +14,7 @@
 
 #include "utils/con_hash.h"
 #include "cache/kv_store.h"
+#include "cache/store_engine.h"
 #include "common/kv_types.h"
 
 namespace dfkv {
@@ -23,6 +24,10 @@ class DiskCacheGroup {
   struct Options {
     std::vector<std::string> cache_dirs;   // one per NVMe SSD
     uint64_t capacity_bytes = (1ull << 30);  // TOTAL, split evenly across disks
+    // Backend: "file" (KVStore, default) or "slab" (DiskSlabStore). Empty =>
+    // read DFKV_STORE_ENGINE (default "file"). Selectable so slab lands off by
+    // default with zero production impact.
+    std::string engine;
   };
 
   explicit DiskCacheGroup(Options opt);
@@ -56,10 +61,10 @@ class DiskCacheGroup {
   size_t DiskObjects(size_t i) const { return disks_[i]->Count(); }
 
  private:
-  KVStore* Route(const BlockKey& key) const;
+  StoreEngine* Route(const BlockKey& key) const;
 
-  std::vector<std::unique_ptr<KVStore>> disks_;
-  std::unordered_map<std::string, KVStore*> by_id_;  // disk id -> store
+  std::vector<std::unique_ptr<StoreEngine>> disks_;
+  std::unordered_map<std::string, StoreEngine*> by_id_;  // disk id -> store
   ConHash ring_;
 };
 

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -216,7 +216,10 @@ Status DiskSlabStore::Cache(const BlockKey& key, const void* data, size_t len) {
   // that isn't reused before a crash simply "resurrects" its (still-valid,
   // content-addressed) key on restart -- correct cache data, never corruption
   // (design's resurrectable-remove semantics).
-  for (const auto& ev : evicted) payload_len_.erase(ev);
+  for (const auto& ev : evicted) {
+    auto pit = payload_len_.find(ev);
+    if (pit != payload_len_.end()) { evicted_bytes_ += pit->second; payload_len_.erase(pit); }
+  }
   if (!WritePayload(ref, data, len) ||
       !WriteRecord(ref, key, static_cast<uint32_t>(len), /*valid=*/true)) {
     alloc_->Remove(fn);  // roll back the reservation on I/O failure
@@ -224,6 +227,27 @@ Status DiskSlabStore::Cache(const BlockKey& key, const void* data, size_t len) {
   }
   payload_len_[fn] = static_cast<uint32_t>(len);
   return Status::kOk;
+}
+
+Status DiskSlabStore::CacheDirect(const BlockKey& key, char* data, size_t len,
+                                  size_t cap) {
+  (void)cap;  // buffered engine: no aligned-buffer requirement, just the bytes
+  return Cache(key, data, len);
+}
+
+Status DiskSlabStore::RangeDirect(const BlockKey& key, uint64_t offset,
+                                  uint64_t length, char* io_buf, size_t io_cap,
+                                  const char** out_data, size_t* out_len) {
+  size_t got = 0;
+  Status st = RangeInto(key, offset, length, io_buf, io_cap, &got);
+  if (st == Status::kOk) { if (out_data) *out_data = io_buf; if (out_len) *out_len = got; }
+  return st;
+}
+
+Status DiskSlabStore::RangeDirectPrep(const BlockKey&, uint64_t, uint64_t, size_t,
+                                      RangePrep* out) {
+  if (out) *out = RangePrep{};  // fd = -1
+  return Status::kInvalid;      // no async prep -> RDMA server uses sync RangeDirect
 }
 
 Status DiskSlabStore::Range(const BlockKey& key, uint64_t offset, uint64_t length,
@@ -287,5 +311,9 @@ size_t DiskSlabStore::Count() const { return alloc_->Count(); }
 uint64_t DiskSlabStore::UsedBytes() const { return alloc_->UsedBytes(); }
 uint64_t DiskSlabStore::Capacity() const { return alloc_->Capacity(); }
 uint64_t DiskSlabStore::Evictions() const { return alloc_->Evictions(); }
+uint64_t DiskSlabStore::EvictedBytes() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return evicted_bytes_;
+}
 
 }  // namespace dfkv

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -23,12 +23,13 @@
 #include <vector>
 
 #include "cache/slab_allocator.h"
+#include "cache/store_engine.h"
 #include "common/kv_types.h"
 #include "common/status.h"
 
 namespace dfkv {
 
-class DiskSlabStore {
+class DiskSlabStore : public StoreEngine {
  public:
   struct Options {
     std::string dir;
@@ -49,18 +50,31 @@ class DiskSlabStore {
   DiskSlabStore(const DiskSlabStore&) = delete;
   DiskSlabStore& operator=(const DiskSlabStore&) = delete;
 
-  Status Cache(const BlockKey& key, const void* data, size_t len);
+  Status Cache(const BlockKey& key, const void* data, size_t len) override;
+  // Buffered engine: the aligned direct-PUT buffer is just written as bytes.
+  Status CacheDirect(const BlockKey& key, char* data, size_t len, size_t cap) override;
   Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
-               std::string* out);
+               std::string* out) override;
   Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,
-                   char* dst, size_t dst_cap, size_t* out_len);
-  bool IsCached(const BlockKey& key) const;
-  Status Remove(const BlockKey& key);
+                   char* dst, size_t dst_cap, size_t* out_len) override;
+  // Buffered engine: read straight into io_buf and point out_data at it (no
+  // O_DIRECT alignment head); the RDMA server scatter-sends from io_buf.
+  Status RangeDirect(const BlockKey& key, uint64_t offset, uint64_t length,
+                     char* io_buf, size_t io_cap, const char** out_data,
+                     size_t* out_len) override;
+  // No async prep for a buffered engine: return kInvalid so the RDMA server
+  // uses the synchronous RangeDirect path.
+  Status RangeDirectPrep(const BlockKey& key, uint64_t offset, uint64_t length,
+                         size_t io_cap, RangePrep* out) override;
+  bool IsCached(const BlockKey& key) const override;
+  Status Remove(const BlockKey& key) override;
 
-  size_t Count() const;
-  uint64_t UsedBytes() const;
+  size_t Count() const override;
+  uint64_t UsedBytes() const override;
   uint64_t Capacity() const;
-  uint64_t Evictions() const;
+  uint64_t Evictions() const override;
+  uint64_t EvictedBytes() const override;
+  const std::string& Dir() const override { return opt_.dir; }
   uint64_t TableRebuilt() const { return table_rebuilt_; }  // records restored at open
 
  private:
@@ -88,6 +102,7 @@ class DiskSlabStore {
   mutable std::mutex mu_;
   bool ok_ = false;
   uint64_t table_rebuilt_ = 0;
+  uint64_t evicted_bytes_ = 0;
 };
 
 }  // namespace dfkv

--- a/src/cache/kv_store.h
+++ b/src/cache/kv_store.h
@@ -27,10 +27,11 @@
 
 #include "common/kv_types.h"
 #include "common/status.h"
+#include "cache/store_engine.h"
 
 namespace dfkv {
 
-class KVStore {
+class KVStore : public StoreEngine {
  public:
   struct Options {
     std::string cache_dir;
@@ -44,25 +45,25 @@ class KVStore {
   explicit KVStore(Options opt);
 
   // Synchronous, idempotent (skips if already present). No S3 upload.
-  Status Cache(const BlockKey& key, const void* data, size_t len);
+  Status Cache(const BlockKey& key, const void* data, size_t len) override;
   // Same semantics as Cache(), but `data` must point at a 4096-aligned
   // buffer with at least `cap` bytes. The O_DIRECT write uses it directly, so the
   // server PUT path avoids a payload-sized bounce-buffer copy.
-  Status CacheDirect(const BlockKey& key, char* data, size_t len, size_t cap);
+  Status CacheDirect(const BlockKey& key, char* data, size_t len, size_t cap) override;
   // [offset, offset+length) from the local block; NotFound if absent.
   Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
-               std::string* out);
+               std::string* out) override;
   // Like Range but reads straight into a caller buffer (no std::string), saving a
   // copy on the server GET path. Reads up to min(length, file-offset, dst_cap)
   // bytes into dst; *out_len = bytes read. NotFound if absent.
   Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,
-                   char* dst, size_t dst_cap, size_t* out_len);
+                   char* dst, size_t dst_cap, size_t* out_len) override;
   // O_DIRECT range read into a caller-provided aligned buffer. The disk read may
   // cover an aligned superset of the requested range; *out_data points inside
   // io_buf at the exact requested bytes and can be scatter-sent directly.
   Status RangeDirect(const BlockKey& key, uint64_t offset, uint64_t length,
                      char* io_buf, size_t io_cap, const char** out_data,
-                     size_t* out_len);
+                     size_t* out_len) override;
 
   // Async-friendly split of RangeDirect. Does ONLY the cheap, lock-protected
   // prep: index lookup, O_DIRECT open, range clamp, and O_DIRECT alignment math.
@@ -73,36 +74,30 @@ class KVStore {
   //   read aligned_len bytes at aligned_off into io_buf, then the requested bytes
   //   are at io_buf+head for payload_len bytes. payload_len==0 is a valid zero-len
   //   hit (fd<0, nothing to read). io_cap must be >= aligned_len.
-  struct RangePrep {
-    int fd = -1;              // owned by caller on kOk (caller closes); -1 if no read
-    uint64_t aligned_off = 0; // O_DIRECT-aligned read start
-    size_t aligned_len = 0;   // O_DIRECT-aligned read length (multiple of 4096)
-    size_t head = 0;          // offset of requested bytes within the aligned read
-    size_t payload_len = 0;   // exact requested bytes (after clamp to file size)
-  };
+  using RangePrep = ::dfkv::RangePrep;  // shared with StoreEngine
   Status RangeDirectPrep(const BlockKey& key, uint64_t offset, uint64_t length,
-                         size_t io_cap, RangePrep* out);
+                         size_t io_cap, RangePrep* out) override;
 
-  bool IsCached(const BlockKey& key) const;
+  bool IsCached(const BlockKey& key) const override;
 
   // Explicitly drop a cached block: deletes the file, removes it from the
   // shard index + CLOCK ring, and reclaims its bytes (exclusive shard lock).
   // kOk if removed, kNotFound if absent. Used by the LMCache L2 eviction path
   // (dfkv_remove / DfkvL2Adapter.delete); distinct from capacity eviction so
   // it does NOT touch the eviction counters.
-  Status Remove(const BlockKey& key);
+  Status Remove(const BlockKey& key) override;
 
-  uint64_t UsedBytes() const;
-  size_t Count() const;
-  uint64_t Evictions() const { return evictions_.load(std::memory_order_relaxed); }
-  uint64_t EvictedBytes() const { return evicted_bytes_.load(std::memory_order_relaxed); }
+  uint64_t UsedBytes() const override;
+  size_t Count() const override;
+  uint64_t Evictions() const override { return evictions_.load(std::memory_order_relaxed); }
+  uint64_t EvictedBytes() const override { return evicted_bytes_.load(std::memory_order_relaxed); }
   // Orphan ".tmp" files removed at construction (crash-between-write-and-rename
   // leaks). Diagnostic: a persistently non-zero value across restarts points at
   // frequent mid-write kills.
   uint64_t TmpReclaimed() const { return tmp_reclaimed_.load(std::memory_order_relaxed); }
   // PUTs that hit a real ENOSPC, force-evicted, and retried successfully.
   uint64_t EnospcEvictions() const { return enospc_evictions_.load(std::memory_order_relaxed); }
-  const std::string& Dir() const { return opt_.cache_dir; }
+  const std::string& Dir() const override { return opt_.cache_dir; }
 
   // Test-only: override the disk write for the Cache() path so a test can
   // inject a transient ENOSPC (returning false with *out_errno=ENOSPC once,

--- a/src/cache/store_engine.h
+++ b/src/cache/store_engine.h
@@ -1,0 +1,62 @@
+/* StoreEngine — the cache-node local storage backend interface.
+ *
+ * DiskCacheGroup routes a block to one backend per disk; both the original
+ * file-per-block KVStore and the extent-slab DiskSlabStore implement this, so
+ * the engine is selectable (--store-engine / DFKV_STORE_ENGINE) with the file
+ * engine as the default. The RDMA zero-copy fast path (RangeDirect returning a
+ * pointer into the caller's registered buffer) and its io_uring split
+ * (RangeDirectPrep) are part of the interface; a buffered engine (slab) fills
+ * io_buf with a plain read and declines the prep (returns non-kOk) so the RDMA
+ * server falls back to the synchronous RangeDirect. */
+#ifndef DFKV_STORE_ENGINE_H_
+#define DFKV_STORE_ENGINE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "common/kv_types.h"
+#include "common/status.h"
+
+namespace dfkv {
+
+// Output of the cheap, lock-protected prep half of RangeDirect (see
+// KVStore::RangeDirectPrep). A buffered engine leaves fd < 0 and returns a
+// non-kOk status to signal "no async prep; use the synchronous RangeDirect".
+struct RangePrep {
+  int fd = -1;              // owned by caller on kOk (caller closes); -1 if no read
+  uint64_t aligned_off = 0; // O_DIRECT-aligned read start
+  size_t aligned_len = 0;   // O_DIRECT-aligned read length (multiple of 4096)
+  size_t head = 0;          // offset of requested bytes within the aligned read
+  size_t payload_len = 0;   // exact requested bytes (after clamp to file size)
+};
+
+class StoreEngine {
+ public:
+  virtual ~StoreEngine() = default;
+
+  virtual Status Cache(const BlockKey& key, const void* data, size_t len) = 0;
+  virtual Status CacheDirect(const BlockKey& key, char* data, size_t len,
+                             size_t cap) = 0;
+  virtual Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
+                       std::string* out) = 0;
+  virtual Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,
+                           char* dst, size_t dst_cap, size_t* out_len) = 0;
+  virtual Status RangeDirect(const BlockKey& key, uint64_t offset, uint64_t length,
+                             char* io_buf, size_t io_cap, const char** out_data,
+                             size_t* out_len) = 0;
+  virtual Status RangeDirectPrep(const BlockKey& key, uint64_t offset,
+                                 uint64_t length, size_t io_cap, RangePrep* out) = 0;
+  virtual bool IsCached(const BlockKey& key) const = 0;
+  virtual Status Remove(const BlockKey& key) = 0;
+
+  virtual uint64_t UsedBytes() const = 0;
+  virtual size_t Count() const = 0;
+  virtual uint64_t Evictions() const = 0;
+  virtual uint64_t EvictedBytes() const = 0;
+  virtual const std::string& Dir() const = 0;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_STORE_ENGINE_H_

--- a/test/cache/store_engine_test.cc
+++ b/test/cache/store_engine_test.cc
@@ -1,0 +1,113 @@
+// StoreEngine wiring: DiskCacheGroup runs either the file (KVStore, default) or
+// slab (DiskSlabStore) backend, selected by Options.engine / DFKV_STORE_ENGINE.
+// The refactor must keep the file path a byte-for-byte drop-in and make slab a
+// working alternative; both must round-trip and route across disks identically.
+#include "cache/disk_cache_group.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace dfkv;  // NOLINT
+
+namespace {
+class EngineTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    base_ = fs::temp_directory_path() /
+            ("dfkv_eng_" + std::to_string(::testing::UnitTest::GetInstance()
+                                              ->current_test_info()->line()));
+    fs::remove_all(base_);
+    ::unsetenv("DFKV_STORE_ENGINE");
+  }
+  void TearDown() override {
+    fs::remove_all(base_);
+    ::unsetenv("DFKV_STORE_ENGINE");
+  }
+  std::vector<std::string> Dirs(int n) {
+    std::vector<std::string> v;
+    for (int i = 0; i < n; ++i) {
+      auto d = (base_ / ("d" + std::to_string(i))).string();
+      fs::create_directories(d);
+      v.push_back(d);
+    }
+    return v;
+  }
+  fs::path base_;
+};
+
+// Round-trip Cache/Range/RangeInto/Remove for N keys spread across a group.
+void ExerciseGroup(DiskCacheGroup& g) {
+  for (uint64_t i = 0; i < 40; ++i) {
+    std::string v = "val-" + std::to_string(i) + std::string(50, 'x');
+    ASSERT_EQ(g.Cache(BlockKey{i, 0, 1}, v.data(), v.size()), Status::kOk) << i;
+  }
+  EXPECT_EQ(g.Count(), 40u);
+  for (uint64_t i = 0; i < 40; ++i) {
+    std::string v = "val-" + std::to_string(i) + std::string(50, 'x');
+    std::string out;
+    ASSERT_EQ(g.Range(BlockKey{i, 0, 1}, 0, v.size(), &out), Status::kOk) << i;
+    EXPECT_EQ(out, v) << i;
+    EXPECT_TRUE(g.IsCached(BlockKey{i, 0, 1}));
+    char buf[128];
+    size_t got = 0;
+    ASSERT_EQ(g.RangeInto(BlockKey{i, 0, 1}, 0, sizeof(buf), buf, sizeof(buf), &got),
+              Status::kOk) << i;
+    EXPECT_EQ(std::string(buf, got), v) << i;
+  }
+  ASSERT_EQ(g.Remove(BlockKey{0, 0, 1}), Status::kOk);
+  EXPECT_FALSE(g.IsCached(BlockKey{0, 0, 1}));
+  std::string miss;
+  EXPECT_EQ(g.Range(BlockKey{9999, 0, 1}, 0, 10, &miss), Status::kNotFound);
+}
+}  // namespace
+
+TEST_F(EngineTest, FileEngineRoundTripsAcrossDisks) {
+  DiskCacheGroup::Options o;
+  o.cache_dirs = Dirs(3);
+  o.capacity_bytes = 3ull << 30;
+  o.engine = "file";
+  DiskCacheGroup g(o);
+  ExerciseGroup(g);
+}
+
+TEST_F(EngineTest, SlabEngineRoundTripsAcrossDisks) {
+  DiskCacheGroup::Options o;
+  o.cache_dirs = Dirs(3);
+  o.capacity_bytes = 3ull << 30;  // one 1 GiB extent per disk
+  o.engine = "slab";
+  DiskCacheGroup g(o);
+  ExerciseGroup(g);
+  EXPECT_GT(g.UsedBytes(), 0u);
+}
+
+TEST_F(EngineTest, DefaultIsFileEngine) {
+  // No Options.engine and no env -> file backend, which lays out blocks/ dirs.
+  DiskCacheGroup::Options o;
+  o.cache_dirs = Dirs(1);
+  o.capacity_bytes = 1ull << 30;
+  DiskCacheGroup g(o);
+  std::string v(64, 'f');
+  ASSERT_EQ(g.Cache(BlockKey{7, 0, 1}, v.data(), v.size()), Status::kOk);
+  // The file engine writes blocks/<bucket>/... ; the slab engine writes
+  // extents/ + slots.tbl. Presence of "blocks" proves the default is file.
+  EXPECT_TRUE(fs::exists(fs::path(o.cache_dirs[0]) / "blocks"));
+  EXPECT_FALSE(fs::exists(fs::path(o.cache_dirs[0]) / "slots.tbl"));
+}
+
+TEST_F(EngineTest, EnvSelectsSlabWhenOptionEmpty) {
+  ::setenv("DFKV_STORE_ENGINE", "slab", 1);
+  DiskCacheGroup::Options o;
+  o.cache_dirs = Dirs(1);
+  o.capacity_bytes = 1ull << 30;
+  // Options.engine empty -> read the env.
+  DiskCacheGroup g(o);
+  std::string v(64, 's');
+  ASSERT_EQ(g.Cache(BlockKey{8, 0, 1}, v.data(), v.size()), Status::kOk);
+  EXPECT_TRUE(fs::exists(fs::path(o.cache_dirs[0]) / "slots.tbl"));  // slab layout
+  EXPECT_FALSE(fs::exists(fs::path(o.cache_dirs[0]) / "blocks"));
+}


### PR DESCRIPTION
## What

Wires the extent-slab store (`DiskSlabStore`, B4-6) in as a **selectable backend** behind a new `StoreEngine` interface, with the file-per-block `KVStore` as the **unchanged default** — so slab lands with **zero production impact** and the switch is one flag. This completes the slab-store rework (B4-5 allocator → B4-6 disk store → B4-7 wiring).

- **New `StoreEngine`** interface (Cache/CacheDirect/Range/RangeInto/RangeDirect/RangeDirectPrep/IsCached/Remove + stats). `KVStore` implements it (its nested `RangePrep` becomes an alias of the shared `dfkv::RangePrep`, so external `KVStore::RangePrep` references are unchanged). `DiskSlabStore` implements it too: buffered `CacheDirect` = `Cache`; `RangeDirect` reads straight into `io_buf` and points `out_data` at it; `RangeDirectPrep` returns `kInvalid` (no async prep for a buffered engine → the RDMA server falls back to the synchronous `RangeDirect`).
- **`DiskCacheGroup`** now holds `unique_ptr<StoreEngine>` per disk and picks the backend from `Options.engine` / `DFKV_STORE_ENGINE` (default `"file"`). `KvNodeServer` is untouched — it still uses `DiskCacheGroup`'s public API.
- `dfkv_server --store-engine=file|slab` sets `DFKV_STORE_ENGINE`.

## Tests
`store_engine_test`: file **and** slab both round-trip Cache/Range/RangeInto/Remove across a 3-disk group; default (no option/env) is the file backend (`blocks/` layout, no `slots.tbl`); env selects slab (`slots.tbl` + `extents/`). The **full existing suite (default = file) is unchanged**, proving the refactor is a byte-for-byte drop-in; `rdma_loopback` (which drives `RangeDirect`) stays green. Real `dfkv_server` boots with `--store-engine=slab` and creates the slab layout. Local: default **251/251**, RDMA+URING **274/274**, `rdma_loopback` **18/18**.

Slab is intentionally **off by default**; flipping a node to it is a separate ops decision (needs the clean-disk cold-start migration in the RUNBOOK).
