### PR TITLE
feat(cache): RamTier -- write-through RAM hot tier on SlabAllocator (P3 core)

### DIFF
--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -1,0 +1,207 @@
+#include "cache/ram_tier.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+
+namespace dfkv {
+
+RamTier::RamTier(Options opt, FlushFn flush)
+    : opt_(opt), flush_(std::move(flush)) {
+  if (opt_.slot_granularity < 4096) opt_.slot_granularity = 4096;  // O_DIRECT floor
+  if (opt_.bytes < opt_.slot_granularity) opt_.bytes = opt_.slot_granularity;
+  void* p = nullptr;
+  // 4096-aligned base => slot addresses (offset is a slot_size multiple, itself
+  // a granularity multiple) are O_DIRECT-aligned for the flusher (gap 10.4).
+  if (posix_memalign(&p, 4096, opt_.bytes) != 0 || p == nullptr) return;
+  arena_ = static_cast<char*>(p);
+
+  SlabAllocator::Options ao;
+  ao.extent_bytes = opt_.bytes;   // the whole arena is one extent
+  ao.num_extents = 1;
+  ao.align = opt_.slot_granularity;
+  ao.max_waste = 0.25;
+  alloc_ = std::make_unique<SlabAllocator>(ao);
+  flusher_ = std::thread([this] { FlushLoop(); });
+}
+
+RamTier::~RamTier() {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    stop_ = true;
+  }
+  flush_cv_.notify_all();
+  if (flusher_.joinable()) flusher_.join();
+  if (arena_) std::free(arena_);
+}
+
+void RamTier::SetArenaMr(void* mr) {
+  std::lock_guard<std::mutex> lk(mu_);
+  arena_mr_ = mr;
+}
+
+bool RamTier::Put(const BlockKey& key, const void* data, size_t len) {
+  if (!arena_) return false;
+  if (data == nullptr && len != 0) return false;
+  const std::string fn = key.Filename();
+
+  uint64_t offset = 0;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    // Resident, or another thread is mid-copy on this same (content-addressed)
+    // key -> dedup. The in-progress writer produces identical bytes, so returning
+    // "accepted" here is correct read-after-write for this key.
+    if (index_.count(fn) || writing_.count(fn)) return true;
+    SlabAllocator::SlotRef ref;
+    std::vector<std::string> evicted;
+    if (!alloc_->Put(fn, len, &ref, &evicted)) {
+      // Backpressure (gap 10.3): arena full of non-evictable (flushing / in-
+      // flight) slots. Decline -> caller does the normal synchronous disk write.
+      put_bypass_.fetch_add(1, std::memory_order_relaxed);
+      return false;
+    }
+    for (const auto& ev : evicted) index_.erase(ev);  // evicted are durable+idle
+    // Flush-pin the slot: RAM_ONLY, not evictable until the async flush lands.
+    alloc_->Pin(fn);
+    writing_.insert(fn);  // reserve the key so a concurrent same-key Put dedups
+    offset = ref.offset;
+    // NOT visible yet: index_ install is deferred until after the copy, so a
+    // concurrent GetPrep can't read the slot mid-copy.
+  }
+
+  std::memcpy(arena_ + offset, data, len);  // copy outside the lock (MB-scale)
+
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    Entry e;
+    e.offset = offset;
+    e.len = static_cast<uint32_t>(len);
+    e.durable = false;
+    index_[fn] = e;
+    writing_.erase(fn);  // copy done -> now visible to GetPrep
+    flushq_.push_back(QItem{fn, key, 0});
+  }
+  flush_cv_.notify_one();
+  puts_.fetch_add(1, std::memory_order_relaxed);
+  return true;
+}
+
+bool RamTier::GetPrep(const BlockKey& key, uint64_t offset, uint64_t length,
+                      Hit* out) {
+  const std::string fn = key.Filename();
+  std::lock_guard<std::mutex> lk(mu_);
+  auto it = index_.find(fn);
+  if (it == index_.end()) {
+    misses_.fetch_add(1, std::memory_order_relaxed);
+    return false;
+  }
+  const Entry& e = it->second;
+  // Send-pin: the RDMA send reads the shared arena in place; the slot must not
+  // be evicted/reused until the send completes (gap 10.1).
+  alloc_->Pin(fn);
+  const uint64_t start = std::min<uint64_t>(offset, e.len);
+  const uint64_t avail = e.len - start;
+  const uint64_t n = std::min(length ? length : avail, avail);
+  if (out) {
+    out->ptr = arena_ + e.offset + start;
+    out->len = static_cast<size_t>(n);
+    out->mr = arena_mr_;
+    out->token = next_token_++;
+    pinned_[out->token] = fn;
+  }
+  hits_.fetch_add(1, std::memory_order_relaxed);
+  return true;
+}
+
+void RamTier::Release(uint64_t token) {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto it = pinned_.find(token);
+  if (it == pinned_.end()) return;
+  alloc_->Unpin(it->second);  // release the send-pin
+  pinned_.erase(it);
+}
+
+bool RamTier::Contains(const BlockKey& key) const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return index_.find(key.Filename()) != index_.end();
+}
+
+bool RamTier::Remove(const BlockKey& key) {
+  const std::string fn = key.Filename();
+  std::lock_guard<std::mutex> lk(mu_);
+  auto it = index_.find(fn);
+  if (it == index_.end()) return false;
+  // Best-effort for a cache: only a DURABLE, not-in-flight slot can be freed
+  // safely. A still-flushing slot holds the flush-pin (the flusher owns it); an
+  // in-flight slot holds a send-pin. Either way, decline -- the caller retries.
+  if (!it->second.durable) return false;
+  bool in_flight = false;
+  for (const auto& kv : pinned_) if (kv.second == fn) { in_flight = true; break; }
+  if (in_flight) return false;
+  DropLocked(fn);
+  return true;
+}
+
+void RamTier::DropLocked(const std::string& fn) {
+  alloc_->Remove(fn);   // frees the slot (must be unpinned)
+  index_.erase(fn);
+}
+
+void RamTier::FlushLoop() {
+  for (;;) {
+    QItem item;
+    {
+      std::unique_lock<std::mutex> lk(mu_);
+      flush_cv_.wait(lk, [this] { return stop_ || !flushq_.empty(); });
+      if (stop_ && flushq_.empty()) return;
+      item = std::move(flushq_.front());
+      flushq_.pop_front();
+    }
+
+    // Snapshot the slot (guaranteed present: a queued item is flush-pinned, so
+    // it can't be evicted or Removed).
+    const void* data = nullptr;
+    size_t len = 0;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      auto it = index_.find(item.fn);
+      if (it == index_.end() || it->second.durable) continue;  // gone/already done
+      data = arena_ + it->second.offset;
+      len = it->second.len;
+    }
+
+    const bool ok = flush_ ? flush_(item.key, data, len) : true;
+
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      auto it = index_.find(item.fn);
+      if (it == index_.end()) continue;  // defensive
+      if (ok) {
+        it->second.durable = true;
+        alloc_->Unpin(item.fn);  // release the flush-pin -> now evictable
+        flushed_.fetch_add(1, std::memory_order_relaxed);
+      } else if (++item.tries < opt_.flush_retries) {
+        flushq_.push_back(std::move(item));  // retry later
+        flush_cv_.notify_one();
+      } else {
+        // Give up: drop from RAM (releases flush-pin + frees slot). GET falls
+        // back to a miss (recompute) -- correct cache semantics, no arena leak.
+        alloc_->Unpin(item.fn);
+        DropLocked(item.fn);
+        flush_dropped_.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+  }
+}
+
+size_t RamTier::Count() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return index_.size();
+}
+
+size_t RamTier::FlushBacklog() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return flushq_.size();
+}
+
+}  // namespace dfkv

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -1,0 +1,145 @@
+/* RamTier — a write-through RAM hot tier that fronts the disk cache.
+ *
+ * Motivation (P3): a COLD dfkv load is disk-bound (~480 MB/s O_DIRECT), which
+ * dominates PD decode TTFT. For PD-warm GETs, serving the KV straight from a
+ * pre-registered RAM arena over RDMA -- no open, no pread, no disk -- removes
+ * that bottleneck. PUT is write-through: the value is copied into a RAM slot and
+ * made visible synchronously (read-after-write), then flushed to disk in the
+ * background for durability and capacity overflow.
+ *
+ * Slot lifecycle reuses SlabAllocator (size-class + CLOCK + pin); the design's
+ * state machine maps directly onto the allocator's pin refcount:
+ *   - flush-pin: taken on Put, released when the async flush reaches disk. While
+ *     held the slot is RAM_ONLY and must not be evicted (no disk copy yet).
+ *   - send-pin: taken on GetPrep (an RDMA send reads the shared arena in place),
+ *     released on send completion.
+ *   refcount == 0  <=>  DURABLE && no send in flight  <=>  evictable.
+ * SlabAllocator only ever evicts unpinned slots, so this is exactly the design's
+ * "only a flushed, not-in-flight slot may be reclaimed" rule (gaps 10.1 + 4.3).
+ *
+ * Backpressure (gap 10.3): if the arena is full of non-evictable slots (flush
+ * fell behind), Put returns false and the caller falls back to the normal
+ * synchronous disk write -- never blocks, never fails read-after-write.
+ * Alignment (gap 10.4): the arena base is posix_memalign(4096) and slot sizes
+ * are 4096-multiples, so a slot address is O_DIRECT-aligned for the flusher.
+ *
+ * Off by default (DFKV_RAM_TIER=0); this class is the standalone core, wired in
+ * by later PRs. RDMA MR registration is deferred (SetArenaMr) so this stays
+ * hermetically testable without libibverbs. */
+#ifndef DFKV_RAM_TIER_H_
+#define DFKV_RAM_TIER_H_
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "cache/slab_allocator.h"
+#include "common/kv_types.h"
+
+namespace dfkv {
+
+class RamTier {
+ public:
+  struct Options {
+    uint64_t bytes = (4ull << 30);       // arena size (DFKV_RAM_TIER_BYTES)
+    uint32_t slot_granularity = 4096;    // slot quantum (>= O_DIRECT align)
+    uint32_t flush_retries = 3;          // per-item flush attempts before drop
+  };
+
+  // Persists a slot to disk. Returns true on success (slot -> DURABLE). Called
+  // off the hot path by the background flusher; `data` points into the arena.
+  using FlushFn = std::function<bool(const BlockKey& key, const void* data, size_t len)>;
+
+  // A pinned arena location handed to the RDMA send path. `token` must be passed
+  // back to Release() once the send completes (releases the send-pin).
+  struct Hit {
+    const char* ptr = nullptr;
+    size_t len = 0;
+    void* mr = nullptr;      // arena MR (nullptr until SetArenaMr); for RDMA lkey
+    uint64_t token = 0;      // opaque; pass to Release()
+  };
+
+  RamTier(Options opt, FlushFn flush);
+  ~RamTier();                // stops the flusher, joins
+
+  RamTier(const RamTier&) = delete;
+  RamTier& operator=(const RamTier&) = delete;
+
+  bool ok() const { return arena_ != nullptr; }
+
+  // Write-through: copy into a RAM slot + make visible + enqueue flush. Returns
+  // true if accepted into RAM (caller may skip the sync disk write; the flusher
+  // will persist). Returns false on backpressure (arena full of non-evictable
+  // slots) or if len exceeds the arena -- caller then does the normal disk write.
+  bool Put(const BlockKey& key, const void* data, size_t len);
+
+  // On hit, pins the slot (send-pin) and returns its arena location. The caller
+  // MUST call Release(hit.token) when the RDMA send completes. Miss => false.
+  bool GetPrep(const BlockKey& key, uint64_t offset, uint64_t length, Hit* out);
+  void Release(uint64_t token);
+
+  bool Contains(const BlockKey& key) const;
+  bool Remove(const BlockKey& key);  // drop from RAM (cache); true if present
+
+  // Registers the arena's RDMA MR (set once by the RDMA server after reg_mr).
+  void SetArenaMr(void* mr);
+  char* arena() const { return arena_; }
+  uint64_t arena_bytes() const { return opt_.bytes; }
+
+  // metrics (relaxed)
+  uint64_t Hits() const { return hits_.load(std::memory_order_relaxed); }
+  uint64_t Misses() const { return misses_.load(std::memory_order_relaxed); }
+  uint64_t Puts() const { return puts_.load(std::memory_order_relaxed); }
+  uint64_t PutBypass() const { return put_bypass_.load(std::memory_order_relaxed); }
+  uint64_t Flushed() const { return flushed_.load(std::memory_order_relaxed); }
+  uint64_t FlushDropped() const { return flush_dropped_.load(std::memory_order_relaxed); }
+  uint64_t Evictions() const { return alloc_->Evictions(); }
+  size_t Count() const;
+  size_t FlushBacklog() const;  // queued, not-yet-durable items
+
+ private:
+  struct Entry {
+    uint64_t offset = 0;   // byte offset into arena_
+    uint32_t len = 0;      // payload length
+    bool durable = false;  // flushed to disk (metrics; eviction uses alloc pin)
+  };
+  struct QItem { std::string fn; BlockKey key; uint32_t tries = 0; };
+
+  void FlushLoop();
+  void DropLocked(const std::string& fn);  // remove key from index_ + alloc + unpin
+
+  Options opt_;
+  FlushFn flush_;
+  char* arena_ = nullptr;
+  void* arena_mr_ = nullptr;
+  std::unique_ptr<SlabAllocator> alloc_;
+
+  mutable std::mutex mu_;
+  std::unordered_map<std::string, Entry> index_;         // fn -> arena entry (visible)
+  // Keys whose slot is reserved+pinned but whose arena copy is still in progress
+  // (memcpy runs outside the lock so a GET never blocks on a PUT). A concurrent
+  // same-key Put sees this and dedups instead of copying the same slot twice.
+  std::unordered_set<std::string> writing_;
+  std::unordered_map<uint64_t, std::string> pinned_;     // token -> fn (send-pins)
+  uint64_t next_token_ = 1;
+  std::deque<QItem> flushq_;
+  std::condition_variable flush_cv_;
+  bool stop_ = false;
+  std::thread flusher_;
+
+  std::atomic<uint64_t> hits_{0}, misses_{0}, puts_{0}, put_bypass_{0};
+  std::atomic<uint64_t> flushed_{0}, flush_dropped_{0};
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_RAM_TIER_H_

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -1,0 +1,213 @@
+// RamTier: write-through RAM hot tier on SlabAllocator. Hermetic (no RDMA/disk;
+// the flush sink is an injected callback). Covers read-after-write, the
+// RAM_ONLY->DURABLE state machine via pins, send-in-flight pin blocking
+// eviction, backpressure bypass when flush stalls, flush retry/drop, sub-range
+// GetPrep, Remove semantics, and a concurrent TSan stress.
+#include "cache/ram_tier.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+using dfkv::BlockKey;
+using dfkv::RamTier;
+using namespace std::chrono_literals;
+
+namespace {
+BlockKey K(uint64_t id) { return BlockKey{id, 0, 1}; }
+
+// A controllable flush sink: records flushed keys, can be gated (block until
+// opened) and can be made to fail.
+struct FlushSink {
+  std::mutex m;
+  std::condition_variable cv;
+  std::set<std::string> flushed;
+  bool gate_open = true;      // when false, flush blocks
+  bool fail = false;          // when true, flush returns false
+  int calls = 0;
+
+  RamTier::FlushFn fn() {
+    return [this](const BlockKey& k, const void*, size_t) {
+      std::unique_lock<std::mutex> lk(m);
+      ++calls;
+      cv.wait(lk, [this] { return gate_open; });
+      if (fail) return false;
+      flushed.insert(k.Filename());
+      cv.notify_all();
+      return true;
+    };
+  }
+  void open() { { std::lock_guard<std::mutex> lk(m); gate_open = true; } cv.notify_all(); }
+  void close() { std::lock_guard<std::mutex> lk(m); gate_open = false; }
+};
+
+// Poll a predicate up to ~2s.
+template <class F>
+bool WaitFor(F pred) {
+  for (int i = 0; i < 2000; ++i) {
+    if (pred()) return true;
+    std::this_thread::sleep_for(1ms);
+  }
+  return pred();
+}
+
+RamTier::Options Opts(uint64_t bytes, uint32_t gran = 4096) {
+  RamTier::Options o;
+  o.bytes = bytes;
+  o.slot_granularity = gran;
+  return o;
+}
+}  // namespace
+
+TEST(RamTier, ReadAfterWriteBeforeFlush) {
+  FlushSink sink;
+  sink.close();  // hold flushes so the slot stays RAM_ONLY
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  ASSERT_TRUE(rt.ok());
+  std::string v = "hot-kv-payload";
+  ASSERT_TRUE(rt.Put(K(1), v.data(), v.size()));
+  // Visible immediately, even though the flush hasn't run.
+  RamTier::Hit h;
+  ASSERT_TRUE(rt.GetPrep(K(1), 0, v.size(), &h));
+  EXPECT_EQ(std::string(h.ptr, h.len), v);
+  EXPECT_EQ(rt.Hits(), 1u);
+  rt.Release(h.token);
+  sink.open();
+}
+
+TEST(RamTier, FlushMakesDurable) {
+  FlushSink sink;
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  std::string v(1000, 'd');
+  ASSERT_TRUE(rt.Put(K(2), v.data(), v.size()));
+  EXPECT_TRUE(WaitFor([&] { return rt.Flushed() == 1u; }));
+  {
+    std::lock_guard<std::mutex> lk(sink.m);
+    EXPECT_TRUE(sink.flushed.count(K(2).Filename()));
+  }
+  EXPECT_EQ(rt.FlushBacklog(), 0u);
+}
+
+TEST(RamTier, MissReturnsFalse) {
+  FlushSink sink;
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  RamTier::Hit h;
+  EXPECT_FALSE(rt.GetPrep(K(99), 0, 10, &h));
+  EXPECT_EQ(rt.Misses(), 1u);
+}
+
+TEST(RamTier, SubRangeGetPrep) {
+  FlushSink sink;
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  std::string v = "0123456789";
+  ASSERT_TRUE(rt.Put(K(3), v.data(), v.size()));
+  RamTier::Hit h;
+  ASSERT_TRUE(rt.GetPrep(K(3), 3, 4, &h));
+  EXPECT_EQ(std::string(h.ptr, h.len), "3456");
+  rt.Release(h.token);
+  // offset past end -> zero-length hit (still a hit)
+  ASSERT_TRUE(rt.GetPrep(K(3), 100, 10, &h));
+  EXPECT_EQ(h.len, 0u);
+  rt.Release(h.token);
+}
+
+TEST(RamTier, SendPinBlocksEvictionUntilRelease) {
+  FlushSink sink;
+  RamTier rt(Opts(2 * 4096, 4096), sink.fn());  // exactly 2 slots
+  std::string v(4096, 'x');
+  ASSERT_TRUE(rt.Put(K(10), v.data(), v.size()));
+  ASSERT_TRUE(rt.Put(K(11), v.data(), v.size()));
+  EXPECT_TRUE(WaitFor([&] { return rt.Flushed() == 2u; }));  // both durable
+
+  RamTier::Hit h;
+  ASSERT_TRUE(rt.GetPrep(K(10), 0, v.size(), &h));  // send-pin on K10
+  // Putting a 3rd must evict the *unpinned* durable one (K11), never K10.
+  ASSERT_TRUE(rt.Put(K(12), v.data(), v.size()));
+  EXPECT_TRUE(WaitFor([&] { return rt.Flushed() == 3u; }));
+  EXPECT_TRUE(rt.Contains(K(10))) << "send-pinned slot must survive";
+  EXPECT_TRUE(rt.Contains(K(12)));
+  EXPECT_FALSE(rt.Contains(K(11)));
+  EXPECT_GE(rt.Evictions(), 1u);
+  rt.Release(h.token);
+}
+
+TEST(RamTier, BackpressureBypassWhenFlushStalls) {
+  FlushSink sink;
+  sink.close();  // stall all flushes -> slots stay RAM_ONLY (flush-pinned)
+  RamTier rt(Opts(2 * 4096, 4096), sink.fn());
+  std::string v(4096, 'p');
+  ASSERT_TRUE(rt.Put(K(20), v.data(), v.size()));
+  ASSERT_TRUE(rt.Put(K(21), v.data(), v.size()));
+  // Arena full of non-evictable slots -> the next Put is declined (bypass).
+  EXPECT_FALSE(rt.Put(K(22), v.data(), v.size()));
+  EXPECT_EQ(rt.PutBypass(), 1u);
+  // Drain: opening the gate lets flushes land, freeing capacity again.
+  sink.open();
+  EXPECT_TRUE(WaitFor([&] { return rt.Flushed() == 2u; }));
+  EXPECT_TRUE(rt.Put(K(22), v.data(), v.size()));
+}
+
+TEST(RamTier, FlushFailureRetriesThenDrops) {
+  FlushSink sink;
+  sink.fail = true;  // every flush attempt fails
+  RamTier::Options o = Opts(8 * 4096);
+  o.flush_retries = 3;
+  RamTier rt(o, sink.fn());
+  std::string v(500, 'f');
+  ASSERT_TRUE(rt.Put(K(30), v.data(), v.size()));
+  // After flush_retries failed attempts the entry is dropped from RAM.
+  EXPECT_TRUE(WaitFor([&] { return rt.FlushDropped() == 1u; }));
+  EXPECT_FALSE(rt.Contains(K(30)));
+  {
+    std::lock_guard<std::mutex> lk(sink.m);
+    EXPECT_GE(sink.calls, 3);
+  }
+}
+
+TEST(RamTier, RemoveOnlyDropsDurableIdle) {
+  FlushSink sink;
+  sink.close();
+  RamTier rt(Opts(8 * 4096), sink.fn());
+  std::string v(200, 'r');
+  ASSERT_TRUE(rt.Put(K(40), v.data(), v.size()));
+  EXPECT_FALSE(rt.Remove(K(40))) << "non-durable (flushing) -> declined";
+  sink.open();
+  EXPECT_TRUE(WaitFor([&] { return rt.Flushed() == 1u; }));
+  RamTier::Hit h;
+  ASSERT_TRUE(rt.GetPrep(K(40), 0, v.size(), &h));  // now send-in-flight
+  EXPECT_FALSE(rt.Remove(K(40))) << "in-flight -> declined";
+  rt.Release(h.token);
+  EXPECT_TRUE(rt.Remove(K(40))) << "durable + idle -> removed";
+  EXPECT_FALSE(rt.Contains(K(40)));
+}
+
+TEST(RamTier, ConcurrentPutGetReleaseIsRaceFree) {
+  FlushSink sink;
+  RamTier rt(Opts(512 * 4096), sink.fn());
+  constexpr int T = 8, N = 1500;
+  std::atomic<int> hits{0};
+  std::vector<std::thread> ts;
+  for (int t = 0; t < T; ++t) {
+    ts.emplace_back([&, t] {
+      std::string v(300, 'c');
+      for (int i = 0; i < N; ++i) {
+        BlockKey k = K((t * N + i) % 3000);
+        rt.Put(k, v.data(), v.size());
+        RamTier::Hit h;
+        if (rt.GetPrep(k, 0, v.size(), &h)) {
+          hits.fetch_add(1);
+          rt.Release(h.token);
+        }
+      }
+    });
+  }
+  for (auto& th : ts) th.join();
+  EXPECT_GT(hits.load(), 0);
+}


### PR DESCRIPTION
## What

The **standalone core of the P3 RAM hot tier** (batch 5). A COLD dfkv load is disk-bound (~480 MB/s O_DIRECT) and dominates PD decode TTFT; serving a PD-warm GET straight from a **pre-registered RAM arena** over RDMA — no open, no pread, no disk — removes that bottleneck. PUT is **write-through**: the value is copied into a RAM slot, made visible synchronously (read-after-write), then flushed to disk in the background.

## State machine = SlabAllocator pins
Slot lifecycle **reuses `SlabAllocator`** (size-class + CLOCK + pin) — this is why B4-5 was built media-agnostic. The design's state machine maps directly onto the pin refcount:
- **flush-pin**: taken on `Put`, released when the async flush reaches disk; while held the slot is `RAM_ONLY` and never evicted (no disk copy yet).
- **send-pin**: taken on `GetPrep` (an RDMA send reads the shared arena in place), released on send completion via `Release(token)`.

`refcount == 0` ⟺ `DURABLE && no send in flight` ⟺ evictable — exactly the design's "only a flushed, not-in-flight slot may be reclaimed" rule (review gaps 10.1 + 4.3), for free from the allocator.

## All four review gaps handled
- **10.1 send-in-flight pin**: `GetPrep` pins, `Release` unpins; eviction skips pinned.
- **10.3 flush backpressure**: when the arena is full of non-evictable slots, `Put` returns `false` (bypass) so the caller does the normal sync disk write — never blocks, never breaks read-after-write.
- **10.4 4096 alignment**: arena base is `posix_memalign(4096)` and slot sizes are `granularity(>=4096)`-multiples → a slot is O_DIRECT-aligned for the flusher.
- **10.2 (FIFO reply)** is a serve-loop concern, handled in the wiring PRs (B5-2/B5-3).

The arena copy runs **outside the lock** (a GET never blocks on a PUT's MB-scale memcpy); a per-key in-progress guard dedups a concurrent same-key Put so two writers can't race one slot (**caught by TSan, then fixed**). Flush failure retries then drops (GET falls back to a miss; no arena leak). RDMA MR registration is deferred (`SetArenaMr`) so this stays hermetically testable.

**Off by default**; wired in by B5-2 (`kv_node_server` GET/PUT) and B5-3 (RDMA hit direct-send).

## Tests
`ram_tier_test`: read-after-write before flush, flush→durable, miss, sub-range GetPrep, **send-pin blocks eviction until Release**, **backpressure bypass when flush stalls**, flush-failure retry-then-drop, Remove only drops durable+idle, and a concurrent put/get/release stress — **clean under ThreadSanitizer** (incl. the flusher thread). Local: default **260/260**, RDMA+URING **283/283**.
