### PR TITLE
feat(cache): wire RamTier into KvNodeServer (write-through + RAM-served GET)

### DIFF
--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -1,6 +1,8 @@
 #include "cache/kv_node_server.h"
 
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 
 #include <vector>
@@ -22,13 +24,39 @@ inline double NowSec() {
 }  // namespace
 
 KvNodeServer::KvNodeServer(const std::string& cache_dir, uint64_t capacity_bytes)
-    : group_(DiskCacheGroup::Options{{cache_dir}, capacity_bytes}) {}
+    : group_(DiskCacheGroup::Options{{cache_dir}, capacity_bytes}) { InitRamTier(); }
 
 KvNodeServer::KvNodeServer(const std::vector<std::string>& cache_dirs,
                            uint64_t capacity_bytes)
-    : group_(DiskCacheGroup::Options{cache_dirs, capacity_bytes}) {}
+    : group_(DiskCacheGroup::Options{cache_dirs, capacity_bytes}) { InitRamTier(); }
 
-KvNodeServer::~KvNodeServer() { Stop(); }
+KvNodeServer::~KvNodeServer() {
+  // Order matters: Stop() first joins the accept + handler threads so no request
+  // is still reading ram_; THEN reset ram_ (stops+joins its flusher, whose
+  // callback calls group_.Cache -- group_ is a member, still alive here); group_
+  // is destroyed last, after this body.
+  Stop();
+  ram_.reset();
+}
+
+void KvNodeServer::InitRamTier() {
+  // Off by default. DFKV_RAM_TIER in {1,on,true,yes} enables the RAM hot tier;
+  // DFKV_RAM_TIER_BYTES sizes the pre-registered arena (default 4 GiB).
+  const char* e = std::getenv("DFKV_RAM_TIER");
+  if (!e || !*e) return;
+  const std::string v(e);
+  if (v != "1" && v != "on" && v != "true" && v != "yes") return;
+  RamTier::Options o;
+  if (const char* b = std::getenv("DFKV_RAM_TIER_BYTES")) {
+    unsigned long long n = std::strtoull(b, nullptr, 10);
+    if (n > 0) o.bytes = n;
+  }
+  // Flusher persists a RAM slot to the disk group (same bytes GET returns).
+  auto tier = std::make_unique<RamTier>(o, [this](const BlockKey& k, const void* d, size_t l) {
+    return group_.Cache(k, d, l) == Status::kOk;
+  });
+  if (tier->ok()) ram_ = std::move(tier);  // arena alloc failed => stay disk-only
+}
 
 Status KvNodeServer::Start(int port) {
   listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
@@ -191,6 +219,20 @@ std::string KvNodeServer::MetricsText() const {
     s += get_lat_.RenderBody("dfkv_op_latency_seconds", get_lbl);
     s += put_lat_.RenderBody("dfkv_op_latency_seconds", put_lbl);
   }
+  // RAM hot tier (P3), emitted only when enabled so a disk-only node's scrape is
+  // unchanged. ram_hit/ram_miss let you compute the RAM hit rate; ram_put_bypass
+  // is the flush-backpressure signal from the design's gap 10.3.
+  if (ram_) {
+    metric("dfkv_ram_hit_total", "counter", "GETs served from the RAM hot tier", ram_->Hits());
+    metric("dfkv_ram_miss_total", "counter", "GETs that missed RAM (fell to disk)", ram_->Misses());
+    metric("dfkv_ram_put_total", "counter", "PUTs accepted into the RAM hot tier", ram_->Puts());
+    metric("dfkv_ram_put_bypass_total", "counter", "PUTs bypassing RAM (flush backpressure)", ram_->PutBypass());
+    metric("dfkv_ram_flushed_total", "counter", "RAM slots flushed to disk (now durable)", ram_->Flushed());
+    metric("dfkv_ram_flush_dropped_total", "counter", "RAM slots dropped after flush failure", ram_->FlushDropped());
+    metric("dfkv_ram_evictions_total", "counter", "RAM slots evicted under capacity pressure", ram_->Evictions());
+    metric("dfkv_ram_objects", "gauge", "Blocks currently resident in the RAM hot tier", ram_->Count());
+    metric("dfkv_ram_flush_backlog", "gauge", "RAM slots queued for flush (not yet durable)", ram_->FlushBacklog());
+  }
   return s;
 }
 
@@ -230,12 +272,22 @@ Status KvNodeServer::ProcessRequest(uint8_t op_raw, uint64_t id, uint32_t index,
     case WireOp::kCache: {
       bool samp = lat_sampler_.ShouldSample();
       double t0 = samp ? NowSec() : 0.0;
-      st = group_.Cache(key, payload, payload_len);
-      if (st == Status::kOk) {
+      // Write-through RAM tier: on acceptance the value is synchronously visible
+      // in RAM (read-after-write) and flushed to disk in the background. On
+      // backpressure (arena full of un-flushed slots) Put declines and we take
+      // the normal disk path.
+      if (ram_ && ram_->Put(key, payload, payload_len)) {
+        st = Status::kOk;
         cache_put_.fetch_add(1, std::memory_order_relaxed);
         bytes_written_.fetch_add(payload_len, std::memory_order_relaxed);
-      } else if (st == Status::kIOError) {
-        put_io_err_.fetch_add(1, std::memory_order_relaxed);
+      } else {
+        st = group_.Cache(key, payload, payload_len);
+        if (st == Status::kOk) {
+          cache_put_.fetch_add(1, std::memory_order_relaxed);
+          bytes_written_.fetch_add(payload_len, std::memory_order_relaxed);
+        } else if (st == Status::kIOError) {
+          put_io_err_.fetch_add(1, std::memory_order_relaxed);
+        }
       }
       if (samp) put_lat_.Observe(NowSec() - t0);
       break;
@@ -243,27 +295,56 @@ Status KvNodeServer::ProcessRequest(uint8_t op_raw, uint64_t id, uint32_t index,
     case WireOp::kRange: {
       bool samp = lat_sampler_.ShouldSample();
       double t0 = samp ? NowSec() : 0.0;
-      st = group_.Range(key, offset, length, out_data);
-      if (st == Status::kOk) {
-        cache_hit_.fetch_add(1, std::memory_order_relaxed);
-        bytes_read_.fetch_add(out_data->size(), std::memory_order_relaxed);
-      } else if (st == Status::kNotFound) {
-        cache_miss_.fetch_add(1, std::memory_order_relaxed);
-      } else if (st == Status::kIOError) {
-        get_io_err_.fetch_add(1, std::memory_order_relaxed);
+      bool ram_served = false;
+      if (ram_) {  // RAM hot tier: serve straight from the arena (copy out), no disk
+        RamTier::Hit h;
+        if (ram_->GetPrep(key, offset, length, &h)) {
+          out_data->assign(h.ptr, h.len);
+          ram_->Release(h.token);
+          st = Status::kOk;
+          cache_hit_.fetch_add(1, std::memory_order_relaxed);
+          bytes_read_.fetch_add(out_data->size(), std::memory_order_relaxed);
+          ram_served = true;
+        }
+      }
+      if (!ram_served) {
+        st = group_.Range(key, offset, length, out_data);
+        if (st == Status::kOk) {
+          cache_hit_.fetch_add(1, std::memory_order_relaxed);
+          bytes_read_.fetch_add(out_data->size(), std::memory_order_relaxed);
+        } else if (st == Status::kNotFound) {
+          cache_miss_.fetch_add(1, std::memory_order_relaxed);
+        } else if (st == Status::kIOError) {
+          get_io_err_.fetch_add(1, std::memory_order_relaxed);
+        }
       }
       if (samp) get_lat_.Observe(NowSec() - t0);
       break;
     }
     case WireOp::kExist:
-      if (group_.IsCached(key)) { st = Status::kOk; exist_hit_.fetch_add(1, std::memory_order_relaxed); }
-      else { st = Status::kNotFound; exist_miss_.fetch_add(1, std::memory_order_relaxed); }
+      // A RAM-resident block (possibly RAM-only, not yet flushed) must count as
+      // present, else Exist would report absent for a just-written key.
+      if ((ram_ && ram_->Contains(key)) || group_.IsCached(key)) {
+        st = Status::kOk; exist_hit_.fetch_add(1, std::memory_order_relaxed);
+      } else {
+        st = Status::kNotFound; exist_miss_.fetch_add(1, std::memory_order_relaxed);
+      }
       break;
-    case WireOp::kRemove:
-      st = group_.Remove(key);
-      if (st == Status::kOk) remove_ok_.fetch_add(1, std::memory_order_relaxed);
-      else if (st == Status::kNotFound) remove_miss_.fetch_add(1, std::memory_order_relaxed);
+    case WireOp::kRemove: {
+      // Drop from both tiers. RamTier::Remove is best-effort (a still-flushing or
+      // in-flight slot declines and is reclaimed later under pressure); the L2
+      // eviction this backs targets durable blocks, which drop cleanly.
+      bool ram_had = ram_ && ram_->Remove(key);
+      Status ds = group_.Remove(key);
+      if (ram_had || ds == Status::kOk) {
+        st = Status::kOk; remove_ok_.fetch_add(1, std::memory_order_relaxed);
+      } else if (ds == Status::kNotFound) {
+        st = Status::kNotFound; remove_miss_.fetch_add(1, std::memory_order_relaxed);
+      } else {
+        st = ds;
+      }
       break;
+    }
     case WireOp::kStats:
       *out_data = MetricsText();
       st = Status::kOk;
@@ -288,6 +369,19 @@ Status KvNodeServer::RangeInto(uint64_t id, uint32_t index, uint32_t ksize,
   BlockKey key{id, index, ksize};
   bool samp = lat_sampler_.ShouldSample();
   double t0 = samp ? NowSec() : 0.0;
+  if (ram_) {
+    RamTier::Hit h;
+    if (ram_->GetPrep(key, offset, length, &h)) {  // RAM hit: copy out, no disk
+      size_t n = h.len < dst_cap ? h.len : dst_cap;
+      std::memcpy(dst, h.ptr, n);
+      ram_->Release(h.token);
+      if (out_len) *out_len = n;
+      cache_hit_.fetch_add(1, std::memory_order_relaxed);
+      bytes_read_.fetch_add(n, std::memory_order_relaxed);
+      if (samp) get_lat_.Observe(NowSec() - t0);
+      return Status::kOk;
+    }
+  }
   Status st = group_.RangeInto(key, offset, length, dst, dst_cap, out_len);
   if (st == Status::kOk) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
@@ -306,14 +400,23 @@ Status KvNodeServer::CacheDirect(uint64_t id, uint32_t index, uint32_t ksize,
   BlockKey key{id, index, ksize};
   bool samp = lat_sampler_.ShouldSample();
   double t0 = samp ? NowSec() : 0.0;
-  Status st = group_.CacheDirect(key, data, len, cap);
-  if (st == Status::kOk) {
+  // RAM write-through (same [ValueHeader|payload] blob GET returns); backpressure
+  // or disabled falls through to the O_DIRECT disk write.
+  Status st;
+  if (ram_ && ram_->Put(key, data, len)) {
+    st = Status::kOk;
     cache_put_.fetch_add(1, std::memory_order_relaxed);
     bytes_written_.fetch_add(len, std::memory_order_relaxed);
-  } else if (st == Status::kIOError) {
-    put_io_err_.fetch_add(1, std::memory_order_relaxed);
-  } else if (st == Status::kInvalid) {
-    invalid_ops_.fetch_add(1, std::memory_order_relaxed);
+  } else {
+    st = group_.CacheDirect(key, data, len, cap);
+    if (st == Status::kOk) {
+      cache_put_.fetch_add(1, std::memory_order_relaxed);
+      bytes_written_.fetch_add(len, std::memory_order_relaxed);
+    } else if (st == Status::kIOError) {
+      put_io_err_.fetch_add(1, std::memory_order_relaxed);
+    } else if (st == Status::kInvalid) {
+      invalid_ops_.fetch_add(1, std::memory_order_relaxed);
+    }
   }
   if (samp) put_lat_.Observe(NowSec() - t0);
   return st;
@@ -326,6 +429,23 @@ Status KvNodeServer::RangeDirect(uint64_t id, uint32_t index, uint32_t ksize,
   BlockKey key{id, index, ksize};
   bool samp = lat_sampler_.ShouldSample();
   double t0 = samp ? NowSec() : 0.0;
+  if (ram_) {
+    RamTier::Hit h;
+    if (ram_->GetPrep(key, offset, length, &h)) {
+      // RAM hit: copy the value into the caller's registered io_buf so the RDMA
+      // layer scatter-sends it from there (no disk, no open, no pread). True
+      // zero-copy (send straight from the arena MR) is B5-3.
+      size_t n = h.len < io_cap ? h.len : io_cap;
+      std::memcpy(io_buf, h.ptr, n);
+      ram_->Release(h.token);
+      if (out_data) *out_data = io_buf;
+      if (out_len) *out_len = n;
+      cache_hit_.fetch_add(1, std::memory_order_relaxed);
+      bytes_read_.fetch_add(n, std::memory_order_relaxed);
+      if (samp) get_lat_.Observe(NowSec() - t0);
+      return Status::kOk;
+    }
+  }
   Status st = group_.RangeDirect(key, offset, length, io_buf, io_cap, out_data, out_len);
   if (st == Status::kOk) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
@@ -343,6 +463,14 @@ Status KvNodeServer::RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize
                                      uint64_t offset, uint64_t length,
                                      size_t io_cap, KVStore::RangePrep* out) {
   BlockKey key{id, index, ksize};
+  // A RAM-resident key has no fd to hand io_uring (and may be RAM-only, not yet
+  // on disk). Decline the async prep (kInvalid) WITHOUT counting a miss so the
+  // RDMA serve loop falls back to the synchronous RangeDirect, which serves it
+  // from the arena. (Only reached when the RAM tier is enabled.)
+  if (ram_ && ram_->Contains(key)) {
+    if (out) *out = KVStore::RangePrep{};
+    return Status::kInvalid;
+  }
   Status st = group_.RangeDirectPrep(key, offset, length, io_cap, out);
   // Only miss/io-error are final here; a kOk prep is accounted on read completion
   // (RangeDirectComplete) because the async read can still fail.

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "cache/disk_cache_group.h"
+#include "cache/ram_tier.h"
 #include "utils/latency_hist.h"
 
 namespace dfkv {
@@ -103,6 +104,7 @@ class KvNodeServer {
  private:
   void AcceptLoop();
   void Handle(int fd);
+  void InitRamTier();     // construct ram_ if DFKV_RAM_TIER is enabled (env)
   void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
   std::atomic<size_t> cache_put_{0}, cache_hit_{0}, cache_miss_{0};
   std::atomic<size_t> exist_hit_{0}, exist_miss_{0};
@@ -120,6 +122,12 @@ class KvNodeServer {
   std::chrono::steady_clock::time_point start_time_ = std::chrono::steady_clock::now();
 
   DiskCacheGroup group_;
+  // Optional RAM hot tier (P3). Declared AFTER group_ so it is destroyed FIRST:
+  // ~RamTier stops+joins the flusher, whose callback calls group_.Cache, before
+  // group_ is torn down. nullptr unless DFKV_RAM_TIER is enabled. Write-through:
+  // PUT lands in RAM (sync-visible) + async-flushes to group_; GET checks RAM
+  // first (served from the arena) then falls back to group_.
+  std::unique_ptr<RamTier> ram_;
   int listen_fd_ = -1;
   int port_ = 0;
   std::atomic<bool> running_{false};

--- a/test/cache/ram_tier_wiring_test.cc
+++ b/test/cache/ram_tier_wiring_test.cc
@@ -1,0 +1,158 @@
+// RamTier wiring into KvNodeServer: with DFKV_RAM_TIER=1, PUT is write-through
+// to RAM (sync-visible, async-flushed) and GET is served from RAM; disabled by
+// default the node behaves exactly as before. End-to-end over the TCP transport.
+#include "cache/kv_node_server.h"
+#include "client/key_map.h"
+#include "transport/tcp_transport.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace fs = std::filesystem;
+using namespace dfkv;  // NOLINT
+
+using namespace std::chrono_literals;
+
+namespace {
+// Extract a single-sample counter/gauge value from Prometheus text (line
+// "<name>{...} <v>" or "<name> <v>"); returns -1 if absent.
+long MetricVal(const std::string& text, const std::string& name) {
+  size_t ls = 0;
+  while (ls < text.size()) {
+    size_t le = text.find('\n', ls);
+    if (le == std::string::npos) le = text.size();
+    const std::string line = text.substr(ls, le - ls);
+    ls = le + 1;
+    if (line.empty() || line[0] == '#') continue;                 // skip HELP/TYPE
+    if (line.compare(0, name.size(), name) != 0) continue;        // must start with name
+    char after = line.size() > name.size() ? line[name.size()] : '\0';
+    if (after != '{' && after != ' ') continue;                  // exact metric, not a prefix
+    size_t sp = line.rfind(' ');
+    if (sp != std::string::npos) return std::stol(line.substr(sp + 1));
+  }
+  return -1;
+}
+
+std::unique_ptr<KvNodeServer> Start(const fs::path& dir, std::string* addr) {
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  auto s = std::make_unique<KvNodeServer>(dir.string(), 1ull << 30);
+  EXPECT_EQ(s->Start(0), Status::kOk);
+  *addr = "127.0.0.1:" + std::to_string(s->port());
+  return s;
+}
+
+template <class F>
+bool WaitFor(F pred) {
+  for (int i = 0; i < 2000; ++i) {
+    if (pred()) return true;
+    std::this_thread::sleep_for(1ms);
+  }
+  return pred();
+}
+}  // namespace
+
+TEST(RamTierWiring, WriteThroughAndServeFromRam) {
+  ::setenv("DFKV_RAM_TIER", "1", 1);
+  ::setenv("DFKV_RAM_TIER_BYTES", "16777216", 1);  // 16 MiB arena
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_ramwire_a";
+  auto s = Start(dir, &addr);
+  TcpTransport t;
+
+  // PUT 20 blocks, then GET each back -- read-after-write straight from RAM.
+  for (int i = 0; i < 20; ++i) {
+    std::string v = "ram-block-" + std::to_string(i) + std::string(200, 'z');
+    ASSERT_EQ(t.Cache(addr, ToBlockKey("k" + std::to_string(i)), v.data(), v.size()),
+              Status::kOk) << i;
+  }
+  for (int i = 0; i < 20; ++i) {
+    std::string v = "ram-block-" + std::to_string(i) + std::string(200, 'z');
+    std::string out;
+    ASSERT_EQ(t.Range(addr, ToBlockKey("k" + std::to_string(i)), 0, v.size(), &out),
+              Status::kOk) << i;
+    EXPECT_EQ(out, v) << i;
+  }
+
+  std::string m = s->MetricsText();
+  EXPECT_GE(MetricVal(m, "dfkv_ram_put_total"), 20);
+  EXPECT_GE(MetricVal(m, "dfkv_ram_hit_total"), 20);
+  EXPECT_EQ(MetricVal(m, "dfkv_ram_miss_total"), 0);
+  // The async flusher persists every block to disk in the background.
+  EXPECT_TRUE(WaitFor([&] { return MetricVal(s->MetricsText(), "dfkv_ram_flushed_total") >= 20; }));
+
+  ::unsetenv("DFKV_RAM_TIER");
+  ::unsetenv("DFKV_RAM_TIER_BYTES");
+  fs::remove_all(dir);
+}
+
+TEST(RamTierWiring, SurvivesAsMissWhenRangePastEnd) {
+  ::setenv("DFKV_RAM_TIER", "1", 1);
+  ::setenv("DFKV_RAM_TIER_BYTES", "8388608", 1);
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_ramwire_b";
+  auto s = Start(dir, &addr);
+  TcpTransport t;
+  std::string v = "0123456789";
+  ASSERT_EQ(t.Cache(addr, ToBlockKey("p"), v.data(), v.size()), Status::kOk);
+  std::string out;
+  ASSERT_EQ(t.Range(addr, ToBlockKey("p"), 3, 4, &out), Status::kOk);  // RAM sub-range
+  EXPECT_EQ(out, "3456");
+  // absent key -> miss even with RAM on
+  EXPECT_EQ(t.Range(addr, ToBlockKey("absent"), 0, 4, &out), Status::kNotFound);
+  EXPECT_GE(MetricVal(s->MetricsText(), "dfkv_ram_miss_total"), 1);
+
+  ::unsetenv("DFKV_RAM_TIER");
+  ::unsetenv("DFKV_RAM_TIER_BYTES");
+  fs::remove_all(dir);
+}
+
+TEST(RamTierWiring, ExistAndRemoveSeeRam) {
+  ::setenv("DFKV_RAM_TIER", "1", 1);
+  ::setenv("DFKV_RAM_TIER_BYTES", "8388608", 1);
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_ramwire_d";
+  auto s = Start(dir, &addr);
+  TcpTransport t;
+  std::string v(300, 'e');
+  ASSERT_EQ(t.Cache(addr, ToBlockKey("live"), v.data(), v.size()), Status::kOk);
+  bool e = false;
+  ASSERT_EQ(t.Exist(addr, ToBlockKey("live"), &e), Status::kOk);
+  EXPECT_TRUE(e) << "a RAM-resident block must report as existing";
+  // Let it flush to disk so Remove targets a durable block, then remove it.
+  EXPECT_TRUE(WaitFor([&] { return MetricVal(s->MetricsText(), "dfkv_ram_flushed_total") >= 1; }));
+  ASSERT_EQ(t.Remove(addr, ToBlockKey("live")), Status::kOk);
+  ASSERT_EQ(t.Exist(addr, ToBlockKey("live"), &e), Status::kOk);
+  EXPECT_FALSE(e) << "after Remove the block is gone from both tiers";
+  std::string out;
+  EXPECT_EQ(t.Range(addr, ToBlockKey("live"), 0, v.size(), &out), Status::kNotFound);
+
+  ::unsetenv("DFKV_RAM_TIER");
+  ::unsetenv("DFKV_RAM_TIER_BYTES");
+  fs::remove_all(dir);
+}
+
+TEST(RamTierWiring, DisabledByDefaultNoRamMetrics) {
+  ::unsetenv("DFKV_RAM_TIER");  // ensure off
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_ramwire_c";
+  auto s = Start(dir, &addr);
+  TcpTransport t;
+  std::string v(128, 'd');
+  ASSERT_EQ(t.Cache(addr, ToBlockKey("x"), v.data(), v.size()), Status::kOk);
+  std::string out;
+  ASSERT_EQ(t.Range(addr, ToBlockKey("x"), 0, v.size(), &out), Status::kOk);  // via disk
+  EXPECT_EQ(out, v);
+  std::string m = s->MetricsText();
+  EXPECT_EQ(MetricVal(m, "dfkv_ram_hit_total"), -1) << "no RAM metrics when disabled";
+  EXPECT_EQ(MetricVal(m, "dfkv_ram_put_total"), -1);
+  EXPECT_EQ(s->m_cache_put(), 1u);   // normal disk accounting intact
+  EXPECT_EQ(s->m_cache_hit(), 1u);
+  fs::remove_all(dir);
+}

--- a/test/cache/ram_tier_wiring_test.cc
+++ b/test/cache/ram_tier_wiring_test.cc
@@ -87,6 +87,7 @@ TEST(RamTierWiring, WriteThroughAndServeFromRam) {
   // The async flusher persists every block to disk in the background.
   EXPECT_TRUE(WaitFor([&] { return MetricVal(s->MetricsText(), "dfkv_ram_flushed_total") >= 20; }));
 
+  s.reset();  // stop the flusher before removing the dir (no write race)
   ::unsetenv("DFKV_RAM_TIER");
   ::unsetenv("DFKV_RAM_TIER_BYTES");
   fs::remove_all(dir);
@@ -108,6 +109,7 @@ TEST(RamTierWiring, SurvivesAsMissWhenRangePastEnd) {
   EXPECT_EQ(t.Range(addr, ToBlockKey("absent"), 0, 4, &out), Status::kNotFound);
   EXPECT_GE(MetricVal(s->MetricsText(), "dfkv_ram_miss_total"), 1);
 
+  s.reset();  // stop the flusher before removing the dir (no write race)
   ::unsetenv("DFKV_RAM_TIER");
   ::unsetenv("DFKV_RAM_TIER_BYTES");
   fs::remove_all(dir);
@@ -133,6 +135,7 @@ TEST(RamTierWiring, ExistAndRemoveSeeRam) {
   std::string out;
   EXPECT_EQ(t.Range(addr, ToBlockKey("live"), 0, v.size(), &out), Status::kNotFound);
 
+  s.reset();  // stop the flusher before removing the dir (no write race)
   ::unsetenv("DFKV_RAM_TIER");
   ::unsetenv("DFKV_RAM_TIER_BYTES");
   fs::remove_all(dir);
@@ -154,5 +157,6 @@ TEST(RamTierWiring, DisabledByDefaultNoRamMetrics) {
   EXPECT_EQ(MetricVal(m, "dfkv_ram_put_total"), -1);
   EXPECT_EQ(s->m_cache_put(), 1u);   // normal disk accounting intact
   EXPECT_EQ(s->m_cache_hit(), 1u);
+  s.reset();
   fs::remove_all(dir);
 }


### PR DESCRIPTION
## What

Hooks the P3 RAM hot tier (B5-1) into the node's GET/PUT/Exist/Remove paths, **off by default** (`DFKV_RAM_TIER` unset). Enabled, a PUT is **written through** to RAM — synchronously visible (read-after-write) and flushed to the disk group in the background — and a GET is **served from the arena** without touching disk.

- **`InitRamTier()`**: constructs the tier when `DFKV_RAM_TIER` ∈ {1,on,true,yes}; `DFKV_RAM_TIER_BYTES` sizes the arena (default 4 GiB). The flusher persists each slot via `group_.Cache` (the same `[ValueHeader|payload]` blob a GET returns). Arena-alloc failure ⇒ node stays disk-only.
- **PUT** (`ProcessRequest` kCache + `CacheDirect`): `ram_->Put` first; on backpressure (arena full of un-flushed slots) it declines and the normal disk write runs — never blocks, never breaks read-after-write.
- **GET** (kRange + `RangeInto` + `RangeDirect`): `ram_->GetPrep` first; a hit copies the value out of the arena into the caller's buffer (no disk/open/pread) and Releases the pin. *(True zero-copy send straight from the arena MR is B5-3.)*
- **`RangeDirectPrep`** declines (`kInvalid`, no miss count) for a RAM-resident key so the io_uring serve loop falls back to the sync `RangeDirect` that serves RAM — a RAM-only key (not yet on disk) is never a false miss.
- **Exist/Remove** see RAM: Exist counts a RAM-resident block present; Remove drops from both tiers (best-effort on RAM).
- **Metrics** (only when enabled): `dfkv_ram_hit/miss/put/put_bypass/flushed/flush_dropped/evictions_total` + `ram_objects` / `ram_flush_backlog` gauges (RAM hit-rate + gap-10.3 backpressure).

**Destructor order fixed (caught by TSan)**: `Stop()` joins the handler threads *before* `ram_.reset()`, so no in-flight request reads `ram_` as it's torn down; `group_` (a member) outlives the flusher.

## Tests
`ram_tier_wiring_test` (end-to-end over TCP): write-through then serve-from-RAM for 20 blocks with background flush to disk, RAM sub-range GET + absent-key miss, Exist/Remove see RAM, and disabled-by-default emits no RAM metrics with disk accounting intact. **TSan-clean** (flusher + handler threads). Local: default **264/264**, RDMA+URING **287/287**.

Next: B5-3 makes the RAM hit a true zero-copy RDMA send from the arena MR (skip the copy-out), with the send-pin released on `IBV_WC_SEND`.
