### PR TITLE
feat(cache): RDMA zero-copy serve of RAM hot-tier hits (P3 B5-3)

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -169,6 +169,20 @@ int main(int argc, char** argv) {
         [&srv](bool ok, size_t bytes_read) {
           srv.RangeDirectComplete(ok, bytes_read);
         });
+    // RAM hot tier (P3 B5-3): when enabled, register the arena as a pool MR and
+    // wire the zero-copy serve hooks so a RAM hit is scatter-sent straight from
+    // the arena (no copy into the connection buffer, no disk). No-op if off.
+    if (srv.ram_enabled()) {
+      rsrv->RegisterMemory(srv.ram_arena(), srv.ram_arena_bytes());
+      rsrv->set_ram_range_handler(
+          [&srv](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
+                 const char** out_ptr, size_t* out_len, uint64_t* out_token) {
+            return srv.RamRangePrep(id, idx, ks, off, len, out_ptr, out_len, out_token);
+          });
+      rsrv->set_ram_release_handler([&srv](uint64_t tok) { srv.RamRelease(tok); });
+      DFKV_LOG_INFO("dfkv_server RAM hot tier: RDMA zero-copy serve enabled (arena " +
+                    std::to_string(srv.ram_arena_bytes()) + " bytes)");
+    }
     if (rsrv->Start(rdma_port) == Status::kOk)
       DFKV_LOG_INFO("dfkv_server RDMA listening (TCP bootstrap) on port " +
                     std::to_string(rsrv->port()) +

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -491,6 +491,25 @@ void KvNodeServer::RangeDirectComplete(bool ok, size_t bytes_read) {
   }
 }
 
+bool KvNodeServer::RamRangePrep(uint64_t id, uint32_t index, uint32_t ksize,
+                                uint64_t offset, uint64_t length,
+                                const char** out_ptr, size_t* out_len,
+                                uint64_t* out_token) {
+  if (!ram_) return false;
+  RamTier::Hit h;
+  if (!ram_->GetPrep(BlockKey{id, index, ksize}, offset, length, &h)) return false;
+  if (out_ptr) *out_ptr = h.ptr;
+  if (out_len) *out_len = h.len;
+  if (out_token) *out_token = h.token;
+  cache_hit_.fetch_add(1, std::memory_order_relaxed);
+  bytes_read_.fetch_add(h.len, std::memory_order_relaxed);
+  return true;
+}
+
+void KvNodeServer::RamRelease(uint64_t token) {
+  if (ram_) ram_->Release(token);
+}
+
 // Keep-alive: serve requests on this connection until the peer closes it.
 void KvNodeServer::Handle(int fd) {
   // Bound the declared payload_len BEFORE the allocation below: without this

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -101,6 +101,20 @@ class KvNodeServer {
   // Account a completed prep-based GET (called after the async read finishes).
   void RangeDirectComplete(bool ok, size_t bytes_read);
 
+  // --- RAM hot tier zero-copy serve hooks (P3 B5-3) ----------------------------
+  // These let the RDMA server send a RAM hit STRAIGHT from the arena MR (no copy
+  // into the connection buffer). All no-ops / false when the RAM tier is off.
+  bool ram_enabled() const { return ram_ != nullptr; }
+  char* ram_arena() const { return ram_ ? ram_->arena() : nullptr; }
+  uint64_t ram_arena_bytes() const { return ram_ ? ram_->arena_bytes() : 0; }
+  // On a RAM hit, pins the slot and returns its arena pointer + length + a token;
+  // the caller MUST call RamRelease(token) once the RDMA send completes (the NIC
+  // reads the shared arena in place -- gap 10.1). Bumps hit/miss + bytes-read.
+  bool RamRangePrep(uint64_t id, uint32_t index, uint32_t ksize, uint64_t offset,
+                    uint64_t length, const char** out_ptr, size_t* out_len,
+                    uint64_t* out_token);
+  void RamRelease(uint64_t token);
+
  private:
   void AcceptLoop();
   void Handle(int fd);

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -114,6 +114,10 @@ size_t RdmaServer::live_conn_count() {
   return conns_.size();
 }
 
+void RdmaServer::RegisterMemory(void* base, size_t size) {
+  if (base && size) user_regions_.emplace_back(base, size);  // applied per-conn in Serve
+}
+
 void RdmaServer::AcceptLoop() {
   while (running_) {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
@@ -215,6 +219,10 @@ void RdmaServer::Serve(int boot_fd) {
     ::close(boot_fd); return;
   }
   if (!ep.Connect(rdma::ParseQpInfo(peer))) { ::close(boot_fd); return; }
+  // Register the RAM arena (and any other declared region) as a pool MR on this
+  // connection's PD so a RAM-hit payload resolves to an MR with no per-op reg_mr
+  // (B5-3). No-op when nothing was registered.
+  if (!user_regions_.empty()) ep.EnsurePoolMrs(user_regions_);
   auto post_request_recv = [&](size_t slot) {
     if (!ep.dbuf(slot) || !ep.dmr(slot) || ep.dbuf_cap() <= ValueHeader::kSize)
       return ep.PostRecv(slot);
@@ -256,6 +264,7 @@ void RdmaServer::Serve(int boot_fd) {
     const void* payload = nullptr;
     size_t payload_len = 0;
     ibv_mr* payload_mr = nullptr;
+    uint64_t release_token = 0;  // RAM-hit send-in-flight pin; 0 = none (B5-3)
   };
 
   // Build the reply for one request. Generic ops are materialized in sbuf. For
@@ -297,6 +306,34 @@ void RdmaServer::Serve(int boot_fd) {
       if (!ep.dbuf(recv_slot) || !ep.dmr(recv_slot)) return false;
       if (rq.length > static_cast<uint64_t>(ValueHeader::kSize + max_msg_))
         return invalid_reply();
+      // RAM hot tier (B5-3): if the block is resident in the arena, scatter-send
+      // it STRAIGHT from the arena MR -- no copy into dbuf, no disk. The slot is
+      // pinned until this send completes (release_token -> ram_release_handler_).
+      if (ram_range_handler_) {
+        const char* rptr = nullptr; size_t rlen = 0; uint64_t tok = 0;
+        if (ram_range_handler_(rq.id, rq.index, rq.size, rq.offset, rq.length,
+                               &rptr, &rlen, &tok)) {
+          ibv_mr* amr = rlen ? ep.RegisterUser(const_cast<char*>(rptr), rlen) : nullptr;
+          if (rlen != 0 && amr == nullptr) {  // MR resolve failed -> release + fall back
+            if (ram_release_handler_) ram_release_handler_(tok);
+          } else {
+            EncodeResp(sb, Status::kOk, rlen);
+            reply->first_len = kRespPrefix;
+            if (rlen != 0) {
+              reply->scatter = true;
+              reply->defer_recv_rearm = true;
+              reply->recv_slot = recv_slot;
+              reply->payload = rptr;
+              reply->payload_len = rlen;
+              reply->payload_mr = amr;
+              reply->release_token = tok;
+            } else {
+              if (ram_release_handler_) ram_release_handler_(tok);  // 0-len: nothing to send
+            }
+            return true;
+          }
+        }
+      }
       const char* out_data = nullptr;
       size_t out_len = 0;
       Status st = range_handler_(rq.id, rq.index, rq.size, rq.offset, rq.length,
@@ -359,6 +396,16 @@ void RdmaServer::Serve(int boot_fd) {
   std::vector<ibv_wc> wcs(K);
   constexpr size_t kNoSlot = static_cast<size_t>(-1);
   std::vector<size_t> rearm_on_send(K, kNoSlot);
+  // Parallel to rearm_on_send: the RAM-hit pin token to release when this send
+  // slot's IBV_WC_SEND fires (the arena bytes were read by the NIC in place).
+  // 0 = none (B5-3). All-zero unless a ram_range_handler_ hit went out.
+  std::vector<uint64_t> release_on_send(K, 0);
+  auto release_completed_send = [&](size_t sid) {
+    if (sid < release_on_send.size() && release_on_send[sid] != 0) {
+      if (ram_release_handler_) ram_release_handler_(release_on_send[sid]);
+      release_on_send[sid] = 0;
+    }
+  };
   bool fail = false;
   const int idle_ms = ServerIdleMs();
   active_conns_.fetch_add(1, std::memory_order_relaxed);
@@ -426,6 +473,7 @@ void RdmaServer::Serve(int boot_fd) {
               if (!post_request_recv(rearm_on_send[sid])) { fail = true; break; }
               rearm_on_send[sid] = kNoSlot;
             }
+            release_completed_send(sid);  // release any RAM-hit pin (B5-3)
             free_send.push_back(sid);
             continue;
           }
@@ -516,6 +564,7 @@ void RdmaServer::Serve(int boot_fd) {
             } else if (!post_request_recv(qd.recv_slot)) {
               fail = true; break;
             }
+            release_on_send[qd.send_slot] = reply.release_token;  // RAM-hit pin (B5-3)
             bool sent = reply.scatter
                             ? ep.PostSendScatter(qd.send_slot, reply.first_len,
                                                  reply.payload, reply.payload_len,
@@ -558,6 +607,9 @@ void RdmaServer::Serve(int boot_fd) {
       // Connection ending: close any fds still owned by un-emitted queue entries.
       for (auto& qd : queue) if (qd.fd >= 0) ::close(qd.fd);
     }
+    // Release RAM-hit pins for sends that never completed (conn tore down) so the
+    // arena slots don't stay pinned forever (B5-3).
+    for (size_t i = 0; i < release_on_send.size(); ++i) release_completed_send(i);
     active_conns_.fetch_sub(1, std::memory_order_relaxed);
     { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
     return;
@@ -581,6 +633,7 @@ sync_serve_loop:;
           if (!post_request_recv(rearm_on_send[sid])) { fail = true; break; }
           rearm_on_send[sid] = kNoSlot;
         }
+        release_completed_send(sid);  // release any RAM-hit pin (B5-3)
         free_send.push_back(sid);
         continue;
       }
@@ -599,6 +652,7 @@ sync_serve_loop:;
       } else if (!post_request_recv(r)) {
         fail = true; break;  // re-arm (request consumed)
       }
+      release_on_send[s] = reply.release_token;  // RAM-hit pin (B5-3)
       bool sent = reply.scatter
                       ? ep.PostSendScatter(s, reply.first_len, reply.payload,
                                            reply.payload_len, reply.payload_mr)
@@ -606,6 +660,8 @@ sync_serve_loop:;
       if (!sent) { fail = true; break; }
     }
   }
+  // Release RAM-hit pins for sends that never completed (conn tore down, B5-3).
+  for (size_t i = 0; i < release_on_send.size(); ++i) release_completed_send(i);
   active_conns_.fetch_sub(1, std::memory_order_relaxed);
   { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
   // ep dtor tears down the QP; the peer observes the drop as an error completion.

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <thread>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "common/status.h"
@@ -86,6 +87,27 @@ class RdmaServer {
   void set_range_complete_handler(RangeCompleteHandler h) {
     range_complete_handler_ = std::move(h);
   }
+
+  // --- RAM hot-tier zero-copy GET (P3 B5-3, ADDITIVE + OFF unless wired) --------
+  // On a kRange, the serve loop first asks ram_range_handler_ for a hit: on true
+  // it returns (arena ptr, len, token) into a caller RAM arena, and the reply is
+  // scatter-sent [resp | arena bytes] straight from the arena MR -- no copy into
+  // the connection buffer, no disk. The NIC reads the shared arena during the
+  // send, so the slot stays pinned until IBV_WC_SEND, when the serve loop calls
+  // ram_release_handler_(token) (mirrors rearm_on_send). Both must be set AND the
+  // arena registered via RegisterMemory for the path to activate; otherwise the
+  // existing range_handler_ (copy-out) path runs unchanged.
+  using RamRangeHandler = std::function<bool(
+      uint64_t id, uint32_t index, uint32_t ksize, uint64_t offset,
+      uint64_t length, const char** out_ptr, size_t* out_len, uint64_t* out_token)>;
+  using RamReleaseHandler = std::function<void(uint64_t token)>;
+  void set_ram_range_handler(RamRangeHandler h) { ram_range_handler_ = std::move(h); }
+  void set_ram_release_handler(RamReleaseHandler h) { ram_release_handler_ = std::move(h); }
+  // Register a caller memory region (the RAM arena) as a pool MR on every
+  // connection's PD, so a RAM-hit payload resolves to an MR with no per-op
+  // ibv_reg_mr. Call before Start(); regions are applied as each connection opens.
+  void RegisterMemory(void* base, size_t size);
+
   ~RdmaServer();
 
   Status Start(int port);  // TCP bootstrap port
@@ -127,6 +149,9 @@ class RdmaServer {
   CacheDirectHandler cache_direct_handler_;
   RangePrepHandler range_prep_handler_;
   RangeCompleteHandler range_complete_handler_;
+  RamRangeHandler ram_range_handler_;
+  RamReleaseHandler ram_release_handler_;
+  std::vector<std::pair<void*, size_t>> user_regions_;  // RAM arena pool MRs (RegisterMemory)
   size_t max_msg_;
   size_t control_cap_;
   std::string dev_name_;

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -844,3 +844,93 @@ TEST(RdmaLoopback, UringAsyncGetManyConcurrentInOrder) {
   ::unsetenv("DFKV_SERVER_URING_DEPTH");
   ::unsetenv("DFKV_RDMA_DEPTH");
 }
+
+// --- P3 B5-3: RAM hot-tier zero-copy RDMA serve --------------------------------
+// A cache node with the RAM tier enabled must serve a GET straight from the
+// pre-registered arena MR (scatter-send, no copy into the connection buffer, no
+// disk), and the bytes must round-trip correctly. dfkv_ram_hit_total proves the
+// zero-copy path was taken; the send-in-flight pin is released on IBV_WC_SEND.
+namespace {
+struct RamRdmaNode {
+  fs::path dir;
+  std::unique_ptr<KvNodeServer> srv;
+  std::unique_ptr<RdmaServer> rsrv;
+  std::string addr;
+
+  explicit RamRdmaNode(const std::string& tag, size_t max_msg = kMaxMsg) {
+    ::setenv("DFKV_RAM_TIER", "1", 1);
+    ::setenv("DFKV_RAM_TIER_BYTES", "8388608", 1);  // 8 MiB arena
+    dir = fs::temp_directory_path() / ("dfkv_ramrdma_" + tag);
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    srv = std::make_unique<KvNodeServer>(dir.string(), 1ull << 30);
+    EXPECT_EQ(srv->Start(0), Status::kOk);
+    rsrv = std::make_unique<RdmaServer>(
+        [this](uint8_t op, uint64_t id, uint32_t idx, uint32_t ks, uint64_t off,
+               uint64_t len, const char* pl, uint64_t pll, std::string* out) {
+          return srv->ProcessRequest(op, id, idx, ks, off, len, pl, pll, out);
+        },
+        max_msg);
+    rsrv->set_range_handler(
+        [this](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
+               char* io_buf, size_t cap, const char** out_data, size_t* out_len) {
+          return srv->RangeDirect(id, idx, ks, off, len, io_buf, cap, out_data, out_len);
+        });
+    rsrv->set_cache_direct_handler(
+        [this](uint64_t id, uint32_t idx, uint32_t ks, char* data, size_t len,
+               size_t cap) { return srv->CacheDirect(id, idx, ks, data, len, cap); });
+    // The B5-3 wiring (mirrors dfkv_server_main): register the arena as a pool MR
+    // and set the zero-copy serve hooks.
+    if (srv->ram_enabled()) {
+      rsrv->RegisterMemory(srv->ram_arena(), srv->ram_arena_bytes());
+      rsrv->set_ram_range_handler(
+          [this](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
+                 const char** p, size_t* l, uint64_t* tok) {
+            return srv->RamRangePrep(id, idx, ks, off, len, p, l, tok);
+          });
+      rsrv->set_ram_release_handler([this](uint64_t tok) { srv->RamRelease(tok); });
+    }
+    EXPECT_EQ(rsrv->Start(0), Status::kOk);
+    addr = "127.0.0.1:" + std::to_string(rsrv->port());
+  }
+  ~RamRdmaNode() {
+    if (rsrv) rsrv->Stop();
+    if (srv) srv->Stop();
+    srv.reset();
+    ::unsetenv("DFKV_RAM_TIER");
+    ::unsetenv("DFKV_RAM_TIER_BYTES");
+    fs::remove_all(dir);
+  }
+};
+}  // namespace
+
+TEST(RdmaLoopback, RamTierZeroCopyServe) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device (load rdma_rxe for Soft-RoCE)";
+  RamRdmaNode node("ram");
+  ASSERT_TRUE(node.srv->ram_enabled());
+  RdmaTransport rt(kMaxMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+
+  // PUT then GET a spread of blocks over RDMA; each must round-trip byte-for-byte
+  // even though the GET is served zero-copy from the arena MR.
+  const int N = 40;
+  std::vector<std::string> vals;
+  for (int i = 0; i < N; ++i) {
+    std::string v = "ram-rdma-" + std::to_string(i) + std::string(300 + i, 'q');
+    vals.push_back(v);
+    ASSERT_TRUE(c.Put("z" + std::to_string(i), v.data(), v.size())) << i;
+  }
+  for (int i = 0; i < N; ++i) {
+    std::string out(vals[i].size(), '\0');
+    ASSERT_TRUE(c.Get("z" + std::to_string(i), &out[0], out.size())) << i;
+    EXPECT_EQ(out, vals[i]) << i;
+  }
+
+  const std::string m = node.srv->MetricsText();
+  EXPECT_GT(CounterVal(m, "dfkv_ram_hit_total"), 0) << "GET must be served from RAM";
+  // Every send completed, so no arena slot is left send-pinned: a re-GET still
+  // works (pin released on IBV_WC_SEND, not leaked).
+  std::string out2(vals[0].size(), '\0');
+  ASSERT_TRUE(c.Get("z0", &out2[0], out2.size()));
+  EXPECT_EQ(out2, vals[0]);
+}


### PR DESCRIPTION
## What

Completes **P3**: a RAM hit is now scatter-sent **straight from the arena MR**, removing the one host memcpy (arena → connection buffer) that B5-2 still paid. **Additive and gated** — when the RAM tier is off (production default) no hook is set and the serve loop is byte-identical to before.

- **`RdmaServer::RegisterMemory(base, size)`**: registers the arena as a pool MR on every connection's PD (`EnsurePoolMrs` at connect), so a RAM-hit payload resolves to an MR via `RegisterUser` with no per-op `ibv_reg_mr`.
- **`ram_range_handler_` / `ram_release_handler_`**: on a kRange the serve loop asks the RAM tier first; a hit builds a scatter reply `[resp | arena bytes]` with `payload_mr` = the arena MR and a `release_token`.
- **Send-in-flight pin (gap 10.1)**: the NIC reads the shared arena in place, so the slot stays pinned until `IBV_WC_SEND`. `release_on_send[]` mirrors `rearm_on_send[]` — on the send completion the serve loop calls `ram_release_handler_(token)`. Both serve paths (sync + io_uring fallback) **and connection teardown** release outstanding pins, so a torn-down conn never leaks a pinned arena slot.
- **`KvNodeServer`** exposes `ram_enabled`/`ram_arena`/`ram_arena_bytes` + `RamRangePrep` (GetPrep + hit/bytes accounting) + `RamRelease`; `RamRangePrep` reuses the **B5-1 pin/token/Release API built for exactly this**.
- `dfkv_server_main` wires `RegisterMemory` + the two hooks when the tier is enabled.

The **RAM-off path is unchanged**: the new kRange branch is skipped when `ram_range_handler_` is unset, and `release_on_send` is all-zero (a no-op branch on send completion).

## Tests
`rdma_loopback` **RamTierZeroCopyServe** (Soft-RoCE): PUT then GET 40 blocks over RDMA with the RAM tier on, each round-trips **byte-for-byte served zero-copy from the arena** (`dfkv_ram_hit_total` > 0), and a re-GET proves the send-in-flight pin is **released on completion, not leaked**. **TSan-clean** on the new release path. The full existing suite (RAM off) is unchanged. Local: default **264/264**, RDMA+URING **288/288**, `rdma_loopback` **19/19**.

This closes batch 5 (P3 RAM hot tier): B5-1 core → B5-2 wiring → B5-3 zero-copy serve.
