### PR TITLE
docs: architecture guide for the storage/protocol rework + bump to v1.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # dfkv — standalone distributed KV cache for SGLang HiCache (no brpc/MDS/S3 deps).
 cmake_minimum_required(VERSION 3.20)
-project(dfkv VERSION 1.6.6 LANGUAGES CXX)
+project(dfkv VERSION 1.7.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ three engines through thin adapters over one portable core:
   a clean NotFound; no object-store fallback), synchronous durable-visible writes.
   Supports **multiple NVMe SSDs per node** (`--dir d1,d2,d3`, intra-node Ketama).
   With `--mds`, `--group`, `--id`, `--advertise`, `--weight` it registers into the
-  MDS tier; the old static `--members` flag has been removed.
+  MDS tier; the old static `--members` flag has been removed. Pluggable storage
+  backend `--store-engine=file|slab` (default `file`) and an optional
+  write-through **RAM hot tier** (`DFKV_RAM_TIER=1`) — see
+  [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 - **`dfkv_mds`** — stateless Membership Directory Service daemon. Flags:
   `--listen <port>` and `--etcd <host:port>` (default `127.0.0.1:2379`). The only
   etcd client in the system; holds each node's etcd lease on its behalf. Deploy as
@@ -36,9 +39,10 @@ three engines through thin adapters over one portable core:
 
 ## Design in one breath
 SGLang HiCache (zero-copy v1) → `dfkv_hicache.py` (ctypes) → `libdfkv` client
-(Ketama route + header wrap/verify) → TCP/RDMA → `dfkv_server` (DiskCacheGroup
-over N NVMe, LRU). Distributed = client-side consistent hashing; no replication
-(regenerable KV → node loss = miss → recompute).
+(Ketama route + header wrap/verify) → TCP/RDMA → `dfkv_server` → optional RAM hot
+tier → DiskCacheGroup over N NVMe (per-disk `StoreEngine`: `file` or `slab`), LRU.
+Distributed = client-side consistent hashing; no replication (regenerable KV →
+node loss = miss → recompute). Full architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 **Membership** is managed by the MDS tier (`dfkv_mds` + etcd). Nodes register
 with the MDS on startup and send periodic heartbeats; etcd leases (TTL 30 s)
@@ -83,14 +87,16 @@ Per-engine connect/config: `docs/hicache/DEPLOY.md` · `docs/vllm/DEPLOY.md` · 
 ## Layout
 ```
 src/        portable C++ core: common/ (shared types) · utils/ (generic helpers) ·
-            transport/ (TCP/RDMA + wire protocol) · cache/ (storage engine + dfkv_server) ·
+            transport/ (TCP/RDMA + v1/v2 wire protocol) · cache/ (StoreEngine: file
+            KVStore | slab SlabAllocator+DiskSlabStore · RamTier · dfkv_server) ·
             client/ (KV client + C ABI) · mds/ (membership service + dfkv_mds) · tools/ (CLIs)
 integration/hicache/  dfkv_hicache.py (SGLang dynamic backend plugin) + dfkv_telemetry/
                       (canonical shared telemetry pkg, vendored by the other connectors)
 integration/lmcache/  dfkv_connector  (LMCache RemoteConnector, ctypes over libdfkv.so)
 integration/vllm/     dfkv_vllm       (vLLM KVConnectorBase_V1, GPUDirect RDMA, bypass LMCache)
 test/       gtest suites + test/python (unittest + no-torch sglang shim)
-docs/       DEPLOY.md (dfkv CLUSTER deploy: etcd + MDS + server + systemd) · INTEGRATION.md (fuse into dingo-cache)
+docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire protocol) ·
+            DEPLOY.md (dfkv CLUSTER deploy: etcd + MDS + server + systemd) · INTEGRATION.md (fuse into dingo-cache)
 docs/hicache/  SGLang HiCache connector docs (DEPLOY — connect/config/use)
 docs/lmcache/  LMCache connector docs (DESIGN · IMPLEMENTATION · DEPLOY)
 docs/vllm/     vLLM connector docs (DEPLOY — config reference + recommended settings)
@@ -110,6 +116,25 @@ docs/vllm/     vLLM connector docs (DEPLOY — config reference + recommended se
   reference + recommended settings) and `integration/vllm/README.md`.
 
 ## Operability & performance features
+- **Pluggable storage engine** (`--store-engine=file|slab`, default `file`): the
+  `file` engine is one file per block (battle-tested); the `slab` engine is a
+  fixed pool of pre-allocated **extent files** carved into slots by a media-agnostic
+  size-class allocator, with a compact `slots.tbl` so the index **rebuilds on
+  restart** (cache warmth across a rolling upgrade) — removing the one-file-per-block
+  hazards (tmp leak / ENOSPC dead-end / unbounded inodes / lock-held unlink /
+  open-per-GET). Crash-safe (CRC32 per slot record). Off by default.
+- **RAM hot tier** (`DFKV_RAM_TIER=1`, off by default): a pre-registered RAM arena
+  fronting the disk — PUT is **write-through** (synchronously visible, async-flushed
+  to disk) and a warm GET is served **straight from the arena over RDMA** (zero-copy
+  scatter-send from the arena MR, no open/pread/disk), removing the disk-bound COLD
+  load bottleneck. Send-in-flight slot pinning + flush backpressure keep it correct;
+  `dfkv_ram_*` metrics expose hit-rate + backpressure. See
+  [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) §5–6.
+- **Versioned wire protocol** (v1/v2): v2 adds a request `seq` echoed in the reply;
+  servers **dual-accept** both versions (no flag-day rolling upgrade). Client opt-in
+  via `DFKV_WIRE_VERSION=2` (default v1). Block identity is **96-bit** (id + index
+  from MD5) to make same-model hash collisions — a silent cross-key read — vanishingly
+  unlikely. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) §3–4.
 - **Connection pooling + keep-alive** (TCP_NODELAY): ~250× lower latency vs dial-per-call.
 - **Batch APIs** with concurrent fan-out across nodes (`BatchPut/Get/Exist`, C ABI + plugin).
 - **Connect/IO timeouts + stale-connection retry**: a hung node fails fast, never hangs.
@@ -151,6 +176,7 @@ docs/vllm/     vLLM connector docs (DEPLOY — config reference + recommended se
 - **Packaging**: CPack (deb/rpm/tgz) + Dockerfile; **graceful shutdown**; leveled logging.
 
 ## Status
-TDD; **88 C++ ctest entries + Python plugin & connector tests green**, 0 warnings, **ThreadSanitizer-clean**.
+TDD; **264 C++ ctest entries (default) / 288 (RDMA+io_uring) + Python plugin &
+connector tests green**, 0 warnings, **ThreadSanitizer-clean**.
 CI: gcc/clang build+test, TSan, RDMA datapath (Soft-RoCE loopback), RDMA compile-check, static-artifact build. License: Apache-2.0.
-See `docs/DEPLOY.md` (rollout) and the round report in the ai_david KB.
+Architecture & design: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). Rollout: `docs/DEPLOY.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,231 @@
+# dfkv Architecture
+
+A tour of how dfkv is put together: the layers a request flows through, the
+pluggable storage engines, the optional RAM hot tier, and the versioned wire
+protocol. For deployment see [DEPLOY.md](DEPLOY.md); for metrics see
+[METRICS.md](METRICS.md); for engine connectors see `docs/{hicache,lmcache,vllm}/`.
+
+---
+
+## 1. Layers
+
+```
+        LLM inference engine (SGLang HiCache / LMCache / vLLM)
+                              │  thin adapter (ctypes / KVConnector)
+                              ▼
+   ┌──────────────────────────────────────────────────────────────┐
+   │  libdfkv client  — key→96-bit id, Ketama route, header guard  │
+   │                    Put / Get / Exist / Remove + batch/SG APIs  │
+   └───────────────┬──────────────────────────────┬───────────────┘
+        MDS discovery (etcd epoch)          transport: TCP or RDMA (RC)
+                    │                               │  versioned wire frame
+                    ▼                               ▼
+   ┌──────────────────────┐        ┌──────────────────────────────────────┐
+   │ dfkv_mds (+ etcd)    │        │  dfkv_server (cache node)             │
+   │ membership directory │        │  ┌────────────────────────────────┐  │
+   └──────────────────────┘        │  │ RamTier (opt) — write-through   │  │
+                                    │  │  RAM arena, RDMA zero-copy GET  │  │
+                                    │  └───────────────┬────────────────┘  │
+                                    │      miss ▼      │ async flush        │
+                                    │  ┌──────────────────────────────────┐│
+                                    │  │ DiskCacheGroup — Ketama over N    ││
+                                    │  │  disks, each a StoreEngine:       ││
+                                    │  │   file (KVStore)  |  slab         ││
+                                    │  └──────────────────────────────────┘│
+                                    └──────────────────────────────────────┘
+```
+
+Distribution is **client-side consistent hashing**; there is no replication
+(regenerable KV → a node loss is a miss → recompute). Membership is dynamic via
+the MDS tier — see the README for the two-layer offline detection.
+
+---
+
+## 2. Request data path
+
+**PUT** `client.Put(key, value)`
+1. Client computes the block identity and wraps the value with a 48-byte
+   `ValueHeader` (model / page-size / dtype / layer geometry guard), then routes
+   to one node by Ketama over the key.
+2. Server `ProcessRequest(kCache)` / `CacheDirect` (RDMA aligned): if the RAM
+   tier is on, the value is **written through** to a RAM slot (synchronously
+   visible) and flushed to disk in the background; otherwise it goes straight to
+   the disk `StoreEngine`.
+
+**GET** `client.Get(key, dst)`
+1. Route + request. Server checks the RAM tier first (served from the arena, no
+   disk); on a miss it reads from the disk engine. On RDMA the payload is
+   scatter-sent zero-copy (from the arena MR, or straight from the O_DIRECT read
+   buffer) into the caller's registered buffer.
+2. The client verifies the `ValueHeader` geometry — a mismatch (wrong model /
+   page-size / dtype / layer, or a stale/corrupt block) is treated as a **miss**
+   (recompute), never silent wrong bytes.
+
+---
+
+## 3. Block identity (96-bit)
+
+A block's identity is `BlockKey{id, index, size}`:
+
+- `id` = MD5[0..8) of the key string (little-endian u64) — the ring routing hash
+  input and the primary identity.
+- `index` = MD5[8..12) (little-endian u32) — extends identity to **96 bits**.
+- `size` = a fixed identity constant (never the payload length, so Put/Get/Exist
+  build the same `Filename()`).
+
+Why 96 bits: at the ~1e9 lifetime-write scale of a 5 TiB × N-node ring, a 64-bit
+id alone has a few-percent birthday-collision probability — and a collision is
+**not a clean miss but a silent cross-key read** (the geometry header only checks
+model/page/dtype/layer, so two same-model pages that collide pass validation).
+Filling the previously-always-zero `index` with more hash bits cuts collision
+probability by 2³² with no wire or storage change; `id` is unchanged so routing
+is unaffected.
+
+---
+
+## 4. Wire protocol & versioning
+
+Fixed-prefix binary frames (`src/transport/wire.h`):
+
+| | v1 request | v1 response | v2 request | v2 response |
+|-|-----------|-------------|-----------|-------------|
+| prefix bytes | 42 | 10 | 50 | 18 |
+
+**v2** appends an 8-byte request `seq` echoed in the response, so a client can
+validate that a reply matches the request it paired by FIFO order (defense
+against a torn/misordered stream). The server is **dual-accept**: it decodes
+either version and replies in the matching version, so a fleet upgrades with **no
+flag day** — new servers serve old clients and vice-versa.
+
+- TCP client wire version is chosen once via `DFKV_WIRE_VERSION` (default `1`).
+- TCP and MDS servers dual-accept v1/v2.
+- **RDMA stays v1-only**: its zero-copy PUT posts the receive scatter split
+  (`[prefix+ValueHeader | payload]`) *before* the version is known, and a v2
+  prefix (8 bytes longer) would misalign the ValueHeader across the split. A
+  version-adaptive recv-scatter is future work; RDMA rejects non-v1 frames.
+
+---
+
+## 5. Storage engine layer
+
+`DiskCacheGroup` routes a block to one disk (Ketama over `BlockKey.Filename()`)
+and holds one `StoreEngine` per disk. The backend is selected by
+`--store-engine` / `DFKV_STORE_ENGINE` (default `file`):
+
+```
+StoreEngine (interface): Cache / CacheDirect / Range / RangeInto /
+                         RangeDirect / RangeDirectPrep / IsCached / Remove + stats
+   ├── file  →  KVStore        (one file per block; the original engine)
+   └── slab  →  DiskSlabStore  (extent files + slots.tbl; the rework)
+```
+
+### 5a. `file` engine — KVStore (default)
+
+One file per block under `blocks/<bucket>/…`, O_DIRECT read/write, per-shard
+`shared_mutex` index + CLOCK-second-chance LRU. Battle-tested; the default. Its
+"one file per block" geometry is the root of several operational hazards (tmp
+leak, ENOSPC dead-end, unbounded inode growth, lock-held unlink, open-per-GET),
+which the slab engine removes.
+
+### 5b. `slab` engine — DiskSlabStore (opt-in)
+
+A fixed pool of pre-allocated **extent files**, each bound on demand to one
+**size class** and carved into uniform slots by the media-agnostic
+`SlabAllocator`:
+
+- **SlabAllocator** — owns slot *layout* (which extent, which offset), not bytes.
+  Size-class slab + per-class CLOCK eviction + pin refcount. `slot_granularity`
+  bounds the per-extent slot count. Reused by the RAM tier (§6).
+- **DiskSlabStore** — maps a key's slot to an extent-file offset (buffered I/O;
+  extent fds stay resident, no open-per-GET) and records `{key → slot}` in a
+  compact 64-byte-per-slot **`slots.tbl`**. On restart the index **rebuilds from
+  `slots.tbl`**, keeping cache warmth across a rolling upgrade without per-block
+  file churn.
+
+**Crash safety**: every `slots.tbl` record is CRC32-checked, so a torn record
+reads as free (its key becomes a clean miss = recompute, never corruption). A
+meta magic mismatch is refused; an extent/granularity config mismatch re-inits
+fresh. Eviction leaves a freed slot's record as-is (a slot's record always
+reflects its last occupant), so an unreused evicted slot merely "resurrects" its
+still-valid content-addressed key on restart.
+
+**When to use slab**: it is a strategic replacement for the file engine on nodes
+where the per-block-file hazards bite. It is **off by default**; switching a node
+needs a clean-disk cold start (a separate ops migration).
+
+---
+
+## 6. RAM hot tier (P3, opt-in)
+
+A COLD dfkv load is disk-bound (~480 MB/s O_DIRECT) and dominates PD-decode TTFT.
+The RAM tier fronts the disk with a pre-registered RAM arena so a PD-warm GET is
+served straight from RAM over RDMA — no open, no pread, no disk. Enabled with
+`DFKV_RAM_TIER=1` (`DFKV_RAM_TIER_BYTES` sizes the arena; default off).
+
+**Write-through**: `Put` copies the value into a RAM slot (via a `SlabAllocator`
+over the arena), makes it **synchronously visible** (read-after-write), and
+enqueues a background flush to the disk engine.
+
+**State machine = allocator pin refcount.** The slot lifecycle maps directly onto
+the allocator's pin count — this is why the allocator was built media-agnostic:
+
+| state | pin holders | evictable? |
+|-------|-------------|------------|
+| RAM_ONLY (flush pending) | flush-pin | no |
+| in-flight (RDMA send reading arena) | send-pin | no |
+| DURABLE & idle | none (refcount 0) | **yes** |
+
+- **flush-pin** — taken on `Put`, released when the async flush reaches disk.
+- **send-pin** — taken on `GetPrep` (an RDMA send reads the shared arena in
+  place), released on the send completion (`IBV_WC_SEND`).
+
+**RDMA zero-copy serve**: the arena is registered once as a pool MR on each
+connection's PD (`RegisterMemory`). On a RAM hit the serve loop scatter-sends
+`[response | arena bytes]` straight from the arena MR and records the send-pin's
+release token in `release_on_send[]` (mirrors the existing `rearm_on_send[]`);
+the pin is released when that send's `IBV_WC_SEND` fires. Connection teardown
+releases any outstanding pins, so a torn-down connection never leaks a pinned
+slot. When the RAM tier is off, none of this path is wired and the serve loop is
+byte-identical to before.
+
+**Backpressure & durability**: if the arena fills with non-evictable
+(flush-pending / in-flight) slots, `Put` declines and the caller takes the normal
+synchronous disk write — never blocks, never breaks read-after-write. Only a
+DURABLE slot may be evicted, so an eviction never loses the sole copy. RAM is
+volatile but dfkv is a cache (a miss = recompute), so a crash costs only a
+recompute of the unflushed tail.
+
+Observability: `dfkv_ram_hit/miss/put/put_bypass/flushed/flush_dropped/
+evictions_total` + `ram_objects` / `ram_flush_backlog` (emitted only when
+enabled) — see [METRICS.md](METRICS.md).
+
+---
+
+## 7. Configuration matrix (feature defaults)
+
+Every subsystem added by the storage/protocol rework is **off by default** —
+a stock `v1.7.0` node behaves exactly like `v1.6.x`.
+
+| Feature | Enable with | Default | Notes |
+|---------|-------------|---------|-------|
+| wire v2 (client) | `DFKV_WIRE_VERSION=2` | v1 | servers dual-accept regardless |
+| slab storage engine | `--store-engine=slab` / `DFKV_STORE_ENGINE=slab` | `file` | needs clean-disk cold start |
+| RAM hot tier | `DFKV_RAM_TIER=1` (+ `DFKV_RAM_TIER_BYTES`) | off | write-through + RDMA zero-copy GET |
+| RDMA transport | build `-DDFKV_WITH_RDMA=ON`, `DFKV_RDMA=1` | TCP | device by name `DFKV_RDMA_DEV` |
+| io_uring async GET | build `-DDFKV_WITH_URING`, `DFKV_SERVER_URING=1` | off | disk-read path only |
+
+---
+
+## 8. Source map
+
+```
+src/common/     ValueHeader, BlockKey, Status — portable shared types
+src/transport/  wire.h (v1/v2 frames) · tcp_transport · rdma_transport / rdma_verbs
+src/cache/      store_engine.h (interface) · kv_store (file) ·
+                slab_allocator + disk_slab_store (slab) · ram_tier (RAM hot tier) ·
+                disk_cache_group (per-disk routing) · kv_node_server · rdma_server ·
+                dfkv_server_main
+src/client/     kv_client + C ABI · key_map (96-bit identity)
+src/mds/        membership service + dfkv_mds
+src/tools/      dfkvctl / dfkv_smoke / dfkv_bench
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -121,6 +121,11 @@ LimitMEMLOCK=infinity        # RDMA 需要锁页内存
 [Install]
 WantedBy=multi-user.target
 ```
+
+> **可选存储/加速开关（均默认关，向后兼容；见 [ARCHITECTURE.md](ARCHITECTURE.md) §5–7）**
+> - `--store-engine=file|slab`（默认 `file`）：`slab` = extent 池 + slots.tbl 重启保温，消除"每块一文件"隐患。**切 slab 需清盘冷启**（旧 blocks/ 布局不复用），属独立迁移动作。
+> - `Environment=DFKV_RAM_TIER=1`（默认关）：开写直通 RAM 热层；`DFKV_RAM_TIER_BYTES=<bytes>` 定 arena 大小（预注册即 pin 内存，须核 `MemoryMax` 有余量）。开后观测 `dfkv_ram_hit_total` / `dfkv_ram_put_bypass_total`（见 METRICS.md §3.1）。RDMA 构建下 RAM 命中走 arena MR 零拷贝直发。
+> 滚动升级 v1.7.0 建议：**先全默认滚一遍**（等价现网）；RAM 热层、slab 引擎再各自单节点灰度评估。
 ```bash
 systemctl daemon-reload && systemctl enable --now dfkv
 journalctl -u dfkv -n 10 --no-pager

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -51,6 +51,18 @@ RDMA 构建额外（折叠进同一 /metrics）：
 | `dfkv_rdma_active_conns` | gauge | 当前服务中的 RDMA 连接 |
 | `dfkv_rdma_idle_reclaims_total` | counter | 空闲超时回收的连接数 |
 
+RAM 热层（**仅 `DFKV_RAM_TIER=1` 时输出**；关时无此系列，向后兼容）：
+| 指标 | 类型 | 含义 |
+|------|------|------|
+| `dfkv_ram_hit_total` / `dfkv_ram_miss_total` | counter | GET 命中 RAM / 未命中落盘（命中率 = hit/(hit+miss)） |
+| `dfkv_ram_put_total` | counter | 写直通进 RAM 的 PUT 数 |
+| `dfkv_ram_put_bypass_total` | counter | **背压**：arena 满（flush 落后）→ PUT 旁路直写盘，非零即 flush 跟不上 |
+| `dfkv_ram_flushed_total` / `dfkv_ram_flush_dropped_total` | counter | RAM slot 落盘转 DURABLE / flush 多次失败后丢弃 |
+| `dfkv_ram_evictions_total` | counter | RAM slot 容量压力淘汰数 |
+| `dfkv_ram_objects` / `dfkv_ram_flush_backlog` | gauge | 当前 RAM 常驻块 / 待 flush（未 DURABLE）队列深度 |
+
+> 关键运维信号：COLD `load_get_avg_ms` 骤降 + `dfkv_ram_hit_total` 上升 = RAM 热层生效；`dfkv_ram_put_bypass_total` 或 `dfkv_ram_flush_backlog` 持续升高 = flush 落盘带宽不足，需扩 flush 或降 PUT 速率（见 [docs/ARCHITECTURE.md](ARCHITECTURE.md) §6 背压）。
+
 ### 3.2 MDS（`dfkv_mds` /metrics）
 | 指标 | 类型 | 含义 |
 |---|---|---|


### PR DESCRIPTION
## What

Documents the storage/protocol rework landed since v1.6.6 and bumps the project to **v1.7.0**.

- **`docs/ARCHITECTURE.md` (new)** — the layered request path, 96-bit block identity, v1/v2 wire framing + dual-accept rolling upgrade, the pluggable `StoreEngine` layer (`file` KVStore vs `slab` SlabAllocator + DiskSlabStore + crash-safe `slots.tbl` rebuild), the write-through RAM hot tier (pin-refcount state machine + RDMA zero-copy serve + backpressure), and a **feature-default matrix** (everything off by default → a stock v1.7.0 node behaves like v1.6.x).
- **README** — new features (pluggable engine, RAM tier, versioned wire + 96-bit key) in the operability list; design-in-one-breath / layout / status (264 default, 288 RDMA+uring ctest) updated; links to ARCHITECTURE.md.
- **METRICS.md** — the `dfkv_ram_*` series (only emitted when `DFKV_RAM_TIER=1`) + key ops signals.
- **DEPLOY.md** — `--store-engine` and `DFKV_RAM_TIER` on the systemd unit, with rolling-upgrade guidance (roll all-default first, then gray-canary the RAM tier / slab engine per node).
- **CMakeLists** — `VERSION 1.6.6 → 1.7.0`.

Docs + version only; no code change. Prepares the v1.7.0 release.
