### PR TITLE
feat(rdma): pipeline-depth negotiation over the bootstrap QpInfo pad (DPQ1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ if(DFKV_BUILD_TESTS)
   file(GLOB_RECURSE DFKV_TESTS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/test/*_test.cc)
   # rdma_loopback_test needs the RDMA transport/server symbols -> RDMA build only.
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
+  list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)
   foreach(t ${DFKV_TESTS})
     get_filename_component(name ${t} NAME_WE)
     add_executable(${name} ${t})
@@ -132,6 +133,9 @@ if(DFKV_BUILD_TESTS)
     add_executable(rdma_loopback_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
     target_link_libraries(rdma_loopback_test PRIVATE dfkv_core GTest::gtest_main)
     gtest_discover_tests(rdma_loopback_test)
+    add_executable(qp_depth_negotiation_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)
+    target_link_libraries(qp_depth_negotiation_test PRIVATE dfkv_core GTest::gtest_main)
+    gtest_discover_tests(qp_depth_negotiation_test)
   endif()
 
   # Python plugin test (ctypes -> libdfkv.so -> dfkv_server). No GPU/torch.

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -216,7 +216,9 @@ void RdmaServer::Serve(int boot_fd) {
   numa::PinThreadToNode(ep.numa_node());  // keep this conn's serve thread NUMA-local to its NIC
   // QP bootstrap: read client's info, send ours (symmetric to the client).
   char peer[rdma::kQpInfoBytes], mine[rdma::kQpInfoBytes];
-  rdma::SerializeQpInfo(ep.Local(), mine);
+  rdma::QpInfo my = ep.Local();
+  my.depth = static_cast<uint16_t>(std::min<size_t>(K, 256));  // DPQ1: advertise our posted-recv depth
+  rdma::SerializeQpInfo(my, mine);
   if (!net::ReadAll(boot_fd, peer, rdma::kQpInfoBytes) ||
       !net::WriteAll(boot_fd, mine, rdma::kQpInfoBytes)) {
     ::close(boot_fd); return;

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <limits>
 
+#include "utils/log.h"
 #include "utils/net_util.h"     // Dial / WriteAll / ReadAll / Put*/Get*
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
 #include "utils/numa_util.h"     // numa::DeviceNode / CurrentNode / Enabled
@@ -180,13 +181,25 @@ RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, bool* from_
   std::memset(devbuf, 0, sizeof(devbuf));
   std::memcpy(devbuf, dev.data(), std::min(dev.size(), sizeof(devbuf) - 1));
   char mine[rdma::kQpInfoBytes], peer[rdma::kQpInfoBytes];
-  rdma::SerializeQpInfo(c->ep.Local(), mine);
+  rdma::QpInfo my = c->ep.Local();
+  my.depth = static_cast<uint16_t>(std::min<size_t>(depth_, 256));  // DPQ1 advertisement
+  rdma::SerializeQpInfo(my, mine);
   if (!net::WriteAll(fd, devbuf, rdma::kDevNameBytes) ||
       !net::WriteAll(fd, mine, rdma::kQpInfoBytes) ||
       !net::ReadAll(fd, peer, rdma::kQpInfoBytes)) {
     ::close(fd); delete c; return nullptr;
   }
-  if (!c->ep.Connect(rdma::ParseQpInfo(peer))) { ::close(fd); delete c; return nullptr; }
+  const rdma::QpInfo pq = rdma::ParseQpInfo(peer);
+  if (!c->ep.Connect(pq)) { ::close(fd); delete c; return nullptr; }
+  // Honor the server's advertised depth: clamp our batching window so we never
+  // pipeline past its posted receives (RNR-retry silent degradation otherwise).
+  if (pq.depth > 0) {
+    c->ep.set_remote_depth(pq.depth);
+    if (pq.depth < depth_)
+      DFKV_LOG_INFO("rdma: server depth " + std::to_string(pq.depth) +
+                    " < client depth " + std::to_string(depth_) +
+                    ": batching window clamped to " + std::to_string(pq.depth));
+  }
   // Wait for the server's "ready" byte: it has posted its recvs, so our first
   // SEND won't hit RNR.
   char ready = 0;
@@ -339,7 +352,7 @@ std::vector<Status> RdmaTransport::CacheMany(const std::string& node,
     Conn* c = Acquire(node, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.depth();
+    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
@@ -387,7 +400,7 @@ std::vector<Status> RdmaTransport::RangeMany(const std::string& node,
     Conn* c = Acquire(node, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.depth();
+    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
@@ -437,7 +450,7 @@ std::vector<Status> RdmaTransport::ExistMany(const std::string& node,
     Conn* c = Acquire(node, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.depth();
+    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
@@ -496,7 +509,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
     Conn* c = Acquire(node, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.depth();
+    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
@@ -578,7 +591,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
     Conn* c = Acquire(node, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.depth();
+    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
@@ -670,7 +683,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       }
     }
 
-    const size_t W = ep.depth();
+    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
@@ -780,7 +793,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       }
     }
 
-    const size_t W = ep.depth();
+    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -133,6 +133,11 @@ void SerializeQpInfo(const QpInfo& in, char out[kQpInfoBytes]) {
   net::PutU32(out + 4, in.psn);
   std::memcpy(out + 8, &in.lid, 2);   // host LE; both ends x86_64
   std::memcpy(out + 10, in.gid, 16);
+  if (in.depth > 0) {                 // depth advertisement rides the pad (DPQ1)
+    net::PutU32(out + 26, kQpDepthMagic);
+    const uint16_t d = in.depth;
+    std::memcpy(out + 30, &d, 2);
+  }
 }
 
 QpInfo ParseQpInfo(const char in[kQpInfoBytes]) {
@@ -141,6 +146,12 @@ QpInfo ParseQpInfo(const char in[kQpInfoBytes]) {
   q.psn = net::GetU32(in + 4);
   std::memcpy(&q.lid, in + 8, 2);
   std::memcpy(q.gid, in + 10, 16);
+  // Legacy peers memset the pad to zero, so the magic is an exact signal.
+  if (net::GetU32(in + 26) == kQpDepthMagic) {
+    uint16_t d = 0;
+    std::memcpy(&d, in + 30, 2);
+    if (d >= 1 && d <= 256) q.depth = d;  // out-of-range = treat as absent
+  }
   return q;
 }
 

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -30,14 +30,31 @@ namespace rdma {
 
 // QP connection info exchanged over the TCP bootstrap channel (fixed 32 bytes,
 // little-endian). lid==0 => use GRH/GID routing (RoCE); else IB LID routing.
+//
+// Wire layout: qpn u32 | psn u32 | lid u16 | gid[16] | pad[6]. Peers before the
+// depth negotiation MEMSET the whole 32 bytes and never read the pad, so the
+// pad is a deterministic-zero extension area: a non-zero magic there can ONLY
+// come from a peer that wrote it on purpose -- exact detection, no length
+// change, and every old/new pairing keeps connecting (a rolling-upgrade
+// requirement; contrast the MDS member codec, which was born with tagged
+// trailing extensions, while this blob was not).
+//
+// Extension DPQ1 (pad bytes [26,30) = magic, [30,32) = depth u16): each side
+// advertises its pipeline depth -- how many in-flight requests its posted
+// receives absorb. The CLIENT acts on it: pipelining past the server's posted
+// receives hits RNR retries and degrades silently 3-4x (measured on hd05), so
+// the client clamps its batching window to the advertised value
+// (RcEndpoint::window()). depth==0 = legacy peer / no advertisement.
 struct QpInfo {
   uint32_t qpn = 0;
   uint32_t psn = 0;
   uint16_t lid = 0;
   uint8_t gid[16] = {0};
   uint8_t pad[6] = {0};
+  uint16_t depth = 0;  // not a standalone wire field: rides the pad (see above)
 };
 constexpr size_t kQpInfoBytes = 32;
+constexpr uint32_t kQpDepthMagic = 0x31515044u;  // ASCII DPQ1 (LE)
 void SerializeQpInfo(const QpInfo& in, char out[kQpInfoBytes]);
 QpInfo ParseQpInfo(const char in[kQpInfoBytes]);
 
@@ -75,6 +92,16 @@ class RcEndpoint {
   bool Connect(const QpInfo& remote);                  // INIT -> RTR -> RTS
 
   size_t depth() const { return depth_; }
+  // Depth negotiation (DPQ1): the peer's advertised pipeline depth (0 = legacy
+  // peer, unknown). window() is the SAFE batching window -- never pipeline more
+  // requests than the peer's posted receives, or they RNR-retry and the whole
+  // window degrades silently. Falls back to the local depth against legacy
+  // peers (the pre-negotiation behavior: an ops-level contract).
+  void set_remote_depth(uint16_t d) { remote_depth_ = d; }
+  uint16_t remote_depth() const { return remote_depth_; }
+  size_t window() const {
+    return (remote_depth_ > 0 && remote_depth_ < depth_) ? remote_depth_ : depth_;
+  }
   size_t user_mr_cap() const { return user_mr_cap_; }  // >= depth (test/diagnostic)
   size_t cap() const { return cap_; }
   int numa_node() const { return numa_node_; }  // device's NUMA node, or -1
@@ -173,6 +200,7 @@ class RcEndpoint {
   unsigned cq_armed_unacked_ = 0;
 
   size_t cap_ = 0, depth_ = 0, dbuf_cap_ = 0;
+  uint16_t remote_depth_ = 0;  // DPQ1 advertisement from the peer (0 = legacy)
   size_t max_sge_ = 2;  // QP max_send_sge/max_recv_sge = min(kMaxSge, device cap)
   std::vector<char*> sbuf_, rbuf_, dbuf_;
   std::vector<ibv_mr*> smr_, rmr_, dmr_;

--- a/test/transport/qp_depth_negotiation_test.cc
+++ b/test/transport/qp_depth_negotiation_test.cc
@@ -1,0 +1,92 @@
+// DPQ1 depth negotiation over the QpInfo pad (see rdma_verbs.h). The pad is a
+// deterministic-zero extension area (legacy peers memset the whole blob), so
+// these tests pin the exact-compatibility argument:
+//   new -> new : depth round-trips
+//   old -> new : zero pad parses as depth 0 (no advertisement)
+//   new -> old : legacy fields untouched by the extension bytes
+//   garbage    : wrong magic / out-of-range depth = treated as absent
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "transport/rdma_verbs.h"
+
+using dfkv::rdma::kQpInfoBytes;
+using dfkv::rdma::ParseQpInfo;
+using dfkv::rdma::QpInfo;
+using dfkv::rdma::SerializeQpInfo;
+
+namespace {
+QpInfo Sample(uint16_t depth) {
+  QpInfo q;
+  q.qpn = 0x123456;
+  q.psn = 0xabcdef;
+  q.lid = 42;
+  for (int i = 0; i < 16; ++i) q.gid[i] = static_cast<uint8_t>(i * 3);
+  q.depth = depth;
+  return q;
+}
+void ExpectLegacyFieldsEqual(const QpInfo& a, const QpInfo& b) {
+  EXPECT_EQ(a.qpn, b.qpn);
+  EXPECT_EQ(a.psn, b.psn);
+  EXPECT_EQ(a.lid, b.lid);
+  EXPECT_EQ(std::memcmp(a.gid, b.gid, 16), 0);
+}
+}  // namespace
+
+TEST(QpDepthNegotiation, DepthRoundTrips) {
+  char buf[kQpInfoBytes];
+  SerializeQpInfo(Sample(32), buf);
+  QpInfo out = ParseQpInfo(buf);
+  ExpectLegacyFieldsEqual(out, Sample(32));
+  EXPECT_EQ(out.depth, 32);
+}
+
+TEST(QpDepthNegotiation, LegacyZeroPadMeansNoAdvertisement) {
+  // A legacy peer's serializer memsets the blob and writes only the fields:
+  // emulate it by serializing WITHOUT depth (writer skips the magic).
+  char buf[kQpInfoBytes];
+  SerializeQpInfo(Sample(0), buf);
+  // pad must be all-zero (what an old parser would also have produced)
+  for (size_t i = 26; i < kQpInfoBytes; ++i)
+    EXPECT_EQ(buf[i], 0) << "byte " << i;
+  QpInfo out = ParseQpInfo(buf);
+  EXPECT_EQ(out.depth, 0);
+  ExpectLegacyFieldsEqual(out, Sample(0));
+}
+
+TEST(QpDepthNegotiation, ExtensionInvisibleToLegacyFields) {
+  // new -> old: an old parser reads bytes [0,26) only; the extension must not
+  // perturb them. Emulate the old parser by comparing the field bytes.
+  char with[kQpInfoBytes], without[kQpInfoBytes];
+  SerializeQpInfo(Sample(64), with);
+  SerializeQpInfo(Sample(0), without);
+  EXPECT_EQ(std::memcmp(with, without, 26), 0)
+      << "extension leaked into the legacy field area";
+}
+
+TEST(QpDepthNegotiation, WrongMagicOrBadDepthTreatedAsAbsent) {
+  char buf[kQpInfoBytes];
+  SerializeQpInfo(Sample(16), buf);
+  buf[26] ^= 0x5A;  // corrupt the magic
+  EXPECT_EQ(ParseQpInfo(buf).depth, 0);
+  SerializeQpInfo(Sample(16), buf);
+  buf[30] = 0; buf[31] = 0;  // depth 0 under a valid magic: out of range
+  EXPECT_EQ(ParseQpInfo(buf).depth, 0);
+  SerializeQpInfo(Sample(16), buf);
+  uint16_t big = 300;  // > 256: out of contract range
+  std::memcpy(buf + 30, &big, 2);
+  EXPECT_EQ(ParseQpInfo(buf).depth, 0);
+}
+
+TEST(QpDepthNegotiation, WindowClampsOnlyDownward) {
+  // window() semantics live on RcEndpoint but reduce to this arithmetic:
+  // remote 0 (legacy) or remote >= local => local; remote < local => remote.
+  auto window = [](size_t local, uint16_t remote) -> size_t {
+    return (remote > 0 && remote < local) ? remote : local;
+  };
+  EXPECT_EQ(window(32, 0), 32u);    // legacy server: pre-negotiation behavior
+  EXPECT_EQ(window(32, 8), 8u);     // server smaller: clamp
+  EXPECT_EQ(window(8, 32), 8u);     // server larger: keep local
+  EXPECT_EQ(window(8, 8), 8u);
+}


### PR DESCRIPTION
## Problem

`DFKV_RDMA_DEPTH` is read independently by client and server from their own environments, and the contract *client depth ≤ server's posted receives* lived only in a comment. Violating it doesn't fail — excess in-flight requests hit RNR retries and degrade **silently**: single-connection pipelined GETs measured **1.39 vs 4.42 GB/s (batch=8)** and **1.31 vs 5.81 (batch=32)** on an hd05 canary, mismatched vs matched (root-caused in #104's review; that PR added the `qd=` ring-INFO field as the audit-side mitigation — this PR is the fix-side).

## Design: extension without a wire-format change

The 32-byte bootstrap `QpInfo` blob uses only 26 bytes, and pre-negotiation peers `memset` the whole blob — so pad bytes [26,32) are a **deterministic-zero extension area**: a non-zero magic there can only come from a peer that wrote it deliberately. Exact detection, no probability argument, no length change.

**DPQ1**: magic u32 at [26,30), depth u16 at [30,32). Both sides advertise their pipeline depth; the **client** acts on it — `RcEndpoint::window()` clamps every batch path's window to the server's advertised posted-recv depth (INFO log when clamping). depth 0 / wrong magic / out-of-range ⇒ legacy peer ⇒ pre-negotiation behavior.

## Compatibility (rolling-upgrade safe, all four pairings connect)

| pairing | behavior |
|---|---|
| old → new | zero pad = no advertisement |
| new → old | old parser reads bytes [0,26) only; extension invisible |
| new → new | clamp active |
| old → old | unchanged |

Pinned by hermetic codec tests: round-trip, zero-pad legacy, legacy-field-area purity, corrupt magic / out-of-range depth, clamp arithmetic.

## Notes

- Independent of #104 (only shared file is `rdma_server.cc`, disjoint hunks).
- With this in, the deployment guidance relaxes from "configure both sides identically" to "set the server; new clients follow automatically" — mixed-version fleets still need the ops contract until both sides are upgraded.

Suites: RDMA 285/285, default no-RDMA 261/261.

https://claude.ai/code/session_01K9c2tv7qHon3yEZJLGtn3S