### PR TITLE
feat(vllm-connector): DFKV_CONNECTOR_CLIENT_RANKS store convergence (phase 1 of #111)

### DIFF
--- a/integration/vllm/src/dfkv_vllm/client_ranks.py
+++ b/integration/vllm/src/dfkv_vllm/client_ranks.py
@@ -1,0 +1,60 @@
+"""CLIENT_RANKS resolution (issue #111): how many TP ranks act as dfkv
+clients for STORE striping. Pure logic, no torch/vllm imports, unit-testable.
+
+Never rejects: an incompatible layout CLAMPS to full participation (today's
+behavior) with a reason string -- one fleet-wide env template must be safe to
+push to every instance regardless of model layout (user requirement).
+
+  DFKV_CONNECTOR_CLIENT_RANKS = "<N>" | "auto" | unset
+    unset          -> tp_size (today's behavior, no surprises on upgrade)
+    auto           -> 1 when the KV object is TP-replicated, else tp_size
+    N (int)        -> min(N, tp_size) when replicated, else tp_size
+
+Replicated == MLA latent with a full-TP dedup stride and no DCP/PCP sharding:
+each rank holds identical KV bytes, so any subset of ranks can store on
+behalf of all (SGLang HiCache has shipped the N=1 mode as backup_skip)."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+ENV_NAME = "DFKV_CONNECTOR_CLIENT_RANKS"
+
+
+def resolve_client_ranks(
+    requested: str | None,
+    tp_size: int,
+    replicated: bool,
+) -> tuple[int, str]:
+    """Returns (effective_ranks, reason). effective == tp_size means legacy
+    full participation; the caller must leave the store path untouched then."""
+    if not requested:
+        return tp_size, "default(tp)"
+    req = requested.strip().lower()
+    if not replicated:
+        # DCP/PCP-sharded or GQA-grouped KV: every rank's bytes are unique,
+        # convergence would drop data. Clamp to full participation, loudly.
+        return tp_size, f"clamped(kv-not-replicated, requested={requested})"
+    if req == "auto":
+        return 1, "auto(mla-replicated)"
+    try:
+        n = int(req)
+    except ValueError:
+        return tp_size, f"clamped(unparseable={requested!r})"
+    if n < 1 or n > tp_size:
+        n = min(max(n, 1), tp_size)
+        return n, f"clamped(range, requested={requested})"
+    return n, f"requested({n})"
+
+
+def participant(tp_rank: int, tp_size: int, effective: int) -> int | None:
+    """Store-stripe index of this rank, or None if it does not store.
+    Participants are spread evenly (spacing tp_size//effective) so they land
+    on different NICs/NUMA nodes rather than all crowding rank 0..N-1."""
+    spacing = tp_size // effective
+    if tp_rank % spacing != 0:
+        return None
+    idx = tp_rank // spacing
+    return idx if idx < effective else None

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -48,6 +48,8 @@ from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 # dfkv: get_dp_engine_index replaces mooncake_utils.get_mooncake_dp_engine_index;
 # dfkv handles its own RDMA bootstrap so the transfer-engine helpers are dropped.
 from ._determinism import ensure_deterministic_block_hashing
+from .client_ranks import ENV_NAME as CLIENT_RANKS_ENV
+from .client_ranks import participant, resolve_client_ranks
 from .coordinator import (
     ExternalCachedBlockPool,
     DfkvStoreCoordinator,
@@ -221,6 +223,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
             record_operation=record_operation,
         )
         self.put_step = put_step
+        # CLIENT_RANKS store convergence (issue #111): stripe index/step over
+        # the participating ranks. stripe_idx None = this rank stores nothing
+        # (a converged peer stores on its behalf; KV is TP-replicated).
+        # Defaults reproduce the legacy tp_rank % put_step striping exactly.
+        self.stripe_idx: int | None = tp_rank % put_step
+        self.stripe_step: int = put_step
         self.coord = coord
         self.kv_role = kv_role
         self.stored_requests: defaultdict[str, int] = defaultdict(int)
@@ -314,8 +322,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     block_hashes.append(BlockHash(bytes.fromhex(key.chunk_hash)))
                     group_indices.append(g_idx)
 
-            # Apply put_step striding for TP
-            sl = slice(self.tp_rank % self.put_step, None, self.put_step)
+            # Apply store striding: legacy = tp_rank % put_step over put_step;
+            # under CLIENT_RANKS convergence = index over the participant set,
+            # and non-participants select nothing (empty slice keeps the
+            # request lifecycle -- bookkeeping/finish -- identical).
+            if self.stripe_idx is None:
+                sl = slice(0, 0)
+            else:
+                sl = slice(self.stripe_idx % self.stripe_step, None, self.stripe_step)
             starts = starts[sl]
             ends = ends[sl]
             keys = keys[sl]
@@ -774,6 +788,28 @@ class DfkvStoreWorker:
         if self.dcp_size > 1 and self.put_step > 1:
             self.put_step = max(1, self.put_step // self.dcp_size)
 
+        # CLIENT_RANKS (issue #111): converge store-side dfkv clients onto a
+        # subset of ranks when the KV object is TP-replicated. Layout-clamped,
+        # never rejects (one fleet-wide env template must be safe everywhere).
+        replicated = (
+            self.use_mla
+            and self.put_step == self.tp_size
+            and self.dcp_size <= 1
+            and getattr(self, "pcp_size", 1) <= 1
+        )
+        requested = os.environ.get(CLIENT_RANKS_ENV)
+        self.client_ranks, cr_reason = resolve_client_ranks(
+            requested, self.tp_size, replicated
+        )
+        logger.info(
+            "client_ranks: requested=%s effective=%d/%d reason=%s%s",
+            requested or "<unset>",
+            self.client_ranks,
+            self.tp_size,
+            cr_reason,
+            " (store convergence active)" if self.client_ranks < self.tp_size else "",
+        )
+
         self.metadata = KeyMetadata(
             model_name=model_config.model.rstrip("/").split("/")[-1],
             tp_rank=self.head_or_tp_rank,
@@ -1001,6 +1037,12 @@ class DfkvStoreWorker:
                 self.enable_kv_events,
                 record_operation=self._record_kv_connector_operation,
             )
+            if self.client_ranks < self.tp_size:
+                # Converged mode: re-stripe stores over the participant set.
+                self.kv_send_thread.stripe_idx = participant(
+                    self.tp_rank, self.tp_size, self.client_ranks
+                )
+                self.kv_send_thread.stripe_step = self.client_ranks
             self.kv_send_thread.start()
 
         ready_event_recving = threading.Event()

--- a/integration/vllm/tests/test_client_ranks.py
+++ b/integration/vllm/tests/test_client_ranks.py
@@ -1,0 +1,41 @@
+"""CLIENT_RANKS clamp semantics (issue #111): must never reject, must never
+converge non-replicated layouts, and participant spread must cover exactly
+the effective count."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from dfkv_vllm.client_ranks import participant, resolve_client_ranks
+
+
+def test_default_is_full_participation():
+    assert resolve_client_ranks(None, 8, True)[0] == 8
+    assert resolve_client_ranks("", 8, True)[0] == 8
+
+
+def test_auto_converges_only_replicated():
+    assert resolve_client_ranks("auto", 8, True)[0] == 1
+    eff, reason = resolve_client_ranks("auto", 8, False)
+    assert eff == 8 and "clamped" in reason
+
+
+def test_explicit_n_clamps_but_never_errors():
+    assert resolve_client_ranks("2", 8, True)[0] == 2
+    eff, reason = resolve_client_ranks("2", 8, False)   # sharded layout
+    assert eff == 8 and "kv-not-replicated" in reason
+    assert resolve_client_ranks("99", 8, True)[0] == 8  # over TP
+    assert resolve_client_ranks("0", 8, True)[0] == 1   # under 1
+    eff, reason = resolve_client_ranks("garbage", 8, True)
+    assert eff == 8 and "unparseable" in reason
+
+
+def test_participant_spread_is_even_and_exact():
+    # N=2 of TP8: ranks 0 and 4 (different NUMA/NIC halves), indices 0,1.
+    got = {r: participant(r, 8, 2) for r in range(8)}
+    assert got == {0: 0, 1: None, 2: None, 3: None, 4: 1, 5: None, 6: None, 7: None}
+    # N=TP: everyone participates with idx == rank (legacy identity).
+    assert [participant(r, 4, 4) for r in range(4)] == [0, 1, 2, 3]
+    # N=1: only rank 0.
+    assert [participant(r, 4, 1) for r in range(4)] == [0, None, None, None]


### PR DESCRIPTION
Phase 1 of #111 (draft until phase 2 lands).

## What's in
- `DFKV_CONNECTOR_CLIENT_RANKS = <N> | auto | unset` — **layout-clamped, never rejects**: one fleet-wide env template is safe on every instance. Sharded layouts (DCP/PCP/GQA-grouped) clamp to full participation with a logged reason; `auto` = MLA-replicated ? 1 : TP; unset = TP (no upgrade surprises).
- Store-side convergence: N evenly-spread participants (spacing tp/N → different NICs/NUMA) re-stripe the stores; non-participants skip stores via an empty stripe (request lifecycle untouched).
- Resolved-truth log line: `client_ranks: requested=… effective=…/… reason=…` (audit which instances actually converged).
- Pure resolution logic in `client_ranks.py` (no torch/vllm imports) + 4 unit tests (clamp semantics, participant spread).

## Phase 2 (next, needs GPU iteration)
Load-side convergence = the actual connection-count reduction: dfkv GETs land in **host MRs** and vLLM TP workers are **same-host processes**, so non-participant ranks can take pages from a participant's staging via POSIX shared memory — no NCCL from the async recv threads (collectives there are unsafe), no extra network. Participant timeout → peers treat as miss. Will be developed and measured on hd04 elm-test.

Related: #112 (DCP1 per-conn buffer sizing — the other factor of `conns × qd × bufsize`).

https://claude.ai/code/session_01K9c2tv7qHon3yEZJLGtn3S