### PR TITLE
fix(hicache): isolate PP stages in storage keys (append _pp{pp_rank})

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -2,8 +2,17 @@
 dynamic). Zero-copy v1 path: hands raw host-buffer pointers from
 mem_pool_host.get_page_buffer_meta() straight to the DingoFS KV client (C ABI).
 
-MLA (GLM-5.1): one packed-latent object per page, key has NO tp_rank suffix, and
-only tp_rank 0 writes (backup_skip) since the latent is replicated across TP.
+Key scheme:
+- MLA (GLM-5.1): one packed-latent object per page. The latent is replicated
+  across *TP*, so the key has NO tp_rank suffix and only tp_rank 0 writes
+  (backup_skip). PP splits the model by *layer*, so the latent is NOT replicated
+  across PP stages — when pp_size > 1 every key carries _pp{pp_rank} (including
+  MLA) so stages holding different layer-slices do not collide.
+- MHA: two objects (_k/_v) per page, suffixed by tp_size/tp_rank (+ _pp{pp_rank}
+  when PP is on).
+
+This mirrors SGLang's reference HiCacheFile suffix (hicache_storage.py), where
+`enable_pp` appends `_{pp_size}_{pp_rank}` unconditionally — including MLA.
 
 This file is the production plugin. On a GPU host it imports the real SGLang
 HiCacheStorage; the test harness supplies a no-torch shim with the same surface.
@@ -140,6 +149,16 @@ class DfkvHiCache(HiCacheStorage):
         self.tp_rank = int(storage_config.tp_rank)
         self.tp_size = int(storage_config.tp_size)
         self.is_mla = bool(storage_config.is_mla_model)
+        # Pipeline-parallel rank/size. PP splits the model across stages by
+        # layer, so each pp_rank holds a *different* slice of KV (unlike TP,
+        # where MLA latent is replicated). Storage keys MUST therefore carry
+        # pp_rank when pp_size > 1, or PP stages overwrite each other's pages.
+        # Mirrors SGLang's reference HiCacheFile suffix (hicache_storage.py:
+        # `if enable_pp: config_suffix += f"_{pp_size}_{pp_rank}"`, applied
+        # unconditionally — including MLA models).
+        self.pp_rank = int(getattr(storage_config, "pp_rank", 0))
+        self.pp_size = int(getattr(storage_config, "pp_size", 1))
+        self.enable_pp = self.pp_size > 1
         # One-shot guard for the logical-anchor notice (V4/DSA models whose
         # primary "kv" pool holds no host buffer — see _note_logical_anchor_once).
         self._anchor_noop_warned = False
@@ -364,11 +383,18 @@ class DfkvHiCache(HiCacheStorage):
         Returns True on success."""
         return self._lib.dfkv_start_mds_discovery(self._h, mds_endpoints.encode(), group.encode(), poll_ms) == 0
 
-    # --- key scheme: MLA single object (no rank suffix); MHA two objects ---
+    # --- key scheme: MLA single object (no tp_rank suffix); MHA two objects ---
+    # PP note: when pp_size > 1, every path appends _pp{pp_rank} so stages
+    # holding different layer-slices of KV do not collide on the same key.
+    # This applies to MLA too — PP splits by layer, the latent is NOT
+    # replicated across PP stages (only across TP). See __init__.
+    def _pp_suffix(self) -> str:
+        return f"_pp{self.pp_rank}" if self.enable_pp else ""
+
     def _keys(self, page_hash: str) -> List[str]:
         if self.is_mla:
-            return [f"{self.model}/{page_hash}_k"]
-        base = f"{self.model}/{page_hash}_{self.tp_size}_{self.tp_rank}"
+            return [f"{self.model}/{page_hash}_k{self._pp_suffix()}"]
+        base = f"{self.model}/{page_hash}_{self.tp_size}_{self.tp_rank}{self._pp_suffix()}"
         return [base + "_k", base + "_v"]
 
     def _sub(self) -> int:
@@ -543,9 +569,11 @@ class DfkvHiCache(HiCacheStorage):
     # --- v2 pool-aware interface (multi-pool models: Mamba/SWA/DeepSeek-V4) ---
     def _pool_keys(self, pool_name: str, page_hash: str) -> List[str]:
         # primary KV pool keeps the MLA/MHA split; auxiliary pools are single-object.
+        # Both carry the PP suffix for the same layer-slice reason as _keys().
+        pps = self._pp_suffix()
         if pool_name in ("kv", "__default__"):
             return self._keys(page_hash)
-        base = f"{self.model}/{page_hash}_{pool_name}"
+        base = f"{self.model}/{page_hash}_{pool_name}{pps}"
         return [base + "_k"] if self.is_mla else [base + "_k", base + "_v"]
 
     def _pool_sub(self, pool_name: str) -> int:

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -142,10 +142,12 @@ class DingoFSHiCacheTest(unittest.TestCase):
         self.procs.append(p)
         return f"{tag}=127.0.0.1:{port}", port, d
 
-    def _cfg(self, members, tp_rank=0, tp_size=8, page_size=64, model="glm-5.1"):
+    def _cfg(self, members, tp_rank=0, tp_size=8, page_size=64, model="glm-5.1",
+             pp_rank=0, pp_size=1, is_mla_model=True):
         return HiCacheStorageConfig(
-            tp_rank=tp_rank, tp_size=tp_size, is_mla_model=True,
+            tp_rank=tp_rank, tp_size=tp_size, is_mla_model=is_mla_model,
             is_page_first_layout=False, model_name=model,
+            pp_rank=pp_rank, pp_size=pp_size,
             extra_config={
                 "members": members, "model_hash": 0x51,
                 "dtype_tag": 0x46384534, "page_size": page_size,
@@ -314,6 +316,74 @@ class DingoFSHiCacheTest(unittest.TestCase):
         self.assertEqual(m["set_observations"], 1)
         self.assertEqual(m["get_observations"], 1)
 
+    # --- PP key-isolation tests (pure logic, no server/lib needed) ---
+    # _keys()/_pool_keys() are pure functions of self.{model,tp_rank,tp_size,
+    # is_mla,pp_rank,pp_size,enable_pp}. Bypass __init__ (which needs libdfkv.so
+    # + a live server) via __new__ and set those attrs directly.
+    def _keyonly(self, **kw):
+        st = dfkv_hicache.DfkvHiCache.__new__(dfkv_hicache.DfkvHiCache)
+        st.model = kw.get("model", "glm-5.1")
+        st.tp_rank = kw.get("tp_rank", 0)
+        st.tp_size = kw.get("tp_size", 8)
+        st.is_mla = kw.get("is_mla", True)
+        st.pp_rank = kw.get("pp_rank", 0)
+        st.pp_size = kw.get("pp_size", 1)
+        st.enable_pp = st.pp_size > 1
+        return st
+
+    def test_keys_pp_off_matches_legacy_format(self):
+        # PP disabled: key format must be unchanged (back-compat with existing
+        # clusters running pp_size=1).
+        mla = self._keyonly(is_mla=True)
+        self.assertEqual(mla._keys("abc"), ["glm-5.1/abc_k"])
+        mha = self._keyonly(is_mla=False, tp_rank=2, tp_size=8)
+        self.assertEqual(mha._keys("abc"),
+                         ["glm-5.1/abc_8_2_k", "glm-5.1/abc_8_2_v"])
+
+    def test_keys_mha_pp_on_appends_pp_rank(self):
+        # PP on: MHA keys carry _pp{rank}; different pp_rank -> different keys.
+        pp0 = self._keyonly(is_mla=False, tp_rank=0, tp_size=8, pp_rank=0, pp_size=4)
+        pp1 = self._keyonly(is_mla=False, tp_rank=0, tp_size=8, pp_rank=1, pp_size=4)
+        self.assertEqual(pp0._keys("xyz"),
+                         ["glm-5.1/xyz_8_0_pp0_k", "glm-5.1/xyz_8_0_pp0_v"])
+        self.assertEqual(pp1._keys("xyz"),
+                         ["glm-5.1/xyz_8_0_pp1_k", "glm-5.1/xyz_8_0_pp1_v"])
+        # The whole point: PP0 and PP1 must not share a key.
+        self.assertNotEqual(set(pp0._keys("xyz")), set(pp1._keys("xyz")))
+
+    def test_keys_mla_pp_on_appends_pp_rank(self):
+        # PP on: MLA keys ALSO carry _pp{rank}. PP splits by layer, the MLA
+        # latent is NOT replicated across PP stages (only across TP), so PP0
+        # and PP1 must not collide on the same MLA object.
+        pp0 = self._keyonly(is_mla=True, pp_rank=0, pp_size=2)
+        pp1 = self._keyonly(is_mla=True, pp_rank=1, pp_size=2)
+        self.assertEqual(pp0._keys("h"), ["glm-5.1/h_k_pp0"])
+        self.assertEqual(pp1._keys("h"), ["glm-5.1/h_k_pp1"])
+        self.assertNotEqual(pp0._keys("h"), pp1._keys("h"))
+
+    def test_pool_keys_aux_pool_carries_pp_suffix(self):
+        # Auxiliary pools (e.g. SWA/INDEXER side-pools) must also isolate by PP.
+        pp0 = self._keyonly(is_mla=True, pp_rank=0, pp_size=2)
+        pp1 = self._keyonly(is_mla=True, pp_rank=1, pp_size=2)
+        self.assertEqual(pp0._pool_keys("extra", "p"),
+                         ["glm-5.1/p_extra_pp0_k"])
+        self.assertEqual(pp1._pool_keys("extra", "p"),
+                         ["glm-5.1/p_extra_pp1_k"])
+        # primary "kv" pool routes through _keys (already covered above).
+        self.assertEqual(pp0._pool_keys("kv", "p"), ["glm-5.1/p_k_pp0"])
+
+    def test_keys_pp_isolates_across_full_tp_pp_matrix(self):
+        # Exhaustive: no two (tp_rank, pp_rank) pairs may produce the same key
+        # set on the same page_hash for MHA.
+        seen = set()
+        for tp_r in range(4):
+            for pp_r in range(3):
+                st = self._keyonly(is_mla=False, tp_rank=tp_r, tp_size=4,
+                                   pp_rank=pp_r, pp_size=3)
+                k = tuple(sorted(st._keys("page")))
+                self.assertNotIn(k, seen, f"key collision at tp{tp_r}/pp{pp_r}: {k}")
+                seen.add(k)
+
     def test_mla_writes_single_object_per_page(self):
         members, port, ndir = self._node("mla")
         pool = FakeMlaPool(2, self.PAGE_BYTES, self.PAGE_SIZE)
@@ -352,6 +422,30 @@ class DingoFSHiCacheTest(unittest.TestCase):
         reader = self._plugin(self._cfg(members, page_size=32), pool_r)
         self.assertEqual(reader.batch_get_v1(["h0"], list(range(self.PAGE_SIZE))),
                          [False])
+
+    def test_pp_stages_isolate_on_same_page_hash(self):
+        # Two PP stages (pp_rank 0 and 1) writing the SAME page_hash must land
+        # in separate storage objects — PP splits the model by layer, so each
+        # stage holds a different KV slice for the same prefix. Before the fix,
+        # _keys() ignored pp_rank and the stages overwrote each other.
+        members, _, _ = self._node("pp")
+        pool0 = FakeMlaPool(1, self.PAGE_BYTES, self.PAGE_SIZE)
+        pool0.fill_page(0, 0xAA)
+        st0 = self._plugin(self._cfg(members, pp_rank=0, pp_size=2), pool0)
+        st0.batch_set_v1(["shared"], list(range(self.PAGE_SIZE)))
+        # pp_rank=1 writes a different payload for the same page_hash; with the
+        # fix it must NOT clobber pp_rank=0's object.
+        pool1 = FakeMlaPool(1, self.PAGE_BYTES, self.PAGE_SIZE)
+        pool1.fill_page(0, 0xBB)
+        st1 = self._plugin(self._cfg(members, pp_rank=1, pp_size=2), pool1)
+        st1.batch_set_v1(["shared"], list(range(self.PAGE_SIZE)))
+        # pp_rank=0 reads back its OWN bytes, not pp_rank=1's.
+        pool0_r = FakeMlaPool(1, self.PAGE_BYTES, self.PAGE_SIZE)
+        st0_r = self._plugin(self._cfg(members, pp_rank=0, pp_size=2), pool0_r)
+        self.assertEqual(st0_r.batch_get_v1(["shared"], list(range(self.PAGE_SIZE))),
+                         [True])
+        self.assertTrue((pool0_r.buf[0:self.PAGE_BYTES] == 0xAA).all(),
+                        "pp_rank=0 payload clobbered by pp_rank=1")
 
     def test_batch_v2_multi_pool_roundtrip(self):
         from sglang.srt.mem_cache.hicache_storage import PoolTransfer


### PR DESCRIPTION
## Problem

When SGLang runs with `pp_size > 1`, the model is split across pipeline stages **by layer**, so each `pp_rank` holds a *different* KV slice for the same `page_hash`. The connector's `_keys()` / `_pool_keys()` built storage keys from `tp_rank` only — **PP stages collided on the same key and overwrote each other's pages**.

On GLM-5.2 (DSA sparse MLA) this surfaced as **L3 prefetch/lookup failures crashing the scheduler (CUDA coredump)**. The field workaround has been *"dfkv L3 ⇒ pp_size=1"* — i.e. dfkv and PP could not be used together.

## Root cause

`integration/hicache/dfkv_hicache.py:368` `_keys()` ignored `pp_rank` entirely:

```python
def _keys(self, page_hash):
    if self.is_mla:
        return [f"{self.model}/{page_hash}_k"]          # no pp_rank
    base = f"{self.model}/{page_hash}_{self.tp_size}_{self.tp_rank}"  # no pp_rank
    return [base + "_k", base + "_v"]
```

SGLang's reference `HiCacheFile` backend (`hicache_storage.py:333`) already appends `_{pp_size}_{pp_rank}` when PP is on — **unconditionally, including MLA** — because PP (layer-split) is orthogonal to TP (latent-replicated). The connector diverged from that reference and silently dropped the PP axis.

## Fix

Read `pp_rank`/`pp_size` from `HiCacheStorageConfig` in `__init__` and append `_pp{pp_rank}` to every key path when `pp_size > 1`:

| path | before | after (PP on) |
|---|---|---|
| MLA primary | `{model}/{hash}_k` | `{model}/{hash}_k_pp{rank}` |
| MHA primary | `{model}/{hash}_{tp}_{rank}_k` | `{model}/{hash}_{tp}_{rank}_pp{prrank}_k` |
| aux pool | `{model}/{hash}_{pool}_k` | `{model}/{hash}_{pool}_pp{rank}_k` |

**PP off (`pp_size=1`) is byte-identical to the legacy format** — existing clusters are unaffected.

### Why MLA too

`backup_skip` is a *TP-axis* optimization (MLA latent replicated across TP ⇒ only `tp_rank 0` writes). PP splits by **layer** — the MLA latent is NOT replicated across PP stages — so each `pp_rank` must write its own slice under its own key. `backup_skip` logic is unchanged (still keyed on `tp_rank`).

## Tests

`test/python/test_dfkv_hicache.py` — 6 new tests:

**Pure logic (no libdfkv/server, run anywhere):**
- `test_keys_pp_off_matches_legacy_format` — back-compat: PP off ⇒ legacy key format
- `test_keys_mha_pp_on_appends_pp_rank` — MHA keys carry `_pp{rank}`
- `test_keys_mla_pp_on_appends_pp_rank` — MLA keys also carry `_pp{rank}` (the crux)
- `test_pool_keys_aux_pool_carries_pp_suffix` — auxiliary pools isolated too
- `test_keys_pp_isolates_across_full_tp_pp_matrix` — exhaustive no-collision over TP×PP

**End-to-end (needs `dfkv_server` binary, runs in CI):**
- `test_pp_stages_isolate_on_same_page_hash` — two `pp_rank` connectors writing the same `page_hash` read back their own payloads, not each other's

The 5 pure-logic tests pass locally (no native deps). The e2e test is gated on `build/dfkv_server` like the rest of the suite.

## Field impact

Unblocks dfkv L3 under `pp_size > 1` for layer-split long-context serving. Previously dfkv + PP was a hard-mutex on GLM-5.2 DSA (had to pick one: drop dfkv, or drop PP). Documented in `01-工作/20260619-054503-GLM5.2-H100-agg推理配置探索/` (internal).

## Checklist

- [x] PP-off key format byte-identical to legacy (back-compat)
- [x] MLA + PP handled (not just MHA)
- [x] Auxiliary pools handled
- [x] Pure-logic tests run without native deps
- [x] `backup_skip` TP semantics preserved unchanged
- [ ] CI: e2e `test_pp_stages_isolate_on_same_page_hash` to confirm on a real `dfkv_server`

**Note:** This fixes the connector-side key isolation. The DSA mixed-pool (KV+INDEXER) prefetch path under PP segment-splitting may still have SGLang-upstream rough edges (per the 2026-06-19 exploration: "dfkv 预取检索失败→scheduler 崩"). This PR removes the connector-side key collision as a cause; if crashes persist under PP+DSA, the remaining work is on the SGLang upstream prefetch path, not here.