### PR TITLE
fix(lmcache): encode layer_id in key_mapper to isolate per-layer keys

### DIFF
--- a/integration/lmcache/src/dfkv_connector/key_mapper.py
+++ b/integration/lmcache/src/dfkv_connector/key_mapper.py
@@ -6,6 +6,11 @@ dfkv keys are opaque strings — the server shards on a hash of the whole string
 
     "{model_name}@{world_size}@{worker_id}@{chunk_hash_hex}"
 
+plus, when the key is a LMCache ``LayerCacheEngineKey`` (the per-layer key
+emitted under ``use_layerwise=True``), a trailing ``@{layer_id}``:
+
+    "{model_name}@{world_size}@{worker_id}@{chunk_hash_hex}@{layer_id}"
+
 Differences from the dingofs connector's key_mapper:
   - The full ``chunk_hash`` is used (not truncated to 32 bits). The dingofs
     connector truncated to match the upstream NativeConnectorL2Adapter's 4-byte
@@ -18,6 +23,15 @@ dtype is intentionally NOT encoded: chunk_hash is already a content hash, so two
 keys with the same model+rank+hash but different dtype are effectively the same
 chunk. (dfkv's value header still carries the geometry as a self-consistency tag,
 so a read with a different geometry safely misses.)
+
+layer_id IS encoded when present. LMCache's layerwise mode
+(``config.use_layerwise=True``, forced on for HPU) splits each chunk into
+``num_layers`` per-layer keys (``LayerCacheEngineKey``, same chunk_hash + worker
+but distinct ``layer_id``) and stores each one independently through the
+RemoteConnector. Without the layer_id in the dfkv key those N per-layer objects
+collapse to one key and overwrite each other → cross-layer corruption. The base
+``CacheEngineKey`` has no layer_id attribute, so ``getattr(..., None)`` keeps
+this path byte-identical to the legacy format when layerwise is off.
 """
 
 from __future__ import annotations
@@ -28,5 +42,14 @@ __all__ = ["cache_engine_key_to_dfkv_str"]
 
 
 def cache_engine_key_to_dfkv_str(key: CacheEngineKey) -> str:
-    """Render a CacheEngineKey as a dfkv key string."""
-    return f"{key.model_name}@{key.world_size}@{key.worker_id}@{key.chunk_hash:x}"
+    """Render a CacheEngineKey as a dfkv key string.
+
+    Appends ``@{layer_id}`` when ``key`` is a ``LayerCacheEngineKey`` (i.e. LMCache
+    layerwise mode) so per-layer objects do not collide. Omit it for the base
+    ``CacheEngineKey`` (non-layerwise mode) — byte-identical to the legacy format.
+    """
+    base = f"{key.model_name}@{key.world_size}@{key.worker_id}@{key.chunk_hash:x}"
+    layer_id = getattr(key, "layer_id", None)
+    if layer_id is not None:
+        return f"{base}@{layer_id}"
+    return base

--- a/integration/lmcache/tests/test_key_mapper.py
+++ b/integration/lmcache/tests/test_key_mapper.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for dfkv LMCache key_mapper (cache_engine_key_to_dfkv_str).
+
+Exercises the LMCache ``CacheEngineKey`` → dfkv key string serialization with
+fake key objects (``types.SimpleNamespace``), so it needs NEITHER lmcache/torch
+NOR a real dfkv ring / libdfkv.so. The ``key_mapper`` module's only external
+dependency is the ``CacheEngineKey`` *type* used in its annotation, which we
+substitute via ``sys.modules`` so the import succeeds without lmcache installed.
+
+Covers:
+  - Non-layerwise (base CacheEngineKey): legacy format, byte-identical to before.
+  - Layerwise (LayerCacheEngineKey): ``@{layer_id}`` appended; N layers of the
+    same chunk_hash + worker produce N distinct dfkv keys (no collision).
+
+Run:
+    python3 integration/lmcache/tests/test_key_mapper.py
+or with pytest:
+    python3 -m pytest integration/lmcache/tests/test_key_mapper.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+
+# --- Stub lmcache.utils so key_mapper imports without lmcache/torch installed.
+# The real CacheEngineKey lives in lmcache.utils; key_mapper references it only
+# in an annotation (a bare name lookup at import time), so a module object with
+# the attribute set is enough. The tests use SimpleNamespace fake keys, not the
+# real class, so no torch is needed.
+if "lmcache" not in sys.modules:
+    sys.modules["lmcache"] = types.ModuleType("lmcache")
+if "lmcache.utils" not in sys.modules:
+    _stub = types.ModuleType("lmcache.utils")
+
+    class CacheEngineKey:  # minimal stand-in for the annotation target
+        pass
+
+    _stub.CacheEngineKey = CacheEngineKey
+    sys.modules["lmcache.utils"] = _stub
+
+# Load key_mapper.py directly by path (bypassing the dfkv_connector package
+# __init__, which pulls in adapter → lmcache.logging and would need the full
+# lmcache install). key_mapper has no other dfkv_connector-internal deps.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "_dfkv_key_mapper_under_test",
+    os.path.join(_HERE, "..", "src", "dfkv_connector", "key_mapper.py"),
+)
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+cache_engine_key_to_dfkv_str = _MOD.cache_engine_key_to_dfkv_str
+
+
+def _base_key(model="glm-5.1", world_size=8, worker_id=0, chunk_hash=0xABCDEF):
+    """A base CacheEngineKey stand-in (no layer_id attribute)."""
+    return types.SimpleNamespace(
+        model_name=model,
+        world_size=world_size,
+        worker_id=worker_id,
+        chunk_hash=chunk_hash,
+    )
+
+
+def _layer_key(model="glm-5.1", world_size=8, worker_id=0, chunk_hash=0xABCDEF,
+               layer_id=0):
+    """A LayerCacheEngineKey stand-in (has layer_id)."""
+    k = _base_key(model, world_size, worker_id, chunk_hash)
+    k.layer_id = layer_id
+    return k
+
+
+def test_base_key_legacy_format():
+    # Non-layerwise: format must be unchanged (back-compat with deployments
+    # running use_layerwise=False, the default).
+    k = _base_key(worker_id=2, chunk_hash=0x1234)
+    assert cache_engine_key_to_dfkv_str(k) == "glm-5.1@8@2@1234"
+
+
+def test_base_key_full_hash_preserved():
+    # chunk_hash is rendered as full hex (not truncated).
+    k = _base_key(chunk_hash=0xDEADBEEFCAFE)
+    assert cache_engine_key_to_dfkv_str(k) == "glm-5.1@8@0@deadbeefcafe"
+
+
+def test_layer_key_appends_layer_id():
+    # Layerwise: @layer_id appended, mirroring LMCache's LayerCacheEngineKey
+    # .to_string() which emits "...@{dtype}@{layer_id}".
+    k = _layer_key(chunk_hash=0x99, layer_id=7)
+    assert cache_engine_key_to_dfkv_str(k) == "glm-5.1@8@0@99@7"
+
+
+def test_layer_keys_same_chunk_different_layers_distinct():
+    # THE BUG THIS FIXES: under use_layerwise=True, LMCache splits one chunk
+    # into num_layers per-layer keys (same chunk_hash + worker, distinct
+    # layer_id). Before the fix, these all collapsed to one dfkv key and
+    # overwrote each other. They must now be distinct.
+    keys = [_layer_key(chunk_hash=0x100, layer_id=L) for L in range(8)]
+    strs = [cache_engine_key_to_dfkv_str(k) for k in keys]
+    assert len(set(strs)) == 8, f"layer keys collided: {strs}"
+    # And each carries its own layer_id.
+    for L, s in enumerate(keys):
+        assert cache_engine_key_to_dfkv_str(s).endswith(f"@{L}")
+
+
+def test_base_and_layer_zero_distinct():
+    # A base key (no layer_id) and a layer key with layer_id=0 must NOT be equal:
+    # the base key represents the whole-chunk blob (non-layerwise), the layer=0
+    # key represents just layer 0's blob (layerwise). Encoding layer_id=0 makes
+    # them distinct, which is correct — they are different objects.
+    base = _base_key(chunk_hash=0x200)
+    layer0 = _layer_key(chunk_hash=0x200, layer_id=0)
+    assert cache_engine_key_to_dfkv_str(base) == "glm-5.1@8@0@200"
+    assert cache_engine_key_to_dfkv_str(layer0) == "glm-5.1@8@0@200@0"
+    assert cache_engine_key_to_dfkv_str(base) != cache_engine_key_to_dfkv_str(layer0)
+
+
+def test_layer_id_zero_is_encoded():
+    # layer_id=0 is a real layer, not "absent" — must be encoded (otherwise
+    # layer 0 collides with the non-layerwise base key, and with the chunk
+    # itself). getattr(..., None) returns 0 (not None) so the @0 suffix is added.
+    k = _layer_key(layer_id=0)
+    assert cache_engine_key_to_dfkv_str(k).endswith("@0")
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception as e:
+            failed += 1
+            import traceback
+            print(f"FAIL {fn.__name__}: {e}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)


### PR DESCRIPTION
## Problem

Under LMCache's **layerwise mode** (`config.use_layerwise=True`, forced on for HPU), the cache engine splits each chunk into `num_layers` per-layer keys via `key.split_layers(num_layers)` — each a `LayerCacheEngineKey` with the **same `chunk_hash` + `worker_id` but a distinct `layer_id`** — and stores each independently through the `RemoteConnector` (`lmcache/v1/cache_engine.py:1335`).

The dfkv `key_mapper` rendered keys as:

```
{model}@{world_size}@{worker_id}@{chunk_hash}
```

**dropping `layer_id`**. Result: the N per-layer objects for one chunk all collapsed to the **same dfkv key** and overwrote each other → **cross-layer corruption** (get returns whichever layer wrote last; `contains` prefix checks are wrong).

## Root cause

`integration/lmcache/src/dfkv_connector/key_mapper.py:32` ignored the `layer_id` attribute of `LayerCacheEngineKey`. The base `CacheEngineKey` (used when `use_layerwise=False`, the default) has no `layer_id` field (`@dataclass(slots=True)` with fixed fields), so the non-layerwise path is unaffected.

This is the **same class of key-dimension bug as #115** (SGLang HiCache PP key isolation) — a storage key that drops a distinguishing axis, causing distinct logical objects to collide. Found while auditing dfkv connectors for #115.

## Fix

Append `@{layer_id}` when the key exposes a `layer_id` attribute (`LayerCacheEngineKey`), via `getattr(key, "layer_id", None)`:

```python
base = f"{key.model_name}@{key.world_size}@{key.worker_id}@{key.chunk_hash:x}"
layer_id = getattr(key, "layer_id", None)
if layer_id is not None:
    return f"{base}@{layer_id}"
return base
```

- **Base `CacheEngineKey`** (non-layerwise) → `getattr` returns `None` → no suffix → **byte-identical to legacy format**, so existing non-layerwise deployments read old cached data unchanged.
- **`LayerCacheEngineKey`** (layerwise) → appends `@{layer_id}` → N layers produce N distinct keys.

This mirrors LMCache's own `LayerCacheEngineKey.to_string()`, which emits `...@{dtype}@{layer_id}`.

## Scope

| Path | Key type | Affected? |
|---|---|---|
| Legacy in-process `RemoteConnector` (`cache_engine_key_to_dfkv_str`) | `CacheEngineKey` / `LayerCacheEngineKey` | ✅ **fixed** |
| MP-server `L2Adapter` (`_object_key_to_string`, `ObjectKey`) | `ObjectKey` (no layer_id concept) | ❌ unaffected (object granularity is above layer level) |

`use_layerwise` defaults to `False` (`lmcache/v1/config.py:103`), so this bug is **only triggered when users explicitly enable layerwise** (or on HPU, where it's forced on). Default GPU deployments are not affected, but anyone who turned on layerwise for finer-grained caching was silently corrupting KV.

## Tests

`integration/lmcache/tests/test_key_mapper.py` — 6 pure-logic tests, **no lmcache/torch/dfkv-server deps** (uses `types.SimpleNamespace` fake keys + a `lmcache.utils` stub). Run anywhere:

- `test_base_key_legacy_format` — non-layerwise back-compat
- `test_base_key_full_hash_preserved` — chunk_hash not truncated
- `test_layer_key_appends_layer_id` — `@layer_id` suffix
- `test_layer_keys_same_chunk_different_layers_distinct` — **the bug**: N layers same chunk → N distinct keys
- `test_base_and_layer_zero_distinct` — base key vs layer-0 key don't collide
- `test_layer_id_zero_is_encoded` — `layer_id=0` is a real layer, encoded (not treated as absent)

All 6 pass locally without native deps.

## Checklist

- [x] Non-layerwise key format byte-identical to legacy (back-compat)
- [x] `layer_id=0` encoded (real layer, not "absent")
- [x] Pure-logic tests run without lmcache/torch/server
- [x] MP-server L2-adapter path confirmed unaffected (ObjectKey has no layer_id)
- [ ] CI: full LMCache test suite (needs lmcache+torch) to confirm no regression

## Related

- Companion to #115 (SGLang HiCache PP key isolation) — same class of bug, different axis (layer_id vs pp_rank), different connector.
- KB: `记忆库/语义记忆/推理引擎/跨引擎对照.md` §8 (PP/layer key isolation row).