### PR TITLE
build(cmake): read version from VERSION file (single source of truth)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 # dfkv — standalone distributed KV cache for SGLang HiCache (no brpc/MDS/S3 deps).
 cmake_minimum_required(VERSION 3.20)
-project(dfkv VERSION 1.12.1 LANGUAGES CXX)
+# Single source of truth for the version is the VERSION file (also shipped in
+# the release tarball). CMake reads it here so `project(dfkv VERSION ...)`
+# stays in sync with VERSION without a bump-both-files step (which bit v1.12.0:
+# the VERSION file was bumped but project() wasn't, so the binary's --version
+# reported 1.11.0). Strip trailing whitespace/newline.
+file(READ "${CMAKE_SOURCE_DIR}/VERSION" _dfkv_ver_raw)
+string(STRIP "${_dfkv_ver_raw}" _dfkv_ver)
+project(dfkv VERSION "${_dfkv_ver}" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## What

Eliminates the two-source version drift that bit v1.12.0.

### Root cause (v1.12.0 defect)
`project(dfkv VERSION ...)` was hardcoded in `CMakeLists.txt:3`, parallel to the `VERSION` file, with no sync mechanism. The v1.12.0 bump PR updated `VERSION` but not `project()`, so:
- `VERSION` file → `1.12.0` (drove tarball naming)
- `project()` → `1.11.0` (baked into binary via `DFKV_VERSION` in `version.cc`)
- Binary `--version` reported `1.11.0` (fixed in v1.12.1 by updating both — but root cause remained)

### Fix
CMake reads + strips the `VERSION` file at configure time:
```cmake
file(READ "${CMAKE_SOURCE_DIR}/VERSION" _dfkv_ver_raw)
string(STRIP "${_dfkv_ver_raw}" _dfkv_ver)
project(dfkv VERSION "${_dfkv_ver}" LANGUAGES CXX)
```
`VERSION` becomes the single source. Future bumps touch one file. The release tarball already ships `VERSION` (ci.yml packages it), so out-of-tree rebuilds of a released tarball also work.

## Verification
CI `portable-static-build` job builds `dfkv_server`; `dfkv_server --version` will report the `VERSION` file's value (currently `1.12.1`). The next bump PR only edits `VERSION` and the binary string follows automatically.

## Scope
Part 2 (D) of the A+B+C parameter-control cleanup. No code changes — only the version constant is affected. Bumps the next version naturally (no VERSION change in this PR; stays 1.12.1).

## Compatibility
None — version string only.