### PR TITLE
feat(client): dfkv_open_v2 — structured config, scoped env (no leak)

### DIFF
--- a/src/client/dfkv_c_api.cc
+++ b/src/client/dfkv_c_api.cc
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <exception>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -52,6 +53,72 @@ dfkv_client_t dfkv_open(const char* members, uint64_t model_hash,
     return nullptr;
   } catch (...) {
     DFKV_LOG_ERROR("dfkv_open failed: unknown exception");
+    return nullptr;
+  }
+}
+
+namespace {
+// Process-wide mutex serializing dfkv_open_v2's scoped-env dance. setenv() is
+// not thread-safe and the transport constructors read DFKV_* at construction,
+// so two concurrent v2 opens would race on the process environment. Connector
+// construction happens at init time (low concurrency), so a global lock is fine.
+std::mutex g_v2_env_mu;
+
+// RAII: snapshot the named env vars, apply v2 overrides (non-zero/non-NULL),
+// and restore the snapshot on destruction — so v2's settings don't leak into
+// the process environment after the client is built. NULL/0 fields leave their
+// env untouched (fall back to whatever DFKV_* the process already has).
+class ScopedEnv {
+ public:
+  struct KV { const char* name; const char* value; bool set; };
+  std::vector<KV> saved;
+  ~ScopedEnv() {
+    for (auto& kv : saved) {
+      if (kv.set) ::setenv(kv.name, kv.value ? kv.value : "", 1);
+      else ::unsetenv(kv.name);
+    }
+  }
+  void override_(const char* name, const char* value) {
+    const char* prev = std::getenv(name);
+    saved.push_back({name, prev, prev != nullptr});
+    ::setenv(name, value ? value : "", 1);
+  }
+};
+}  // namespace
+
+dfkv_client_t dfkv_open_v2(const dfkv_client_config_t* cfg) {
+  if (!cfg) return nullptr;
+  try {
+    std::lock_guard<std::mutex> lk(g_v2_env_mu);
+    ScopedEnv env;
+    // Apply transport/tuning overrides (0/NULL => leave env untouched).
+    if (cfg->rdma_depth)
+      env.override_("DFKV_RDMA_DEPTH", std::to_string(cfg->rdma_depth).c_str());
+    if (cfg->rdma_numa)
+      env.override_("DFKV_RDMA_NUMA", std::to_string(cfg->rdma_numa).c_str());
+    if (cfg->rdma_dev)
+      env.override_("DFKV_RDMA_DEV", cfg->rdma_dev);
+    if (cfg->require_rdma) {
+      env.override_("DFKV_REQUIRE_RDMA", "1");
+      env.override_("DFKV_RDMA", "1");
+    }
+    // Geometry identity (same as dfkv_open).
+    ValueHeader self = ValueHeader::Make(
+        cfg->model_hash, cfg->page_size, cfg->dtype_tag,
+        static_cast<uint16_t>(cfg->flags), static_cast<uint16_t>(cfg->tp_size),
+        static_cast<uint16_t>(cfg->tp_rank), static_cast<uint16_t>(cfg->layer_num),
+        static_cast<uint16_t>(cfg->head_num), static_cast<uint16_t>(cfg->head_dim));
+    auto mem = ParseMembers(cfg->members);
+    KVClient* c = new KVClient(std::move(mem), self);
+    // Batch concurrency is a per-client knob (not transport), so it's safe to
+    // set after construction (no env involvement).
+    if (cfg->batch_concurrency) c->set_batch_concurrency(cfg->batch_concurrency);
+    return c;
+  } catch (const std::exception& e) {
+    DFKV_LOG_ERROR(std::string("dfkv_open_v2 failed: ") + e.what());
+    return nullptr;
+  } catch (...) {
+    DFKV_LOG_ERROR("dfkv_open_v2 failed: unknown exception");
     return nullptr;
   }
 }

--- a/src/client/dfkv_c_api.h
+++ b/src/client/dfkv_c_api.h
@@ -21,6 +21,33 @@ dfkv_client_t dfkv_open(const char* members, uint64_t model_hash,
                         uint32_t tp_size, uint32_t tp_rank, uint32_t layer_num,
                         uint32_t head_num, uint32_t head_dim);
 
+// v2: structured config. Fields beyond the geometry identity are transport /
+// tuning knobs that v1 could only set via process-wide DFKV_* env vars (a
+// global side-effect — multiple connectors in one process overwrote each
+// other's settings). v2 takes them per-client; 0/NULL means "use the env
+// fallback" so v2 is a strict superset of v1 behavior.
+//
+// Geometry fields (members + model_hash..head_dim) mirror dfkv_open's args.
+// Transport/tuning fields:
+//   rdma_depth      — RDMA write pipeline depth (env DFKV_RDMA_DEPTH; 0=env)
+//   rdma_numa       — 0=env, 1=enable NUMA-local rail selection (DFKV_RDMA_NUMA)
+//   rdma_dev        — comma-separated device list (DFKV_RDMA_DEV; NULL=env)
+//   require_rdma    — 0=env, 1=require RDMA, fail if no device (DFKV_REQUIRE_RDMA)
+//   batch_concurrency — 0=env/default, else cap concurrent batch ops per client
+typedef struct dfkv_client_config {
+  const char* members;        // required ("name=ip:port,..." or "" for MDS discovery)
+  uint64_t model_hash;
+  uint32_t page_size, dtype_tag, flags;
+  uint32_t tp_size, tp_rank, layer_num, head_num, head_dim;
+  uint32_t rdma_depth;        // 0 = env fallback
+  uint32_t rdma_numa;         // 0 = env fallback
+  const char* rdma_dev;       // NULL = env fallback
+  uint32_t require_rdma;      // 0 = env fallback
+  uint32_t batch_concurrency; // 0 = env/default
+} dfkv_client_config_t;
+
+dfkv_client_t dfkv_open_v2(const dfkv_client_config_t* cfg);
+
 int dfkv_put(dfkv_client_t c, const char* key, const void* ptr, uint64_t n);  // 0=ok
 int dfkv_get(dfkv_client_t c, const char* key, void* ptr, uint64_t n);        // 1=hit,0=miss
 // Variable-size get: writes the stored payload (whatever length it was put with)

--- a/test/client/c_api_test.cc
+++ b/test/client/c_api_test.cc
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -137,5 +138,57 @@ TEST(CApiGuard, ZeroLengthBatchIsOk) {
   EXPECT_EQ(dfkv_batch_put(c, nullptr, nullptr, nullptr, 0, nullptr), 0);
   EXPECT_EQ(dfkv_batch_get(c, nullptr, nullptr, nullptr, 0, nullptr), 0);
   EXPECT_EQ(dfkv_batch_exist(c, nullptr, 0, nullptr), 0);
+  dfkv_close(c);
+}
+
+// v2 ABI: dfkv_open_v2 with a config struct. Geometry-only (transport fields
+// 0/NULL => env fallback, same as v1) must behave identically to dfkv_open:
+// discovery-only client, empty ring, ops route-miss without a server.
+TEST(CApiV2, NullConfigRejected) {
+  EXPECT_EQ(dfkv_open_v2(nullptr), nullptr);
+}
+
+TEST(CApiV2, GeometryOnlyMatchesV1) {
+  dfkv_client_config_t cfg{};
+  cfg.members = "";
+  cfg.model_hash = 1;
+  cfg.page_size = 64;
+  // transport/tuning fields left 0/NULL => env fallback (v1 behavior)
+  dfkv_client_t c = dfkv_open_v2(&cfg);
+  ASSERT_NE(c, nullptr);
+  EXPECT_EQ(dfkv_get(c, "k", nullptr, 0), 0);  // empty ring => miss, no crash
+  EXPECT_EQ(dfkv_set_batch_concurrency(c, 4), 0);
+  dfkv_close(c);
+}
+
+TEST(CApiV2, BatchConcurrencyApplied) {
+  dfkv_client_config_t cfg{};
+  cfg.members = "";
+  cfg.model_hash = 1;
+  cfg.page_size = 64;
+  cfg.batch_concurrency = 16;
+  dfkv_client_t c = dfkv_open_v2(&cfg);
+  ASSERT_NE(c, nullptr);
+  // The knob was set at construction; a subsequent set is harmless and confirms
+  // the client is usable.
+  EXPECT_EQ(dfkv_set_batch_concurrency(c, 8), 0);
+  dfkv_close(c);
+}
+
+// v2's scoped-env dance must not leak DFKV_* into the process env after the
+// client is built. A non-zero rdma_depth override is applied during open and
+// restored on return.
+TEST(CApiV2, ScopedEnvDoesNotLeak) {
+  ::unsetenv("DFKV_RDMA_DEPTH");
+  dfkv_client_config_t cfg{};
+  cfg.members = "";
+  cfg.model_hash = 1;
+  cfg.page_size = 64;
+  cfg.rdma_depth = 32;
+  dfkv_client_t c = dfkv_open_v2(&cfg);
+  ASSERT_NE(c, nullptr);
+  // After open_v2 returns, the override must be gone (restored to unset).
+  const char* v = std::getenv("DFKV_RDMA_DEPTH");
+  EXPECT_TRUE(v == nullptr) << "DFKV_RDMA_DEPTH leaked: " << (v ? v : "");
   dfkv_close(c);
 }


### PR DESCRIPTION
## What

Adds a v2 client ABI that takes a config struct, so transport/tuning knobs no longer have to be set via process-wide `DFKV_*` env vars (a global side-effect that lets two connector instances in one process clobber each other).

### v1 problem
`dfkv_open` is 10 positional args; RDMA depth/NUMA/dev, `require_rdma`, `batch_concurrency` can only be tuned via `DFKV_*` env. The Python connectors do `os.environ[...] = ...` at module load — global, permanent, last-writer-wins.

### v2 fix
```c
typedef struct dfkv_client_config {
  const char* members;
  uint64_t model_hash;
  uint32_t page_size, dtype_tag, flags;
  uint32_t tp_size, tp_rank, layer_num, head_num, head_dim;
  uint32_t rdma_depth;        // 0 = env fallback
  uint32_t rdma_numa;         // 0 = env fallback
  const char* rdma_dev;       // NULL = env fallback
  uint32_t require_rdma;      // 0 = env fallback
  uint32_t batch_concurrency; // 0 = env/default
} dfkv_client_config_t;

dfkv_client_t dfkv_open_v2(const dfkv_client_config_t* cfg);
```

Transport/tuning fields are applied via **scoped env** (snapshot → override → construct KVClient → restore):
- 0/NULL fields leave `DFKV_*` untouched → v1-compatible env fallback.
- Non-zero fields win for **this** client's construction only; the process environment is restored on return — no leak, no cross-instance clobber.
- A process-wide mutex serializes the scoped-env dance (`setenv` isn't thread-safe; connector construction is init-time, low concurrency).

`batch_concurrency` is a per-client atomic (not transport/env), set directly on `KVClient` after construction — no env involvement.

Geometry fields mirror v1 exactly. `dfkv_open` is **unchanged** (not a wrapper around v2 — keeps the env-only path for existing callers). v2 is a strict superset.

## Tests (`test/client/c_api_test.cc`)
- `NullConfigRejected` — `dfkv_open_v2(nullptr)` ⇒ nullptr
- `GeometryOnlyMatchesV1` — all transport fields 0/NULL ⇒ behaves like v1 (discovery-only, empty ring, route-miss)
- `BatchConcurrencyApplied` — knob set at construction
- `ScopedEnvDoesNotLeak` — `rdma_depth=32` override is gone from process env after `open_v2` returns

## Scope
Part 3 (B1) of the A+B+C parameter-control cleanup. The three Python connectors switch to v2 in **PR4 (B2+B3)**, dropping their `os.environ[...]=` side-effects. PR1 (server flag facades, #119) and PR2 (version single-source, #120) already merged.

## ABI
`dfkv_open_v2` + `dfkv_client_config_t` are additive; `dfkv_open` and the rest of the C ABI unchanged. `libdfkv.so` stays backward-compatible.

## Why scoped env (not a transport config struct)
The alternative — threading a config struct through `KVClient → MakeClientTransport → RdmaTransport` — touches the `Transport` interface and every env-read site in `rdma_transport.cc` (depth/connect_ms/io_ms/op_timeout_ms/pool_max). Scoped env contains the change to the C ABI layer, is thread-safe under the mutex, and the leak is bounded to the construction window (milliseconds). The Python side (PR4) stops permanently polluting env; this PR makes the C layer able to honor per-client overrides.