### PR TITLE
feat(connectors): switch all three connectors to dfkv_open_v2

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -36,6 +36,26 @@ from dfkv_telemetry import tracing as _tracing
 _FLAG_IS_MLA = 0x1
 
 
+class _DfkvClientConfig(ctypes.Structure):
+    """Mirrors dfkv_client_config_t in src/client/dfkv_c_api.h. Field order and
+    types MUST match the C struct (ctypes lays them out in declaration order).
+    Used by dfkv_open_v2 so transport/tuning knobs go per-client via a scoped
+    env inside the C layer, not via process-wide os.environ[...]."""
+    _fields_ = [
+        ("members", ctypes.c_char_p),
+        ("model_hash", ctypes.c_uint64),
+        ("page_size", ctypes.c_uint32), ("dtype_tag", ctypes.c_uint32),
+        ("flags", ctypes.c_uint32),
+        ("tp_size", ctypes.c_uint32), ("tp_rank", ctypes.c_uint32),
+        ("layer_num", ctypes.c_uint32), ("head_num", ctypes.c_uint32),
+        ("head_dim", ctypes.c_uint32),
+        ("rdma_depth", ctypes.c_uint32), ("rdma_numa", ctypes.c_uint32),
+        ("rdma_dev", ctypes.c_char_p),
+        ("require_rdma", ctypes.c_uint32),
+        ("batch_concurrency", ctypes.c_uint32),
+    ]
+
+
 def _truthy(v) -> bool:
     if isinstance(v, str):
         return v.strip().lower() not in ("", "0", "false", "no", "off")
@@ -52,6 +72,10 @@ def _load_lib(path: Optional[str] = None) -> ctypes.CDLL:
                               ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32,
                               ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32,
                               ctypes.c_uint32]
+    # v2 structured config (PR#121): transport/tuning knobs via config struct,
+    # scoped env inside the C layer — no process-wide os.environ[...] side-effect.
+    lib.dfkv_open_v2.restype = ctypes.c_void_p
+    lib.dfkv_open_v2.argtypes = [ctypes.c_void_p]  # const dfkv_client_config_t*
     lib.dfkv_put.restype = ctypes.c_int
     lib.dfkv_put.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_uint64]
     lib.dfkv_get.restype = ctypes.c_int
@@ -202,18 +226,13 @@ class DfkvHiCache(HiCacheStorage):
             members = cfg.get("members", "")
             if not mds and not members:
                 raise ValueError("dingofs hicache: extra_config needs 'mds_endpoints' (MDS discovery) or 'members' (static)")
-            # RDMA write pipelining: depth>1 keeps multiple PUTs in flight on one
-            # connection, hiding per-op latency (single-rank MLA writes are
-            # latency-bound). The C client reads DFKV_RDMA_DEPTH when it builds the
-            # transport inside dfkv_open below, so set it from extra_config first.
-            # NOTE: the dfkv_server must set the SAME (or larger) DFKV_RDMA_DEPTH in
-            # its own env -- client depth must be <= server depth.
-            if cfg.get("rdma_depth"):
-                os.environ["DFKV_RDMA_DEPTH"] = str(int(cfg["rdma_depth"]))
-            if _truthy(cfg.get("require_rdma")):
-                os.environ["DFKV_REQUIRE_RDMA"] = "1"
-                if not _truthy(os.environ.get("DFKV_RDMA")):
-                    os.environ["DFKV_RDMA"] = "1"
+            # RDMA transport/tuning knobs go through the v2 config struct → scoped
+            # env inside dfkv_open_v2 (no process-wide os.environ[...] leak). The
+            # C client reads DFKV_RDMA_* during transport construction inside the
+            # scoped window; on return the process env is restored, so two
+            # connector instances in one process no longer clobber each other.
+            # NOTE: the dfkv_server must set the SAME (or larger) DFKV_RDMA_DEPTH
+            # in its own env -- client depth must be <= server depth.
             # rail_affinity (per-tp_rank narrowing) is DEPRECATED and now a no-op:
             # it keyed off tp_rank, which is always 0 under DP-attention (every rank
             # is its own attention TP group of size 1), so it collapsed all ranks to
@@ -225,26 +244,33 @@ class DfkvHiCache(HiCacheStorage):
                 print("[dfkv] WARNING: 'rail_affinity' is deprecated and ignored; "
                       "set DFKV_RDMA_NUMA=1 + multi-rail DFKV_RDMA_DEV for NUMA-aware "
                       "rail selection in the client.", file=_sys.stderr, flush=True)
-            if cfg.get("rdma_numa"):
-                os.environ.setdefault("DFKV_RDMA_NUMA", "1")
-            # self._lib was loaded above (before configure) so the native version
-            # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0
             model_hash = int(cfg.get("model_hash", 0)) & 0xFFFFFFFFFFFFFFFF
-            self._h = self._lib.dfkv_open(
-                members.encode(), model_hash,
-                int(cfg.get("page_size", 64)), int(cfg.get("dtype_tag", 0)), flags,
-                self.tp_size, self.tp_rank,
-                int(cfg.get("layer_num", 0)), int(cfg.get("head_num", 0)),
-                int(cfg.get("head_dim", 0)))
+            rdma_dev = cfg.get("rdma_dev", "") or os.environ.get("DFKV_RDMA_DEV", "")
+            ccfg = _DfkvClientConfig(
+                members=members.encode() if members else b"",
+                model_hash=model_hash,
+                page_size=int(cfg.get("page_size", 64)),
+                dtype_tag=int(cfg.get("dtype_tag", 0)),
+                flags=flags,
+                tp_size=self.tp_size, tp_rank=self.tp_rank,
+                layer_num=int(cfg.get("layer_num", 0)),
+                head_num=int(cfg.get("head_num", 0)),
+                head_dim=int(cfg.get("head_dim", 0)),
+                rdma_depth=int(cfg.get("rdma_depth", 0)) or 0,
+                rdma_numa=1 if _truthy(cfg.get("rdma_numa")) else 0,
+                rdma_dev=rdma_dev.encode() if rdma_dev else None,
+                require_rdma=1 if _truthy(cfg.get("require_rdma")) else 0,
+                batch_concurrency=int(cfg.get("batch_concurrency", 0)) or 0,
+            )
+            self._h = self._lib.dfkv_open_v2(ctypes.byref(ccfg))
             if not self._h:
-                raise RuntimeError("dfkv_open failed")
+                raise RuntimeError("dfkv_open_v2 failed")
             mode_b = self._lib.dfkv_transport_mode(self._h)
             self.transport_mode = (
                 mode_b.decode("utf-8", errors="replace") if mode_b else "unknown"
             )
-            if (_truthy(cfg.get("require_rdma")) or
-                    _truthy(os.environ.get("DFKV_REQUIRE_RDMA"))):
+            if _truthy(cfg.get("require_rdma")):
                 if self.transport_mode != "rdma":
                     self._lib.dfkv_close(self._h)
                     self._h = None
@@ -252,9 +278,6 @@ class DfkvHiCache(HiCacheStorage):
                         "dfkv requires RDMA zero-copy transport, "
                         f"got {self.transport_mode}"
                     )
-            if cfg.get("batch_concurrency"):
-                self._lib.dfkv_set_batch_concurrency(
-                    self._h, ctypes.c_uint64(int(cfg["batch_concurrency"])))
             if mds:
                 group = cfg.get("mds_group", "default")
                 poll_ms = int(cfg.get("mds_poll_ms", 3000))

--- a/integration/lmcache/src/dfkv_connector/native_client.py
+++ b/integration/lmcache/src/dfkv_connector/native_client.py
@@ -56,6 +56,10 @@ def load_lib(path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_open.restype = c_void_p
     lib.dfkv_open.argtypes = [c_char_p, c_uint64, c_uint32, c_uint32, c_uint32,
                               c_uint32, c_uint32, c_uint32, c_uint32, c_uint32]
+    # v2 structured config (PR#121): transport/tuning knobs via config struct,
+    # scoped env inside the C layer — no process-wide os.environ[...] side-effect.
+    lib.dfkv_open_v2.restype = c_void_p
+    lib.dfkv_open_v2.argtypes = [c_void_p]  # const dfkv_client_config_t*
     lib.dfkv_put.restype = c_int
     lib.dfkv_put.argtypes = [c_void_p, c_char_p, c_void_p, c_uint64]
     lib.dfkv_get.restype = c_int
@@ -129,6 +133,22 @@ def _total_size(bufs: Sequence[memoryview]) -> int:
     return sum(mv.nbytes for mv in bufs)
 
 
+class _DfkvClientConfig(ctypes.Structure):
+    """Mirrors dfkv_client_config_t (src/client/dfkv_c_api.h). Field order/types
+    MUST match the C struct. Used by dfkv_open_v2 so transport/tuning knobs go
+    per-client via a scoped env inside the C layer."""
+    _fields_ = [
+        ("members", c_char_p),
+        ("model_hash", c_uint64),
+        ("page_size", c_uint32), ("dtype_tag", c_uint32), ("flags", c_uint32),
+        ("tp_size", c_uint32), ("tp_rank", c_uint32),
+        ("layer_num", c_uint32), ("head_num", c_uint32), ("head_dim", c_uint32),
+        ("rdma_depth", c_uint32), ("rdma_numa", c_uint32),
+        ("rdma_dev", c_char_p),
+        ("require_rdma", c_uint32), ("batch_concurrency", c_uint32),
+    ]
+
+
 class DfkvNativeClient:
     """Awaitable interface over libdfkv.so (ctypes + thread-pool executor)."""
 
@@ -158,20 +178,26 @@ class DfkvNativeClient:
             g = geometry
 
             members = raw_endpoint if membership == "static" else ""
-            self._h = self._lib.dfkv_open(
-                members.encode(),
-                c_uint64(int(g["model_hash"]) & 0xFFFFFFFFFFFFFFFF),
-                int(g["page_size"]) & 0xFFFFFFFF,
-                int(g["dtype_tag"]) & 0xFFFFFFFF,
-                int(g["flags"]) & 0xFFFFFFFF,
-                int(g["tp_size"]) & 0xFFFFFFFF,
-                int(g["tp_rank"]) & 0xFFFFFFFF,
-                int(g["layer_num"]) & 0xFFFFFFFF,
-                int(g["head_num"]) & 0xFFFFFFFF,
-                int(g["head_dim"]) & 0xFFFFFFFF,
+            # v2 config: transport/tuning fields 0/NULL => env fallback (LMCache
+            # connector doesn't tune RDMA via extra_config; DFKV_RDMA_* env still
+            # works as before). batch_concurrency 0 => client default.
+            ccfg = _DfkvClientConfig(
+                members=members.encode() if members else b"",
+                model_hash=c_uint64(int(g["model_hash"]) & 0xFFFFFFFFFFFFFFFF),
+                page_size=c_uint32(int(g["page_size"]) & 0xFFFFFFFF),
+                dtype_tag=c_uint32(int(g["dtype_tag"]) & 0xFFFFFFFF),
+                flags=c_uint32(int(g["flags"]) & 0xFFFFFFFF),
+                tp_size=c_uint32(int(g["tp_size"]) & 0xFFFFFFFF),
+                tp_rank=c_uint32(int(g["tp_rank"]) & 0xFFFFFFFF),
+                layer_num=c_uint32(int(g["layer_num"]) & 0xFFFFFFFF),
+                head_num=c_uint32(int(g["head_num"]) & 0xFFFFFFFF),
+                head_dim=c_uint32(int(g["head_dim"]) & 0xFFFFFFFF),
+                rdma_depth=0, rdma_numa=0, rdma_dev=None,
+                require_rdma=0, batch_concurrency=0,
             )
+            self._h = self._lib.dfkv_open_v2(ctypes.byref(ccfg))
             if not self._h:
-                raise RuntimeError("dfkv_open failed")
+                raise RuntimeError("dfkv_open_v2 failed")
             mode_b = self._lib.dfkv_transport_mode(self._h)
             self.transport_mode = (
                 mode_b.decode("utf-8", errors="replace") if mode_b else "unknown"

--- a/integration/vllm/src/dfkv_vllm/_cabi.py
+++ b/integration/vllm/src/dfkv_vllm/_cabi.py
@@ -43,6 +43,11 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_open.restype = c_void_p
     lib.dfkv_open.argtypes = [c_char_p, c_uint64] + [c_uint32] * 8
 
+    # v2 structured config (PR#121): transport/tuning knobs via config struct,
+    # scoped env inside the C layer — no process-wide os.environ[...] side-effect.
+    lib.dfkv_open_v2.restype = c_void_p
+    lib.dfkv_open_v2.argtypes = [c_void_p]  # const dfkv_client_config_t*
+
     # int = dfkv_start_mds_discovery(c, mds_endpoints, group, poll_ms)
     # Background MDS-based membership discovery (production path): the ring is
     # built/refreshed from the MDS tier instead of a static --members list.

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -36,6 +36,22 @@ c_int = ctypes.c_int
 _GEOMETRY_ZEROS = (0,) * 8
 
 
+class _DfkvClientConfig(ctypes.Structure):
+    """Mirrors dfkv_client_config_t (src/client/dfkv_c_api.h). Field order/types
+    MUST match the C struct. Used by dfkv_open_v2 so transport/tuning knobs go
+    per-client via a scoped env inside the C layer."""
+    _fields_ = [
+        ("members", c_char_p),
+        ("model_hash", c_uint64),
+        ("page_size", c_uint32), ("dtype_tag", c_uint32), ("flags", c_uint32),
+        ("tp_size", c_uint32), ("tp_rank", c_uint32),
+        ("layer_num", c_uint32), ("head_num", c_uint32), ("head_dim", c_uint32),
+        ("rdma_depth", c_uint32), ("rdma_numa", c_uint32),
+        ("rdma_dev", c_char_p),
+        ("require_rdma", c_uint32), ("batch_concurrency", c_uint32),
+    ]
+
+
 def _env_rank() -> int:
     """Best-effort TP/worker rank for the connector_id label (each rank is its own
     process, so host:pid is already unique; this just adds readable detail)."""
@@ -73,16 +89,29 @@ class DfkvDeviceClient:
         self._lib = load_lib(lib_path)
         # MDS path opens with an empty/seed member list and lets discovery build
         # the ring; the static path opens directly with the given members.
-        self._h = self._lib.dfkv_open(
-            members.encode(),
-            c_uint64(model_hash & 0xFFFFFFFFFFFFFFFF),
-            *(c_uint32(int(g) & 0xFFFFFFFF) for g in geometry),
+        # v2 config: batch_concurrency is set per-client (no env), and transport
+        # fields (rdma_*) are left 0/NULL => env fallback (vLLM connector doesn't
+        # tune RDMA via extra_config; DFKV_RDMA_* env still works as before).
+        ccfg = _DfkvClientConfig(
+            members=members.encode() if members else b"",
+            model_hash=c_uint64(model_hash & 0xFFFFFFFFFFFFFFFF),
+            page_size=c_uint32(int(geometry[0]) & 0xFFFFFFFF),
+            dtype_tag=c_uint32(int(geometry[1]) & 0xFFFFFFFF),
+            flags=c_uint32(int(geometry[2]) & 0xFFFFFFFF),
+            tp_size=c_uint32(int(geometry[3]) & 0xFFFFFFFF),
+            tp_rank=c_uint32(int(geometry[4]) & 0xFFFFFFFF),
+            layer_num=c_uint32(int(geometry[5]) & 0xFFFFFFFF),
+            head_num=c_uint32(int(geometry[6]) & 0xFFFFFFFF),
+            head_dim=c_uint32(int(geometry[7]) & 0xFFFFFFFF),
+            rdma_depth=0, rdma_numa=0, rdma_dev=None,
+            require_rdma=0,
+            batch_concurrency=c_uint32(int(batch_concurrency) & 0xFFFFFFFF),
         )
+        self._h = self._lib.dfkv_open_v2(ctypes.byref(ccfg))
         if not self._h:
             raise RuntimeError(
-                f"dfkv_open failed (members={members!r}, mds={mds_endpoints!r})"
+                f"dfkv_open_v2 failed (members={members!r}, mds={mds_endpoints!r})"
             )
-        self._lib.dfkv_set_batch_concurrency(self._h, c_uint64(batch_concurrency))
         if mds_endpoints:
             rc = self._lib.dfkv_start_mds_discovery(
                 self._h, mds_endpoints.encode(), mds_group.encode(), int(mds_poll_ms)

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -174,16 +174,20 @@ class DingoFSHiCacheTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
 
-    def test_rdma_depth_extra_config_sets_env(self):
-        # extra_config rdma_depth must propagate to DFKV_RDMA_DEPTH so the C client
-        # builds its transport with write pipelining (#1). Set before dfkv_open.
+    def test_rdma_depth_extra_config_does_not_leak_env(self):
+        # v2 (PR#122): extra_config rdma_depth goes through the dfkv_open_v2
+        # config struct → scoped env inside the C layer → restored on return.
+        # The process env must NOT be permanently polluted (the old behavior
+        # clobbered other connector instances in the same process).
         members, _, _ = self._node("rdepth")
         os.environ.pop("DFKV_RDMA_DEPTH", None)
         try:
             cfg = self._cfg(members)
             cfg.extra_config["rdma_depth"] = 8
             dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
-            self.assertEqual(os.environ.get("DFKV_RDMA_DEPTH"), "8")
+            # Construction succeeded (rdma_depth applied via v2 scoped env) AND
+            # the process env is unchanged — no leak.
+            self.assertIsNone(os.environ.get("DFKV_RDMA_DEPTH"))
         finally:
             os.environ.pop("DFKV_RDMA_DEPTH", None)
 
@@ -221,16 +225,17 @@ class DingoFSHiCacheTest(unittest.TestCase):
         self.assertEqual(self._rail_for(members, rails, tp_rank=5, tp_size=8)[0], rails)
         self.assertEqual(self._rail_for(members, rails, tp_rank=7, tp_size=8)[0], rails)
 
-    def test_rdma_numa_extra_config_sets_env(self):
-        # The new rdma_numa knob opts into client-side NUMA-aware rail selection
-        # by setting DFKV_RDMA_NUMA=1 (replaces rail_affinity's old side effect).
+    def test_rdma_numa_extra_config_does_not_leak_env(self):
+        # v2 (PR#122): extra_config rdma_numa goes through dfkv_open_v2's config
+        # struct → scoped env → restored. The process env must NOT be permanently
+        # set (old behavior set DFKV_RDMA_NUMA=1 globally via setdefault).
         members, _, _ = self._node("rnuma")
         os.environ.pop("DFKV_RDMA_NUMA", None)
         try:
             cfg = self._cfg(members)
             cfg.extra_config["rdma_numa"] = True
             dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
-            self.assertEqual(os.environ.get("DFKV_RDMA_NUMA"), "1")
+            self.assertIsNone(os.environ.get("DFKV_RDMA_NUMA"))
         finally:
             os.environ.pop("DFKV_RDMA_NUMA", None)
 


### PR DESCRIPTION
## What

SGLang, vLLM, and LMCache connectors now use `dfkv_open_v2` (PR #121) with a per-client config struct, instead of `dfkv_open`'s positional args + process-wide `os.environ[...]` side-effects.

## SGLang HiCache (the real side-effect bug)
Dropped 4 `os.environ[...] = ...` assignments that ran at **every** connector construction and globally clobbered the process env:

| Dropped | Now via v2 config |
|---|---|
| `DFKV_RDMA_DEPTH` | `ccfg.rdma_depth` |
| `DFKV_REQUIRE_RDMA` | `ccfg.require_rdma` |
| `DFKV_RDMA` | (folded into `require_rdma`) |
| `DFKV_RDMA_NUMA` (setdefault) | `ccfg.rdma_numa` |

Two connector instances in one process with different `rdma_depth`/`require_rdma` used to overwrite each other. Now those knobs ride the v2 config struct → scoped env inside `dfkv_open_v2` → restored on return. **No leak, no cross-instance clobber.**

`DFKV_PROBE_INTERVAL_MS` kept as env — it's a client-self probe knob (not transport construction), no cross-instance semantic conflict.

## vLLM + LMCache (unify on v2; no setenv to remove)
These two had no `os.environ[...]` side-effects, but switch to v2 for a uniform interface:
- Build `_DfkvClientConfig`, call `dfkv_open_v2`.
- Transport fields (`rdma_*`) are 0/NULL → env fallback (these connectors don't tune RDMA via `extra_config`; `DFKV_RDMA_*` env still works).
- vLLM: `batch_concurrency` folded into `open_v2` (was a separate `dfkv_set_batch_concurrency` call).

## Why per-connector `_DfkvClientConfig` (not a shared module)
The three connectors are independent packages (separate `sys.path` / pip install). Cross-package import isn't clean. The struct is small (15 fields) and identical across all three — field order/types mirror `src/client/dfkv_c_api.h`.

## Tests
- Pure-logic key-isolation tests (PR #115/#116) still green locally — they bypass `__init__` via `__new__`, so the v2 open path isn't exercised by them.
- The v2 open path needs `libdfkv.so` (CI has it); connector-level v2 behavior is exercised by the existing connector test suites on CI.
- PR #121's `c_api_test.cc` covers the v2 ABI itself (null config, geometry-only, batch_concurrency, scoped-env-no-leak).

## Scope
Part 4 (B2+B3) of the A+B+C parameter-control cleanup. Depends on PR #121 (B1, `dfkv_open_v2`) — merged. PR #119 (server flag facades) and #120 (version single-source) also merged.

## Compatibility
- `extra_config` keys unchanged — existing deployments keep working.
- `DFKV_RDMA_*` env still works as fallback (v2 transport fields 0/NULL → env).
- `dfkv_open` (v1) unchanged for any out-of-tree callers.