### PR TITLE
docs: sync CONNECTORS/DEPLOY/ARCHITECTURE with v2 config + CONFIG.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,14 +211,16 @@ enabled) — see [METRICS.md](METRICS.md).
 ## 7. Configuration matrix (feature defaults)
 
 Every subsystem added by the storage/protocol rework is **off by default** —
-a stock `v1.7.0` node behaves exactly like `v1.6.x`.
+a stock `v1.7.0` node behaves exactly like `v1.6.x`. Full parameter reference
+(flags + env + client config struct + connector extra_config) is in
+[CONFIG.md](CONFIG.md); this matrix is the per-feature quick view.
 
 | Feature | Enable with | Default | Notes |
 |---------|-------------|---------|-------|
 | slab storage engine | `--store-engine=slab` / `DFKV_STORE_ENGINE=slab` | `file` | needs clean-disk cold start |
-| RAM hot tier | `DFKV_RAM_TIER=1` (+ `DFKV_RAM_TIER_BYTES`) | off | write-through + RDMA zero-copy GET |
-| RDMA transport | build `-DDFKV_WITH_RDMA=ON`, `DFKV_RDMA=1` | TCP | device by name `DFKV_RDMA_DEV` |
-| io_uring async GET | build `-DDFKV_WITH_URING`, `DFKV_SERVER_URING=1` | off | disk-read path only |
+| RAM hot tier | `--ram-tier on` / `DFKV_RAM_TIER=1` (+ `--ram-tier-bytes` / `DFKV_RAM_TIER_BYTES`) | off | write-through + RDMA zero-copy GET |
+| RDMA transport | build `-DDFKV_WITH_RDMA=ON`, `DFKV_RDMA=1` | TCP | device by name `DFKV_RDMA_DEV` / `--rdma-dev` |
+| io_uring async GET | build `-DDFKV_WITH_URING`, `--server-uring 1` / `DFKV_SERVER_URING=1` | off | disk-read path only |
 
 ---
 

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -146,8 +146,12 @@ export DFKV_RDMA_MAX_PAYLOAD_BYTES=67108864  # 可选：单 chunk payload 上限
 > ⚠️ hd04 当前只有 `ib7s400p0,ib7s400p1` 两轨 up，但标准训练计算网节点是 8×400G，
 > 按本机实际 up 的口列全。
 
-传输相关 env 亦可走 extra_config（`dfkv_open` 前自动设 env，extra_config 优先）：
-`"rdma_depth":K`、`"require_rdma":1`、`"rdma_numa":1`。
+传输相关 env 亦可走 extra_config：`"rdma_depth":K`、`"require_rdma":1`、
+`"rdma_numa":1`、`"rdma_dev":"..."`。**v1.12.1+（PR#121/#122）这些走 `dfkv_open_v2`
+的 config struct → C 层 scoped env（构造时临时设、返回时恢复），不再永久污染进程
+env**——多 connector 实例同进程不会互相覆盖（旧版 `os.environ[...]=...` 的副作用已消除）。
+env 仍作 fallback（extra_config/struct 字段为 0/NULL 时读 `DFKV_*` env）。完整参数矩阵见
+[CONFIG.md](CONFIG.md)。
 
 ### 2.2 SGLang 启动 + 后端配置
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -122,11 +122,11 @@ LimitMEMLOCK=infinity        # RDMA 需要锁页内存
 WantedBy=multi-user.target
 ```
 
-> **可选存储/加速开关（见 [ARCHITECTURE.md](ARCHITECTURE.md) §5–7）。行为开关均为「门面 flag + `DFKV_*` env 双生」，flag 覆盖预设 env；运行时真值经 `dfkvctl ring` INFO 列审计（`engine=`/`wr=`/`ram=`）。**
+> **可选存储/加速开关（见 [ARCHITECTURE.md](ARCHITECTURE.md) §5–7；完整参数清单见 [CONFIG.md](CONFIG.md)）。行为开关均为「门面 flag + `DFKV_*` env 双生」，flag 覆盖预设 env；运行时真值经 `dfkvctl ring` INFO 列审计（`engine=`/`wr=`/`ram=`）。**
 > - `--store-engine file|slab`（默认 `file`）：`slab` = extent 池 + slots.tbl 重启保温，消除"每块一文件"隐患。**切 slab 需清盘冷启**（旧 blocks/ 布局不复用），属独立迁移动作。
 > - `--slab-write direct|buffered`（**默认 `direct`**）：slab 数据面全程 O_DIRECT（写+对齐读+异步 prep），零 page cache/脏页占用——GPU 节点上突发吸收交给显式 RAM 热层而非内核缓存；extent 在 direct 模式下 fallocate 实体化（升级后 df 显示预分配为预期行为）。文件系统拒绝 O_DIRECT（如 tmpfs）时整店回退 buffered，以 `wr=` 上报真值。
 > - `--ram-tier on`（默认关）：写直通 RAM 热层 + RDMA arena 零拷贝 GET；`--ram-tier-bytes <bytes>` 定 arena 大小（预注册即 pin 内存，须核 `MemoryMax` 有余量）。开后观测 `dfkv_ram_hit_total` / `dfkv_ram_put_bypass_total`（见 METRICS.md §3.1）。**direct 模式下 flusher 经 CacheDirect DIO 落盘，RAM 池写入量不过 page cache。**
-> - 微调项（env only）：`DFKV_SLAB_TABLE_SYNC_MS`（slots.tbl fdatasync 节奏，默认 100，0=关；限定崩溃复活窗口）、`DFKV_RAM_FLUSH_THREADS`（RAM 落盘 worker 数，默认=盘数）。
+> - 微调项：`--slab-table-sync-ms` / `DFKV_SLAB_TABLE_SYNC_MS`（slots.tbl fdatasync 节奏，默认 100，0=关；限定崩溃复活窗口）、`--ram-flush-threads` / `DFKV_RAM_FLUSH_THREADS`（RAM 落盘 worker 数，默认=盘数）。v1.12.0+ 起均有 flag facade（见 [CONFIG.md](CONFIG.md) §1.2）。
 > - `--slab-granularity <bytes>`（默认 1 MiB）：slot 量子，小值负载调小（64KB 值在 1MiB 粒度下浪费 94%）。**改动 = 布局变化 = 该店清空冷启**，按迁移动作对待。
 > - `--put-inflight-limit <n>`（默认 0=关）：并发盘写超过 n 的 PUT 以 kCacheFull 快速拒绝（客户端视为普通 put 失败、不进 cooldown）= 用受控 miss 换掉过载排队尾延迟。RDMA 与 TCP 两条数据路径同受此门约束；RAM 热层的异步 flusher 落盘**不受**此门限制（否则背压会放大为 flush 丢弃）。
 > - RAM 热层 arena 预触 + RDMA MR 注册都在启动期走页：**arena 每 16 GiB 约 +5-10s 启动时间**，配大 arena（≥64 GiB）时同步调大 systemd `TimeoutStartSec`（默认 90s）并让就绪探测等待 metrics 端口。


### PR DESCRIPTION
## What

Syncs the three existing docs with the post-#119/#121/#122 reality, now that [CONFIG.md](CONFIG.md) (PR #123) is the authoritative parameter reference.

## Changes

### CONNECTORS.md §2.1
"传输相关 env 亦可走 extra_config（`dfkv_open` 前自动设 env）" described the old `os.environ[...]=...` side-effect that PR #122 **removed**. Rewrote to the v2 path: `extra_config` `rdma_*` → `dfkv_open_v2` config struct → C-layer scoped env (no leak), env as fallback.

### DEPLOY.md §3
"微调项（env only）" listed `DFKV_SLAB_TABLE_SYNC_MS` / `DFKV_RAM_FLUSH_THREADS` as env-only, but PR #119 added `--slab-table-sync-ms` / `--ram-flush-threads` flag facades. Updated to flag+env pairs. Header now points at CONFIG.md for the full list.

### ARCHITECTURE.md §7
Feature matrix listed `DFKV_RAM_TIER` / `DFKV_SERVER_URING` as env-only; added their `--ram-tier` / `--server-uring` flag twins (PR #119). Added a pointer to CONFIG.md for the full parameter reference.

## Scope
Docs only — no code, no behavior change. Companion to PR #123 (CONFIG.md).

## Follow-up
`dfkv-rollout` (separate repo) still uses `DFKV_RDMA_DEPTH` env injection in its systemd template — still works (env fallback preserved), but could migrate to `--rdma-depth` flag. That's a cross-repo change needing four-center canary, tracked separately in KB.