### PR TITLE
fix(hicache/vllm/lmcache): connector_id ':' rejected by MDS → dfkvctl clients always empty

### DIFF
--- a/integration/hicache/dfkv_telemetry/config.py
+++ b/integration/hicache/dfkv_telemetry/config.py
@@ -107,7 +107,17 @@ def resolve_connector_id(cfg: Optional[dict], tp_rank: int = 0) -> str:
     so the dashboard can enumerate / drill into a single instance.
 
     Explicit ``connector_id`` (extra_config or DFKV_CONNECTOR_ID) wins; otherwise
-    auto-derive ``<host>:<pid>:<tp_rank>`` which is unique per process/rank."""
+    auto-derive ``<host>_<pid>_<tp_rank>`` which is unique per process/rank.
+
+    The separator MUST be in the MDS ``IsValidGroupOrId`` alphabet
+    ``[A-Za-z0-9._-]`` — a ``:`` (the previous default) makes the whole id fail
+    validation, so ``MdsServer::UpsertClient`` returns ``kInvalid``, the
+    registrar's ``SendOnce`` never sees ``kOk``, and ``MdsRegistrar::Loop`` is
+    stuck retrying ``kClientRegister`` forever and never advances to the
+    heartbeat loop — ``dfkvctl clients`` stays empty despite thousands of
+    register requests. Underscore is path-safe and not part of any hostname
+    convention (hostnames are ``[a-z0-9-]``), so it cannot collide with the
+    host segment."""
     cid = resolve(cfg, "connector_id", ENV_CONNECTOR_ID, "")
     if cid:
         return str(cid)
@@ -115,4 +125,4 @@ def resolve_connector_id(cfg: Optional[dict], tp_rank: int = 0) -> str:
         host = socket.gethostname()
     except Exception:
         host = "unknown"
-    return "{}:{}:{}".format(host, os.getpid(), int(tp_rank))
+    return "{}_{}_{}".format(host, os.getpid(), int(tp_rank))

--- a/integration/lmcache/src/dfkv_connector/_telemetry/config.py
+++ b/integration/lmcache/src/dfkv_connector/_telemetry/config.py
@@ -107,7 +107,17 @@ def resolve_connector_id(cfg: Optional[dict], tp_rank: int = 0) -> str:
     so the dashboard can enumerate / drill into a single instance.
 
     Explicit ``connector_id`` (extra_config or DFKV_CONNECTOR_ID) wins; otherwise
-    auto-derive ``<host>:<pid>:<tp_rank>`` which is unique per process/rank."""
+    auto-derive ``<host>_<pid>_<tp_rank>`` which is unique per process/rank.
+
+    The separator MUST be in the MDS ``IsValidGroupOrId`` alphabet
+    ``[A-Za-z0-9._-]`` — a ``:`` (the previous default) makes the whole id fail
+    validation, so ``MdsServer::UpsertClient`` returns ``kInvalid``, the
+    registrar's ``SendOnce`` never sees ``kOk``, and ``MdsRegistrar::Loop`` is
+    stuck retrying ``kClientRegister`` forever and never advances to the
+    heartbeat loop — ``dfkvctl clients`` stays empty despite thousands of
+    register requests. Underscore is path-safe and not part of any hostname
+    convention (hostnames are ``[a-z0-9-]``), so it cannot collide with the
+    host segment."""
     cid = resolve(cfg, "connector_id", ENV_CONNECTOR_ID, "")
     if cid:
         return str(cid)
@@ -115,4 +125,4 @@ def resolve_connector_id(cfg: Optional[dict], tp_rank: int = 0) -> str:
         host = socket.gethostname()
     except Exception:
         host = "unknown"
-    return "{}:{}:{}".format(host, os.getpid(), int(tp_rank))
+    return "{}_{}_{}".format(host, os.getpid(), int(tp_rank))

--- a/integration/vllm/src/dfkv_vllm/_telemetry/config.py
+++ b/integration/vllm/src/dfkv_vllm/_telemetry/config.py
@@ -107,7 +107,17 @@ def resolve_connector_id(cfg: Optional[dict], tp_rank: int = 0) -> str:
     so the dashboard can enumerate / drill into a single instance.
 
     Explicit ``connector_id`` (extra_config or DFKV_CONNECTOR_ID) wins; otherwise
-    auto-derive ``<host>:<pid>:<tp_rank>`` which is unique per process/rank."""
+    auto-derive ``<host>_<pid>_<tp_rank>`` which is unique per process/rank.
+
+    The separator MUST be in the MDS ``IsValidGroupOrId`` alphabet
+    ``[A-Za-z0-9._-]`` — a ``:`` (the previous default) makes the whole id fail
+    validation, so ``MdsServer::UpsertClient`` returns ``kInvalid``, the
+    registrar's ``SendOnce`` never sees ``kOk``, and ``MdsRegistrar::Loop`` is
+    stuck retrying ``kClientRegister`` forever and never advances to the
+    heartbeat loop — ``dfkvctl clients`` stays empty despite thousands of
+    register requests. Underscore is path-safe and not part of any hostname
+    convention (hostnames are ``[a-z0-9-]``), so it cannot collide with the
+    host segment."""
     cid = resolve(cfg, "connector_id", ENV_CONNECTOR_ID, "")
     if cid:
         return str(cid)
@@ -115,4 +125,4 @@ def resolve_connector_id(cfg: Optional[dict], tp_rank: int = 0) -> str:
         host = socket.gethostname()
     except Exception:
         host = "unknown"
-    return "{}:{}:{}".format(host, os.getpid(), int(tp_rank))
+    return "{}_{}_{}".format(host, os.getpid(), int(tp_rank))

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -1010,7 +1010,12 @@ class DfkvClientRegistrationTest(unittest.TestCase):
         self.assertIn("model=glm-5.2", info)
         self.assertIn("tp_size=8", info)
         self.assertIn("tp_rank=3", info)
-        self.assertTrue(cid)  # client_id resolves to host:pid:rank
+        self.assertTrue(cid)  # client_id resolves to host_pid_rank
+        # The id is the etcd key tail /clients/<id>, so it must pass the MDS
+        # IsValidGroupOrId alphabet [A-Za-z0-9._-] (no ":" — see resolve_connector_id).
+        self.assertTrue(all(
+            (c.isalnum() and c.isascii()) or c in "._-" for c in cid),
+            f"cid {cid!r} has chars outside IsValidGroupOrId alphabet")
 
     def test_opt_out_via_extra_config(self):
         # client_register=0 in extra_config disables registration; discovery still runs.

--- a/test/python/test_dfkv_telemetry.py
+++ b/test/python/test_dfkv_telemetry.py
@@ -57,8 +57,20 @@ class DisabledByDefaultTest(TelemetryTestBase):
 class ConnectorIdTest(TelemetryTestBase):
     def test_default_id_is_host_pid_rank(self):
         cid = config.resolve_connector_id({}, tp_rank=2)
-        self.assertEqual(cid.rsplit(":", 1)[1], "2")
-        self.assertEqual(cid, "{}:{}:2".format(__import__("socket").gethostname(), os.getpid()))
+        self.assertEqual(cid.rsplit("_", 1)[1], "2")
+        self.assertEqual(cid, "{}_{}_2".format(__import__("socket").gethostname(), os.getpid()))
+
+    def test_default_id_passes_mds_isvalidgrouporid(self):
+        # The auto-derived id is the etcd key tail /dfkv/v1/groups/<g>/clients/<id>,
+        # so it MUST match the MDS IsValidGroupOrId alphabet [A-Za-z0-9._-]. A ":"
+        # (an earlier default) is rejected -> UpsertClient returns kInvalid -> the
+        # registrar never advances to the heartbeat loop -> dfkvctl clients is empty.
+        cid = config.resolve_connector_id({}, tp_rank=3)
+        self.assertTrue(cid and len(cid) <= 128)
+        for c in cid:
+            self.assertTrue(
+                (c.isalnum() and c.isascii()) or c in "._-",
+                f"connector_id {cid!r} has char {c!r} outside IsValidGroupOrId alphabet")
 
     def test_env_overrides_default(self):
         os.environ[config.ENV_CONNECTOR_ID] = "node-A-rank0"


### PR DESCRIPTION
## Problem

`dfkvctl clients` stays empty (`clients=0`) for SGLang / vLLM / LMCache connectors even after upgrading to v1.15.1 (which wires the SGLang HiCache connector to call `dfkv_start_client_registration`). Observed on xb01 (GLM-5.2-NVFP4 SGLang, 8×B200 TP):

- `dfkv_mds_client_register_requests_total` climbs past 1700 and keeps rising (~8 req/s = 8 TP ranks re-registering every second)
- `dfkv_mds_client_keepalives_total` stays **0** forever
- `dfkvctl clients` → `group=glm clients=0`
- etcd `/dfkv/v1/groups/glm/clients/` prefix empty

## Root cause

`resolve_connector_id` (shared verbatim by all three connectors: `integration/hicache/dfkv_telemetry/config.py`, `integration/vllm/.../_telemetry/config.py`, `integration/lmcache/.../_telemetry/config.py`) auto-derives:

```
<host>:<pid>:<tp_rank>      e.g. xb01-gpu-200b-0064:2257653:0
```

The `:` separator is **outside** the MDS `IsValidGroupOrId` alphabet `[A-Za-z0-9._-]` (`src/common/membership.h:69`). So:

1. MDS `UpsertClient` (`src/mds/mds_server.cc:115`) hits `IsValidGroupOrId(m.id)` → returns `kInvalid`
2. `MdsRegistrar::SendOnce` reads `st != kOk` → returns `false`
3. `MdsRegistrar::Loop` first loop (`mds_registrar.cc:87`) retries `kClientRegister` every 1s, **never breaks out** to the heartbeat loop (`mds_registrar.cc:91`)
4. → register storm, zero heartbeats, lease never persists, `dfkvctl clients` empty

The data path is unaffected (registration is pure observability — discovery already brought the ring up), so this fails silently.

## Fix

Switch the separator from `:` to `_` (in-alphabet; hostnames are `[a-z0-9-]` so `_` cannot collide with the host segment):

```
<host>_<pid>_<tp_rank>      e.g. xb01-gpu-200b-0064_2257653_0
```

Applied to all three identical `config.py` copies + docstring explaining the invariant (separator MUST be in `IsValidGroupOrId` alphabet).

## Tests

- Updated `ConnectorIdTest.test_default_id_is_host_pid_rank` to the new format.
- Added `test_default_id_passes_mds_isvalidgrouporid` — asserts every char of the auto-derived id is in `[A-Za-z0-9._-]` and length ≤ 128.
- Added an in-alphabet assertion to `DfkvClientRegistrationTest.test_registers_on_mds_path_with_hicache_info`.
- Local: `python3 -m unittest ConnectorIdTest DfkvClientRegistrationTest` → 11/11 green.

## Verification (xb01, GLM-5.2-NVFP4 SGLang, 8×B200 TP)

| metric | before (`:`) | after (`_`) |
|---|---|---|
| `dfkvctl clients` | `clients=0` | **`clients=8`** (all ranks listed) |
| client_id | `xb01-…:174:0` (rejected) | `xb01-gpu-200b-0064_174_0` (valid) |
| `client_register_requests_total` | 1700+ climbing | 7017 then **stops** |
| `client_keepalives_total` | 0 | **40 → 48** (8 ranks × 10s hb) |
| `dfkv_mds_group_clients{group=glm}` | 0 | **8** |
| etcd `/clients/` | empty | **8 keys** |

Inference + dfkv L3 data path unaffected throughout.

## Compatibility

Pure Python, no wire/protocol/ABI change. Only changes the auto-derived id string. Users who set an explicit `connector_id` (extra_config or `DFKV_CONNECTOR_ID`) are unaffected. The id appears as the etcd key tail and as a `dfkvctl clients` column — no downstream parses the separator.