### PR TITLE
fix(vllm): scope on-wire cache key by model_hash so EXIST honors isolation

### DIFF
--- a/integration/vllm/src/dfkv_vllm/data.py
+++ b/integration/vllm/src/dfkv_vllm/data.py
@@ -33,6 +33,19 @@ class KeyMetadata:
     dcp_rank: int
     pp_rank: int
     group_id: int = 0
+    # Embed model_hash in the on-wire key. The dfkv C client isolates GET/PUT by
+    # model_hash (stored in the ValueHeader) but EXIST checks key-presence only
+    # and ignores model_hash -- so a key stored under model_hash A is reported
+    # present when probed under model_hash B, while GET under B misses. The
+    # scheduler's lookup uses EXIST and the worker's load uses GET, so this
+    # inconsistency makes lookup a false positive: the request is scheduled to
+    # load blocks that GET then misses, gets flagged for recompute, and is
+    # rescheduled -- looping forever (never prefills/saves). Putting model_hash
+    # in the key makes EXIST/GET/PUT all operate on the SAME model-hash-scoped
+    # keyspace, so a different model_hash yields different keys and EXIST can no
+    # longer cross-match. Default 0 preserves the legacy key for callers that do
+    # not set it.
+    model_hash: int = 0
 
 
 @dataclass(order=True)
@@ -46,6 +59,7 @@ class PoolKey:
         return hash(
             (
                 self.key_metadata.model_name,
+                self.key_metadata.model_hash,
                 self.key_metadata.tp_rank,
                 self.key_metadata.pcp_rank,
                 self.key_metadata.dcp_rank,
@@ -58,6 +72,7 @@ class PoolKey:
     def to_string(self) -> str:
         return (
             f"{self.key_metadata.model_name}"
+            f"@mh:{self.key_metadata.model_hash}"
             f"@tp_rank:{self.key_metadata.tp_rank}"
             f"@pcp{self.key_metadata.pcp_rank}"
             f"@dcp{self.key_metadata.dcp_rank}"

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -813,6 +813,15 @@ class DfkvStoreWorker:
 
         self.metadata = KeyMetadata(
             model_name=model_config.model.rstrip("/").split("/")[-1],
+            # Scope the on-wire key by model_hash: the dfkv EXIST op ignores
+            # model_hash (only GET/PUT honor it via the ValueHeader), so without
+            # this the scheduler's EXIST-based lookup cross-matches another
+            # model_hash's keys and loops forever on GET misses. See KeyMetadata.
+            model_hash=int(
+                vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+                    "model_hash", 0
+                )
+            ),
             tp_rank=self.head_or_tp_rank,
             pcp_rank=self.pcp_rank,
             dcp_rank=self.dcp_rank,


### PR DESCRIPTION
## Problem

MTP (speculative decoding) + dfkv, and more generally **re-deploying the same model under a fresh `model_hash`**, hangs: every request loops in `WAITING_FOR_REMOTE_KVS` with the log spamming

```
dfkv load_errors: N blocks flagged
Recovered from KV load failure: 1 request(s) rescheduled (... tokens affected)
```

The request never prefills or saves, so throughput goes to zero.

## Root cause

The dfkv C client isolates **GET/PUT** by `model_hash` (carried in the `ValueHeader`), but the **EXIST** op checks key-presence only and **ignores `model_hash`**. The connector's on-wire key (`PoolKey.to_string`) did not include `model_hash`, so a block stored under `model_hash=A` is reported *present* when probed under `model_hash=B`, while GET under B misses.

The scheduler-side lookup uses `batch_exist`; the worker-side load uses `batch_get`. When the same `model_name`+content was previously stored under a **different** `model_hash`, lookup becomes a false positive:

1. `batch_exist` → present (cross-matches the other model_hash's key)
2. vLLM schedules the request to load those prefix blocks
3. `batch_get` (this model_hash) → miss → blocks flagged for recompute
4. request rescheduled → lookup again reports present → **loop forever**

This is **not** speculative-decoding specific — MTP just made it surface, because by then the ring already held that content under an earlier `model_hash`. A first-ever store, or a distinct `model_name`, coincidentally avoids it.

### Reproduced (definitive)

```
PUT unique key under model_hash=111111 → ok
model_hash=111111 batch_exist → [1]   (correct)
model_hash=222222 batch_exist → [1]   ← BUG: another model_hash's key reported present
model_hash=222222 batch_get   → hit=0 ← GET correctly isolates (miss)
```

## Fix

Embed `model_hash` in `KeyMetadata` / `PoolKey.to_string` (`@mh:{n}`), so EXIST/GET/PUT all operate on the same model-hash-scoped keyspace. A different `model_hash` now yields different keys that EXIST can no longer cross-match.

(The deeper fix would be to make the C-lib `dfkv_batch_exist` verify `model_hash` like GET does; scoping the key is a self-contained connector-level fix that restores correct isolation regardless.)

## Verification (hd04, GLM-5.2-Int4 + MTP + dfkv, glm-a ring)

| | before | after |
|---|---|---|
| needle-in-haystack (temp=0) | hang | ✅ correct to 78k+ tokens |
| save happens | no (0) | ✅ yes |
| `load_errors` reschedule loop | thousands, looping | ✅ 0 |
| lookup on a fresh model_hash | present=250 (false positive) | ✅ present=0 |

Also passing a multi-size needle soak.

## Compatibility

Keys are now `model_hash`-scoped, so KV stored by an older connector (no `@mh:`) is not found by a new one — a one-time cache miss + repopulate. No correctness impact (dfkv is a cache).
