### PR TITLE
fix(client): scope BlockKey identity by model_hash so EXIST honors isolation

### DIFF
--- a/src/client/key_map.h
+++ b/src/client/key_map.h
@@ -28,11 +28,41 @@ namespace dfkv {
 // Identity-only size constant. Real payload length lives in the value header.
 inline constexpr uint32_t kKvFixedSize = 1;
 
-inline BlockKey ToBlockKey(const std::string& key) {
+// model_hash is folded into the block identity so EXIST/GET/PUT/REMOVE are all
+// scoped by model_hash at the key layer. EXIST is a pure server-side key-
+// presence check that never reads the value header, so without this it cross-
+// matches another model_hash's key (same model_name+content) as present, while
+// GET -- which compares the header's model_hash client-side -- misses. That
+// EXIST-present/GET-miss split makes the scheduler's lookup a false positive:
+// the request is scheduled to load blocks that GET then misses, the blocks are
+// flagged for recompute, the request is rescheduled, lookup reports present
+// again -> it loops forever and never prefills/saves. Salting the identity hash
+// with model_hash makes a different model_hash yield a different BlockKey that
+// EXIST can no longer cross-match. Routing (a separate hash over the raw key)
+// is unchanged, so same-content pages still land on the same node -- only the
+// stored/probed identity differs. A mixed old/new-lib fleet cross-misses once
+// (clean cache warm-up, never corruption), same as the id/index change above.
+inline BlockKey ToBlockKey(const std::string& key, uint64_t model_hash = 0) {
   uint8_t d[16];
-  Md5(key.data(), key.size(), d);  // one hash; split into id + index
+  if (model_hash == 0) {
+    // Legacy / shared keyspace (model_hash==0 == "no isolation"): hash the raw
+    // key so id stays byte-identical to the old library -- existing data and a
+    // mixed old/new fleet are unaffected.
+    Md5(key.data(), key.size(), d);
+  } else {
+    // Isolated keyspace: salt the identity hash with model_hash (LE) so a
+    // different model_hash yields a different BlockKey (see note above). Only
+    // non-zero (i.e. explicitly-set) model_hashes -- the ones that were buggy --
+    // change key; their old data re-warms once, never corrupts.
+    std::string salted;
+    salted.reserve(sizeof(model_hash) + key.size());
+    for (int i = 0; i < 8; ++i)
+      salted.push_back(static_cast<char>(model_hash >> (8 * i)));
+    salted.append(key);
+    Md5(salted.data(), salted.size(), d);
+  }
   uint64_t id = 0;
-  for (int i = 0; i < 8; ++i) id |= uint64_t(d[i]) << (8 * i);         // bytes 0..7 (== Md5_64)
+  for (int i = 0; i < 8; ++i) id |= uint64_t(d[i]) << (8 * i);         // bytes 0..7
   uint32_t index = uint32_t(d[8]) | (uint32_t(d[9]) << 8) |
                    (uint32_t(d[10]) << 16) | (uint32_t(d[11]) << 24);   // bytes 8..11
   return BlockKey{id, index, kKvFixedSize};

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -151,7 +151,7 @@ void KVClient::StopProbe() {
 void KVClient::ProbeLoop() {
   // A sentinel key that no real workload writes; kExist of it is a cheap round
   // trip that measures the node's responsiveness (kNotFound is a healthy reply).
-  const BlockKey probe = ToBlockKey("__dfkv_probe__");
+  const BlockKey probe = ToBlockKey("__dfkv_probe__", self_hdr_.model_hash);
   while (probe_running_.load(std::memory_order_relaxed)) {
     std::vector<std::string> addrs;
     {
@@ -246,7 +246,7 @@ bool KVClient::Put(const std::string& key, const void* value, size_t n) {
 
   ValueHeader h = self_hdr_;
   h.payload_len = n;  // geometry comes from self_hdr_; no payload checksum (v3)
-  BlockKey bk = ToBlockKey(key);
+  BlockKey bk = ToBlockKey(key, self_hdr_.model_hash);
   Status st;
   if (t_->pipelined()) {
     // Zero copy: build only the 48B header, scatter-send [header|value] with the
@@ -279,7 +279,7 @@ bool KVClient::Get(const std::string& key, void* out, size_t n) {
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
 
-  BlockKey bk = ToBlockKey(key);
+  BlockKey bk = ToBlockKey(key, self_hdr_.model_hash);
   if (t_->pipelined()) {
     // Zero copy AND zero touch: the payload scatters straight into `out` and the
     // CPU never reads it; only the 48B header comes back (hdrs[0]) for geometry verify.
@@ -327,7 +327,7 @@ bool KVClient::GetAuto(const std::string& key, std::string* out, size_t max_byte
   if (node.empty()) return false;
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
-  BlockKey bk = ToBlockKey(key);
+  BlockKey bk = ToBlockKey(key, self_hdr_.model_hash);
 
   if (t_->pipelined()) {
     // Zero-copy via RangeInto (a 1-element batch), matching Get(): the payload
@@ -377,7 +377,7 @@ bool KVClient::GetAuto(const std::string& key, void* out, size_t cap, size_t* ou
   if (node.empty()) return false;
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
-  BlockKey bk = ToBlockKey(key);
+  BlockKey bk = ToBlockKey(key, self_hdr_.model_hash);
 
   if (t_->pipelined()) {
     // Zero-copy: the payload scatters straight into the caller's buffer and the
@@ -425,7 +425,7 @@ bool KVClient::Exist(const std::string& key) {
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
   bool e = false;
-  Status st = t_->Exist(node, ToBlockKey(key), &e);
+  Status st = t_->Exist(node, ToBlockKey(key, self_hdr_.model_hash), &e);
   // Fresh clock: `now` was taken before a round trip that can burn the whole
   // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
@@ -440,7 +440,7 @@ bool KVClient::Remove(const std::string& key) {
   if (node.empty()) return false;
   uint64_t now = NowMs();
   if (!health_.Healthy(node, now)) return false;
-  Status st = t_->Remove(node, ToBlockKey(key));
+  Status st = t_->Remove(node, ToBlockKey(key, self_hdr_.model_hash));
   // Fresh clock: `now` was taken before a round trip that can burn the whole
   // io_timeout, which would shorten (or void) the cooldown this MarkBad sets.
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
@@ -483,7 +483,7 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
     std::vector<CacheSrc> srcs;
     srcs.reserve(idx.size());
     for (size_t k : idx)
-      srcs.push_back(CacheSrc{ToBlockKey(items[k].key), hdrs[k].data(),
+      srcs.push_back(CacheSrc{ToBlockKey(items[k].key, self_hdr_.model_hash), hdrs[k].data(),
                               ValueHeader::kSize, items[k].value, items[k].n});
     std::vector<Status> sts = t_->CacheFrom(node, srcs);
     for (size_t m = 0; m < idx.size(); ++m) ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
@@ -531,7 +531,7 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
     keys.reserve(idx.size());
     dsts.reserve(idx.size());
     for (size_t k : idx) {
-      keys.push_back(ToBlockKey(items[k].key));
+      keys.push_back(ToBlockKey(items[k].key, self_hdr_.model_hash));
       dsts.push_back(RangeDst{items[k].out, n});
     }
     // Zero-copy + zero-touch: the payload lands straight in items[].out (CPU never
@@ -595,7 +595,7 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
     keys.reserve(idx.size());
     dsts.reserve(idx.size());
     for (size_t k : idx) {
-      keys.push_back(ToBlockKey(items[k].key));
+      keys.push_back(ToBlockKey(items[k].key, self_hdr_.model_hash));
       dsts.push_back(RangeDst{items[k].out, cap});
     }
     std::vector<std::string> hdrs;
@@ -651,7 +651,7 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
     const std::vector<size_t>& idx = groups[g].second;
     std::vector<BlockKey> bkeys;
     bkeys.reserve(idx.size());
-    for (size_t k : idx) bkeys.push_back(ToBlockKey(keys[k]));
+    for (size_t k : idx) bkeys.push_back(ToBlockKey(keys[k], self_hdr_.model_hash));
     std::vector<char> ex;
     std::vector<Status> sts = t_->ExistMany(node, bkeys, &ex);
     bool resp = false, ioerr = false;
@@ -692,7 +692,7 @@ std::vector<bool> KVClient::BatchRemove(const std::vector<std::string>& keys) {
     const std::vector<size_t>& idx = groups[g].second;
     std::vector<BlockKey> bkeys;
     bkeys.reserve(idx.size());
-    for (size_t k : idx) bkeys.push_back(ToBlockKey(keys[k]));
+    for (size_t k : idx) bkeys.push_back(ToBlockKey(keys[k], self_hdr_.model_hash));
     std::vector<Status> sts = t_->RemoveMany(node, bkeys);
     bool resp = false, ioerr = false;
     // kInvalid (oversize/per-item guard) is neither: it must not clear the
@@ -751,7 +751,7 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     srcs.reserve(idx.size());
     for (size_t k : idx) {
       CacheSrcMulti s;
-      s.key = ToBlockKey(items[k].key);
+      s.key = ToBlockKey(items[k].key, self_hdr_.model_hash);
       s.header = hdrs[k].data();
       s.header_len = ValueHeader::kSize;
       s.payloads.reserve(items[k].ptrs.size());
@@ -814,7 +814,7 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
     keys.reserve(idx.size());
     dsts.reserve(idx.size());
     for (size_t k : idx) {
-      keys.push_back(ToBlockKey(items[k].key));
+      keys.push_back(ToBlockKey(items[k].key, self_hdr_.model_hash));
       RangeDstMulti d;
       d.payloads.reserve(items[k].dsts.size());
       for (size_t j = 0; j < items[k].dsts.size(); ++j)

--- a/test/client/get_auto_pipelined_test.cc
+++ b/test/client/get_auto_pipelined_test.cc
@@ -83,7 +83,7 @@ TEST(GetAutoPipelined, VoidBufferUsesRangeIntoNotRange) {
   FakePipelinedTransport t;
   KVClient c = MakeClient(&t);
   std::string v(1234, 'p');
-  t.blobs[ToBlockKey("kv").Filename()] = v;
+  t.blobs[ToBlockKey("kv", 0x51ULL).Filename()] = v;
 
   std::vector<char> buf(4096);
   size_t got = 0;
@@ -98,7 +98,7 @@ TEST(GetAutoPipelined, StringOverloadTrimsToTrueLength) {
   FakePipelinedTransport t;
   KVClient c = MakeClient(&t);
   std::string v(777, 'q');
-  t.blobs[ToBlockKey("ks").Filename()] = v;
+  t.blobs[ToBlockKey("ks", 0x51ULL).Filename()] = v;
 
   std::string out;
   ASSERT_TRUE(c.GetAuto("ks", &out, 8192));
@@ -115,7 +115,7 @@ TEST(GetAutoPipelined, ValueLargerThanEightMiBIsServed) {
   KVClient c = MakeClient(&t);
   const size_t big = (10u << 20);  // 10 MiB > 8 MiB control_cap
   std::string v(big, 'B');
-  t.blobs[ToBlockKey("kbig").Filename()] = v;
+  t.blobs[ToBlockKey("kbig", 0x51ULL).Filename()] = v;
 
   std::string out;
   ASSERT_TRUE(c.GetAuto("kbig", &out, 16u << 20));
@@ -128,7 +128,7 @@ TEST(GetAutoPipelined, ValueLargerThanEightMiBIsServed) {
 TEST(GetAutoPipelined, CapSmallerThanPayloadIsMiss) {
   FakePipelinedTransport t;
   KVClient c = MakeClient(&t);
-  t.blobs[ToBlockKey("kbig2").Filename()] = std::string(5000, 'z');
+  t.blobs[ToBlockKey("kbig2", 0x51ULL).Filename()] = std::string(5000, 'z');
 
   std::vector<char> buf(1024);
   size_t got = 0;

--- a/test/client/key_map_test.cc
+++ b/test/client/key_map_test.cc
@@ -65,6 +65,39 @@ TEST(KeyMap, DifferentKeysGiveDifferentIdsNoCollisionInSample) {
   EXPECT_EQ(ids.size(), 20000u);  // 64-bit hash: no collision in 20k sample
 }
 
+TEST(KeyMap, ModelHashZeroIsLegacyRawKeyHash) {
+  // model_hash==0 (unset / "no isolation") must stay byte-identical to the old
+  // library so existing data and a mixed old/new fleet are unaffected.
+  const std::string key = "glm-5.2/page_777_k";
+  EXPECT_EQ(ToBlockKey(key, 0).id, dfkv::Md5_64(key));
+  EXPECT_EQ(ToBlockKey(key).id, dfkv::Md5_64(key));  // default arg == 0
+}
+
+TEST(KeyMap, DifferentModelHashGivesDifferentKey) {
+  // The fix: a different model_hash for the SAME content yields a different
+  // BlockKey, so EXIST/GET/PUT/REMOVE are scoped by model_hash at the key layer
+  // (EXIST no longer cross-matches another model_hash's key). Deterministic per
+  // (key, model_hash).
+  const std::string key = "glm-5.2/pg_42_k";
+  BlockKey a1 = ToBlockKey(key, 111111);
+  BlockKey a2 = ToBlockKey(key, 111111);
+  BlockKey b = ToBlockKey(key, 222222);
+  EXPECT_EQ(a1.Filename(), a2.Filename());          // deterministic per model_hash
+  EXPECT_NE(a1.Filename(), b.Filename());           // different model_hash -> different key
+  EXPECT_NE(ToBlockKey(key, 0).Filename(), b.Filename());  // and different from legacy
+}
+
+TEST(KeyMap, NoCrossModelHashCollisionInSample) {
+  // Same content under many model_hashes must all land on distinct identities.
+  std::set<std::pair<uint64_t, uint32_t>> ids;
+  const std::string key = "glm-5.2/shared_content_k";
+  for (uint64_t mh = 1; mh <= 20000; ++mh) {
+    BlockKey k = ToBlockKey(key, mh);
+    ids.insert({k.id, k.index});
+  }
+  EXPECT_EQ(ids.size(), 20000u);
+}
+
 TEST(KeyMap, FilenameAndStoreKeyFormat) {
   BlockKey k{123456789ULL, 0u, kKvFixedSize};
   EXPECT_EQ(k.Filename(), "123456789_0_" + std::to_string(kKvFixedSize));

--- a/test/client/kv_client_test.cc
+++ b/test/client/kv_client_test.cc
@@ -170,7 +170,7 @@ TEST_F(KVClientTest, PayloadCorruptionNotDetectedAfterV3) {
   std::string v(1024, 'y');
   ASSERT_TRUE(c.Put("k_crc", v.data(), v.size()));
   // corrupt a payload byte on disk (after the 48B header)
-  BlockKey bk = ToBlockKey("k_crc");
+  BlockKey bk = ToBlockKey("k_crc", 0x51ULL);
   fs::path f = nodes_[0]->dir / bk.StoreKey();
   ASSERT_TRUE(fs::exists(f));
   { std::fstream io(f, std::ios::in | std::ios::out | std::ios::binary);


### PR DESCRIPTION
## Problem

The dfkv client isolates **GET/PUT** by `model_hash` (carried in the value's `ValueHeader`, checked client-side by `HeaderMatches` on GET), but **EXIST** (`BatchExist`/`Exist`) is a pure **server-side key-presence** check that never reads the value header, and `ToBlockKey` did not fold `model_hash` into the key.

So a block stored under `model_hash=A` is reported **present** when probed under `model_hash=B` (EXIST cross-matches), while **GET under B misses** (header `model_hash` mismatch).

A consumer whose scheduler-side lookup uses EXIST and whose load uses GET (e.g. the vLLM `DfkvStoreConnector`) then **loops forever**: lookup=present schedules a load → GET misses → blocks flagged for recompute → request rescheduled → lookup present again → no progress (hang; `dfkv load_errors ... rescheduled` repeating). It surfaces whenever the same `model_name`+content was previously stored under a **different** `model_hash` (e.g. redeploying a model under a fresh `model_hash`), and is **not** speculative-decoding specific.

### Reproduced (definitive)

```
PUT unique key under model_hash=111111 → ok
model_hash=111111  batch_exist → [1]   (correct)
model_hash=222222  batch_exist → [1]   ← BUG: another model_hash's key reported present
model_hash=222222  batch_get   → hit=0 ← GET correctly isolates (miss)
```

## Fix

Fold `model_hash` into the block identity in `ToBlockKey` (salt the MD5 with the little-endian `model_hash`) and thread the client's `self_hdr_.model_hash` through all `ToBlockKey` call sites. EXIST/GET/PUT/REMOVE now all operate on the same model-hash-scoped keyspace, so a different `model_hash` yields a different `BlockKey` that EXIST can no longer cross-match.

**Compatibility (deliberately conservative):**
- `model_hash == 0` (unset / "no isolation") keeps the **legacy raw-key hash** — existing data and a mixed old/new-lib fleet are unaffected; only non-zero (explicitly-set, previously-buggy) `model_hash`es change key and re-warm once (never corruption). The existing `IdUnchangedFromMd5_64` test still holds.
- **Routing is unchanged**: `Route()` hashes the raw key string, independent of the `BlockKey` identity, so same-content pages still land on the same node — only the stored/probed identity differs.

## Tests

Adds `key_map` unit tests: `model_hash==0 == legacy`, `different model_hash => different key` (deterministic per `(key, model_hash)`), and no cross-`model_hash` collision over a 20k sample. Full local suite passes (50+ test binaries, 0 failures).

## Relationship to #133

#133 is a self-contained **connector-level interim** (embeds `model_hash` in the Python `PoolKey.to_string`, ships without a lib rebuild, and was **verified end-to-end on the RDMA cluster**: GLM-5.2-Int4 + MTP + dfkv, before = hang, after = needle correct, `load_errors=0`, 30-min soak clean). This PR is the **proper fix at the source** — it covers *all* client bindings (vLLM / SGLang HiCache / LMCache / direct C) and *all* ops uniformly, not just the vLLM connector. Once this lands and ships, #133's `@mh:` key embed should be reverted (the two are alternatives; keeping both would embed `model_hash` twice). They must not both be active in a shared ring.

## Note (out of scope, flagged for follow-up)

`Remove`/`BatchRemove` also isolate only via the header path on the read side; scoping the key here fixes them too. And the same header-only isolation existed for the **geometry** fields (dtype/tp/page/layer/head) — this PR does not add those to the key, so reusing one `model_hash` across different geometries could still cross-match EXIST. Callers already use a fresh `model_hash` per geometry, so it is latent; worth a follow-up if we want defense-in-depth.
