### PR TITLE
feat(vllm): accept a free-form model_hash label (md5(model_name, label) -> uint64)

### DIFF
--- a/integration/vllm/src/dfkv_vllm/_telemetry/config.py
+++ b/integration/vllm/src/dfkv_vllm/_telemetry/config.py
@@ -8,9 +8,33 @@ the access log, the push-metrics layer and (later) tracing.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import socket
 from typing import Any, Optional
+
+
+def resolve_model_hash(model_name: str, raw: Any) -> int:
+    """Resolve the connector's ``model_hash`` config into the uint64 the dfkv
+    client keys/isolates by.
+
+    The config value is a free-form label (a model version/tag, e.g.
+    ``"glm-5.2-int4-fp8-v2"``) -- NOT a 64-bit integer the operator has to
+    hand-pick. It is folded together with the served model name into a stable
+    64-bit id: ``md5(model_name || label)[:8]`` (little-endian). This:
+
+    * makes misconfiguration safe -- any string is accepted, so a bad value can
+      never crash the engine at startup (the old ``int(...)`` did);
+    * self-disambiguates the namespace -- two different models that happen to
+      share a label still get distinct ids (model_name is part of the material);
+    * is deterministic across processes/hosts (md5, not the per-process-salted
+      built-in ``hash``), so cross-instance / cross-restart cache reuse lines up.
+
+    An empty/unset label isolates by ``model_name`` alone (still deterministic).
+    """
+    label = "" if raw is None else str(raw).strip()
+    material = f"{model_name}\x00{label}".encode("utf-8")
+    return int.from_bytes(hashlib.md5(material).digest()[:8], "little")
 
 # --- master switches (off by default => zero cost) -------------------------
 # Metrics push is on when DFKV_METRICS_ENABLED is truthy, OR the umbrella

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -845,12 +845,25 @@ class DfkvStoreWorker:
                 f"role={self.kv_role},tp_size={self.tp_size},"
                 f"tp_rank={self.tp_rank},ver={_tcfg.dist_version('dfkv-vllm')}"
             )
+        # model_hash config is a free-form label (a model version/tag), folded
+        # with the served model name into the uint64 the dfkv client isolates by:
+        # md5(model_name || label). Any string is accepted (no startup crash on a
+        # non-numeric value), it self-disambiguates across models, and it stays
+        # deterministic so cross-instance/restart reuse lines up. See
+        # _tcfg.resolve_model_hash.
+        model_hash = _tcfg.resolve_model_hash(
+            self.metadata.model_name, extra.get("model_hash", "")
+        )
+        logger.info(
+            "dfkv model_hash: model=%s label=%r -> id=%d",
+            self.metadata.model_name, extra.get("model_hash", ""), model_hash,
+        )
         self.client = DfkvDeviceClient(
             members=extra.get("members", ""),
             mds_endpoints=mds_endpoints,
             mds_group=mds_group,
             mds_poll_ms=int(extra.get("mds_poll_ms", 3000)),
-            model_hash=int(extra.get("model_hash", 0)),
+            model_hash=model_hash,
             lib_path=extra.get("lib"),
             batch_concurrency=int(extra.get("batch_concurrency", 8)),
             client_register=client_register,

--- a/integration/vllm/tests/test_model_hash.py
+++ b/integration/vllm/tests/test_model_hash.py
@@ -1,0 +1,61 @@
+"""resolve_model_hash: the connector's model_hash config is a free-form label
+folded with the served model name into the uint64 the dfkv client isolates by
+(md5(model_name || label)). Must accept any string (never crash on a
+non-numeric value), self-disambiguate across models, and stay deterministic so
+cross-instance / cross-restart reuse lines up."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from dfkv_vllm._telemetry.config import resolve_model_hash
+
+
+def test_deterministic():
+    assert resolve_model_hash("GLM-5.2-Int4", "v2") == resolve_model_hash(
+        "GLM-5.2-Int4", "v2"
+    )
+
+
+def test_stable_golden_value():
+    # Pin the algorithm (md5(model||\0||label)[:8], little-endian). A change here
+    # silently invalidates every deployment's cache, so it must be intentional.
+    assert resolve_model_hash("GLM", "glm-5.2-int4-fp8-v2") == 145915887401238509
+
+
+def test_different_label_different_id():
+    assert resolve_model_hash("GLM-5.2-Int4", "v1") != resolve_model_hash(
+        "GLM-5.2-Int4", "v2"
+    )
+
+
+def test_same_label_different_model_is_isolated():
+    # Two different models sharing a label still get distinct ids.
+    assert resolve_model_hash("model-a", "shared") != resolve_model_hash(
+        "model-b", "shared"
+    )
+
+
+def test_accepts_arbitrary_string_no_crash():
+    # The old int(...) crashed the engine on a non-numeric value; now any string
+    # resolves to a valid uint64.
+    v = resolve_model_hash("GLM", "glm-5.2/int4::fp8 v2!")
+    assert 0 <= v < 2**64
+
+
+def test_empty_and_none_isolate_by_model_name():
+    assert resolve_model_hash("GLM", "") == resolve_model_hash("GLM", None)
+    # still deterministic and model-scoped
+    assert resolve_model_hash("A", "") != resolve_model_hash("B", "")
+
+
+def test_whitespace_is_stripped():
+    assert resolve_model_hash("GLM", " v2 ") == resolve_model_hash("GLM", "v2")
+
+
+def test_numeric_label_is_hashed_like_any_string():
+    # No special-casing of numeric strings (legacy numeric model_hashes are not
+    # preserved -- old cache is intentionally dropped).
+    v = resolve_model_hash("GLM", "20260708100")
+    assert 0 <= v < 2**64


### PR DESCRIPTION
## Motivation

`model_hash` is a `uint64` at the client ABI, and the connector took it as `int(extra["model_hash"])`. In practice the algorithm team has to hand-pick an opaque 64-bit number, which is unfriendly and error-prone:

- A **non-numeric** value (the natural instinct — a model name/version like `glm-5.2-int4-v2`) throws a `ValueError` **inside engine-core init → the inference service crashes on startup**.
- A **typo'd-but-numeric** value silently becomes a *different* namespace → whole-cache miss, even harder to notice.

## Change

Treat the config value as a **free-form label** (a model version/tag) and fold it together with the served model name into the uint64 the client isolates by:

```
model_hash_uint64 = md5(model_name || "\0" || label)[:8]   # little-endian
```

So an operator can write `model_hash: "glm-5.2-int4-fp8-v2"` (meaningful, hard to typo), or anything at all.

**Properties**
- **Never crashes** — any string resolves to a valid uint64.
- **Self-disambiguating** — two different models sharing a label still get distinct ids (`model_name` is in the material), so a careless label reuse across models can't cross-contaminate.
- **Deterministic** across processes/hosts (`md5`, not the per-process-salted built-in `hash`), so cross-instance / cross-restart reuse still lines up.
- The resolved id is **logged at startup** (`dfkv model_hash: model=... label=... -> id=...`), so a misconfig is visible instead of silent.

**Compatibility**: numeric legacy `model_hash`es are intentionally **not** preserved (they now hash like any other label) — existing cache under old numeric ids is dropped and re-warms once (a cache, never correctness). Per maintainer decision.

## Tests

`tests/test_model_hash.py`: determinism, different-label / different-model isolation, arbitrary-string acceptance, empty/None, whitespace strip, and a **golden-value pin** on the algorithm (a change silently invalidates every deployment's cache, so it must be intentional). 8/8 pass.

## Relationship

Independent of and complementary to #134 (which fixed EXIST/GET model_hash isolation in the C-lib): #134 makes model_hash actually isolate; this makes it friendly to configure. Applies on top of current `main`.
