### PR TITLE
ram_tier: partition arena into many extents so varying-size KV stays resident (fixes RAM-tier 100% miss)

### DIFF
--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -56,9 +56,28 @@ RamTier::RamTier(Options opt, FlushFn flush)
                                    : "default") + ")");
   }
 
+  // Partition the arena into MANY extents. SlabAllocator binds each extent to a
+  // single size class; with one giant extent (num_extents=1) the RAM tier could
+  // hold only ONE size class at a time, so a real KV working set (block values
+  // of assorted sizes -- partial blocks, variable-length coalesced chunks)
+  // evicted the whole tier on every cross-class Put (observed on hd04 prod:
+  // ram_objects collapsed to ~1-5 in a 16 GiB arena, every reuse GET missed to
+  // slab -> load ran at disk speed, ~25x slower than a RAM hit). Many smaller
+  // extents let the working set's size classes coexist. Sizing: SlabAllocator
+  // keeps up to kStripeWays(8) extents open per size class, so we want
+  // num_extents >> num_classes*8 (a real KV mix spans ~15-20 size classes). A
+  // 32 MiB extent gives 512 extents on a 16 GiB arena (>> 160) while staying far
+  // above any single KV block, so large values still get many slots per extent.
+  uint64_t ext = 32ull << 20;
+  if (const char* e = std::getenv("DFKV_RAM_TIER_EXTENT_BYTES")) {
+    uint64_t v = std::strtoull(e, nullptr, 10);
+    if (v >= (1ull << 20)) ext = v;
+  }
+  if (ext > opt_.bytes) ext = opt_.bytes;
+  extent_bytes_ = ext;
   SlabAllocator::Options ao;
-  ao.extent_bytes = opt_.bytes;   // the whole arena is one extent
-  ao.num_extents = 1;
+  ao.extent_bytes = ext;
+  ao.num_extents = static_cast<uint32_t>(std::max<uint64_t>(1, opt_.bytes / ext));
   ao.align = opt_.slot_granularity;
   ao.max_waste = 0.25;
   alloc_ = std::make_unique<SlabAllocator>(ao);
@@ -108,8 +127,8 @@ bool RamTier::Put(const BlockKey& key, const void* data, size_t len) {
     // Flush-pin the slot: RAM_ONLY, not evictable until the async flush lands.
     alloc_->Pin(fn);
     writing_.insert(fn);  // reserve the key so a concurrent same-key Put dedups
-    offset = ref.offset;
-    cap = ref.slot_size;
+    offset = ref.extent * extent_bytes_ + ref.offset;  // global arena offset
+    cap = ref.slot_size;                               // (ref.offset is within-extent)
     // NOT visible yet: index_ install is deferred until after the copy, so a
     // concurrent GetPrep can't read the slot mid-copy.
   }

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -135,6 +135,8 @@ class RamTier {
   FlushFn flush_;
   char* arena_ = nullptr;
   void* arena_mr_ = nullptr;
+  uint64_t extent_bytes_ = 0;   // SlabAllocator extent size; global arena offset
+                                // of a slot = ref.extent * extent_bytes_ + ref.offset
   std::unique_ptr<SlabAllocator> alloc_;
 
   mutable std::mutex mu_;

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -95,6 +95,45 @@ TEST(RamTier, FlushMakesDurable) {
   EXPECT_EQ(rt.FlushBacklog(), 0u);
 }
 
+// Regression (hd04 prod, 2026-07): the RAM tier bound its whole arena to ONE
+// SlabAllocator extent, so it could hold only a single size class at a time. A
+// real KV working set has assorted value sizes (partial blocks, variable-length
+// coalesced chunks); each cross-class Put stole the lone extent and evicted the
+// whole tier (ram_objects collapsed to ~1-5 in a 16 GiB arena), so every reuse
+// GET missed to slab and load ran at disk speed. With the arena partitioned into
+// many extents, distinct size classes coexist and stay resident. Also exercises
+// the global-arena-offset math (slots now live in extents > 0).
+TEST(RamTier, VaryingSizesCoexistNoChurn) {
+  ::setenv("DFKV_RAM_TIER_EXTENT_BYTES", "2097152", 1);  // 2 MiB extents
+  FlushSink sink;
+  RamTier rt(Opts(256ull << 20), sink.fn());             // 256 MiB arena -> ~128 extents
+  ASSERT_TRUE(rt.ok());
+  // 6 distinct size classes x 4 keys each (models a real KV mix: a handful of
+  // block sizes, many blocks each). 6 classes * kStripeWays(8) = 48 extents of
+  // headroom vs 128 available. Each value < the 2 MiB extent.
+  const size_t sizes[6] = {40000, 90000, 200000, 380000, 560000, 730000};
+  std::vector<std::pair<uint64_t, size_t>> items;
+  for (int i = 0; i < 24; ++i) {
+    size_t sz = sizes[i % 6];
+    std::vector<char> v(sz, static_cast<char>(i + 1));
+    ASSERT_TRUE(rt.Put(K(1000 + i), v.data(), v.size())) << "put i=" << i;
+    items.emplace_back(1000 + i, sz);
+  }
+  // All resident (no cross-class eviction) and byte-correct after the global
+  // offset resolves each slot's extent.
+  EXPECT_EQ(rt.Count(), items.size());
+  EXPECT_EQ(rt.Evictions(), 0u);
+  for (auto& [id, sz] : items) {
+    RamTier::Hit h;
+    ASSERT_TRUE(rt.GetPrep(K(id), 0, sz, &h)) << "get id=" << id;
+    EXPECT_EQ(h.len, sz);
+    EXPECT_EQ(static_cast<unsigned char>(h.ptr[0]),
+              static_cast<unsigned char>((id - 1000) + 1));
+    rt.Release(h.token);
+  }
+  ::unsetenv("DFKV_RAM_TIER_EXTENT_BYTES");
+}
+
 TEST(RamTier, MissReturnsFalse) {
   FlushSink sink;
   RamTier rt(Opts(64 * 4096), sink.fn());


### PR DESCRIPTION
## Problem

The RAM hot tier bound its whole arena to **one** `SlabAllocator` extent (`num_extents=1`). Since `SlabAllocator` binds each extent to a single **size class**, the tier could hold only one size class at a time. Real KV block values vary in size (partial blocks, variable-length coalesced chunks), so every cross-class `Put` stole the lone extent and evicted the whole tier.

**Observed on hd04 production** (16 GiB arena): `dfkv_ram_objects` collapsed to ~5, `dfkv_ram_hit_total=0` / `dfkv_ram_miss_total=2160` — every KV-reuse load missed the RAM tier and was served from **slab (disk)**. dfkv load ran at disk speed (~0.49 GB/s), so prefill beat a cache load and the hot tier was defeated entirely.

## Fix

Partition the arena into many extents (default **32 MiB/extent** → 512 extents on a 16 GiB arena; `DFKV_RAM_TIER_EXTENT_BYTES` overrides). A real working set's size classes now coexist. Sizing rationale: `num_extents` must exceed `num_classes * kStripeWays(8)`; a KV mix spans ~15–20 classes, so 512 ≫ 160.

`SlotRef.offset` is per-extent (it was a global arena offset only by the `num_extents=1` coincidence), so the global arena offset is now resolved as `ref.extent * extent_bytes + ref.offset`.

## Validation

Controlled repro + fix on an experimental single-node dfkv (hd04 gpul-0041, **real RDMA + GPUDirect**, GLM-5.2 KV geometry), production untouched:

| | varying-size PUT → `ram_objects` | load 2436 keys varsize 2.17 GB, GPU dest, steady state |
|---|---|---|
| **before** | 1 (evictions ≈ puts) | **10.08 GB/s** (ram_hit=4, miss=19480 → slab) |
| **after** | 800 (evictions=0) | **31.58 GB/s** (ram_hit=9744, miss=0 → RAM) — **3.1×** |

Production slab is ~0.49 GB/s (far below this node's local NVMe), so the production win from hitting RAM is larger. Diagnosis first confirmed the transport (24–41 GB/s host) and server RAM-read path were fast, and GPU-dest/scatter were **not** the bottleneck — isolating the RAM-tier miss as the sole cause.

Adds `RamTier.VaryingSizesCoexistNoChurn` regression test (also exercises the global-offset math for slots in extents > 0). Full local suite: 297/297 pass.