### PR TITLE
slab/ram_tier: move eviction off the Put path + O(residents) extent steal

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -64,6 +64,8 @@ int main(int argc, char** argv) {
       "  --ram-flush-threads <n>   RAM tier flush thread count (env DFKV_RAM_FLUSH_THREADS)\n"
       "  --ram-tier-numa <n>  RAM tier NUMA node (env DFKV_RAM_TIER_NUMA)\n"
       "  --slab-table-sync-ms <n>  slab table sync cadence ms (env DFKV_SLAB_TABLE_SYNC_MS)\n"
+      "  --slab-reclaim-ms <n>  slab background free-slot reclaimer cadence ms, 0 = off (env DFKV_SLAB_RECLAIM_MS)\n"
+      "  --ram-reclaim-ms <n>   RAM tier background reclaimer cadence ms, 0 = off (env DFKV_RAM_RECLAIM_MS)\n"
       "  --log <level>        log level: INFO|DEBUG|WARN|ERROR (env DFKV_LOG)\n"
       "  --version, -V        print version and exit\n"
       "  --help, -h           print this help and exit\n"
@@ -82,7 +84,8 @@ int main(int argc, char** argv) {
                    "--rdma-depth", "--rdma-numa", "--rdma-idle-ms",
                    "--rdma-op-timeout-ms", "--server-uring",
                    "--server-uring-depth", "--ram-flush-threads",
-                   "--ram-tier-numa", "--slab-table-sync-ms", "--log"});
+                   "--ram-tier-numa", "--slab-table-sync-ms",
+                   "--slab-reclaim-ms", "--ram-reclaim-ms", "--log"});
   std::string dir = args.Get("--dir", "/tmp/dfkv_node");
   std::string rdma_dev = args.Get("--rdma-dev", "");
   std::string mds = args.Get("--mds", "");
@@ -150,6 +153,13 @@ int main(int argc, char** argv) {
   std::string slab_table_sync_ms = args.Get("--slab-table-sync-ms", "");
   if (!slab_table_sync_ms.empty())
     ::setenv("DFKV_SLAB_TABLE_SYNC_MS", slab_table_sync_ms.c_str(), 1);
+  // Background free-slot reclaimer cadences (ms; 0 disables).
+  std::string slab_reclaim_ms = args.Get("--slab-reclaim-ms", "");
+  if (!slab_reclaim_ms.empty())
+    ::setenv("DFKV_SLAB_RECLAIM_MS", slab_reclaim_ms.c_str(), 1);
+  std::string ram_reclaim_ms = args.Get("--ram-reclaim-ms", "");
+  if (!ram_reclaim_ms.empty())
+    ::setenv("DFKV_RAM_RECLAIM_MS", ram_reclaim_ms.c_str(), 1);
   // Log level (DFKV_LOG: e.g. "INFO", "DEBUG", "WARN").
   std::string log_level = args.Get("--log", "");
   if (!log_level.empty()) ::setenv("DFKV_LOG", log_level.c_str(), 1);

--- a/src/cache/disk_cache_group.cc
+++ b/src/cache/disk_cache_group.cc
@@ -36,6 +36,10 @@ DiskCacheGroup::DiskCacheGroup(Options opt) {
   uint32_t sync_ms = 100;
   if (const char* t = std::getenv("DFKV_SLAB_TABLE_SYNC_MS"))
     sync_ms = static_cast<uint32_t>(std::strtoul(t, nullptr, 10));
+  // Background free-slot reclaimer cadence override (ms; 0 disables). Default 50.
+  uint32_t reclaim_ms = 50;
+  if (const char* r = std::getenv("DFKV_SLAB_RECLAIM_MS"))
+    reclaim_ms = static_cast<uint32_t>(std::strtoul(r, nullptr, 10));
   for (const auto& dir : opt.cache_dirs) {
     std::unique_ptr<StoreEngine> store;
     if (use_slab) {
@@ -45,6 +49,7 @@ DiskCacheGroup::DiskCacheGroup(Options opt) {
       so.direct_writes = slab_direct;
       if (slab_gran) so.slot_granularity = slab_gran;
       so.table_sync_ms = sync_ms;
+      so.reclaim_interval_ms = reclaim_ms;
       auto slab = std::make_unique<DiskSlabStore>(so);
       slabs_.push_back(slab.get());
       // Resolved truth (an fs that rejects O_DIRECT demotes to buffered).
@@ -140,6 +145,7 @@ DiskSlabStore::Stats DiskCacheGroup::SlabStats() const {
     sum.deferred_removes += st.deferred_removes;
     sum.inflight += st.inflight;
     sum.prep_holds += st.prep_holds;
+    sum.reclaimed_slots += st.reclaimed_slots;
   }
   return sum;
 }

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -108,10 +108,28 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
       }
     });
   }
+  if (ok_ && opt_.reclaim_interval_ms > 0) {
+    reclaim_thread_ = std::thread([this] {
+      std::unique_lock<std::mutex> lk(reclaim_mu_);
+      for (;;) {
+        reclaim_cv_.wait_for(lk, std::chrono::milliseconds(opt_.reclaim_interval_ms),
+                             [this] { return reclaim_stop_; });
+        if (reclaim_stop_) return;
+        lk.unlock();
+        ReclaimTick();
+        lk.lock();
+      }
+    });
+  }
   if (ok) *ok = ok_;
 }
 
 DiskSlabStore::~DiskSlabStore() {
+  if (reclaim_thread_.joinable()) {
+    { std::lock_guard<std::mutex> lk(reclaim_mu_); reclaim_stop_ = true; }
+    reclaim_cv_.notify_all();
+    reclaim_thread_.join();
+  }
   if (sync_thread_.joinable()) {
     { std::lock_guard<std::mutex> lk(sync_mu_); sync_stop_ = true; }
     sync_cv_.notify_all();
@@ -576,6 +594,51 @@ uint64_t DiskSlabStore::EvictedBytes() const {
   return evicted_bytes_;
 }
 
+// One reclaimer pass: for every class with new inserts since the last pass,
+// top its free-slot pool up to a demand-driven watermark (enough headroom for
+// ~2 intervals of the observed insert rate, capped at 1/4 of the class's bound
+// capacity so an idle-then-bursty class is never hollowed out). Eviction runs
+// in bounded batches per store-lock hold, so a Put never waits behind a long
+// sweep -- the sweep Put used to run inline now happens here.
+void DiskSlabStore::ReclaimTick() {
+  const auto classes = alloc_->Classes();
+  if (reclaim_last_puts_.size() < classes.size())
+    reclaim_last_puts_.resize(classes.size(), 0);
+  for (size_t i = 0; i < classes.size(); ++i) {
+    const auto& c = classes[i];
+    const uint64_t delta = c.puts - reclaim_last_puts_[i];
+    reclaim_last_puts_[i] = c.puts;
+    if (delta == 0) continue;  // no write demand on this class
+    const size_t capacity = c.resident + c.free_slots;
+    size_t target = std::max<size_t>(64, static_cast<size_t>(2 * delta));
+    target = std::min(target, capacity / 4);
+    if (c.free_slots >= target) continue;
+    size_t budget = 4096;  // per-tick per-class bound
+    for (;;) {
+      std::vector<std::string> evicted;
+      const size_t batch = std::min<size_t>(128, budget);
+      size_t got;
+      {
+        std::lock_guard<std::mutex> lk(mu_);
+        got = alloc_->ReclaimClass(i, target, batch, &evicted);
+        for (const auto& ev : evicted) {
+          auto pit = payload_len_.find(ev);
+          if (pit != payload_len_.end()) {
+            evicted_bytes_ += pit->second;
+            payload_len_.erase(pit);
+          }
+        }
+      }
+      if (got > 0) reclaimed_.fetch_add(got, std::memory_order_relaxed);
+      budget -= std::min(budget, got);
+      // A partial batch means ReclaimClass stopped for an internal reason --
+      // target reached, everything pinned, or an extent went back to the pool
+      // (its cascade-shrink guard). Re-invoking would defeat that guard.
+      if (got < batch || budget == 0) break;
+    }
+  }
+}
+
 DiskSlabStore::Stats DiskSlabStore::GetStats() const {
   Stats st;
   st.dio_write_fallbacks = dio_write_fallbacks_.load(std::memory_order_relaxed);
@@ -588,6 +651,7 @@ DiskSlabStore::Stats DiskSlabStore::GetStats() const {
   st.deferred_removes = deferred_remove_total_;
   st.inflight = inflight_.size();
   st.prep_holds = prep_holds_.size();
+  st.reclaimed_slots = reclaimed_.load(std::memory_order_relaxed);
   return st;
 }
 

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -53,6 +53,12 @@ class DiskSlabStore : public StoreEngine {
     // If the filesystem rejects O_DIRECT (tmpfs in tests/CI), the store falls
     // back to buffered -- DirectWritesActive() reports the resolved truth.
     bool direct_writes = false;
+    // Background free-slot reclaimer cadence (ms; 0 = off). Keeps a demand-
+    // driven headroom of free slots per active class so Put's fast path stays
+    // pop-free-slot; without it every Put under capacity pressure runs the
+    // CLOCK eviction sweep inline under the store lock (the measured write-
+    // path serialization on a full store).
+    uint32_t reclaim_interval_ms = 50;
     // slots.tbl fdatasync cadence (ms; 0 = off). Bounds the crash window in
     // which a REUSED slot's new payload is on disk while the reused record is
     // still page-cache-only -- rebuild would then resurrect the PREVIOUS
@@ -73,6 +79,7 @@ class DiskSlabStore : public StoreEngine {
     uint64_t deferred_removes = 0;     // Removes deferred behind in-flight I/O
     uint64_t inflight = 0;             // keys with an unlocked read/write in flight
     uint64_t prep_holds = 0;           // outstanding async-prep slot holds
+    uint64_t reclaimed_slots = 0;      // slots freed by the background reclaimer
   };
 
   // Opens (or creates) the store under Options::dir, pre-allocating extents and
@@ -188,6 +195,15 @@ class DiskSlabStore : public StoreEngine {
   std::condition_variable sync_cv_;
   std::mutex sync_mu_;
   bool sync_stop_ = false;
+  // Background free-slot reclaimer (see Options::reclaim_interval_ms): runs
+  // ReclaimTick every interval, evicting ahead of demand in bounded batches.
+  void ReclaimTick();
+  std::atomic<uint64_t> reclaimed_{0};
+  std::vector<uint64_t> reclaim_last_puts_;  // reclaim-thread-local puts snapshot
+  std::thread reclaim_thread_;
+  std::condition_variable reclaim_cv_;
+  std::mutex reclaim_mu_;
+  bool reclaim_stop_ = false;
 };
 
 }  // namespace dfkv

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -66,6 +66,9 @@ void KvNodeServer::InitRamTier() {
     unsigned long long n = std::strtoull(f, nullptr, 10);
     if (n > 0 && n <= 64) o.flush_threads = static_cast<uint32_t>(n);
   }
+  // Background free-slot reclaimer cadence (ms; 0 disables). Default 10.
+  if (const char* r = std::getenv("DFKV_RAM_RECLAIM_MS"))
+    o.reclaim_interval_ms = static_cast<uint32_t>(std::strtoul(r, nullptr, 10));
   // Flusher persists a RAM slot to the disk group. CacheDirect (not Cache): the
   // arena slot is 4 KiB-aligned with cap slack, so a direct-mode slab lands it
   // via O_DIRECT -- a buffered flush would route the RAM tier's entire write
@@ -256,6 +259,8 @@ std::string KvNodeServer::MetricsText() const {
            "Keys with an unlocked read/write in flight", ss.inflight);
     metric("dfkv_slab_prep_holds", "gauge",
            "Outstanding async-prep slot holds", ss.prep_holds);
+    metric("dfkv_slab_reclaimed_total", "counter",
+           "Slots freed ahead of demand by the background reclaimer", ss.reclaimed_slots);
   }
   if (put_busy_limit_ > 0)
     metric("dfkv_put_busy_total", "counter",
@@ -272,6 +277,7 @@ std::string KvNodeServer::MetricsText() const {
     metric("dfkv_ram_flushed_total", "counter", "RAM slots flushed to disk (now durable)", ram_->Flushed());
     metric("dfkv_ram_flush_dropped_total", "counter", "RAM slots dropped after flush failure", ram_->FlushDropped());
     metric("dfkv_ram_evictions_total", "counter", "RAM slots evicted under capacity pressure", ram_->Evictions());
+    metric("dfkv_ram_reclaimed_total", "counter", "RAM slots freed ahead of demand by the background reclaimer", ram_->Reclaimed());
     metric("dfkv_ram_objects", "gauge", "Blocks currently resident in the RAM hot tier", ram_->Count());
     metric("dfkv_ram_flush_backlog", "gauge", "RAM slots queued for flush (not yet durable)", ram_->FlushBacklog());
   }

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -123,6 +123,16 @@ RamTier::~RamTier() {
 // allocator call on the pop-free-slot fast path; without it a full arena runs
 // the CLOCK sweep inline under mu_ on every admission.
 void RamTier::ReclaimTick() {
+  // Flush-gated regime: when the flush queue is deep, the arena is mostly
+  // PINNED (not-yet-durable) slots -- free slots are not the admission
+  // constraint, and a CLOCK sweep over a pinned-heavy ring just burns lock
+  // time skipping entries. Sit the tick out; reclaim resumes as the flusher
+  // catches up. 4096 = the per-tick eviction budget: below it one pass could
+  // plausibly matter, above it admission is flusher-bound by definition.
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (flushq_.size() > 4096) return;
+  }
   const auto classes = alloc_->Classes();
   if (reclaim_last_puts_.size() < classes.size())
     reclaim_last_puts_.resize(classes.size(), 0);

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -85,9 +85,27 @@ RamTier::RamTier(Options opt, FlushFn flush)
   flushers_.reserve(nf);
   for (uint32_t i = 0; i < nf; ++i)
     flushers_.emplace_back([this] { FlushLoop(); });
+  if (opt_.reclaim_interval_ms > 0) {
+    reclaim_thread_ = std::thread([this] {
+      std::unique_lock<std::mutex> lk(reclaim_mu_);
+      for (;;) {
+        reclaim_cv_.wait_for(lk, std::chrono::milliseconds(opt_.reclaim_interval_ms),
+                             [this] { return reclaim_stop_; });
+        if (reclaim_stop_) return;
+        lk.unlock();
+        ReclaimTick();
+        lk.lock();
+      }
+    });
+  }
 }
 
 RamTier::~RamTier() {
+  if (reclaim_thread_.joinable()) {
+    { std::lock_guard<std::mutex> lk(reclaim_mu_); reclaim_stop_ = true; }
+    reclaim_cv_.notify_all();
+    reclaim_thread_.join();
+  }
   {
     std::lock_guard<std::mutex> lk(mu_);
     stop_ = true;
@@ -95,6 +113,45 @@ RamTier::~RamTier() {
   flush_cv_.notify_all();
   for (auto& f : flushers_) if (f.joinable()) f.join();
   if (arena_) std::free(arena_);
+}
+
+// One reclaimer pass (mirror of DiskSlabStore::ReclaimTick, arena flavor): for
+// every class with new inserts since the last pass, top its free slots up to a
+// demand-driven watermark, in small batches per mu_ hold. Victims are unpinned
+// (== durable, no send in flight), so dropping them from index_ is the same
+// operation Put performs for its own inline evictions. This keeps Put's
+// allocator call on the pop-free-slot fast path; without it a full arena runs
+// the CLOCK sweep inline under mu_ on every admission.
+void RamTier::ReclaimTick() {
+  const auto classes = alloc_->Classes();
+  if (reclaim_last_puts_.size() < classes.size())
+    reclaim_last_puts_.resize(classes.size(), 0);
+  for (size_t i = 0; i < classes.size(); ++i) {
+    const auto& c = classes[i];
+    const uint64_t delta = c.puts - reclaim_last_puts_[i];
+    reclaim_last_puts_[i] = c.puts;
+    if (delta == 0) continue;  // no write demand on this class
+    const size_t capacity = c.resident + c.free_slots;
+    size_t target = std::max<size_t>(64, static_cast<size_t>(2 * delta));
+    target = std::min(target, capacity / 4);
+    if (c.free_slots >= target) continue;
+    size_t budget = 4096;  // per-tick per-class bound
+    for (;;) {
+      std::vector<std::string> evicted;
+      const size_t batch = std::min<size_t>(64, budget);
+      size_t got;
+      {
+        std::lock_guard<std::mutex> lk(mu_);
+        got = alloc_->ReclaimClass(i, target, batch, &evicted);
+        for (const auto& ev : evicted) index_.erase(ev);
+      }
+      if (got > 0) reclaimed_.fetch_add(got, std::memory_order_relaxed);
+      budget -= std::min(budget, got);
+      // Partial batch = ReclaimClass stopped early (target reached, everything
+      // pinned, or its cascade-shrink guard fired) -- don't re-invoke.
+      if (got < batch || budget == 0) break;
+    }
+  }
 }
 
 void RamTier::SetArenaMr(void* mr) {

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -60,6 +60,12 @@ class RamTier {
     // workers keep ~K devices busy). Same-key flushes can't run concurrently
     // (one queued item per key at a time), so workers need no extra ordering.
     uint32_t flush_threads = 1;
+    // Background free-slot reclaimer cadence (ms; 0 = off). Keeps demand-driven
+    // free-slot headroom per class so Put's allocator call stays pop-free-slot;
+    // without it a full arena runs the CLOCK eviction sweep inline under mu_ on
+    // every admission -- with tens of ingest threads that sweep is the measured
+    // write-path serialization point.
+    uint32_t reclaim_interval_ms = 10;
   };
 
   // Persists a slot to disk. Returns true on success (slot -> DURABLE). Called
@@ -114,6 +120,7 @@ class RamTier {
   uint64_t PutBypass() const { return put_bypass_.load(std::memory_order_relaxed); }
   uint64_t Flushed() const { return flushed_.load(std::memory_order_relaxed); }
   uint64_t FlushDropped() const { return flush_dropped_.load(std::memory_order_relaxed); }
+  uint64_t Reclaimed() const { return reclaimed_.load(std::memory_order_relaxed); }
   uint64_t Evictions() const { return alloc_->Evictions(); }
   uint64_t UsedBytes() const { return alloc_->UsedBytes(); }  // resident slot bytes
   size_t Count() const;
@@ -129,6 +136,7 @@ class RamTier {
   struct QItem { std::string fn; BlockKey key; uint32_t tries = 0; };
 
   void FlushLoop();
+  void ReclaimTick();  // one background free-slot top-up pass (see Options)
   void DropLocked(const std::string& fn);  // remove key from index_ + alloc + unpin
 
   Options opt_;
@@ -151,9 +159,16 @@ class RamTier {
   std::condition_variable flush_cv_;
   bool stop_ = false;
   std::vector<std::thread> flushers_;
+  // Background free-slot reclaimer (own cv/mutex so shutdown never races the
+  // flushers' flush_cv_ protocol).
+  std::vector<uint64_t> reclaim_last_puts_;  // reclaim-thread-local puts snapshot
+  std::thread reclaim_thread_;
+  std::condition_variable reclaim_cv_;
+  std::mutex reclaim_mu_;
+  bool reclaim_stop_ = false;
 
   std::atomic<uint64_t> hits_{0}, misses_{0}, puts_{0}, put_bypass_{0};
-  std::atomic<uint64_t> flushed_{0}, flush_dropped_{0};
+  std::atomic<uint64_t> flushed_{0}, flush_dropped_{0}, reclaimed_{0};
 };
 
 }  // namespace dfkv

--- a/src/cache/slab_allocator.cc
+++ b/src/cache/slab_allocator.cc
@@ -23,6 +23,7 @@ void SlabAllocator::PushFreeLocked(Class& C, uint32_t ext, uint32_t slot) {
   auto& v = C.free_by_ext[ext];
   if (v.empty()) C.ext_rr.push_back(ext);
   v.push_back(slot);
+  C.free_count++;
 }
 
 bool SlabAllocator::PopFreeLocked(Class& C, Slot* out) {
@@ -33,6 +34,7 @@ bool SlabAllocator::PopFreeLocked(Class& C, Slot* out) {
   auto& v = vit->second;
   const uint32_t slot = v.back();
   v.pop_back();
+  C.free_count--;
   if (v.empty()) {
     C.free_by_ext.erase(vit);
     // Swap-erase keeps rr_next pointing at the moved-in extent: no skip, no advance.
@@ -63,12 +65,17 @@ bool SlabAllocator::TakeFreeSlotLocked(Class& C, uint32_t ext, uint32_t slot) {
   if (it == v.end()) return false;
   *it = v.back();
   v.pop_back();
+  C.free_count--;
   if (v.empty()) { C.free_by_ext.erase(vit); DropFromRotationLocked(C, ext); }
   return true;
 }
 
 void SlabAllocator::DropExtentFreeLocked(Class& C, uint32_t ext) {
-  if (C.free_by_ext.erase(ext)) DropFromRotationLocked(C, ext);
+  auto vit = C.free_by_ext.find(ext);
+  if (vit == C.free_by_ext.end()) return;
+  C.free_count -= vit->second.size();
+  C.free_by_ext.erase(vit);
+  DropFromRotationLocked(C, ext);
 }
 
 size_t SlabAllocator::ClassForLen(size_t aligned_len) {
@@ -129,7 +136,9 @@ bool SlabAllocator::Restore(const std::string& key, uint32_t slot_size,
   e.ring_it = C.ring.begin();
   m.free_slots--;
   used_bytes_ += slot_size;
-  index_.emplace(key, std::move(e));
+  auto res = index_.emplace(key, std::move(e));
+  m.residents.push_front(&res.first->first);
+  res.first->second.ext_it = m.residents.begin();
   return true;
 }
 
@@ -159,6 +168,7 @@ void SlabAllocator::FreeSlotLocked(const std::string& key, Entry& e) {
   Class& C = *classes_[cls];
   if (C.hand != C.ring.end() && C.hand == e.ring_it) C.hand = std::next(C.hand);
   C.ring.erase(e.ring_it);
+  extents_[ext].residents.erase(e.ext_it);
   PushFreeLocked(C, ext, slot);
   extents_[ext].free_slots++;
   if (e.refs > 0 && extents_[ext].pinned > 0) extents_[ext].pinned--;
@@ -234,22 +244,30 @@ bool SlabAllocator::StealExtentFor(size_t cls, std::vector<std::string>* evicted
   }
   if (best < 0) return false;
   const uint32_t E = static_cast<uint32_t>(best);
-  const int old_cls = extents_[E].cls;
-  // Evict every resident key living in extent E (scan the index -- steal is rare).
-  std::vector<std::string> victims;
-  for (const auto& kv : index_)
-    if (kv.second.ref.extent == E) victims.push_back(kv.first);
-  for (const auto& v : victims) {
-    auto it = index_.find(v);
-    if (it != index_.end()) { FreeSlotLocked(v, it->second); evicted->push_back(v); evictions_++; }
+  ExtentMeta& m = extents_[E];
+  const int old_cls = m.cls;
+  // Evict every resident key living in extent E, walked off its resident list:
+  // O(residents in E), not O(whole index) -- steal happens on every extent
+  // hand-off during a size-class mix shift, so it must not scan the store.
+  while (!m.residents.empty()) {
+    const std::string victim = *m.residents.front();
+    auto it = index_.find(victim);
+    if (it == index_.end()) { m.residents.pop_front(); continue; }  // stale node (defensive)
+    FreeSlotLocked(victim, it->second);  // erases the front resident node
+    evicted->push_back(victim);
+    evictions_++;
+    // The last eviction can auto-return E to the pool (FreeSlotLocked's
+    // fully-free unbind); residents is empty then, so the loop just ends.
   }
-  // Drop E's now-free slots from the old class's bookkeeping, then unbind E.
-  DropExtentFreeLocked(*classes_[old_cls], E);
-  extents_[E].cls = kUnbound;
-  extents_[E].total_slots = 0;
-  extents_[E].free_slots = 0;
-  extents_[E].pinned = 0;
-  ++unbound_;
+  // Unbind E unless FreeSlotLocked's return-to-pool already did.
+  if (m.cls != kUnbound) {
+    DropExtentFreeLocked(*classes_[old_cls], E);
+    m.cls = kUnbound;
+    m.total_slots = 0;
+    m.free_slots = 0;
+    m.pinned = 0;
+    ++unbound_;
+  }
   ++steals_;
   return BindFreeExtent(cls);  // now picks the freshly-unbound E
 }
@@ -292,9 +310,13 @@ bool SlabAllocator::Put(const std::string& key, size_t len, SlotRef* out,
   Class& C = *classes_[cls];
   C.ring.push_front(key);
   e.ring_it = C.ring.begin();
+  C.puts++;
   extents_[got.extent].free_slots--;
   used_bytes_ += e.ref.slot_size;
   auto res = index_.emplace(key, std::move(e));
+  ExtentMeta& m = extents_[got.extent];
+  m.residents.push_front(&res.first->first);
+  res.first->second.ext_it = m.residents.begin();
   if (out) *out = res.first->second.ref;
   return true;
 }
@@ -354,6 +376,47 @@ bool SlabAllocator::Unpin(const std::string& key) {
   if (it->second.refs == 0 && extents_[it->second.ref.extent].pinned > 0)
     extents_[it->second.ref.extent].pinned--;
   return true;
+}
+
+std::vector<SlabAllocator::ClassStat> SlabAllocator::Classes() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  std::vector<ClassStat> out;
+  out.reserve(classes_.size());
+  for (const auto& c : classes_) {
+    ClassStat s;
+    s.slot_size = c->slot_size;
+    s.free_slots = c->free_count;
+    s.resident = c->ring.size();
+    s.puts = c->puts;
+    out.push_back(s);
+  }
+  return out;
+}
+
+size_t SlabAllocator::ReclaimClass(size_t cls_index, size_t target_free,
+                                   size_t max_victims,
+                                   std::vector<std::string>* evicted) {
+  std::lock_guard<std::mutex> lk(mu_);
+  if (cls_index >= classes_.size()) return 0;
+  Class& C = *classes_[cls_index];
+  size_t n = 0;
+  while (n < max_victims && C.free_count < target_free) {
+    // While the shared pool still has extents, Put grows the class by binding
+    // one (cheap, no residency loss) -- evicting now would only shrink the
+    // cache for headroom the pool provides for free. Reclaim earns its keep
+    // exactly when the pool is exhausted and Put's only inline recourse is the
+    // CLOCK sweep this thread exists to pre-run.
+    if (unbound_ > 0) break;
+    const size_t before = C.free_count;
+    if (!EvictOneFrom(cls_index, evicted)) break;  // all pinned / empty
+    ++n;
+    // An eviction normally gains one free slot. If free_count did NOT grow, the
+    // freed slot's extent went back to the shared pool (fully-free unbind):
+    // stop -- more reclaiming would cascade-shrink this class, and the pool
+    // just gained a whole extent for whoever needs it.
+    if (C.free_count <= before) break;
+  }
+  return n;
 }
 
 size_t SlabAllocator::Count() const {

--- a/src/cache/slab_allocator.h
+++ b/src/cache/slab_allocator.h
@@ -109,6 +109,30 @@ class SlabAllocator {
   bool Pin(const std::string& key);
   bool Unpin(const std::string& key);
 
+  // Per-class occupancy snapshot for an external reclaimer thread. Indices are
+  // stable (classes_ only grows), so a caller can diff `puts` across polls to
+  // detect write demand per class.
+  struct ClassStat {
+    uint32_t slot_size = 0;
+    size_t free_slots = 0;   // free slots across this class's bound extents
+    size_t resident = 0;     // resident keys
+    uint64_t puts = 0;       // cumulative new-key inserts (idempotent hits excluded)
+  };
+  std::vector<ClassStat> Classes() const;
+
+  // Evict up to `max_victims` unpinned entries (CLOCK order) from class
+  // `cls_index` until it holds >= `target_free` free slots. Runs the same sweep
+  // Put would run inline, but from a background thread in bounded batches, so
+  // the Put fast path stays pop-free-slot. No-op while the shared pool still
+  // has unbound extents (Put grows the class by binding one -- cheap, no
+  // residency loss; eviction only earns its keep on a full store). Stops early
+  // if an eviction returned a fully-free extent to the pool (free count went
+  // DOWN: reclaiming further would cascade-shrink the class, and the pool
+  // gained capacity anyway). Returns the number evicted; keys are appended to
+  // *evicted for the caller to drop from its own index.
+  size_t ReclaimClass(size_t cls_index, size_t target_free, size_t max_victims,
+                      std::vector<std::string>* evicted);
+
   // stats (diagnostic)
   size_t Count() const;
   uint64_t UsedBytes() const;       // sum of slot_size over resident keys
@@ -128,6 +152,10 @@ class SlabAllocator {
     uint32_t refs = 0;                       // pin count
     bool referenced = false;                 // CLOCK bit
     std::list<std::string>::iterator ring_it;  // this key's node in its class ring
+    // This key's node in its extent's resident list (points at the index_ map
+    // key, which is node-stable). Lets StealExtentFor enumerate one extent's
+    // residents in O(residents) instead of scanning the whole index.
+    std::list<const std::string*>::iterator ext_it;
   };
   struct Class {
     uint32_t slot_size = 0;
@@ -140,6 +168,8 @@ class SlabAllocator {
     std::unordered_map<uint32_t, std::vector<uint32_t>> free_by_ext;
     std::vector<uint32_t> ext_rr;              // extents with >=1 free slot
     size_t rr_next = 0;                        // rotation cursor into ext_rr
+    size_t free_count = 0;                     // total free slots (== sum over free_by_ext)
+    uint64_t puts = 0;                         // cumulative new-key inserts (demand signal)
     std::list<std::string> ring;               // CLOCK ring of resident keys
     std::list<std::string>::iterator hand;     // persistent eviction cursor
     Class() : hand(ring.end()) {}
@@ -152,6 +182,9 @@ class SlabAllocator {
     uint32_t free_slots = 0; // free slots (== total when fully empty)
     uint32_t total_slots = 0;
     uint32_t pinned = 0;     // resident pinned slots in this extent (steal guard)
+    // Keys resident in this extent (pointers into index_'s node-stable keys);
+    // per-key node handle lives in Entry::ext_it. Empty iff fully free.
+    std::list<const std::string*> residents;
   };
 
   size_t ClassForLen(size_t aligned_len);  // returns class index (creates if needed)

--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <string>
 #include <thread>
@@ -422,4 +423,22 @@ TEST_F(DiskSlabTest, RebindWipesStaleRecordsNoResurrectionAcrossRestart) {
   std::string out;
   ASSERT_EQ(s2.Range(K(500), 0, 0, &out), Status::kOk);
   EXPECT_EQ(out, bval);
+}
+
+// Background reclaimer wiring: on a full store with ongoing writes, slots get
+// freed ahead of demand by the reclaim thread and show up in Stats.
+TEST_F(DiskSlabTest, BackgroundReclaimerFreesSlotsOnFullStore) {
+  bool ok = false;
+  auto o = Opts(2 << 20, 1 << 20, 4096);  // 2 extents x 256 slots of 4 KiB
+  o.reclaim_interval_ms = 1;
+  DiskSlabStore s(o, &ok);
+  ASSERT_TRUE(ok);
+  std::string v(4000, 'x');
+  for (uint64_t i = 0; i < 512; ++i)
+    ASSERT_EQ(s.Cache(K(1000 + i), v.data(), v.size()), Status::kOk);  // fill
+  for (uint64_t i = 0; i < 128; ++i) {  // sustained demand on the full store
+    ASSERT_EQ(s.Cache(K(2000 + i), v.data(), v.size()), Status::kOk);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  EXPECT_GT(s.GetStats().reclaimed_slots, 0u) << "reclaimer never ran";
 }

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -250,3 +250,25 @@ TEST(RamTier, ConcurrentPutGetReleaseIsRaceFree) {
   for (auto& th : ts) th.join();
   EXPECT_GT(hits.load(), 0);
 }
+
+// Background reclaimer wiring: once the arena is full of DURABLE slots and new
+// writes keep coming, the reclaimer (not the Put path) pre-frees slots, so
+// admission rides pop-free-slot and never hits backpressure bypass.
+TEST(RamTier, BackgroundReclaimerPreFreesDurableSlots) {
+  FlushSink sink;
+  auto o = Opts(16 * 4096);  // 16 slots, one extent (pool exhausted at first bind)
+  o.reclaim_interval_ms = 1;
+  RamTier rt(o, sink.fn());
+  ASSERT_TRUE(rt.ok());
+  std::string v(4000, 'r');
+  for (uint64_t i = 0; i < 16; ++i) ASSERT_TRUE(rt.Put(K(100 + i), v.data(), v.size()));
+  ASSERT_TRUE(WaitFor([&] { return rt.FlushBacklog() == 0; }));  // all durable
+  // Sustained new-key writes: demand makes the reclaimer top up free slots.
+  for (uint64_t i = 0; i < 32; ++i) {
+    EXPECT_TRUE(rt.Put(K(200 + i), v.data(), v.size()));
+    std::this_thread::sleep_for(1ms);
+  }
+  EXPECT_TRUE(WaitFor([&] { return rt.Reclaimed() > 0; }))
+      << "reclaimer never pre-freed a slot";
+  EXPECT_EQ(rt.PutBypass(), 0u);
+}

--- a/test/cache/slab_allocator_test.cc
+++ b/test/cache/slab_allocator_test.cc
@@ -295,3 +295,142 @@ TEST(SlabAllocator, RemoveFreesPinnedSlotImmediately) {
   EXPECT_EQ(r2.extent, r1.extent);
   EXPECT_EQ(r2.slot, r1.slot);
 }
+
+// ---- background-reclaimer + resident-list additions (put-path deserialization) ----
+
+// Classes() reports per-class free/resident/puts truthfully across put, evict,
+// remove, and extent hand-offs (the reclaimer's decisions ride on these counts).
+TEST(SlabAllocator, ClassStatsTrackFreeResidentAndPuts) {
+  SlabAllocator a(Opts(4 * 4096, 4));  // 16 slots of one 4096 class
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 10; ++i)
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  auto cs = a.Classes();
+  ASSERT_EQ(cs.size(), 1u);
+  EXPECT_EQ(cs[0].slot_size, 4096u);
+  EXPECT_EQ(cs[0].resident, 10u);
+  EXPECT_EQ(cs[0].free_slots, 6u);
+  EXPECT_EQ(cs[0].puts, 10u);
+  ASSERT_TRUE(a.Put("k0", 4096, &r, &ev));  // idempotent hit: NOT a new insert
+  EXPECT_EQ(a.Classes()[0].puts, 10u);
+  a.Remove("k9");
+  cs = a.Classes();
+  EXPECT_EQ(cs[0].resident, 9u);
+  EXPECT_EQ(cs[0].free_slots, 7u);
+}
+
+// ReclaimClass evicts ahead of demand: it frees slots up to the target, in
+// CLOCK order, without touching pinned entries, and reports the victims so the
+// caller can drop them from its own index.
+TEST(SlabAllocator, ReclaimClassCreatesHeadroomSkippingPinned) {
+  SlabAllocator a(Opts(4 * 4096, 2));  // 8 slots, one class
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 8; ++i)
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  ASSERT_TRUE(a.Pin("k0"));
+  ASSERT_TRUE(a.Pin("k1"));
+  std::vector<std::string> victims;
+  const size_t got = a.ReclaimClass(0, /*target_free=*/3, /*max_victims=*/8, &victims);
+  EXPECT_EQ(got, 3u);
+  EXPECT_EQ(victims.size(), 3u);
+  for (const auto& v : victims) {
+    EXPECT_NE(v, "k0");
+    EXPECT_NE(v, "k1");
+    EXPECT_FALSE(a.Contains(v));
+  }
+  EXPECT_EQ(a.Classes()[0].free_slots, 3u);
+  // A follow-up Put takes a reclaimed slot WITHOUT evicting inline.
+  ev.clear();
+  ASSERT_TRUE(a.Put("fresh", 4096, &r, &ev));
+  EXPECT_TRUE(ev.empty()) << "put should ride the reclaimed headroom";
+}
+
+// ReclaimClass respects max_victims (bounded work per lock hold) and is a no-op
+// when the class already holds the target headroom.
+TEST(SlabAllocator, ReclaimClassBoundedAndIdempotent) {
+  SlabAllocator a(Opts(4 * 4096, 2));
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 8; ++i)
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  std::vector<std::string> victims;
+  EXPECT_EQ(a.ReclaimClass(0, /*target_free=*/4, /*max_victims=*/2, &victims), 2u);
+  EXPECT_EQ(victims.size(), 2u);
+  victims.clear();
+  EXPECT_EQ(a.ReclaimClass(0, /*target_free=*/2, /*max_victims=*/8, &victims), 0u);
+  EXPECT_TRUE(victims.empty());
+  // Out-of-range class index: harmless no-op.
+  EXPECT_EQ(a.ReclaimClass(7, 4, 8, &victims), 0u);
+}
+
+// The cascade-shrink guard: when an eviction returns a fully-free extent to the
+// shared pool (free count goes DOWN, not up), ReclaimClass stops instead of
+// hollowing the class out chasing a target it can no longer reach.
+TEST(SlabAllocator, ReclaimClassStopsOnExtentReturn) {
+  // 12 extents x 1 slot each. Fill all 12, then Remove 8: the rotation now
+  // holds exactly kStripeWays(8) fully-free extents (one more and they start
+  // unbinding). The next eviction pushes the rotation past 8, so ITS extent
+  // returns to the pool -- free count nets zero, and the guard must stop the
+  // pass instead of hollowing out the remaining residents.
+  SlabAllocator a(Opts(4096, 12));
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 12; ++i)
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  for (int i = 0; i < 8; ++i) a.Remove("k" + std::to_string(i));
+  ASSERT_EQ(a.ExtentReturns(), 0u);
+  ASSERT_EQ(a.Classes()[0].free_slots, 8u);
+  std::vector<std::string> victims;
+  const size_t got = a.ReclaimClass(0, /*target_free=*/12, /*max_victims=*/12, &victims);
+  EXPECT_EQ(got, 1u) << "must stop after the eviction that returned an extent";
+  EXPECT_EQ(a.ExtentReturns(), 1u);
+  EXPECT_EQ(a.Classes()[0].resident, 3u);
+}
+
+// Steal now walks the stolen extent's resident list instead of scanning the
+// whole index: behavior must be identical -- exactly that extent's residents
+// are evicted, everything else survives, and the needy class gets the extent.
+TEST(SlabAllocator, StealEvictsExactlyTheStolenExtentsResidents) {
+  SlabAllocator a(Opts(4 * 4096, 2));  // 2 extents x 4 slots
+  std::vector<std::string> ev;
+  SlotRef r;
+  std::vector<std::string> ext_keys[2];
+  for (int i = 0; i < 8; ++i) {
+    const std::string k = "k" + std::to_string(i);
+    ASSERT_TRUE(a.Put(k, 4096, &r, &ev));
+    ext_keys[r.extent].push_back(k);
+  }
+  // A new class (16384 > 4096/0.25 waste bound) finds no pool extent -> steal.
+  ev.clear();
+  ASSERT_TRUE(a.Put("big", 16 * 1024, &r, &ev));
+  EXPECT_EQ(a.Steals(), 1u);
+  EXPECT_EQ(ev.size(), 4u) << "exactly one extent's residents evicted";
+  const uint32_t stolen = r.extent;
+  std::set<std::string> gone(ev.begin(), ev.end());
+  for (const auto& k : ext_keys[stolen]) EXPECT_TRUE(gone.count(k)) << k;
+  for (const auto& k : ext_keys[1 - stolen]) {
+    EXPECT_FALSE(gone.count(k)) << k;
+    EXPECT_TRUE(a.Contains(k)) << k;
+  }
+}
+
+// Restore populates the resident list too: a steal after a rebuild must evict
+// the restored keys of the stolen extent (they live only in the extent list --
+// a regression here silently leaks slots).
+TEST(SlabAllocator, StealAfterRestoreEvictsRestoredResidents) {
+  SlabAllocator a(Opts(4 * 4096, 1));  // one extent x 4 slots
+  for (int i = 0; i < 4; ++i)
+    ASSERT_TRUE(a.Restore("k" + std::to_string(i), 4096, /*extent=*/0,
+                          /*slot=*/static_cast<uint32_t>(i)));
+  EXPECT_EQ(a.Count(), 4u);
+  std::vector<std::string> ev;
+  SlotRef r;
+  ASSERT_TRUE(a.Put("big", 16 * 1024, &r, &ev));  // must steal extent 0
+  EXPECT_EQ(a.Steals(), 1u);
+  EXPECT_EQ(ev.size(), 4u);
+  EXPECT_EQ(a.Count(), 1u);
+  for (int i = 0; i < 4; ++i)
+    EXPECT_FALSE(a.Contains("k" + std::to_string(i)));
+}


### PR DESCRIPTION
## Problem

Benchmarked on a full 5 TiB production-shaped store (xb01 8xB200, v1.17.0, slab+direct+RAM 128G, RDMA loopback, `dfkv_bench --op both`): sustained PUT collapses once the RAM arena / store is full — 12.7 GB/s steady, 6.0 GB/s on a 154 GB cold dataset, 1.6 GB/s with a flush backlog — while disks sit at ~40% util and the pure flush drain runs 10.4 GB/s. The gap is lock time, not I/O:

1. `SlabAllocator::Put` runs the CLOCK eviction sweep **inline under the lock** on every admission once free slots run out (ring is ~2M entries on a full 5 TiB store).
2. `StealExtentFor` scans the **whole index** per stolen extent. "Steal is rare" does not hold during a size-class mix shift: measured PUT p99 82 → 501 → 1215 ms across three class transitions.

## Fix

**1. Background free-slot reclaimer** — `SlabAllocator::ReclaimClass()` (bounded CLOCK sweep toward a free-slot target) + `Classes()` (per-class free/resident/puts snapshot). `DiskSlabStore` and `RamTier` each run a reclaim thread (`DFKV_SLAB_RECLAIM_MS` default 50 / `DFKV_RAM_RECLAIM_MS` default 10, `0` disables; `--slab-reclaim-ms` / `--ram-reclaim-ms` facades) that tops active classes up to a demand-driven watermark (2× the inserts seen since the last tick, capped at ¼ class capacity) in small batches per lock hold, dropping victims from its own index exactly like the inline path does. Put's allocator call stays pop-free-slot in steady state.

Guards, each load-bearing:
- **No eviction while the pool has unbound extents** — Put binds one for free; reclaiming would only shrink residency (and would break the multi-extent residency semantics of #137).
- **Stop when an eviction returns a fully-free extent to the pool** — free count went *down*; continuing cascade-shrinks the class.
- **Sit the tick out while flush-gated** (RamTier, `flushq > 4096`) — a deep flush queue means the arena is mostly flush-pinned slots; sweeping past them just burns `mu_` time (measured 6.1k → 4.3k ops/s regression on 64 KiB saturated writes without this guard; 6.7k with it).

New counters: `dfkv_slab_reclaimed_total`, `dfkv_ram_reclaimed_total`.

**2. O(residents) extent steal** — `ExtentMeta` carries an intrusive list of pointers into `index_`'s node-stable keys (`Entry::ext_it` is the per-key handle, maintained on Put/Restore/FreeSlotLocked). A steal walks exactly the stolen extent's residents.

## Canary results (same node, same protocol, stock vs patch)

| scenario (2.75 MB, t32) | stock v1.17.0 | patched | Δ |
|---|---|---|---|
| steady PUT, full arena | 12.69 GB/s, p99 13.9 ms | **29.87 GB/s, p99 2.6 ms** | **2.4×** |
| cold 154 GB PUT | 5.97 GB/s, p99 39 ms | **43.15 GB/s, p99 2.5 ms** | **7.2×** (at RDMA ingest line rate) |
| cold GET | 28.59 GB/s | 28.47 GB/s | unchanged |
| steady GET | 29.05 GB/s | 35.58 GB/s | +22% |
| 16 MB class-shift PUT | 5.70 GB/s, p99 501 ms | **20.58 GB/s, p99 72.6 ms** | **3.6×** |
| 64 KiB t8 PUT | 22.7k ops/s, p99 3.9 ms | **48.9k ops/s, p99 0.84 ms** | 2.1× |
| 64 KiB t32 saturated PUT | 6.1k ops/s, p99 106 ms | 6.7k ops/s, p99 93 ms | +11% |

64 KiB saturated writes remain flusher-obj/s-bound (one sync DIO write per object) — flush batching is follow-up work, out of scope here. Same for the class-growth policy (EvictOneFrom-before-Steal keeps a new class small against a full store) and per-class capacity protection.

## Tests

8 new tests (reclaim headroom/bounds/pinned-skip, both cascade guards, steal equivalence via residents, steal-after-Restore, RamTier/DiskSlabStore reclaim wiring). 305/305 ctest green; TSan suite green (`python_plugin`'s TSan failure is the pre-existing static-TLS dlopen limitation, identical on main). Canary ran against the real 5 TiB store including a full `Rebuild` of ~1.9M records populating the resident lists.