### PR TITLE
slab: grow a bootstrapping class before self-evicting

### DIFF
--- a/src/cache/slab_allocator.cc
+++ b/src/cache/slab_allocator.cc
@@ -233,7 +233,8 @@ bool SlabAllocator::EvictOneFrom(size_t cls, std::vector<std::string>* evicted) 
   return false;  // every entry in this class is pinned
 }
 
-bool SlabAllocator::StealExtentFor(size_t cls, std::vector<std::string>* evicted) {
+bool SlabAllocator::StealExtentFor(size_t cls, std::vector<std::string>* evicted,
+                                   size_t min_donor_extents) {
   // Cold path: the target class has no slot and the pool is empty. Reclaim an
   // entirely-unpinned extent bound to ANOTHER class, evict its residents, unbind
   // it, and re-bind to the target class. Prefer the emptiest such extent.
@@ -243,6 +244,9 @@ bool SlabAllocator::StealExtentFor(size_t cls, std::vector<std::string>* evicted
     const ExtentMeta& m = extents_[e];
     if (m.cls == kUnbound || m.cls == static_cast<int>(cls)) continue;
     if (m.pinned != 0) continue;  // can't evict a pinned slot
+    if (min_donor_extents > 0 &&
+        classes_[m.cls]->bound_extents <= min_donor_extents)
+      continue;  // donor floor: never shrink a class below its striping width
     if (best < 0 || m.free_slots > best_free) { best = static_cast<int>(e); best_free = m.free_slots; }
   }
   if (best < 0) return false;
@@ -320,6 +324,14 @@ bool SlabAllocator::Put(const std::string& key, size_t len, SlotRef* out,
     // exhausted -- BindFreeExtent bails at unbound_ == 0).
     while (C.ext_rr.size() < kStripeWays && BindFreeExtent(cls)) {}
     if (PopFreeLocked(C, &got)) break;
+    // Growth-first while under the striping width: a class below kStripeWays
+    // extents is still bootstrapping -- self-evicting here pins it at birth
+    // size forever (its growth would be left to accidental all-pinned moments
+    // or the background rebalance tick; this closes the intra-tick window).
+    // Donor floor keeps two bootstrapping classes from ping-ponging.
+    if (C.bound_extents < kStripeWays &&
+        StealExtentFor(cls, evicted, /*min_donor_extents=*/kStripeWays))
+      continue;
     if (EvictOneFrom(cls, evicted)) continue;
     if (StealExtentFor(cls, evicted)) continue;
     return false;  // nothing to free: all candidate slots are pinned

--- a/src/cache/slab_allocator.h
+++ b/src/cache/slab_allocator.h
@@ -209,7 +209,13 @@ class SlabAllocator {
   size_t ClassForExactSize(uint32_t slot_size);  // find/create a class of exactly slot_size
   bool BindFreeExtent(size_t cls);         // bind a pool extent to cls; false if none
   bool EvictOneFrom(size_t cls, std::vector<std::string>* evicted);  // CLOCK evict 1
-  bool StealExtentFor(size_t cls, std::vector<std::string>* evicted); // rebind a full extent
+  // Steal an entirely-unpinned extent from another class and rebind it to cls.
+  // min_donor_extents > 0 restricts donors to classes holding MORE than that
+  // many extents (the growth-first path uses kStripeWays: two under-provisioned
+  // classes must not ping-pong extents off each other). 0 = any donor (the
+  // last-resort semantics this function always had).
+  bool StealExtentFor(size_t cls, std::vector<std::string>* evicted,
+                      size_t min_donor_extents = 0); // rebind a full extent
   // Shared steal core: evict extent E's residents, unbind E, re-bind a pool
   // extent to target_cls. E must be fully unpinned. With mu_ held.
   bool StealExtentLocked(uint32_t E, size_t target_cls,

--- a/test/cache/slab_allocator_test.cc
+++ b/test/cache/slab_allocator_test.cc
@@ -507,3 +507,71 @@ TEST(SlabAllocator, ClassStatsExtentsTracksHandoffs) {
   EXPECT_EQ(bound_after + a.PoolExtents(), 12u) << "bind accounting must balance";
   EXPECT_GT(a.PoolExtents(), 0u);
 }
+
+// ---- inline growth-first additions (close the intra-tick starvation window) ----
+
+// A bootstrapping class (< kStripeWays extents) on a full store must GROW by
+// stealing from a big donor instead of eating itself: without growth-first,
+// self-eviction succeeds as soon as the class has one unpinned resident and
+// pins it at birth size until the background rebalance tick.
+TEST(SlabAllocator, PutGrowsBootstrappingClassBeforeSelfEvicting) {
+  // 16 extents x 4 slots of class A (4096); donor stays above the 8-extent floor.
+  SlabAllocator a(Opts(4 * 4096, 16));
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 64; ++i)
+    ASSERT_TRUE(a.Put("a" + std::to_string(i), 4096, &r, &ev));
+  ASSERT_EQ(a.Classes()[0].extents, 16u);
+  // Class B (16 KiB, 1 slot/extent): burst of 6. Every put after the first
+  // extent fills must STEAL (donor A: 16 > 8), never evict B's own residents.
+  ev.clear();
+  for (int i = 0; i < 6; ++i)
+    ASSERT_TRUE(a.Put("b" + std::to_string(i), 16 * 1024, &r, &ev));
+  for (int i = 0; i < 6; ++i)
+    EXPECT_TRUE(a.Contains("b" + std::to_string(i))) << "b" << i << " self-evicted";
+  auto cs = a.Classes();
+  EXPECT_EQ(cs[1].resident, 6u);
+  EXPECT_EQ(cs[1].extents, 6u);
+  EXPECT_EQ(a.Steals(), 6u);
+}
+
+// Donor floor on the growth-first path: when every other class is at or below
+// kStripeWays extents, a bootstrapping class must NOT steal (no ping-pong
+// between two under-provisioned classes) -- it falls back to self-eviction.
+TEST(SlabAllocator, GrowthFirstRespectsDonorFloor) {
+  // 8 extents x 4 slots, all bound to class A (exactly kStripeWays -> not a donor).
+  SlabAllocator a(Opts(4 * 4096, 8));
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 32; ++i)
+    ASSERT_TRUE(a.Put("a" + std::to_string(i), 4096, &r, &ev));
+  ASSERT_EQ(a.Classes()[0].extents, 8u);
+  // Class B: first put has no self to evict -> LAST-RESORT steal (floor 0) is
+  // allowed and takes one A extent (A drops to 7).
+  ev.clear();
+  ASSERT_TRUE(a.Put("b0", 16 * 1024, &r, &ev));
+  EXPECT_EQ(a.Steals(), 1u);
+  // Second put: B(1 extent, full) is bootstrapping, but A(7) is at/below the
+  // floor -> growth-first refuses; self-eviction evicts b0.
+  ev.clear();
+  ASSERT_TRUE(a.Put("b1", 16 * 1024, &r, &ev));
+  EXPECT_EQ(a.Steals(), 1u) << "must not steal from a donor at/below the floor";
+  ASSERT_EQ(ev.size(), 1u);
+  EXPECT_EQ(ev[0], "b0");
+  EXPECT_EQ(a.Classes()[0].extents, 7u) << "A must not shrink further";
+}
+
+// A class at or above kStripeWays extents behaves exactly as before: steady-
+// state churn is self-eviction, not stealing (growth-first is bootstrap-only).
+TEST(SlabAllocator, MatureClassStillSelfEvicts) {
+  SlabAllocator a(Opts(4096, 16));  // 16 extents x 1 slot, one class
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 16; ++i)
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  ASSERT_EQ(a.Classes()[0].extents, 16u);
+  ev.clear();
+  ASSERT_TRUE(a.Put("k16", 4096, &r, &ev));  // full + mature -> CLOCK evict
+  EXPECT_EQ(ev.size(), 1u);
+  EXPECT_EQ(a.Steals(), 0u);
+}


### PR DESCRIPTION
Phase-3 item 1/4 (inline growth-first). Closes the intra-tick starvation window left by #142's background rebalancer: a class below `kStripeWays` extents now steals (donor floor = classes above `kStripeWays`, preventing ping-pong between two bootstrapping classes) before eating its own residents; mature classes behave exactly as before.

- Bounded inline cost: steal is O(stolen extent's residents) since the resident-list rework (#139).
- 3 new tests (bootstrap-grows, donor-floor-refusal, mature-self-evicts); 313/313 ctest, TSan green (python_plugin pre-existing env failure).
- B200 validation of the combined phase-3 branch set will follow before the v1.20.0 cut.