### PR TITLE
client: auto-scale batch fan-out workers + batch-window timeout knob

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -69,6 +69,11 @@ KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
     t_ = owned_.get();
     DFKV_LOG_INFO("dfkv client transport=" + transport_reason_);
   }
+  // Batch fan-out workers override (0/unset = auto; see set_batch_concurrency).
+  if (const char* bc = std::getenv("DFKV_BATCH_CONCURRENCY")) {
+    long x = std::strtol(bc, nullptr, 10);
+    if (x > 0) batch_concurrency_.store(static_cast<size_t>(x), std::memory_order_relaxed);
+  }
   // Opt-in active per-peer latency probe. Off unless DFKV_PROBE_INTERVAL_MS>0,
   // so default behavior is unchanged (no background traffic).
   if (const char* pe = std::getenv("DFKV_PROBE_INTERVAL_MS")) {
@@ -456,7 +461,7 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
   const size_t N = items.size();
   std::vector<char> ok(N, 0);  // char (not vector<bool>) for thread-safe writes
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
-    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
+    RunParallel(N, BatchWorkers(N), [&](size_t i) {
       ok[i] = Put(items[i].key, items[i].value, items[i].n) ? 1 : 0;
     });
     return std::vector<bool>(ok.begin(), ok.end());
@@ -475,7 +480,7 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
     by_node[node].push_back(i);
   }
   std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
-  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -507,7 +512,7 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
   const size_t N = items.size();
   std::vector<char> hit(N, 0);
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
-    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
+    RunParallel(N, BatchWorkers(N), [&](size_t i) {
       hit[i] = Get(items[i].key, items[i].out, items[i].n) ? 1 : 0;
     });
     return std::vector<bool>(hit.begin(), hit.end());
@@ -520,7 +525,7 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
     by[{node, items[i].n}].push_back(i);
   }
   std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
-  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -567,7 +572,7 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
   std::vector<char> hit(N, 0);
   std::vector<size_t> lens(N, 0);  // distinct indices => thread-safe writes
   if (!t_->pipelined()) {  // TCP: parallelize per item with our own threads.
-    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
+    RunParallel(N, BatchWorkers(N), [&](size_t i) {
       size_t got = 0;
       if (GetAuto(items[i].key, items[i].out, items[i].n, &got)) { hit[i] = 1; lens[i] = got; }
     });
@@ -584,7 +589,7 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
     by[{node, items[i].n}].push_back(i);
   }
   std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
-  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -629,7 +634,7 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
   const size_t N = keys.size();
   std::vector<char> e(N, 0);
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
-    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
+    RunParallel(N, BatchWorkers(N), [&](size_t i) {
       e[i] = Exist(keys[i]) ? 1 : 0;
     });
     return std::vector<bool>(e.begin(), e.end());
@@ -644,7 +649,7 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
     by_node[node].push_back(i);
   }
   std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
-  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -671,7 +676,7 @@ std::vector<bool> KVClient::BatchRemove(const std::vector<std::string>& keys) {
   const size_t N = keys.size();
   std::vector<char> ok(N, 0);
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
-    RunParallel(N, batch_concurrency_.load(std::memory_order_relaxed), [&](size_t i) {
+    RunParallel(N, BatchWorkers(N), [&](size_t i) {
       ok[i] = Remove(keys[i]) ? 1 : 0;
     });
     return std::vector<bool>(ok.begin(), ok.end());
@@ -685,7 +690,7 @@ std::vector<bool> KVClient::BatchRemove(const std::vector<std::string>& keys) {
     by_node[node].push_back(i);
   }
   std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
-  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -742,7 +747,7 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     by_node[node].push_back(i);
   }
   std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
-  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;
@@ -804,7 +809,7 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
     by[{node, cap}].push_back(i);
   }
   std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
-  RunParallel(groups.size(), batch_concurrency_.load(std::memory_order_relaxed), [&](size_t g) {
+  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();
     if (!health_.Healthy(node, now)) return;

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -10,6 +10,7 @@
 #ifndef DFKV_KV_CLIENT_H_
 #define DFKV_KV_CLIENT_H_
 
+#include <algorithm>
 #include <atomic>
 #include <condition_variable>
 #include <map>
@@ -31,6 +32,15 @@
 #include "common/value_header.h"
 
 namespace dfkv {
+
+// Batch fan-out worker sizing: explicit bc wins; 0 = one worker per node group
+// capped at 32 (a fixed small default serializes a wide ring's groups into
+// waves, multiplying the batch tail for single-threaded callers).
+inline size_t AutoBatchWorkers(size_t bc, size_t groups) {
+  constexpr size_t kMaxAutoBatchWorkers = 32;
+  if (bc) return bc;
+  return std::min(std::max<size_t>(groups, 1), kMaxAutoBatchWorkers);
+}
 
 struct KvPutItem { std::string key; const void* value; size_t n; };
 struct KvGetItem { std::string key; void* out; size_t n; };
@@ -106,8 +116,14 @@ class KVClient {
   std::vector<bool> BatchGetAutoSg(const std::vector<KvGetItemSg>& items,
                                    std::vector<size_t>* out_lens);
 
+  // Batch fan-out worker count. 0 (the default) = auto: one worker per node
+  // group, capped at kMaxAutoBatchWorkers -- with the old fixed default of 8, a
+  // 64-key batch over a 47..61-node ring ran its groups in 6-8 serial WAVES,
+  // multiplying the batch tail by the wave count for single-threaded callers
+  // (the production connector shape). Explicit n keeps the old fixed behavior
+  // (dfkv_bench passes --bc 1 so its external threads stay the only load).
   void set_batch_concurrency(size_t n) {
-    batch_concurrency_.store(n ? n : 1, std::memory_order_relaxed);
+    batch_concurrency_.store(n, std::memory_order_relaxed);
   }
 
   // Register a large caller memory region (e.g. the whole SGLang host KV pool) for
@@ -177,7 +193,10 @@ class KVClient {
   Transport* t_;
   std::string transport_reason_ = "unknown";
   // Atomic: configurable via the C ABI; reads on the batch path are relaxed.
-  std::atomic<size_t> batch_concurrency_{8};
+  std::atomic<size_t> batch_concurrency_{0};  // 0 = auto (see set_batch_concurrency)
+  size_t BatchWorkers(size_t groups) const {
+    return AutoBatchWorkers(batch_concurrency_.load(std::memory_order_relaxed), groups);
+  }
   std::unique_ptr<MdsMemberPoller> poller_;
   std::unique_ptr<MdsRegistrar> client_registrar_;  // consumer identity lease (best-effort)
   PeerHealth health_;

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -127,6 +127,10 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
       long x = std::strtol(v, nullptr, 10);
       op_timeout_ms_ = (x == 0) ? -1 : (x > 0 ? static_cast<int>(x) : 5000);
     }
+  {
+    const char* v = std::getenv("DFKV_RDMA_BATCH_OP_TIMEOUT_MS");
+    if (v && *v) { long x = std::strtol(v, nullptr, 10); if (x > 0) batch_op_timeout_ms_ = static_cast<int>(x); }
+  }
   }
   // Idle-connection pool cap. The pool naturally bounds at peak concurrency
   // (each thread holds <=1 conn); this only guards against a thread-count spike
@@ -543,7 +547,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
       std::vector<uint32_t> rbytes(w, 0);
       int need = static_cast<int>(2 * w);
       while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), op_timeout_ms_);
+        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
         if (g <= 0) { conn_ok = false; break; }
         for (int i = 0; i < g; ++i) {
           if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
@@ -633,7 +637,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
       std::vector<uint32_t> rbytes(w, 0);
       int need = static_cast<int>(2 * w);
       while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), op_timeout_ms_);
+        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
         if (g <= 0) { conn_ok = false; break; }
         for (int i = 0; i < g; ++i) {
           if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
@@ -737,7 +741,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       std::vector<uint32_t> rbytes(w, 0);
       int need = static_cast<int>(2 * posted);
       while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), op_timeout_ms_);
+        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
         if (g <= 0) { conn_ok = false; break; }
         for (int i = 0; i < g; ++i) {
           if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
@@ -844,7 +848,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       std::vector<uint32_t> rbytes(w, 0);
       int need = static_cast<int>(2 * posted);
       while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), op_timeout_ms_);
+        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
         if (g <= 0) { conn_ok = false; break; }
         for (int i = 0; i < g; ++i) {
           if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -114,6 +114,14 @@ class RdmaTransport : public Transport {
   // 2-attempt loop in every batch op, mirroring RoundTrip). 0/negative => -1
   // (legacy block-forever). Normal ops finish in ms, so 5s never false-aborts.
   int op_timeout_ms_ = 5000;          // datapath completion timeout (DFKV_RDMA_OP_TIMEOUT_MS)
+  // Batch-window override (DFKV_RDMA_BATCH_OP_TIMEOUT_MS, only the multi-op
+  // Batch*/CacheFrom/RangeInto windows). <=0 = follow op_timeout_ms_. Lowering
+  // it bounds a batch's tail at the price of tearing the connection (all ops of
+  // the window report kIOError = miss, peer enters cooldown) when a server is
+  // merely slow -- an explicit latency-vs-hit-rate trade for wait_complete
+  // schedulers; leave unset for default behavior.
+  int batch_op_timeout_ms_ = 0;
+  int BatchTimeout() const { return batch_op_timeout_ms_ > 0 ? batch_op_timeout_ms_ : op_timeout_ms_; }
   size_t pool_max_ = 256;             // idle conns kept per node (DFKV_RDMA_POOL_MAX)
   std::vector<std::string> devs_;     // RDMA devices (multi-rail); "" = first
   std::vector<int> dev_node_;         // NUMA node per devs_ entry (-1 unknown)

--- a/test/client/c_api_test.cc
+++ b/test/client/c_api_test.cc
@@ -3,6 +3,7 @@
 // against a discovery-only client (empty member list => empty ring), so they
 // need no server: routing fails fast and every slot reports miss/failure.
 #include "client/dfkv_c_api.h"
+#include "client/kv_client.h"
 
 #include <gtest/gtest.h>
 
@@ -138,4 +139,14 @@ TEST(CApiGuard, ZeroLengthBatchIsOk) {
   EXPECT_EQ(dfkv_batch_get(c, nullptr, nullptr, nullptr, 0, nullptr), 0);
   EXPECT_EQ(dfkv_batch_exist(c, nullptr, 0, nullptr), 0);
   dfkv_close(c);
+}
+
+TEST(AutoBatchWorkers, ExplicitWinsAutoScalesCapped) {
+  using dfkv::AutoBatchWorkers;
+  EXPECT_EQ(AutoBatchWorkers(8, 47), 8u);    // explicit bc: old fixed behavior
+  EXPECT_EQ(AutoBatchWorkers(1, 47), 1u);    // bench --bc 1
+  EXPECT_EQ(AutoBatchWorkers(0, 1), 1u);     // auto, single node
+  EXPECT_EQ(AutoBatchWorkers(0, 8), 8u);     // auto, one worker per group
+  EXPECT_EQ(AutoBatchWorkers(0, 47), 32u);   // auto, capped at 32
+  EXPECT_EQ(AutoBatchWorkers(0, 0), 1u);     // degenerate: at least one
 }


### PR DESCRIPTION
Phase-3 item 2/4 (batch tail). Client-lib change: ships in the release, production pods stay pinned until the coordinated client upgrade.

- **Auto worker scaling**: default now one worker per node group (cap 32) instead of fixed 8 — kills the 6-8 serial waves a 64-key batch suffered on a 47-61 node ring (measured shape behind the b8 p99 tail). Explicit `set_batch_concurrency`/`--bc`/`DFKV_BATCH_CONCURRENCY` unchanged.
- **`DFKV_RDMA_BATCH_OP_TIMEOUT_MS`**: opt-in tighter completion timeout for batch windows only; unset = existing 5 s behavior. Trade documented (conn teardown ⇒ miss + cooldown); buffer-safe via QP teardown.

311/311 ctest, TSan green (python_plugin pre-existing).