### PR TITLE
cache: batched flush path (one store visit per worker dequeue, io_uring submit)

### DIFF
--- a/src/cache/disk_cache_group.cc
+++ b/src/cache/disk_cache_group.cc
@@ -1,6 +1,7 @@
 #include "cache/disk_cache_group.h"
 
 #include <cstdlib>
+#include <map>
 
 #include "cache/disk_slab_store.h"
 
@@ -133,6 +134,27 @@ Status DiskCacheGroup::RangeDirectPrep(const BlockKey& key, uint64_t offset,
   return st;
 }
 
+std::vector<Status> DiskCacheGroup::CacheDirectBatch(
+    const std::vector<StoreEngine::CacheBatchItem>& items) {
+  // Split by owning disk (consistent-hash route), one engine batch per disk --
+  // preserves per-key placement while letting the slab engine amortize locks
+  // and submit the disk's payload writes together.
+  std::vector<Status> out(items.size(), Status::kIOError);
+  std::map<StoreEngine*, std::vector<size_t>> by_disk;
+  for (size_t i = 0; i < items.size(); ++i) {
+    StoreEngine* d = Route(items[i].key);
+    if (d) by_disk[d].push_back(i);
+  }
+  for (auto& [d, idx] : by_disk) {
+    std::vector<StoreEngine::CacheBatchItem> sub;
+    sub.reserve(idx.size());
+    for (size_t k : idx) sub.push_back(items[k]);
+    std::vector<Status> sts = d->CacheDirectBatch(sub);
+    for (size_t m = 0; m < idx.size(); ++m) out[idx[m]] = sts[m];
+  }
+  return out;
+}
+
 DiskSlabStore::Stats DiskCacheGroup::SlabStats() const {
   DiskSlabStore::Stats sum;
   for (const auto* d : slabs_) {
@@ -146,6 +168,12 @@ DiskSlabStore::Stats DiskCacheGroup::SlabStats() const {
     sum.inflight += st.inflight;
     sum.prep_holds += st.prep_holds;
     sum.reclaimed_slots += st.reclaimed_slots;
+    // rebalanced_extents was MISSING from this sum since its introduction --
+    // dfkv_slab_rebalanced_total silently read 0 fleet-wide (found while adding
+    // the batch counters; canary data showed 0 despite active rebalances).
+    sum.rebalanced_extents += st.rebalanced_extents;
+    sum.batched_writes += st.batched_writes;
+    sum.uring_write_batches += st.uring_write_batches;
   }
   return sum;
 }

--- a/src/cache/disk_cache_group.h
+++ b/src/cache/disk_cache_group.h
@@ -35,6 +35,8 @@ class DiskCacheGroup {
 
   Status Cache(const BlockKey& key, const void* data, size_t len);
   Status CacheDirect(const BlockKey& key, char* data, size_t len, size_t cap);
+  // Batched CacheDirect: split by disk route, one engine batch per disk.
+  std::vector<Status> CacheDirectBatch(const std::vector<StoreEngine::CacheBatchItem>& items);
   Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
                std::string* out);
   Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -454,7 +454,7 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
         if (!sqe) break;  // SQ full: leave the rest to the loop path
         io_uring_prep_write(sqe, extent_dio_fds_[st[i].ref.extent], it.data,
                             static_cast<unsigned>(alen), st[i].ref.offset);
-        io_uring_sqe_set_data64(sqe, static_cast<uint64_t>(i));
+        io_uring_sqe_set_data(sqe, reinterpret_cast<void*>(static_cast<uintptr_t>(i)));  // set_data64 needs liburing>=2.2; CI ships 2.1
         st[i].io_ok = false;  // set true on CQE
         ++submitted;
       }
@@ -464,7 +464,7 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
         while (rc > 0 && done < submitted) {
           io_uring_cqe* cqe = nullptr;
           if (io_uring_wait_cqe(ring, &cqe) != 0) break;
-          const size_t i = static_cast<size_t>(io_uring_cqe_get_data64(cqe));
+          const size_t i = static_cast<size_t>(reinterpret_cast<uintptr_t>(io_uring_cqe_get_data(cqe)));
           const auto& it = items[i];
           const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
           if (i < N && cqe->res == static_cast<int>(alen)) st[i].io_ok = true;

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -1,5 +1,9 @@
 #include "cache/disk_slab_store.h"
 
+#ifdef DFKV_WITH_URING
+#include <liburing.h>
+#endif
+
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -108,6 +112,14 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
       }
     });
   }
+  // Batched-write submit path (io_uring). Only meaningful with a DFKV_WITH_URING
+  // build AND direct mode; DFKV_SLAB_URING_WRITE=0 is the kill switch.
+#ifdef DFKV_WITH_URING
+  {
+    const char* v = std::getenv("DFKV_SLAB_URING_WRITE");
+    uring_write_enabled_ = !(v && *v == '0');
+  }
+#endif
   if (ok_ && opt_.reclaim_interval_ms > 0) {
     reclaim_thread_ = std::thread([this] {
       std::unique_lock<std::mutex> lk(reclaim_mu_);
@@ -125,6 +137,13 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
 }
 
 DiskSlabStore::~DiskSlabStore() {
+#ifdef DFKV_WITH_URING
+  if (uring_w_) {
+    io_uring_queue_exit(static_cast<io_uring*>(uring_w_));
+    delete static_cast<io_uring*>(uring_w_);
+    uring_w_ = nullptr;
+  }
+#endif
   if (reclaim_thread_.joinable()) {
     { std::lock_guard<std::mutex> lk(reclaim_mu_); reclaim_stop_ = true; }
     reclaim_cv_.notify_all();
@@ -370,6 +389,133 @@ Status DiskSlabStore::CacheDirect(const BlockKey& key, char* data, size_t len,
       dio_write_fallbacks_.fetch_add(1, std::memory_order_relaxed);
     return WritePayload(r, data, len);
   });
+}
+
+
+// Batched CacheDirect. Three phases mirror CacheImpl exactly, amortized:
+//   L1 (one mu_): dedup + allocate + write-pin + inflight for every item;
+//   IO (unlocked): zero-pad + payload writes -- ONE io_uring submit when the
+//     build has uring and DFKV_SLAB_URING_WRITE isn't 0 (small-object flushing
+//     is IOPS-bound at one synchronous DIO write per key), else a loop; then
+//     the 64 B records (buffered pwrites, cheap) in a loop;
+//   L2 (one mu_): per-item deferred-remove check, inflight release, failure
+//     rollback, payload_len_ commit.
+std::vector<Status> DiskSlabStore::CacheDirectBatch(
+    const std::vector<CacheBatchItem>& items) {
+  const size_t N = items.size();
+  std::vector<Status> out(N, Status::kIOError);
+  if (!ok_ || N == 0) return out;  // already N x kIOError / empty
+  struct Slot { std::string fn; SlabAllocator::SlotRef ref; bool active = false; bool io_ok = false; bool direct = false; };
+  std::vector<Slot> st(N);
+  // -- L1: allocate under one lock --
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    for (size_t i = 0; i < N; ++i) {
+      const auto& it = items[i];
+      if (it.data == nullptr && it.len != 0) { out[i] = Status::kInvalid; continue; }
+      st[i].fn = it.key.Filename();
+      if (alloc_->Contains(st[i].fn)) { out[i] = Status::kOk; continue; }  // idempotent (incl. batch-internal dup)
+      std::vector<std::string> evicted;
+      if (!alloc_->Put(st[i].fn, it.len, &st[i].ref, &evicted)) { out[i] = Status::kIOError; continue; }
+      alloc_->Pin(st[i].fn);
+      inflight_[st[i].fn]++;
+      for (const auto& ev : evicted) {
+        auto pit = payload_len_.find(ev);
+        if (pit != payload_len_.end()) { evicted_bytes_ += pit->second; payload_len_.erase(pit); }
+      }
+      st[i].active = true;
+      // Same eligibility test as CacheDirect: aligned buffer + padded cap.
+      const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
+      st[i].direct = !extent_dio_fds_.empty() && it.len != 0 &&
+                     (reinterpret_cast<uintptr_t>(it.data) & 4095) == 0 &&
+                     alen <= it.cap && alen <= st[i].ref.slot_size;
+    }
+  }
+  // -- IO: payloads (uring one-submit when possible), then records --
+  size_t direct_n = 0;
+  for (size_t i = 0; i < N; ++i) if (st[i].active && st[i].direct) direct_n++;
+#ifdef DFKV_WITH_URING
+  bool did_uring = false;
+  if (uring_write_enabled_ && direct_n >= 2) {
+    std::lock_guard<std::mutex> ulk(uring_w_mu_);
+    if (!uring_w_) {
+      auto* r = new io_uring;
+      if (io_uring_queue_init(256, r, 0) == 0) uring_w_ = r; else delete r;
+    }
+    if (uring_w_) {
+      auto* ring = static_cast<io_uring*>(uring_w_);
+      size_t submitted = 0;
+      for (size_t i = 0; i < N; ++i) {
+        if (!st[i].active || !st[i].direct) continue;
+        const auto& it = items[i];
+        const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
+        std::memset(it.data + it.len, 0, alen - it.len);
+        io_uring_sqe* sqe = io_uring_get_sqe(ring);
+        if (!sqe) break;  // SQ full: leave the rest to the loop path
+        io_uring_prep_write(sqe, extent_dio_fds_[st[i].ref.extent], it.data,
+                            static_cast<unsigned>(alen), st[i].ref.offset);
+        io_uring_sqe_set_data64(sqe, static_cast<uint64_t>(i));
+        st[i].io_ok = false;  // set true on CQE
+        ++submitted;
+      }
+      if (submitted) {
+        int rc = io_uring_submit(ring);
+        size_t done = 0;
+        while (rc > 0 && done < submitted) {
+          io_uring_cqe* cqe = nullptr;
+          if (io_uring_wait_cqe(ring, &cqe) != 0) break;
+          const size_t i = static_cast<size_t>(io_uring_cqe_get_data64(cqe));
+          const auto& it = items[i];
+          const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
+          if (i < N && cqe->res == static_cast<int>(alen)) st[i].io_ok = true;
+          io_uring_cqe_seen(ring, cqe);
+          ++done;
+        }
+        did_uring = true;
+        uring_write_batches_.fetch_add(1, std::memory_order_relaxed);
+        batched_writes_.fetch_add(submitted, std::memory_order_relaxed);
+        // A submitted-but-failed (or unsubmitted, SQ-full) item keeps
+        // io_ok=false and falls through to the sequential path below, which
+        // retries it once (direct first, then the buffered fallback inside).
+      }
+    }
+  }
+  (void)did_uring;
+#endif
+  for (size_t i = 0; i < N; ++i) {
+    if (!st[i].active) continue;
+    const auto& it = items[i];
+    if (!st[i].io_ok) {  // not written by uring (loop path / fallback / uring failure)
+      bool w;
+      if (st[i].direct) {
+        w = WritePayloadDirect(st[i].ref, it.data, it.len);
+      } else {
+        if (!extent_dio_fds_.empty() && it.len != 0)
+          dio_write_fallbacks_.fetch_add(1, std::memory_order_relaxed);
+        w = WritePayload(st[i].ref, it.data, it.len);
+      }
+      st[i].io_ok = w;
+    }
+    if (st[i].io_ok)
+      st[i].io_ok = WriteRecord(st[i].ref, it.key, static_cast<uint32_t>(it.len), /*valid=*/true);
+  }
+  // -- L2: commit under one lock --
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    for (size_t i = 0; i < N; ++i) {
+      if (!st[i].active) continue;
+      const bool removed = deferred_remove_.count(st[i].fn) > 0;
+      ReleaseInflightLocked(items[i].key, st[i].fn);
+      if (!st[i].io_ok) {
+        if (!removed) alloc_->Remove(st[i].fn);
+        out[i] = Status::kIOError;
+        continue;
+      }
+      if (!removed) payload_len_[st[i].fn] = static_cast<uint32_t>(items[i].len);
+      out[i] = Status::kOk;
+    }
+  }
+  return out;
 }
 
 Status DiskSlabStore::RangeDirect(const BlockKey& key, uint64_t offset,
@@ -704,6 +850,8 @@ DiskSlabStore::Stats DiskSlabStore::GetStats() const {
   st.prep_holds = prep_holds_.size();
   st.reclaimed_slots = reclaimed_.load(std::memory_order_relaxed);
   st.rebalanced_extents = rebalanced_.load(std::memory_order_relaxed);
+  st.batched_writes = batched_writes_.load(std::memory_order_relaxed);
+  st.uring_write_batches = uring_write_batches_.load(std::memory_order_relaxed);
   return st;
 }
 

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -81,6 +81,8 @@ class DiskSlabStore : public StoreEngine {
     uint64_t prep_holds = 0;           // outstanding async-prep slot holds
     uint64_t reclaimed_slots = 0;      // slots freed by the background reclaimer
     uint64_t rebalanced_extents = 0;   // extents moved hot<-cold by the reclaimer
+    uint64_t batched_writes = 0;       // payload writes that rode a batch submit
+    uint64_t uring_write_batches = 0;  // io_uring one-submit rounds (0 = loop path)
   };
 
   // Opens (or creates) the store under Options::dir, pre-allocating extents and
@@ -95,6 +97,10 @@ class DiskSlabStore : public StoreEngine {
   Status Cache(const BlockKey& key, const void* data, size_t len) override;
   // Buffered engine: the aligned direct-PUT buffer is just written as bytes.
   Status CacheDirect(const BlockKey& key, char* data, size_t len, size_t cap) override;
+  // Batched CacheDirect: ONE lock hold allocates every slot, payloads go out
+  // unlocked (io_uring one-submit when built+enabled, else a sequential loop),
+  // ONE lock hold commits. Per-item semantics identical to CacheDirect.
+  std::vector<Status> CacheDirectBatch(const std::vector<CacheBatchItem>& items) override;
   Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
                std::string* out) override;
   Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,
@@ -206,6 +212,11 @@ class DiskSlabStore : public StoreEngine {
   static constexpr size_t kGrowExtentsPerTick = 2;
   std::atomic<uint64_t> reclaimed_{0};
   std::atomic<uint64_t> rebalanced_{0};
+  std::atomic<uint64_t> batched_writes_{0};
+  std::atomic<uint64_t> uring_write_batches_{0};
+  bool uring_write_enabled_ = false;   // DFKV_SLAB_URING_WRITE (needs DFKV_WITH_URING build)
+  void* uring_w_ = nullptr;            // io_uring* (lazily created, guarded by uring_w_mu_)
+  std::mutex uring_w_mu_;
   std::vector<uint64_t> reclaim_last_puts_;  // reclaim-thread-local puts snapshot
   std::thread reclaim_thread_;
   std::condition_variable reclaim_cv_;

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -81,6 +81,18 @@ void KvNodeServer::InitRamTier() {
       o, [this](const BlockKey& k, char* d, size_t l, size_t cap) {
         return group_.CacheDirect(k, d, l, cap) == Status::kOk;
       });
+  // Batched sink: a flush worker's whole dequeue rides one lock-amortized
+  // (and, with a uring build, one-submit) store visit per disk.
+  tier->set_flush_batch([this](const std::vector<RamTier::FlushItem>& items) {
+    std::vector<StoreEngine::CacheBatchItem> b;
+    b.reserve(items.size());
+    for (const auto& it : items)
+      b.push_back(StoreEngine::CacheBatchItem{it.key, it.data, it.len, it.cap});
+    std::vector<Status> sts = group_.CacheDirectBatch(b);
+    std::vector<bool> ok(items.size(), false);
+    for (size_t i = 0; i < sts.size(); ++i) ok[i] = (sts[i] == Status::kOk);
+    return ok;
+  });
   if (tier->ok()) ram_ = std::move(tier);  // arena alloc failed => stay disk-only
 }
 
@@ -264,6 +276,10 @@ std::string KvNodeServer::MetricsText() const {
            "Outstanding async-prep slot holds", ss.prep_holds);
     metric("dfkv_slab_reclaimed_total", "counter",
            "Slots freed ahead of demand by the background reclaimer", ss.reclaimed_slots);
+    metric("dfkv_slab_batched_writes_total", "counter",
+           "Payload writes that rode a batched store visit", ss.batched_writes);
+    metric("dfkv_slab_uring_write_batches_total", "counter",
+           "io_uring one-submit rounds on the batched write path", ss.uring_write_batches);
     metric("dfkv_slab_rebalanced_total", "counter",
            "Extents moved from cold classes to hot ones by the reclaimer", ss.rebalanced_extents);
   }

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -326,47 +326,73 @@ void RamTier::DropLocked(const std::string& fn) {
 
 void RamTier::FlushLoop() {
   for (;;) {
-    QItem item;
+    // Drain up to kFlushBatchMax queued items in one pass (one worker's batch).
+    std::vector<QItem> batch;
     {
       std::unique_lock<std::mutex> lk(mu_);
       flush_cv_.wait(lk, [this] { return stop_ || !flushq_.empty(); });
       if (stop_ && flushq_.empty()) return;
-      item = std::move(flushq_.front());
-      flushq_.pop_front();
+      while (!flushq_.empty() && batch.size() < kFlushBatchMax) {
+        batch.push_back(std::move(flushq_.front()));
+        flushq_.pop_front();
+      }
     }
 
-    // Snapshot the slot (guaranteed present: a queued item is flush-pinned, so
-    // it can't be evicted or Removed).
-    char* data = nullptr;
-    size_t len = 0, cap = 0;
+    // Snapshot the slots (guaranteed present: queued items are flush-pinned,
+    // so they can't be evicted or Removed). live[] marks items still to flush.
+    const size_t B = batch.size();
+    std::vector<FlushItem> items(B);
+    std::vector<char> live(B, 0);
     {
       std::lock_guard<std::mutex> lk(mu_);
-      auto it = index_.find(item.fn);
-      if (it == index_.end() || it->second.durable) continue;  // gone/already done
-      data = arena_ + it->second.offset;
-      len = it->second.len;
-      cap = it->second.cap;
+      for (size_t i = 0; i < B; ++i) {
+        auto it = index_.find(batch[i].fn);
+        if (it == index_.end() || it->second.durable) continue;  // gone/already done
+        items[i] = FlushItem{batch[i].key, arena_ + it->second.offset,
+                             it->second.len, it->second.cap};
+        live[i] = 1;
+      }
     }
 
-    const bool ok = flush_ ? flush_(item.key, data, len, cap) : true;
+    // Flush: batched sink when wired (one store visit for the whole dequeue),
+    // else the per-item sink. Per-item ok/fail semantics identical either way.
+    std::vector<char> ok(B, 0);
+    if (flush_batch_) {
+      std::vector<FlushItem> sub;
+      std::vector<size_t> map;
+      for (size_t i = 0; i < B; ++i)
+        if (live[i]) { sub.push_back(items[i]); map.push_back(i); }
+      if (!sub.empty()) {
+        std::vector<bool> r = flush_batch_(sub);
+        for (size_t m = 0; m < map.size() && m < r.size(); ++m) ok[map[m]] = r[m] ? 1 : 0;
+      }
+    } else {
+      for (size_t i = 0; i < B; ++i)
+        if (live[i])
+          ok[i] = (flush_ ? flush_(items[i].key, items[i].data, items[i].len, items[i].cap) : true) ? 1 : 0;
+    }
+    if (!flush_ && !flush_batch_) for (size_t i = 0; i < B; ++i) ok[i] = live[i];
 
     {
       std::lock_guard<std::mutex> lk(mu_);
-      auto it = index_.find(item.fn);
-      if (it == index_.end()) continue;  // defensive
-      if (ok) {
-        it->second.durable = true;
-        alloc_->Unpin(item.fn);  // release the flush-pin -> now evictable
-        flushed_.fetch_add(1, std::memory_order_relaxed);
-      } else if (++item.tries < opt_.flush_retries) {
-        flushq_.push_back(std::move(item));  // retry later
-        flush_cv_.notify_one();
-      } else {
-        // Give up: drop from RAM (releases flush-pin + frees slot). GET falls
-        // back to a miss (recompute) -- correct cache semantics, no arena leak.
-        alloc_->Unpin(item.fn);
-        DropLocked(item.fn);
-        flush_dropped_.fetch_add(1, std::memory_order_relaxed);
+      for (size_t i = 0; i < B; ++i) {
+        if (!live[i]) continue;
+        auto it = index_.find(batch[i].fn);
+        if (it == index_.end()) continue;  // defensive
+        if (ok[i]) {
+          it->second.durable = true;
+          alloc_->Unpin(batch[i].fn);  // release the flush-pin -> now evictable
+          flushed_.fetch_add(1, std::memory_order_relaxed);
+        } else if (++batch[i].tries < opt_.flush_retries) {
+          flushq_.push_back(std::move(batch[i]));  // retry later
+          flush_cv_.notify_one();
+        } else {
+          // Give up: drop from RAM (releases flush-pin + frees slot). GET falls
+          // back to a miss (recompute) -- correct cache semantics, no arena leak.
+          alloc_->Unpin(batch[i].fn);
+          DropLocked(batch[i].fn);
+          flush_dropped_.fetch_add(1, std::memory_order_relaxed);
+        }
       }
     }
   }

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -78,6 +78,14 @@ class RamTier {
   // can ignore cap.
   using FlushFn =
       std::function<bool(const BlockKey& key, char* data, size_t len, size_t cap)>;
+  // Batched flush sink (optional). One arena slot per item, same contract as
+  // FlushFn; the server wires this to the disk group's CacheDirectBatch so a
+  // worker's whole dequeue rides one lock-amortized (and, with uring, one-
+  // submit) store visit -- small-object flushing is IOPS-bound at one
+  // synchronous DIO write per key otherwise. Unset = per-item FlushFn.
+  struct FlushItem { BlockKey key; char* data; size_t len; size_t cap; };
+  using FlushBatchFn = std::function<std::vector<bool>(const std::vector<FlushItem>&)>;
+  void set_flush_batch(FlushBatchFn fn) { flush_batch_ = std::move(fn); }
 
   // A pinned arena location handed to the RDMA send path. `token` must be passed
   // back to Release() once the send completes (releases the send-pin).
@@ -139,6 +147,10 @@ class RamTier {
   struct QItem { std::string fn; BlockKey key; uint32_t tries = 0; };
 
   void FlushLoop();
+  // Max items one flush worker drains per store visit. Big enough to amortize
+  // the two store-lock hops + reach a useful uring submit width, small enough
+  // that a batch's slots stay flush-pinned only briefly.
+  static constexpr size_t kFlushBatchMax = 16;
   void ReclaimTick();  // one background grow + free-slot top-up pass (see Options)
   // Rebalance rate cap: extents moved per tick per hot class (32 MiB default
   // extents; converges in well under a second at the 10 ms tick).
@@ -147,6 +159,7 @@ class RamTier {
 
   Options opt_;
   FlushFn flush_;
+  FlushBatchFn flush_batch_;
   char* arena_ = nullptr;
   void* arena_mr_ = nullptr;
   uint64_t extent_bytes_ = 0;   // SlabAllocator extent size; global arena offset

--- a/src/cache/store_engine.h
+++ b/src/cache/store_engine.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "common/kv_types.h"
 #include "common/status.h"
@@ -43,6 +44,18 @@ class StoreEngine {
   virtual Status Cache(const BlockKey& key, const void* data, size_t len) = 0;
   virtual Status CacheDirect(const BlockKey& key, char* data, size_t len,
                              size_t cap) = 0;
+  // Batched CacheDirect: same per-item semantics/status as CacheDirect, but an
+  // engine may amortize its lock round-trips and submit the payload writes
+  // together (the RAM-tier flusher's small-object drain is IOPS-bound at one
+  // synchronous write per key). Default: per-item loop -- engines without a
+  // batch win (file engine) inherit correct behavior.
+  struct CacheBatchItem { BlockKey key; char* data; size_t len; size_t cap; };
+  virtual std::vector<Status> CacheDirectBatch(const std::vector<CacheBatchItem>& items) {
+    std::vector<Status> out;
+    out.reserve(items.size());
+    for (const auto& it : items) out.push_back(CacheDirect(it.key, it.data, it.len, it.cap));
+    return out;
+  }
   virtual Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
                        std::string* out) = 0;
   virtual Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,

--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -469,3 +469,49 @@ TEST_F(DiskSlabTest, ReclaimTickGrowsHotClassFromColdDonor) {
   EXPECT_GT(s.GetStats().rebalanced_extents, 0u) << "growth never kicked in";
   EXPECT_GE(retained, 250u) << "hot class must absorb capacity, not eat itself";
 }
+
+// Batched CacheDirect: same per-item semantics as CacheDirect with one lock
+// hold per phase. Covers happy path, batch-internal dup (idempotent), invalid
+// item, and read-back byte equality (loop path in non-uring builds).
+TEST_F(DiskSlabTest, CacheDirectBatchLandsAllItemsReadable) {
+  bool ok = false;
+  DiskSlabStore s(Opts(1 << 20, 1 << 20, 4096), &ok);
+  ASSERT_TRUE(ok);
+  constexpr int N = 12;
+  std::vector<std::string> vals(N);
+  std::vector<DiskSlabStore::CacheBatchItem> items;
+  for (int i = 0; i < N; ++i) {
+    vals[i].assign(3000 + i * 17, static_cast<char>('a' + i));
+    items.push_back({K(500 + i), vals[i].data(), vals[i].size(), vals[i].size()});
+  }
+  items.push_back({K(500), vals[0].data(), vals[0].size(), vals[0].size()});  // dup of first
+  items.push_back({K(999), nullptr, 10, 10});                                // invalid
+  auto sts = s.CacheDirectBatch(items);
+  ASSERT_EQ(sts.size(), items.size());
+  for (int i = 0; i < N; ++i) EXPECT_EQ(sts[i], Status::kOk) << i;
+  EXPECT_EQ(sts[N], Status::kOk) << "batch-internal dup is idempotent kOk";
+  EXPECT_EQ(sts[N + 1], Status::kInvalid);
+  for (int i = 0; i < N; ++i) {
+    std::string out;
+    ASSERT_EQ(s.Range(K(500 + i), 0, vals[i].size(), &out), Status::kOk) << i;
+    EXPECT_EQ(out, vals[i]) << i;
+  }
+  EXPECT_GE(s.GetStats().batched_writes + 1, 1u);  // counter is uring-only; loop path leaves 0
+}
+
+// Batch under eviction pressure: items exceeding capacity still land (evicting
+// older residents), statuses all kOk, store never over-commits.
+TEST_F(DiskSlabTest, CacheDirectBatchEvictsUnderPressure) {
+  bool ok = false;
+  DiskSlabStore s(Opts(8 * 4096, 8 * 4096, 4096), &ok);  // 8 slots total
+  ASSERT_TRUE(ok);
+  std::string v(4000, 'p');
+  for (uint64_t i = 0; i < 8; ++i) ASSERT_EQ(s.Cache(K(1 + i), v.data(), v.size()), Status::kOk);
+  std::vector<DiskSlabStore::CacheBatchItem> items;
+  std::vector<std::string> vals(4, std::string(4000, 'q'));
+  for (int i = 0; i < 4; ++i) items.push_back({K(100 + i), vals[i].data(), vals[i].size(), vals[i].size()});
+  auto sts = s.CacheDirectBatch(items);
+  for (auto st : sts) EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(s.Count(), 8u);
+  for (int i = 0; i < 4; ++i) EXPECT_TRUE(s.IsCached(K(100 + i)));
+}

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -300,3 +300,39 @@ TEST(RamTier, ReclaimTickGrowsHotClassFromColdDonor) {
   EXPECT_GT(rt.Rebalanced(), 0u) << "growth never kicked in";
   EXPECT_GE(resident, 250u) << "hot class must absorb capacity, not eat itself";
 }
+
+// Batched flush sink: a worker drains multiple queued items into ONE batch
+// call; per-item retry/drop semantics survive partial batch failure.
+TEST(RamTier, BatchFlushDrainsQueueAndRetriesPerItem) {
+  std::mutex m;
+  std::vector<size_t> batch_sizes;
+  std::atomic<int> fail_key{-1};
+  RamTier::Options o = Opts(256 * 4096);
+  o.flush_threads = 1;  // single worker => deterministic batching
+  RamTier rt(o, nullptr);
+  rt.set_flush_batch([&](const std::vector<RamTier::FlushItem>& items) {
+    std::lock_guard<std::mutex> lk(m);
+    batch_sizes.push_back(items.size());
+    std::vector<bool> ok(items.size(), true);
+    for (size_t i = 0; i < items.size(); ++i)
+      if (fail_key >= 0 && items[i].key.id == static_cast<uint64_t>(fail_key.load())) ok[i] = false;
+    return ok;
+  });
+  ASSERT_TRUE(rt.ok());
+  std::string v(4000, 'b');
+  for (uint64_t i = 0; i < 40; ++i) ASSERT_TRUE(rt.Put(K(700 + i), v.data(), v.size()));
+  ASSERT_TRUE(WaitFor([&] { return rt.Flushed() == 40u; }));
+  {
+    std::lock_guard<std::mutex> lk(m);
+    size_t mx = 0; for (size_t b : batch_sizes) mx = std::max(mx, b);
+    EXPECT_GT(mx, 1u) << "worker never batched";
+  }
+  // Partial failure: one key keeps failing -> retried then dropped; others flush.
+  fail_key = 900;
+  ASSERT_TRUE(rt.Put(K(900), v.data(), v.size()));
+  ASSERT_TRUE(rt.Put(K(901), v.data(), v.size()));
+  ASSERT_TRUE(WaitFor([&] { return rt.FlushDropped() == 1u; }));
+  EXPECT_TRUE(WaitFor([&] { return rt.Flushed() >= 41u; }));
+  EXPECT_FALSE(rt.Contains(K(900))) << "dropped after retries";
+  EXPECT_TRUE(rt.Contains(K(901)));
+}


### PR DESCRIPTION
Phase-3 item 3/4 (small-object flush IOPS). RamTier workers drain up to 16 items per pass into a new `StoreEngine::CacheDirectBatch` — one lock hold to allocate, one io_uring submit for the payloads (`DFKV_WITH_URING` builds, `DFKV_SLAB_URING_WRITE=0` kill switch), one lock hold to commit. Per-item semantics byte-identical to `CacheDirect` (idempotent dup / deferred-remove / rollback / retry-then-drop).

Also fixes a #142 leftover: `SlabStats` never aggregated `rebalanced_extents`, so `dfkv_slab_rebalanced_total` read 0 fleet-wide.

313/313 ctest, TSan green, uring build compiles + cache suites pass; the real uring submit gets exercised on the B200 canary (direct-mode NVMe) before the v1.20.0 cut.