### PR TITLE
vllm connector: CLIENT_RANKS phase 2a — producer-side client elision

### DIFF
--- a/integration/vllm/src/dfkv_vllm/client_ranks.py
+++ b/integration/vllm/src/dfkv_vllm/client_ranks.py
@@ -58,3 +58,37 @@ def participant(tp_rank: int, tp_size: int, effective: int) -> int | None:
         return None
     idx = tp_rank // spacing
     return idx if idx < effective else None
+
+
+ELIDE_ENV = "DFKV_CONNECTOR_CLIENT_ELIDE"
+
+
+def should_create_client(
+    role: str,
+    tp_rank: int,
+    tp_size: int,
+    effective: int,
+    elide_requested: bool,
+) -> tuple[bool, str]:
+    """Phase 2a of issue #111 (producer-side client elision): a kv_producer's
+    non-participant ranks never touch dfkv -- their store path early-exits
+    (Phase 1 striping) and a producer has no load path -- so they can skip
+    creating the client entirely: no RDMA connections, no MDS registration,
+    no MR pin. instances x TP -> instances x N connections on the P side.
+
+    Deliberately NOT applied to kv_consumer / kv_both: their load path runs on
+    every rank (each rank fills its own GPU KV), so eliding would turn loads
+    into misses. Load-side convergence (Phase 2b: participant-proxied GET +
+    same-host page sharing) is a separate, measurement-gated design.
+
+    Opt-in (DFKV_CONNECTOR_CLIENT_ELIDE=1) and layout-clamped like Phase 1:
+    unset, or any non-eligible combination, keeps today's behavior exactly."""
+    if not elide_requested:
+        return True, "default(create)"
+    if role != "kv_producer":
+        return True, f"clamped(role={role})"
+    if effective >= tp_size:
+        return True, "clamped(no-convergence)"
+    if participant(tp_rank, tp_size, effective) is not None:
+        return True, "participant"
+    return False, f"elided(producer non-participant, ranks={effective}/{tp_size})"

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -57,7 +57,7 @@ class DfkvDeviceClient:
         members: str = "",
         model_hash: int = 0,
         lib_path: Optional[str] = None,
-        batch_concurrency: int = 8,
+        batch_concurrency: int = 0,  # 0 = library default (>=1.20 auto-scales)
         geometry: Sequence[int] = _GEOMETRY_ZEROS,
         mds_endpoints: str = "",
         mds_group: str = "default",
@@ -86,7 +86,8 @@ class DfkvDeviceClient:
             raise RuntimeError(
                 f"dfkv_open failed (members={members!r}, mds={mds_endpoints!r})"
             )
-        self._lib.dfkv_set_batch_concurrency(self._h, c_uint64(batch_concurrency))
+        if batch_concurrency > 0:
+            self._lib.dfkv_set_batch_concurrency(self._h, c_uint64(batch_concurrency))
         if mds_endpoints:
             rc = self._lib.dfkv_start_mds_discovery(
                 self._h, mds_endpoints.encode(), mds_group.encode(), int(mds_poll_ms)

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -49,7 +49,8 @@ from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 # dfkv handles its own RDMA bootstrap so the transfer-engine helpers are dropped.
 from ._determinism import ensure_deterministic_block_hashing
 from .client_ranks import ENV_NAME as CLIENT_RANKS_ENV
-from .client_ranks import participant, resolve_client_ranks
+from .client_ranks import (ELIDE_ENV, participant, resolve_client_ranks,
+                           should_create_client)
 from .coordinator import (
     ExternalCachedBlockPool,
     DfkvStoreCoordinator,
@@ -584,7 +585,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 # into this chunk's per-layer segments. hit == 1 + len == sum(caps)
                 # means the chunk loaded; a miss or short read marks the originating
                 # block as a load error so vLLM recomputes that span (never fatal).
-                hits, lens = self.client.batch_get_auto_sg(sg_keys, sg_ptrs, sg_caps)
+                if self.client is None:  # elided producer rank: defensive miss
+                    hits, lens = [False] * len(sg_keys), [0] * len(sg_keys)
+                else:
+                    hits, lens = self.client.batch_get_auto_sg(sg_keys, sg_ptrs, sg_caps)
                 failed_block_ids: list[int] = []
                 failed_detail: list[tuple[str, int]] = []
                 for i, (hit, got_len) in enumerate(zip(hits, lens, strict=True)):
@@ -845,14 +849,23 @@ class DfkvStoreWorker:
                 f"role={self.kv_role},tp_size={self.tp_size},"
                 f"tp_rank={self.tp_rank},ver={_tcfg.dist_version('dfkv-vllm')}"
             )
-        self.client = DfkvDeviceClient(
+        # Phase 2a (issue #111): producer non-participants skip the client
+        # entirely (opt-in via DFKV_CONNECTOR_CLIENT_ELIDE=1; layout-clamped).
+        create_client, elide_reason = should_create_client(
+            self.kv_role, self.tp_rank, self.tp_size, self.client_ranks,
+            _tcfg.truthy(os.environ.get(ELIDE_ENV, "0")))
+        if not create_client:
+            logger.info("dfkv client elided: %s", elide_reason)
+            self.client = None
+        else:
+            self.client = DfkvDeviceClient(
             members=extra.get("members", ""),
             mds_endpoints=mds_endpoints,
             mds_group=mds_group,
             mds_poll_ms=int(extra.get("mds_poll_ms", 3000)),
             model_hash=int(extra.get("model_hash", 0)),
             lib_path=extra.get("lib"),
-            batch_concurrency=int(extra.get("batch_concurrency", 8)),
+            batch_concurrency=int(extra.get("batch_concurrency", 0)),  # 0 = lib default (>=1.20 auto)
             client_register=client_register,
             client_id=client_id,
             client_info=client_info,
@@ -1006,7 +1019,8 @@ class DfkvStoreWorker:
             # each physical storage region ONCE (aliased groups reuse the MR).
             if base_addr not in registered_ptrs:
                 registered_ptrs.add(base_addr)
-                self.client.register_memory(base_addr, region_len)
+                if self.client is not None:
+                    self.client.register_memory(base_addr, region_len)
 
             g_idx = layer_to_group[layer_name]
             # Address THIS layer's blocks from its own tensor data_ptr (== the

--- a/integration/vllm/tests/test_client_ranks.py
+++ b/integration/vllm/tests/test_client_ranks.py
@@ -39,3 +39,43 @@ def test_participant_spread_is_even_and_exact():
     assert [participant(r, 4, 4) for r in range(4)] == [0, 1, 2, 3]
     # N=1: only rank 0.
     assert [participant(r, 4, 1) for r in range(4)] == [0, None, None, None]
+
+
+# ---- Phase 2a: producer-side client elision (should_create_client) ----
+
+from dfkv_vllm.client_ranks import should_create_client  # noqa: E402
+
+
+def test_elide_off_always_creates():
+    for role in ("kv_producer", "kv_consumer", "kv_both"):
+        for r in range(8):
+            ok, reason = should_create_client(role, r, 8, 2, False)
+            assert ok and reason == "default(create)"
+
+
+def test_elide_only_producer_non_participants():
+    # tp=8, N=2 -> participants are ranks 0 and 4.
+    for r in range(8):
+        ok, reason = should_create_client("kv_producer", r, 8, 2, True)
+        if r in (0, 4):
+            assert ok and reason == "participant"
+        else:
+            assert not ok and reason.startswith("elided(")
+
+
+def test_elide_never_touches_consumers_or_both():
+    for role in ("kv_consumer", "kv_both"):
+        for r in range(8):
+            ok, reason = should_create_client(role, r, 8, 2, True)
+            assert ok and reason.startswith("clamped(role=")
+
+
+def test_elide_noop_without_convergence():
+    for r in range(8):
+        ok, reason = should_create_client("kv_producer", r, 8, 8, True)
+        assert ok and reason == "clamped(no-convergence)"
+
+
+def test_elide_n1_keeps_rank0_only():
+    created = [should_create_client("kv_producer", r, 8, 1, True)[0] for r in range(8)]
+    assert created == [True] + [False] * 7


### PR DESCRIPTION
Phase-3 item 4/4. The measurement-free subset of #111 phase 2: `DFKV_CONNECTOR_CLIENT_ELIDE=1` makes kv_producer non-participant ranks skip the dfkv client entirely (their store path already early-exits under phase-1 striping; producers have no load path) — P-side connections drop instances×TP → instances×N with zero shm/IPC machinery. Consumers/both never elided; default off = bit-identical current behavior.

Full load-side convergence (phase 2b) stays gated on the design doc's V1-V5 measurements (needs a live PD deployment + the coordinated client upgrade window) — documented as such.

Drive-by: connector no longer pins `batch_concurrency=8` over the library default (auto-scaling from #146 now reaches vLLM users; explicit extra_config still wins).

Connector-Python only; ships in the release, production pods stay pinned until the client upgrade coordination.