### PR TITLE
test(rdma): probe with the Put-side model_hash; ci: gate datapath on rxe probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,17 +141,28 @@ jobs:
         run: |
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDFKV_WITH_RDMA=ON
           cmake --build build -j --target rdma_loopback_test
-      # Best-effort: the runner's Soft-RoCE rxe may not actually round-trip RC
-      # traffic to itself (the test build above is the hard gate; the datapath is
-      # hard-gated locally + on real RDMA HW where rxe loopback works). We still
-      # run it here for signal — continue-on-error so an rxe env quirk can't block.
-      - name: Run RDMA datapath test (best-effort; logs results)
-        continue-on-error: true
+      # Probe-then-gate: blanket continue-on-error masked real assertion failures
+      # for weeks (two broken tests stayed green). Instead, first check that rxe
+      # can actually round-trip RC traffic with the simplest datapath case; only
+      # an env-level probe failure is tolerated. Once the probe passes, the full
+      # suite is a hard gate.
+      - name: Probe rxe loopback connectivity
+        id: rxe_probe
+        run: |
+          ulimit -l unlimited 2>/dev/null || true
+          if ./build/rdma_loopback_test --gtest_filter=RdmaLoopback.PutGetExistMissOverRdma; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::rxe loopback cannot round-trip RC traffic on this runner; datapath suite skipped"
+          fi
+      - name: Run RDMA datapath test (hard gate when rxe works)
+        if: steps.rxe_probe.outputs.ok == 'true'
         run: |
           ulimit -l unlimited 2>/dev/null || true
           ./build/rdma_loopback_test
-      - name: Build + run RDMA datapath test under ThreadSanitizer (best-effort)
-        continue-on-error: true
+      - name: Build + run RDMA datapath test under ThreadSanitizer (hard gate when rxe works)
+        if: steps.rxe_probe.outputs.ok == 'true'
         run: |
           cmake -S . -B build-tsan -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDFKV_WITH_RDMA=ON \
             -DCMAKE_CXX_FLAGS="-fsanitize=thread -g -O1" \

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -104,11 +104,14 @@ TEST(RdmaLoopback, ExistManyWindowedMixedHitMiss) {
     std::string v = "v" + std::to_string(i);
     ASSERT_TRUE(c.Put("p" + std::to_string(i), v.data(), v.size())) << i;
   }
-  // Interleave present (even) and absent (odd) keys.
+  // Interleave present (even) and absent (odd) keys. The probes must carry the
+  // same model_hash the KVClient salted the identity with on Put (SelfHdr());
+  // a bare ToBlockKey probes the mh=0 keyspace and misses everything.
+  const uint64_t mh = SelfHdr().model_hash;
   std::vector<BlockKey> keys;
   for (int i = 0; i < N; ++i) {
-    keys.push_back(ToBlockKey("p" + std::to_string(i)));      // present
-    keys.push_back(ToBlockKey("absent" + std::to_string(i))); // miss
+    keys.push_back(ToBlockKey("p" + std::to_string(i), mh));      // present
+    keys.push_back(ToBlockKey("absent" + std::to_string(i), mh)); // miss
   }
   std::vector<char> exists;
   auto sts = rt.ExistMany(node.addr, keys, &exists);
@@ -678,10 +681,13 @@ TEST(RdmaLoopback, BatchRetriesAfterServerReclaim) {
   // probe must detect that on the first window and re-dial a fresh conn, returning
   // CORRECT results — not kIOError for the whole batch. Direct transport call so no
   // KVClient-level health retry can mask a transport that failed to recover.
+  // Probe with the Put-side model_hash: KVClient salts the block identity with
+  // SelfHdr().model_hash, so a bare ToBlockKey would probe the wrong keyspace.
+  const uint64_t mh = SelfHdr().model_hash;
   std::vector<BlockKey> keys;
   for (int i = 0; i < N; ++i) {
-    keys.push_back(ToBlockKey("b" + std::to_string(i)));     // present (warm)
-    keys.push_back(ToBlockKey("nope" + std::to_string(i)));  // absent
+    keys.push_back(ToBlockKey("b" + std::to_string(i), mh));     // present (warm)
+    keys.push_back(ToBlockKey("nope" + std::to_string(i), mh));  // absent
   }
   std::vector<char> exists;
   auto sts = rt.ExistMany(node.addr, keys, &exists);


### PR DESCRIPTION
## Problem

Two loopback tests (`ExistManyWindowedMixedHitMiss`, `BatchRetriesAfterServerReclaim`) have been failing since the model_hash key-salting fix (#133): they Put through a KVClient whose SelfHdr carries model_hash=0x51, then probe with bare `ToBlockKey` (mh=0) — every present-key probe misses by design.

CI never surfaced this: the RDMA datapath steps ran under a blanket `continue-on-error: true`, so the job stayed green while the suite failed (verified in the v1.20.0 main run logs: both tests FAILED, job conclusion success).

## Fix

- Tests: probe with the Put-side model_hash (comment explains the salting contract).
- CI: replace blanket continue-on-error with **probe-then-gate** — run the simplest datapath case first; only an rxe that cannot round-trip RC traffic is tolerated (warning + skip). Once the probe passes, the full suite and its TSan variant are hard gates.

## Validation

Real-HW hard gate (B200, CX-7 loopback): `rdma_loopback_test` 21/21 passed; full ctest 348/348 (numpy installed for python_plugin).