### PR TITLE
fix(cache): uring batch-flush CQE hygiene — bounds-check, full reap or retire, exact accounting

### DIFF
--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -459,24 +459,57 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
         ++submitted;
       }
       if (submitted) {
-        int rc = io_uring_submit(ring);
+        // io_uring_submit returns how many SQEs the kernel actually consumed.
+        // On a short submit (rc < submitted, or rc < 0) the tail SQEs stay
+        // queued in the SQ and would be pushed by the NEXT batch's submit —
+        // by then their iovecs point at arena slots this flush has released.
+        // Likewise, a CQE left unreaped here would be handed to the next batch
+        // under a same-range user_data index and could mark an unwritten item
+        // io_ok (a stale/short slot then serves reads). Invariant: a batch
+        // either fully reaps the completions it submitted, or the ring is
+        // retired with them; nothing may leak across batches.
+        const int rc = io_uring_submit(ring);
+        const size_t expect = rc > 0 ? static_cast<size_t>(rc) : 0;
         size_t done = 0;
-        while (rc > 0 && done < submitted) {
+        bool reap_ok = true;
+        while (done < expect) {
           io_uring_cqe* cqe = nullptr;
-          if (io_uring_wait_cqe(ring, &cqe) != 0) break;
-          const size_t i = static_cast<size_t>(reinterpret_cast<uintptr_t>(io_uring_cqe_get_data(cqe)));
-          const auto& it = items[i];
-          const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
-          if (i < N && cqe->res == static_cast<int>(alen)) st[i].io_ok = true;
+          const int wrc = io_uring_wait_cqe(ring, &cqe);
+          if (wrc == -EINTR) continue;         // signal: just retry the wait
+          if (wrc != 0) { reap_ok = false; break; }
+          // Bounds-check the completion's index BEFORE touching items[i]: a
+          // corrupt/foreign user_data must not become an out-of-bounds read.
+          const size_t i = static_cast<size_t>(
+              reinterpret_cast<uintptr_t>(io_uring_cqe_get_data(cqe)));
+          if (i < N && st[i].active && st[i].direct) {
+            const auto& it = items[i];
+            const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
+            if (cqe->res == static_cast<int>(alen)) st[i].io_ok = true;
+          }
           io_uring_cqe_seen(ring, cqe);
           ++done;
         }
+        if (!reap_ok || expect != submitted) {
+          // Unreaped CQEs or unsubmitted SQEs remain: retire the ring so they
+          // die with it; the next batch re-inits a fresh one. The affected
+          // items keep io_ok=false and are rewritten by the sequential path
+          // below (their slots are exclusively owned by this flush, so the
+          // rewrite is idempotent).
+          io_uring_queue_exit(ring);
+          delete ring;
+          uring_w_ = nullptr;
+        }
         did_uring = true;
-        uring_write_batches_.fetch_add(1, std::memory_order_relaxed);
-        batched_writes_.fetch_add(submitted, std::memory_order_relaxed);
-        // A submitted-but-failed (or unsubmitted, SQ-full) item keeps
-        // io_ok=false and falls through to the sequential path below, which
-        // retries it once (direct first, then the buffered fallback inside).
+        size_t batch_ok = 0;
+        for (size_t i = 0; i < N; ++i)
+          if (st[i].active && st[i].io_ok) ++batch_ok;
+        if (batch_ok) {
+          uring_write_batches_.fetch_add(1, std::memory_order_relaxed);
+          // Count only CQE-confirmed writes: submitted-but-failed items fall
+          // through to the sequential path and are tallied there (previously
+          // they were double-counted as both batched and dio-fallback).
+          batched_writes_.fetch_add(batch_ok, std::memory_order_relaxed);
+        }
       }
     }
   }

--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -10,6 +10,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <string>
 #include <thread>
@@ -515,3 +517,46 @@ TEST_F(DiskSlabTest, CacheDirectBatchEvictsUnderPressure) {
   EXPECT_EQ(s.Count(), 8u);
   for (int i = 0; i < 4; ++i) EXPECT_TRUE(s.IsCached(K(100 + i)));
 }
+
+#ifdef DFKV_WITH_URING
+// batched_writes must count CQE-confirmed writes exactly: on a healthy fs a
+// fully-successful uring batch tallies every item once (previously the counter
+// tallied *submitted* items, so a submitted-but-failed write was counted as
+// batched AND again by the sequential fallback it fell through to).
+TEST_F(DiskSlabTest, UringBatchCountsOnlyConfirmedWrites) {
+  auto opts = Opts(1 << 20, 1 << 20, 4096);
+  opts.direct_writes = true;
+  bool ok = false;
+  DiskSlabStore s(opts, &ok);
+  ASSERT_TRUE(ok);
+  if (!s.DirectWritesActive()) GTEST_SKIP() << "fs rejected O_DIRECT (tmpfs)";
+  // The uring one-submit path takes only page-aligned payloads (unaligned data
+  // rides the buffered fallback), so hand it 4 KiB-aligned page-multiple items
+  // exactly like RamTier arena slots.
+  constexpr uint64_t N = 8;
+  constexpr size_t kLen = 4096;
+  std::vector<void*> bufs(N);
+  std::vector<DiskSlabStore::CacheBatchItem> items;
+  for (uint64_t i = 0; i < N; ++i) {
+    ASSERT_EQ(posix_memalign(&bufs[i], 4096, kLen), 0);
+    std::memset(bufs[i], static_cast<int>('A' + i), kLen);
+    items.push_back({K(700 + i), static_cast<char*>(bufs[i]), kLen, kLen});
+  }
+  auto sts = s.CacheDirectBatch(items);
+  for (auto st : sts) ASSERT_EQ(st, Status::kOk);
+  const auto stats = s.GetStats();
+  if (stats.uring_write_batches == 0) {
+    for (auto* b : bufs) free(b);
+    GTEST_SKIP() << "uring path not taken (env-disabled or init fallback)";
+  }
+  EXPECT_EQ(stats.uring_write_batches, 1u);
+  EXPECT_EQ(stats.batched_writes, N);
+  EXPECT_EQ(stats.dio_write_fallbacks, 0u);
+  for (uint64_t i = 0; i < N; ++i) {
+    std::string out;
+    ASSERT_EQ(s.Range(K(700 + i), 0, kLen, &out), Status::kOk) << i;
+    EXPECT_EQ(out, std::string(kLen, static_cast<char>('A' + i))) << i;
+  }
+  for (auto* b : bufs) free(b);
+}
+#endif  // DFKV_WITH_URING


### PR DESCRIPTION
## Defects (found in the phase-4 review, verified against v1.20.0)

1. **OOB read**: `items[i]` was dereferenced before the `i < N` bounds check in the CQE loop — a corrupt/foreign `user_data` index became an out-of-bounds read.
2. **Cross-batch CQE pollution / flush-worker wedge**: a `wait_cqe` error broke out leaving CQEs unreaped — the next batch reaps them under its own same-range indices and can mark an unwritten item `io_ok` (a stale/short slot then serves reads). A short submit left tail SQEs queued (pushed by the NEXT batch pointing at recycled arena slots), and waiting for `submitted` completions after a short submit blocked forever holding `uring_w_mu_`, wedging every flush worker. EINTR aborted the reap.
3. **Accounting**: `batched_writes` counted *submitted* items — a submitted-but-failed write tallied as batched AND again as dio-fallback after the sequential retry.

## Fix

Invariant: **a batch either fully reaps the completions it submitted (EINTR retried), or the ring is retired with them** — nothing leaks across batches. Bounds/active/direct guards run before touching `items[i]`. Unconfirmed items keep `io_ok=false` and are rewritten by the sequential fallback (idempotent: slots are exclusively owned by this flush). `batched_writes` counts only CQE-confirmed writes.

New test `DiskSlabTest.UringBatchCountsOnlyConfirmedWrites` exercises the real uring one-submit path (4 KiB-aligned items, direct mode) and pins the exact counters.

## Validation

B200 real-HW: disk_slab_store_test 19/19 (new test rides the uring path, not skipped); full ctest 347/349 — the 2 failures are the pre-existing loopback tests fixed in #150.