### PR TITLE
fix(mds/utils): control-plane hardening — I/O timeouts, parser depth cap, weight clamp

### DIFF
--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -1,5 +1,6 @@
 #include "mds/mds_server.h"
 
+#include <cstdlib>
 #include <map>
 
 #include <netinet/in.h>
@@ -77,18 +78,41 @@ void MdsServer::ReapDoneLocked() {
 
 size_t MdsServer::live_conn_count() {
   std::lock_guard<std::mutex> lk(conn_mu_);
+  ReapDoneLocked();  // count only genuinely-live handlers, not finished-unreaped ones
   return conns_.size();
 }
 
 void MdsServer::AcceptLoop() {
+  // Silent/half-open peers must not pin a handler thread forever (Handle is a
+  // thread-per-conn long-lived loop): bound both directions, like the RDMA
+  // bootstrap does. Legit clients speak every few seconds (member poll /
+  // heartbeat), far inside the 60 s default; a timed-out ReadAll/WriteAll
+  // returns false and the handler closes the conn (the client re-dials).
+  // DFKV_MDS_IO_TIMEOUT_S tunes it (tests use 1); DFKV_MDS_MAX_CONNS caps the
+  // handler-thread count so a connect flood degrades to refused conns instead
+  // of unbounded threads.
+  long tmo_s = 60;
+  if (const char* v = std::getenv("DFKV_MDS_IO_TIMEOUT_S")) {
+    const long t = std::atol(v);
+    if (t > 0) tmo_s = t;
+  }
+  size_t max_conns = 4096;
+  if (const char* v = std::getenv("DFKV_MDS_MAX_CONNS")) {
+    const long m = std::atol(v);
+    if (m > 0) max_conns = static_cast<size_t>(m);
+  }
   while (running_) {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
     if (fd < 0) { if (!running_) break; continue; }
     int one = 1;
     ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+    timeval tv{tmo_s, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
     std::lock_guard<std::mutex> lk(conn_mu_);
     if (!running_) { ::close(fd); break; }
     ReapDoneLocked();  // join handlers that finished since the last accept
+    if (conns_.size() >= max_conns) { ::close(fd); continue; }
     conn_fds_.push_back(fd);
     auto done = std::make_shared<std::atomic<bool>>(false);
     conns_.push_back({std::thread([this, fd, done] {

--- a/src/tools/dfkv_smoke_main.cc
+++ b/src/tools/dfkv_smoke_main.cc
@@ -43,7 +43,10 @@ int main(int argc, char** argv) {
   KVClient c(mem, hdr);
   std::string v(size, '\0');
   for (size_t i = 0; i < size; ++i) v[i] = static_cast<char>(i & 0xFF);
-  const char* key = "dfkv-smoke-key";
+  // Salt the key with the payload size: on a persistent write-once ring, a
+  // fixed key re-probed with a different --size read back the OLD payload and
+  // reported a spurious data mismatch (bench avoids the same trap via pid+size).
+  const std::string key = "dfkv-smoke-key-" + std::to_string(size);
 
   if (!c.Put(key, v.data(), v.size())) { std::fprintf(stderr, "PUT failed\n"); return 1; }
   if (!c.Exist(key)) { std::fprintf(stderr, "EXIST failed\n"); return 1; }

--- a/src/tools/dfkvctl_main.cc
+++ b/src/tools/dfkvctl_main.cc
@@ -73,8 +73,10 @@ static bool QueryClients(const std::string& mds, const std::string& group,
     if (fd < 0) continue;
     char pre[kReqPrefix];
     EncodeReq(pre, WireOp::kListClients, BlockKey{}, 0, 0, group.size());
+    // An empty group is a valid query (server-side default group): it must not
+    // short-circuit the send into a fake failure ('&&' bug — poller uses '||').
     bool ok = net::WriteAll(fd, pre, kReqPrefix) &&
-              (!group.empty() && net::WriteAll(fd, group.data(), group.size()));
+              (group.empty() || net::WriteAll(fd, group.data(), group.size()));
     std::string data;
     if (ok) {
       char rp[kRespPrefix];

--- a/src/utils/con_hash.cc
+++ b/src/utils/con_hash.cc
@@ -11,9 +11,14 @@ void ConHash::AddNode(const std::string& name, int weight) {
 
 void ConHash::Build() {
   ring_.clear();
-  // Ketama: 40 keys * 4 points = 160 vnodes per weight unit.
+  // Ketama: 40 keys * 4 points = 160 vnodes per weight unit. Clamp the weight
+  // to [1, 1024]: 40 * weight overflows int for huge weights (keys goes
+  // negative and the node silently gets ZERO vnodes — dropped from the data
+  // plane while still listed as a member), and weight <= 0 had the same
+  // silent-drop effect. 1024 (163 840 vnodes) is far beyond any real skew.
   for (const auto& [name, weight] : nodes_) {
-    int keys = 40 * weight;
+    const int w = weight < 1 ? 1 : (weight > 1024 ? 1024 : weight);
+    const int keys = 40 * w;
     for (int k = 0; k < keys; ++k) {
       uint8_t d[16];
       std::string s = name + "-" + std::to_string(k);

--- a/src/utils/json_min.h
+++ b/src/utils/json_min.h
@@ -41,6 +41,11 @@ class JsonParser {
   explicit JsonParser(const std::string& s) : s_(s) {}
   const std::string& s_;
   size_t i_ = 0;
+  int depth_ = 0;
+  // etcd responses nest a handful of levels; a deeply-nested (malformed or
+  // hostile) document must fail cleanly instead of exhausting the stack via
+  // the value->object/array->value recursion.
+  static constexpr int kMaxDepth = 64;
 
   void ws() {
     while (i_ < s_.size() &&
@@ -51,8 +56,13 @@ class JsonParser {
     if (i_ >= s_.size()) return false;
     char c = s_[i_];
     if (c == '"') { o->type = JsonValue::kString; return str(&o->scalar); }
-    if (c == '{') return object(o);
-    if (c == '[') return array(o);
+    if (c == '{' || c == '[') {
+      if (depth_ >= kMaxDepth) return false;
+      ++depth_;
+      const bool ok = (c == '{') ? object(o) : array(o);
+      --depth_;
+      return ok;
+    }
     if (c == 't' || c == 'f') return boolean(o);
     if (c == 'n') return null(o);
     return number(o);

--- a/src/utils/metrics_http.cc
+++ b/src/utils/metrics_http.cc
@@ -76,6 +76,11 @@ void MetricsHttpServer::AcceptLoop() {
   while (running_) {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
     if (fd < 0) { if (!running_) break; continue; }
+    // A scrape is one short request/response; a silent peer must not pin the
+    // handler thread (Handle's recv loop otherwise blocks indefinitely).
+    timeval tv{10, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
     std::lock_guard<std::mutex> lk(conn_mu_);
     if (!running_) { ::close(fd); break; }
     ReapDoneLocked();  // join finished scrape handlers (Connection: close => one per scrape)

--- a/test/mds/mds_server_test.cc
+++ b/test/mds/mds_server_test.cc
@@ -385,3 +385,22 @@ TEST(MdsServer, ClientRejectsPathTraversalGroupAndId) {
   EXPECT_EQ(st, Status::kInvalid);
   mds.Stop();
 }
+
+// No etcd needed: the listener + handler lifecycle is all local. A peer that
+// connects and then goes silent must be released by the I/O timeout instead of
+// pinning its handler thread forever (thread-per-conn with no bound).
+TEST(MdsServer, SilentPeerReleasedByIoTimeout) {
+  ::setenv("DFKV_MDS_IO_TIMEOUT_S", "1", 1);
+  MdsServer srv("127.0.0.1:1");  // etcd never contacted: no requests sent
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int fd = net::Dial("127.0.0.1:" + std::to_string(srv.port()), 2000, 2000);
+  ASSERT_GE(fd, 0);
+  // Handler picks the conn up and blocks in ReadAll until the 1 s timeout.
+  for (int i = 0; i < 50 && srv.live_conn_count() == 0; ++i) usleep(20 * 1000);
+  EXPECT_EQ(srv.live_conn_count(), 1u);
+  for (int i = 0; i < 200 && srv.live_conn_count() > 0; ++i) usleep(20 * 1000);
+  EXPECT_EQ(srv.live_conn_count(), 0u) << "silent conn not reaped by timeout";
+  ::close(fd);
+  srv.Stop();
+  ::unsetenv("DFKV_MDS_IO_TIMEOUT_S");
+}

--- a/test/utils/con_hash_weight_test.cc
+++ b/test/utils/con_hash_weight_test.cc
@@ -39,3 +39,34 @@ TEST(ConHashWeight, EqualWeightRoughlyBalanced) {
   double ratio = static_cast<double>(std::max(a, b)) / std::min(a, b);
   EXPECT_LT(ratio, 1.3) << "a=" << a << " b=" << b;
 }
+
+TEST(ConHashWeight, HugeOrNonPositiveWeightStillOnRing) {
+  // 40 * weight used to overflow int for huge weights (keys went negative ->
+  // ZERO vnodes -> the node silently vanished from the data plane); weight <= 0
+  // had the same silent-drop effect. Both must clamp and stay routable.
+  dfkv::ConHash h;
+  h.AddNode("huge", 2000000000);
+  h.AddNode("plain", 1);
+  h.Build();
+  int hit_huge = 0;
+  for (int i = 0; i < 5000; ++i) {
+    std::string node;
+    ASSERT_TRUE(h.Lookup("key" + std::to_string(i), &node));
+    if (node == "huge") ++hit_huge;
+  }
+  EXPECT_GT(hit_huge, 0) << "huge-weight node dropped from the ring";
+
+  // Zero weight clamps up to 1: paired with an equal-share peer both nodes
+  // must take traffic (deterministic — ~50/50 split over 1000 keys).
+  dfkv::ConHash h2;
+  h2.AddNode("zero", 0);
+  h2.AddNode("plain", 1);
+  h2.Build();
+  int hit_zero = 0;
+  for (int i = 0; i < 1000; ++i) {
+    std::string node;
+    ASSERT_TRUE(h2.Lookup("key" + std::to_string(i), &node));
+    if (node == "zero") ++hit_zero;
+  }
+  EXPECT_GT(hit_zero, 0) << "zero-weight node dropped from the ring";
+}

--- a/test/utils/json_min_test.cc
+++ b/test/utils/json_min_test.cc
@@ -41,3 +41,18 @@ TEST(JsonMin, RejectsMalformed) {
   EXPECT_FALSE(JsonParser::Parse("{\"a\":1}garbage", &root));
   EXPECT_FALSE(JsonParser::Parse("", &root));
 }
+
+TEST(JsonMin, DeepNestingFailsCleanlyInsteadOfStackOverflow) {
+  // 100k nested arrays previously recursed value->array->value all the way
+  // down and crashed the process; the depth cap must reject it as a parse
+  // error. A document within the cap still parses.
+  JsonValue root;
+  const int kDeep = 100000;
+  std::string deep(kDeep, '[');
+  deep.append(kDeep, ']');
+  EXPECT_FALSE(JsonParser::Parse(deep, &root));
+  std::string shallow(8, '[');
+  shallow += "1";
+  shallow.append(8, ']');
+  EXPECT_TRUE(JsonParser::Parse(shallow, &root));
+}


### PR DESCRIPTION
Phase-4 review findings, control-plane robustness batch:

- **MDS accept**: `SO_RCVTIMEO/SO_SNDTIMEO` on handler conns (60 s default, `DFKV_MDS_IO_TIMEOUT_S`) + `DFKV_MDS_MAX_CONNS` cap (4096). `Handle()` is a thread-per-conn loop with no bound — a few half-open peers (or a probing LB) pinned handler threads forever, exactly when etcd is already wobbling. Mirrors the RDMA bootstrap's existing timeout (`rdma_server.cc`). `live_conn_count()` now reaps before counting.
- **metrics HTTP**: same 10 s bounds — a silent scrape peer blocked `Handle()`'s recv loop indefinitely.
- **json_min**: depth cap (64) on object/array recursion — a deeply-nested etcd gateway response could crash the MDS via stack exhaustion (new test: 100k-deep doc fails cleanly).
- **con_hash**: clamp weight to [1,1024] — `40*weight` overflowed `int` for huge weights (keys < 0 → node silently got ZERO vnodes → dropped from the data plane while still a listed member); weight ≤ 0 silently dropped too (new test).
- **dfkvctl ListClients**: empty group short-circuited `&&` into a fake send failure (the poller uses `||` correctly).
- **dfkv_smoke**: salt the fixed key with `--size` — re-probing a persistent ring with a different size read the old payload back as a spurious mismatch.

Tests: `MdsServer.SilentPeerReleasedByIoTimeout` (no etcd needed), `JsonMin.DeepNesting…`, `ConHashWeight.HugeOrNonPositive…`.
Validation: B200 real-HW full ctest 349/351 (2 failures = pre-existing loopback tests fixed by #150, not in this branch).