### PR TITLE
fix(rdma): user MR cache cap must cover a full SG window (depth * max_sge)

### DIFF
--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -188,7 +188,6 @@ void RcEndpoint::Close() {
 bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib_port,
                       bool direct_io_buffers, size_t direct_io_cap) {
   cap_ = cap; depth_ = depth; ib_port_ = ib_port;
-  user_mr_cap_ = std::max(kMinUserMr, depth_);  // >= depth: no in-window MR eviction
 
   int wp[2];
   if (::pipe(wp) != 0) return false;  // self-pipe to interrupt WaitComp
@@ -225,6 +224,14 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib
       max_sge_ = kMaxSge;  // query failed: trust the documented device cap
     }
   }
+  // The ad-hoc MR cache must never evict an MR another slot of the SAME window
+  // still references: the SG multi paths register up to max_sge_-1 out-of-pool
+  // segment buffers PER SLOT for the whole window before posting any WR, so the
+  // in-flight worst case is depth * max_sge_ (not depth) distinct MRs. A cap of
+  // max(kMinUserMr, depth) let a depth>=3 window with unregistered SG segments
+  // LRU-evict (ibv_dereg_mr) MRs still held in mrs_per -> use-after-free lkeys,
+  // and on the RECV side a completion scattering into freed memory.
+  user_mr_cap_ = std::max(kMinUserMr, depth_ * max_sge_);
 
   ibv_qp_init_attr qa{};
   qa.send_cq = cq_; qa.recv_cq = cq_;

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -214,10 +214,12 @@ class RcEndpoint {
   // LRU-capped cache of caller-buffer MRs (addr -> {mr, lru-iterator}); front of
   // user_lru_ is MRU. Bounded so a workload with many distinct buffers can't leak
   // registrations (a stable HiCache pool stays fully cached and always hits). The
-  // cap MUST be >= pipeline depth: one window registers up to `depth` distinct
-  // out-of-pool buffers before posting their WRs, so a smaller cap could evict
-  // (ibv_dereg_mr) an MR still referenced by an in-flight WR in the same window
-  // (use-after-dereg). Set to max(kMinUserMr, depth) in Open().
+  // cap MUST cover every MR one window can hold in flight before posting: the
+  // legacy paths register 1 buffer per slot (depth total), but the SG multi
+  // paths register up to max_sge-1 segment buffers PER SLOT and only then post
+  // the whole window — a smaller cap could evict (ibv_dereg_mr) an MR still
+  // referenced in mrs_per (use-after-dereg). Set to
+  // max(kMinUserMr, depth * max_sge) in Open() after max_sge_ is negotiated.
   static constexpr size_t kMinUserMr = 64;
   size_t user_mr_cap_ = kMinUserMr;
   std::list<uintptr_t> user_lru_;

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -303,7 +303,11 @@ TEST(RdmaLoopback, UserMrCapTracksDepth) {
   EXPECT_GE(shallow.user_mr_cap(), shallow.depth());
   rdma::RcEndpoint deep;
   ASSERT_TRUE(deep.Open(nullptr, 16 * 1024, 100));  // depth > default cap of 64
-  EXPECT_GE(deep.user_mr_cap(), 100u) << "cap below depth -> in-window MR eviction risk";
+  // The SG multi paths register up to max_sge-1 out-of-pool segments per slot
+  // and post only after the whole window is registered: the cap must cover
+  // depth * max_sge or a same-window LRU eviction hands a freed MR to a WR.
+  EXPECT_GE(deep.user_mr_cap(), 100u * deep.max_sge())
+      << "cap below depth*max_sge -> in-window MR eviction risk on SG batches";
 }
 
 TEST(RdmaLoopback, PoolMrSharedAcrossBuffers) {
@@ -512,6 +516,63 @@ TEST(RdmaLoopback, ScatterGatherRoundtripOverRdma) {
 // CacheFromMulti/RangeIntoMulti, NOT poison its node batch. Previously the up-front
 // validation std::fill'd every result kInvalid and returned; now the offender is
 // skipped in the window and its siblings on the same node proceed normally.
+// Regression (phase-4 C5): one deep window of SG items where EVERY segment is
+// a distinct unregistered buffer. The ad-hoc MR cache was capped at
+// max(64, depth); the SG multi paths register the whole window's segments
+// (up to depth * (max_sge-1) MRs) BEFORE posting any WR, so slot 3+'s
+// registrations LRU-evicted (ibv_dereg_mr) MRs earlier slots still held in
+// mrs_per — posted WRs then carried freed lkeys (use-after-dereg; on the RECV
+// side a completion scattering into freed memory). With the cap raised to
+// depth * max_sge the whole window stays registered and the batch is correct.
+TEST(RdmaLoopback, SgDeepWindowManyUnregisteredSegmentsSafe) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ::setenv("DFKV_RDMA_DEPTH", "4", 1);
+  RdmaNode node("sgdw");
+  RdmaTransport rt(kMaxMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+  ASSERT_TRUE(rt.pipelined());
+
+  constexpr int kItems = 8;   // > depth: also crosses windows
+  constexpr int kSegs = 29;   // max payload SGEs per slot
+  constexpr size_t kSeg = 512;
+  std::vector<std::vector<std::string>> src(kItems);
+  std::vector<KvPutItemSg> puts;
+  for (int it = 0; it < kItems; ++it) {
+    src[it].resize(kSegs);
+    std::vector<const void*> ptrs;
+    std::vector<size_t> sizes;
+    for (int sg = 0; sg < kSegs; ++sg) {
+      src[it][sg].assign(kSeg, static_cast<char>('a' + (it * 7 + sg) % 26));
+      ptrs.push_back(src[it][sg].data());
+      sizes.push_back(kSeg);
+    }
+    puts.push_back({"sgdw_" + std::to_string(it), ptrs, sizes});
+  }
+  auto pr = c.BatchPutSg(puts);
+  ASSERT_EQ(pr.size(), puts.size());
+  for (int it = 0; it < kItems; ++it) EXPECT_TRUE(pr[it]) << "put item " << it;
+
+  std::vector<std::vector<std::string>> dst(kItems);
+  std::vector<KvGetItemSg> gets;
+  for (int it = 0; it < kItems; ++it) {
+    dst[it].assign(kSegs, std::string(kSeg, '\0'));
+    std::vector<void*> dptrs;
+    std::vector<size_t> caps;
+    for (int sg = 0; sg < kSegs; ++sg) { dptrs.push_back(&dst[it][sg][0]); caps.push_back(kSeg); }
+    gets.push_back({"sgdw_" + std::to_string(it), dptrs, caps});
+  }
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg(gets, &lens);
+  ASSERT_EQ(gr.size(), gets.size());
+  for (int it = 0; it < kItems; ++it) {
+    EXPECT_TRUE(gr[it]) << "get item " << it;
+    EXPECT_EQ(lens[it], kSegs * kSeg) << it;
+    for (int sg = 0; sg < kSegs; ++sg)
+      EXPECT_EQ(dst[it][sg], src[it][sg]) << "item " << it << " seg " << sg;
+  }
+  ::unsetenv("DFKV_RDMA_DEPTH");
+}
+
 TEST(RdmaLoopback, ScatterGatherOversizedFailsOnlyOffender) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   ::setenv("DFKV_RDMA_DEPTH", "4", 1);


### PR DESCRIPTION
Phase-4 review finding (latent UAF, non-default config):

The ad-hoc caller-buffer MR cache was capped at `max(kMinUserMr, depth)` under the invariant *one window registers at most depth out-of-pool buffers*. The SG multi paths break that invariant: they register up to `max_sge-1` segment buffers **per slot** for the **whole window** before posting a single WR — worst case `depth * max_sge` distinct in-flight MRs. With `DFKV_RDMA_DEPTH >= 3` and unregistered SG segment buffers, later slots' registrations LRU-evicted (`ibv_dereg_mr`) MRs earlier slots still referenced in `mrs_per`: posted SENDs carried freed lkeys; on the GET side a RECV scattered into freed memory.

Fix: cap = `max(kMinUserMr, depth * max_sge)`, computed in `Open()` after `max_sge_` negotiation. Default `depth=1` (29 < 64 floor) was never exposed.

Tests: new `SgDeepWindowManyUnregisteredSegmentsSafe` (depth 4, 8 items × 29 distinct unregistered segments, put + get-auto read-back — one window holds up to 116 MRs, old cap 64); `UserMrCapTracksDepth` now pins `cap >= depth * max_sge`.

Validation: B200 real-HW (CX-7): targeted suite 4/4, full ctest 347/349 (2 = pre-existing failures fixed by #150, absent from this branch).