### PR TITLE
feat(mds): guard ring adoption against mass-shrink views (etcd-outage recovery)

### DIFF
--- a/src/mds/mds_member_poller.cc
+++ b/src/mds/mds_member_poller.cc
@@ -3,6 +3,7 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <utility>
 
 #include "common/status.h"
@@ -12,13 +13,28 @@
 
 namespace dfkv {
 
+namespace {
+// Mass-shrink suspicion threshold, percent of the adopted baseline that must
+// disappear IN ONE POLL to trigger hysteresis. 50 clears any realistic
+// same-poll failure burst (a 64-node ring trips only below 32 survivors) while
+// catching the etcd NOSPACE / lease-mass-expiry signature. 0 disables.
+int ShrinkGuardPct() {
+  if (const char* v = std::getenv("DFKV_MDS_SHRINK_GUARD_PCT")) {
+    const long p = std::atol(v);
+    if (p >= 0 && p <= 99) return static_cast<int>(p);
+  }
+  return 50;
+}
+}  // namespace
+
 MdsMemberPoller::MdsMemberPoller(std::vector<std::string> mds_eps, std::string group,
                                  OnChange cb, int poll_ms, int io_timeout_ms)
     : eps_(std::move(mds_eps)),
       group_(std::move(group)),
       cb_(std::move(cb)),
       poll_ms_(poll_ms),
-      io_ms_(io_timeout_ms) {}
+      io_ms_(io_timeout_ms),
+      guard_(kViewsToAccept, ShrinkGuardPct()) {}
 
 MdsMemberPoller::~MdsMemberPoller() { Stop(); }
 
@@ -58,18 +74,15 @@ bool MdsMemberPoller::PollOnce() {
   uint64_t epoch = 0;
   if (!Query(&ms, &epoch)) return false;  // failed RPC never clears the ring
 
-  // Empty-view guard: a *successful* empty response after we have seen real
-  // members is almost always etcd-outage recovery (all leases expired), not a
-  // genuine teardown. Don't swap in an empty ring until it persists for
-  // kEmptyViewsToAccept consecutive polls; adopting late costs nothing (an
-  // empty ring can serve no requests anyway), while adopting early causes a
-  // cluster-wide miss storm and a double remap when members re-register.
-  if (ms.empty() && seen_nonempty_ &&
-      ++consecutive_empty_ < kEmptyViewsToAccept) {
-    ++empty_view_rejected_;
+  // Adoption guard (MemberViewGuard): a *successful* response that is empty OR
+  // sheds most of the adopted baseline at once is almost always etcd-outage
+  // recovery (mass lease expiry), not a genuine teardown; adopting it remaps
+  // the whole cluster into a miss storm and remaps AGAIN when the members
+  // re-register. Suspicious views must persist for kViewsToAccept polls.
+  // Rejecting must not advance the epoch — the eventual adoption of the same
+  // etcd revision would otherwise be suppressed by the epoch dedup below.
+  if (!guard_.Admit(ms.size()))
     return true;  // keep the last ring; do NOT invoke on_change
-  }
-  if (!ms.empty()) { seen_nonempty_ = true; consecutive_empty_ = 0; }
 
   if (!have_epoch_ || epoch != last_epoch_) {
     last_epoch_ = epoch;

--- a/src/mds/mds_member_poller.h
+++ b/src/mds/mds_member_poller.h
@@ -15,6 +15,65 @@
 
 namespace dfkv {
 
+// Guards ring adoption against transient view collapses. Two cases, same
+// hysteresis: a *successful* ListMembers that is (a) empty, or (b) a shrink
+// dropping more than shrink_pct% of the adopted baseline at once — both are
+// almost always etcd-outage recovery (mass lease expiry, e.g. NOSPACE) rather
+// than a genuine teardown. The old guard only covered (a); a partially-expired
+// table ("non-empty but shrunken") sailed through and remapped the whole
+// cluster twice (once on the collapse, once on recovery). Suspicious views
+// must persist for views_to_accept consecutive polls to be believed. Growth
+// and small shrinks (single-node failures) pass through immediately. Pure
+// logic; unit-tested without etcd.
+class MemberViewGuard {
+ public:
+  MemberViewGuard(int views_to_accept, int shrink_pct)
+      : views_to_accept_(views_to_accept), shrink_pct_(shrink_pct) {}
+
+  // May this successful view be adopted now? false = keep the last ring.
+  bool Admit(size_t incoming) {
+    if (!have_baseline_) {  // first successful view: adopt as-is
+      have_baseline_ = true;
+      baseline_ = incoming;
+      return true;
+    }
+    if (incoming == 0 && baseline_ > 0) {
+      if (++empty_streak_ >= views_to_accept_) {
+        baseline_ = 0; empty_streak_ = 0; shrink_streak_ = 0;
+        return true;  // persisted: believe the teardown
+      }
+      ++rejected_empty_;
+      return false;
+    }
+    empty_streak_ = 0;
+    if (shrink_pct_ > 0 && baseline_ > 0 &&
+        incoming < baseline_ * static_cast<size_t>(100 - shrink_pct_) / 100) {
+      if (++shrink_streak_ >= views_to_accept_) {
+        baseline_ = incoming; shrink_streak_ = 0;
+        return true;  // persisted: real mass drain
+      }
+      ++rejected_shrink_;
+      return false;
+    }
+    shrink_streak_ = 0;
+    baseline_ = incoming;
+    return true;
+  }
+
+  uint64_t rejected_empty() const { return rejected_empty_; }
+  uint64_t rejected_shrink() const { return rejected_shrink_; }
+
+ private:
+  const int views_to_accept_;
+  const int shrink_pct_;  // 0 disables the shrink arm (empty arm always on)
+  bool have_baseline_ = false;
+  size_t baseline_ = 0;  // last admitted view's member count
+  int empty_streak_ = 0;
+  int shrink_streak_ = 0;
+  uint64_t rejected_empty_ = 0;
+  uint64_t rejected_shrink_ = 0;
+};
+
 // Client-side discovery: periodically polls the MDS for a group's member view and
 // invokes on_change(members) whenever the epoch (etcd revision) changes. Endpoint
 // selection + failover via MdsEndpoints. One background thread.
@@ -28,8 +87,9 @@ class MdsMemberPoller {
   void Start();
   void Stop();
   bool PollOnce();
-  // Count of member views suppressed by the empty-view guard (diagnostic).
-  uint64_t empty_view_rejected() const { return empty_view_rejected_; }
+  // Views suppressed by the adoption guard (diagnostic).
+  uint64_t empty_view_rejected() const { return guard_.rejected_empty(); }
+  uint64_t shrink_view_rejected() const { return guard_.rejected_shrink(); }
 
  private:
   bool Query(std::vector<MemberInfo>* out, uint64_t* epoch);
@@ -44,16 +104,9 @@ class MdsMemberPoller {
   int io_ms_;
   uint64_t last_epoch_ = 0;
   bool have_epoch_ = false;
-  // Empty-view guard: after etcd loses every lease (outage > TTL), a RECOVERED
-  // MDS answers ListMembers *successfully* with an empty table, which would
-  // otherwise swap in an empty ring (total miss until nodes re-register). If we
-  // have previously seen a non-empty view, require this many consecutive empty
-  // views before believing the cluster is truly gone. First view (incl. empty)
-  // is adopted as-is.
-  static constexpr int kEmptyViewsToAccept = 3;
-  bool seen_nonempty_ = false;
-  int consecutive_empty_ = 0;
-  uint64_t empty_view_rejected_ = 0;  // observability
+  // Suspicious-view hysteresis depth (empty and mass-shrink arms alike).
+  static constexpr int kViewsToAccept = 3;
+  MemberViewGuard guard_;
   std::atomic<bool> running_{false};
   std::thread th_;
   std::mutex mu_;

--- a/test/mds/member_view_guard_test.cc
+++ b/test/mds/member_view_guard_test.cc
@@ -1,0 +1,76 @@
+// MemberViewGuard: ring-adoption hysteresis against transient view collapses
+// (etcd outage / NOSPACE recovery). Pure logic — no etcd, always runs.
+#include "mds/mds_member_poller.h"
+
+#include <gtest/gtest.h>
+
+using dfkv::MemberViewGuard;
+
+TEST(MemberViewGuard, FirstViewAdoptedAsIs) {
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(0));  // even an empty first view
+  MemberViewGuard g2(3, 50);
+  EXPECT_TRUE(g2.Admit(64));
+}
+
+TEST(MemberViewGuard, GrowthAndSmallShrinkPassImmediately) {
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_TRUE(g.Admit(80));   // growth
+  EXPECT_TRUE(g.Admit(79));   // single-node failure must propagate fast
+  EXPECT_TRUE(g.Admit(41));   // 48% drop: below the 50% bar, adopt
+  EXPECT_EQ(g.rejected_shrink(), 0u);
+}
+
+TEST(MemberViewGuard, MassShrinkNeedsPersistence) {
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(64));
+  // etcd NOSPACE signature: most leases expired, a shrunken view appears.
+  EXPECT_FALSE(g.Admit(5));   // poll 1: suspect
+  EXPECT_FALSE(g.Admit(5));   // poll 2: still suspect
+  EXPECT_TRUE(g.Admit(5));    // poll 3: persisted -> believe the drain
+  EXPECT_EQ(g.rejected_shrink(), 2u);
+  // Baseline moved to 5: a further small change passes.
+  EXPECT_TRUE(g.Admit(4));
+}
+
+TEST(MemberViewGuard, RecoveryDuringHysteresisResetsStreak) {
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_FALSE(g.Admit(5));   // transient collapse
+  EXPECT_TRUE(g.Admit(63));   // etcd recovered: adopt, streak resets
+  EXPECT_FALSE(g.Admit(5));   // a NEW collapse restarts its own hysteresis
+  EXPECT_FALSE(g.Admit(5));
+  EXPECT_TRUE(g.Admit(5));
+}
+
+TEST(MemberViewGuard, EmptyArmStillGuards) {
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_FALSE(g.Admit(0));
+  EXPECT_FALSE(g.Admit(0));
+  EXPECT_TRUE(g.Admit(0));    // persisted: teardown believed
+  EXPECT_EQ(g.rejected_empty(), 2u);
+  // After an adopted empty view the next non-empty is a re-registration: adopt.
+  EXPECT_TRUE(g.Admit(64));
+}
+
+TEST(MemberViewGuard, ShrinkArmDisabledByZeroPct) {
+  MemberViewGuard g(3, 0);
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_TRUE(g.Admit(1));    // pct=0: legacy behavior, shrink passes
+  EXPECT_FALSE(g.Admit(0));   // empty arm is always on
+}
+
+TEST(MemberViewGuard, EmptyThenShrunkenRecoveryIsNotDoubleCounted) {
+  // Outage recovery often looks like: empty, empty, then a partial table as
+  // members trickle back. The partial view vs the OLD baseline is a shrink,
+  // but adopting it beats serving the stale full ring for another cycle once
+  // it persists.
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_FALSE(g.Admit(0));
+  EXPECT_FALSE(g.Admit(20));  // partial recovery: shrink hysteresis
+  EXPECT_FALSE(g.Admit(20));
+  EXPECT_TRUE(g.Admit(20));   // persisted partial view adopted
+}


### PR DESCRIPTION
Phase-4 review P1 — the code-side blind spot behind the hd04 etcd NOSPACE incident:

The empty-view guard only covered **total** lease loss. A recovered etcd that lost **most** leases (NOSPACE, leader churn) answers ListMembers *successfully* with a non-empty-but-shrunken table — it sailed straight through, every client rebuilt its ring around the survivors (cluster-wide remap + miss storm), then rebuilt AGAIN when members re-registered.

**Fix**: generalize the hysteresis into `MemberViewGuard` (pure logic, unit-tested without etcd). A successful view that is empty OR sheds > `DFKV_MDS_SHRINK_GUARD_PCT` (default 50%, 0 disables) of the adopted baseline in one poll must persist 3 consecutive polls to be believed. Growth and small shrinks (single-node failures) pass immediately — a 64-node ring trips only below 32 survivors, far past any realistic same-poll failure burst. Rejection does not advance the poll epoch (else epoch-dedup would suppress the eventual adoption). New counter `shrink_view_rejected`.

Semantics preserved: first view adopted as-is; empty-arm behavior identical to the old guard; real mass drains adopt after 3 polls (~9 s at the default 3 s cadence).

Tests: 7 new pure-logic cases incl. the NOSPACE signature, recovery-during-hysteresis, empty-then-partial-recovery. Validation: B200 full ctest 353/355 (2 = pre-existing, fixed by #150).