### PR TITLE
perf/fix(client,rdma): persistent fan-out pool; per-item oversize + local-reg-failure semantics

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -3,9 +3,13 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <functional>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
 #include <vector>
@@ -34,20 +38,102 @@ namespace {
 // constant so even those keys cache.
 constexpr size_t kSgMaxPayloadSegs = 29;
 
-// Run fn(i) for i in [0,n) across up to `workers` threads (atomic work-steal).
-void RunParallel(size_t n, size_t workers, const std::function<void(size_t)>& fn) {
-  if (n == 0) return;
-  if (workers > n) workers = n;
-  if (workers <= 1) { for (size_t i = 0; i < n; ++i) fn(i); return; }
-  std::atomic<size_t> next{0};
-  std::vector<std::thread> ts;
-  ts.reserve(workers);
-  for (size_t w = 0; w < workers; ++w) {
-    ts.emplace_back([&] {
-      for (size_t i = next.fetch_add(1); i < n; i = next.fetch_add(1)) fn(i);
-    });
+// Shared fan-out pool for the Batch* paths. The old RunParallel created and
+// joined up to 32 std::threads PER CALL; a connector issuing batches at high
+// rate paid ~10-30 us of thread create/teardown per worker on every batch,
+// plus the scheduler churn. Workers here are created lazily once (cap 32,
+// process lifetime) and assist parallel-for jobs; the caller thread always
+// participates, so a job never waits on pool availability to start.
+class FanoutPool {
+ public:
+  // Leaky singleton: workers block in cv-wait at process exit; a static
+  // destructor joining them would hang shutdown, so the pool is never
+  // destroyed (threads are detached and die with the process).
+  static FanoutPool& Instance() {
+    static FanoutPool* p = new FanoutPool();
+    return *p;
   }
-  for (auto& t : ts) t.join();
+
+  void Run(size_t n, size_t workers, const std::function<void(size_t)>& fn) {
+    if (n == 0) return;
+    if (workers > n) workers = n;
+    if (workers > kMaxThreads) workers = kMaxThreads;
+    if (workers <= 1) {  // serial path: exceptions propagate as before
+      for (size_t i = 0; i < n; ++i) fn(i);
+      return;
+    }
+    auto job = std::make_shared<Job>();
+    job->n = n;
+    job->fn = fn;  // one std::function copy per batch (vs a thread per worker)
+    const size_t helpers = workers - 1;
+    EnsureThreads(helpers);
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      for (size_t i = 0; i < helpers; ++i) queue_.push_back(job);
+    }
+    cv_.notify_all();
+    Work(*job);  // caller participates; late helpers find no indices and drop out
+    std::unique_lock<std::mutex> lk(job->m);
+    job->done_cv.wait(lk, [&] { return job->done.load(std::memory_order_acquire) == job->n; });
+  }
+
+ private:
+  struct Job {
+    size_t n = 0;
+    std::function<void(size_t)> fn;
+    std::atomic<size_t> next{0};
+    std::atomic<size_t> done{0};
+    std::mutex m;
+    std::condition_variable done_cv;
+  };
+
+  static void Work(Job& j) {
+    for (size_t i = j.next.fetch_add(1); i < j.n; i = j.next.fetch_add(1)) {
+      // An escaping exception previously hit the std::thread entry and called
+      // std::terminate (while the serial path propagated it) — a cache client
+      // must degrade the ITEM, not kill the process. The item's slot keeps its
+      // pre-initialized failure value (miss/failed-put), which the connector
+      // already handles.
+      try { j.fn(i); } catch (...) {}
+      if (j.done.fetch_add(1, std::memory_order_acq_rel) + 1 == j.n) {
+        std::lock_guard<std::mutex> lk(j.m);  // pairs with the waiter's wait
+        j.done_cv.notify_all();
+      }
+    }
+  }
+
+  void EnsureThreads(size_t want) {
+    std::lock_guard<std::mutex> lk(mu_);
+    while (threads_ < want && threads_ < kMaxThreads) {
+      std::thread([this] { Loop(); }).detach();
+      ++threads_;
+    }
+  }
+
+  void Loop() {
+    for (;;) {
+      std::shared_ptr<Job> j;
+      {
+        std::unique_lock<std::mutex> lk(mu_);
+        cv_.wait(lk, [this] { return !queue_.empty(); });
+        j = std::move(queue_.front());
+        queue_.pop_front();
+      }
+      Work(*j);
+    }
+  }
+
+  static constexpr size_t kMaxThreads = 32;
+  std::mutex mu_;
+  std::condition_variable cv_;
+  std::deque<std::shared_ptr<Job>> queue_;
+  size_t threads_ = 0;  // guarded by mu_
+};
+
+// Run fn(i) for i in [0,n) across up to `workers` threads (atomic work-steal,
+// shared persistent pool).
+void RunParallel(size_t n, size_t workers, const std::function<void(size_t)>& fn) {
+  FanoutPool::Instance().Run(n, workers, fn);
 }
 }  // namespace
 

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -500,12 +500,13 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
     std::fill(res.begin(), res.end(), Status::kInvalid);
     return res;
   }
-  for (const auto& dst : dsts) {
-    if (dst.n > OpBound()) {
-      std::fill(res.begin(), res.end(), Status::kInvalid);
-      return res;
-    }
-  }
+  // Per-item bound check: an oversized dst fails ONLY itself (kInvalid, which
+  // the client's health accounting ignores) — the multi variants already
+  // fail-soft per item; poisoning the whole node batch made one oversized key
+  // cost every sibling its cache hit.
+  std::vector<char> bad(n, 0);
+  for (size_t i = 0; i < n; ++i)
+    if (dsts[i].n > OpBound()) bad[i] = 1;
 
   // 2-attempt loop: retry a stale pooled conn once on a fresh one. Range is a read
   // (idempotent) and the scatter lands in the caller's buffers, so replaying the
@@ -513,6 +514,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
   // local resource issue, not staleness, so it stays terminal — no retry.)
   for (int attempt = 0; attempt < 2; ++attempt) {
     std::fill(res.begin(), res.end(), Status::kIOError);
+    for (size_t i = 0; i < n; ++i) if (bad[i]) res[i] = Status::kInvalid;
     hdrs->assign(n, std::string());
     bool from_pool = false;
     Conn* c = Acquire(node, &from_pool, attempt > 0);
@@ -522,32 +524,43 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
-      // Register the destination buffers (cached). Any failure => give the conn
-      // back and fall back to the copy-based path for the whole call.
+      // Register the destination buffers (cached).
       std::vector<ibv_mr*> mrs(w, nullptr);
       bool regok = true;
       for (size_t j = 0; j < w && regok; ++j) {
+        if (bad[base + j]) continue;          // oversized: slot never posted
         if (dsts[base + j].n == 0) continue;  // empty: header-only reply into rbuf, no MR
         mrs[j] = ep.RegisterUser(dsts[base + j].payload, dsts[base + j].n);
         if (!mrs[j]) regok = false;
       }
-      if (!regok) { Release(node, c); return res; }
+      if (!regok) {
+        // LOCAL resource failure (ibv_reg_mr), not the peer's fault: report the
+        // unprocessed remainder as kInvalid so the caller's health accounting
+        // does not MarkBad (cooldown) a healthy node for our own MR pressure.
+        for (size_t i = base; i < n; ++i) if (!bad[i]) res[i] = Status::kInvalid;
+        Release(node, c);
+        return res;
+      }
       // Scatter recv [hdr -> rbuf | payload -> caller buffer], then send the Range req.
       // Empty (n==0) dsts use a plain recv (the reply is just resp-prefix + header).
+      size_t posted = 0;
       for (size_t j = 0; j < w && conn_ok; ++j) {
+        if (bad[base + j]) continue;  // stays kInvalid; slot not posted
         bool armed = dsts[base + j].n
                          ? ep.PostRecvScatter(j, dsts[base + j].payload, dsts[base + j].n, mrs[j], hdr_bytes)
                          : ep.PostRecv(j);
         if (!armed) { conn_ok = false; break; }
         EncodeReq(ep.sbuf(j), WireOp::kRange, keys[base + j], 0, header_size + dsts[base + j].n, 0);
         if (!ep.PostSend(j, kReqPrefix)) { conn_ok = false; break; }
+        ++posted;
       }
       if (!conn_ok) break;
-      std::vector<ibv_wc> wcs(2 * w);
+      if (posted == 0) continue;  // whole window oversized
+      std::vector<ibv_wc> wcs(2 * posted);
       std::vector<uint32_t> rbytes(w, 0);
-      int need = static_cast<int>(2 * w);
+      int need = static_cast<int>(2 * posted);
       while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
+        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * posted), BatchTimeout());
         if (g <= 0) { conn_ok = false; break; }
         for (int i = 0; i < g; ++i) {
           if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
@@ -558,6 +571,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
       }
       if (!conn_ok) break;
       for (size_t j = 0; j < w; ++j) {
+        if (bad[base + j]) continue;
         uint32_t rb = rbytes[j];
         if (rb < kRespPrefix) continue;
         Status st; uint64_t dl = 0;
@@ -584,11 +598,12 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
   if (n == 0) return res;
   // Do not silently fall back to the base copy path: RDMA CacheFrom is the
   // connector's zero-copy PUT route, so oversize/reg failures are explicit.
-  for (const auto& s : srcs) {
-    if (s.header_len > control_cap_ - kReqPrefix || s.payload_len > OpBound()) {
-      std::fill(res.begin(), res.end(), Status::kInvalid);
-      return res;
-    }
+  // Per-item: an oversized item fails ONLY itself (kInvalid, ignored by the
+  // client's health accounting) — same fail-soft the multi variants ship.
+  std::vector<char> bad(n, 0);
+  for (size_t i = 0; i < n; ++i) {
+    const CacheSrc& s = srcs[i];
+    if (s.header_len > control_cap_ - kReqPrefix || s.payload_len > OpBound()) bad[i] = 1;
   }
 
   // 2-attempt loop: retry a stale pooled conn once on a fresh one. Cache is
@@ -596,6 +611,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
   // harmless. Mirrors RoundTrip. (MR-registration failure stays terminal.)
   for (int attempt = 0; attempt < 2; ++attempt) {
     std::fill(res.begin(), res.end(), Status::kIOError);
+    for (size_t i = 0; i < n; ++i) if (bad[i]) res[i] = Status::kInvalid;
     bool from_pool = false;
     Conn* c = Acquire(node, &from_pool, attempt > 0);
     if (!c) return res;
@@ -604,40 +620,50 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
     bool conn_ok = true;
     for (size_t base = 0; base < n && conn_ok; base += W) {
       const size_t w = std::min(W, n - base);
-      // Register the payload buffers (cached). Any failure => give the conn back
-      // and fall back to the copy path for the whole call (Cache is idempotent, so
-      // re-sending already-sent earlier windows is harmless — same as RangeInto).
+      // Register the payload buffers (cached).
       std::vector<ibv_mr*> mrs(w, nullptr);
       bool regok = true;
       for (size_t j = 0; j < w && regok; ++j) {
         const CacheSrc& s = srcs[base + j];
+        if (bad[base + j]) continue;       // oversized: slot never posted
         if (s.payload_len == 0) continue;  // empty value: header-only 1-SGE send, no MR
         // const_cast: a SEND source is only read by the NIC; the LOCAL_WRITE-only
         // MR is never written, and RegisterUser keys its cache by address.
         mrs[j] = ep.RegisterUser(const_cast<void*>(s.payload), s.payload_len);
         if (!mrs[j]) regok = false;
       }
-      if (!regok) { Release(node, c); return res; }
+      if (!regok) {
+        // LOCAL resource failure (ibv_reg_mr), not the peer's fault: kInvalid
+        // for the unprocessed remainder so health accounting does not MarkBad
+        // (cooldown) a healthy node for our own MR pressure.
+        for (size_t i = base; i < n; ++i) if (!bad[i]) res[i] = Status::kInvalid;
+        Release(node, c);
+        return res;
+      }
       // Build [req prefix | value header] into sbuf[j], scatter-send with the
       // payload coming straight from the caller's registered buffer. The wire
       // payload_len field is header_len + user payload_len (the full stored blob).
+      size_t posted = 0;
       for (size_t j = 0; j < w && conn_ok; ++j) {
         const CacheSrc& s = srcs[base + j];
+        if (bad[base + j]) continue;  // stays kInvalid; slot not posted
         EncodeReq(ep.sbuf(j), WireOp::kCache, s.key, 0, 0, s.header_len + s.payload_len);
         if (s.header_len) std::memcpy(ep.sbuf(j) + kReqPrefix, s.header, s.header_len);
         if (!ep.PostRecv(j)) { conn_ok = false; break; }
         if (!ep.PostSendScatter(j, kReqPrefix + s.header_len, s.payload, s.payload_len, mrs[j])) {
           conn_ok = false; break;
         }
+        ++posted;
       }
       if (!conn_ok) break;
-      // Reap 2*w completions (send + recv per slot) before reusing any slot or
-      // returning — the NIC reads the user payload until the SEND completes.
-      std::vector<ibv_wc> wcs(2 * w);
+      if (posted == 0) continue;  // whole window oversized
+      // Reap 2*posted completions (send + recv per posted slot) before reusing
+      // any slot or returning — the NIC reads the payload until SEND completes.
+      std::vector<ibv_wc> wcs(2 * posted);
       std::vector<uint32_t> rbytes(w, 0);
-      int need = static_cast<int>(2 * w);
+      int need = static_cast<int>(2 * posted);
       while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
+        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * posted), BatchTimeout());
         if (g <= 0) { conn_ok = false; break; }
         for (int i = 0; i < g; ++i) {
           if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
@@ -648,6 +674,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
       }
       if (!conn_ok) break;
       for (size_t j = 0; j < w; ++j) {
+        if (bad[base + j]) continue;
         Status st; uint64_t dl = 0;
         if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
       }

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -156,6 +156,31 @@ TEST(RdmaLoopback, BatchExistReusesPooledConn) {
       << " new conns; pipelined path should reuse the pooled connection";
 }
 
+// Non-SG batch PUT: one oversized item must fail ONLY itself, not poison the
+// whole same-node batch. Previously any item over the per-op payload bound
+// filled every sibling's status with kInvalid — all lost their cache write.
+TEST(RdmaLoopback, BatchPutOversizedFailsOnlyOffender) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  RdmaNode node("bpo");
+  RdmaTransport rt(kMaxMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+  std::string small(4096, 's');
+  std::string big(kMaxMsg + 4096, 'b');  // exceeds the per-op payload bound
+  std::vector<KvPutItem> items = {
+      {"bpo_a", small.data(), small.size()},
+      {"bpo_big", big.data(), big.size()},
+      {"bpo_c", small.data(), small.size()},
+  };
+  auto pr = c.BatchPut(items);
+  ASSERT_EQ(pr.size(), 3u);
+  EXPECT_TRUE(pr[0]) << "sibling poisoned by the oversized item";
+  EXPECT_FALSE(pr[1]);
+  EXPECT_TRUE(pr[2]) << "sibling poisoned by the oversized item";
+  EXPECT_TRUE(c.Exist("bpo_a"));
+  EXPECT_FALSE(c.Exist("bpo_big"));
+  EXPECT_TRUE(c.Exist("bpo_c"));
+}
+
 TEST(RdmaLoopback, PutGetExistMissOverRdma) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device (load rdma_rxe for Soft-RoCE)";
   RdmaNode node("pgem");


### PR DESCRIPTION
Phase-4 review batch (client robustness + fan-out efficiency):

1. **Persistent fan-out pool**: `RunParallel` created and joined up to 32 `std::thread`s **per Batch\* call** (~10-30 µs each + scheduler churn at connector batch rates). Replaced with a lazily-grown persistent pool (cap 32, leaky singleton, detached workers); the caller thread always participates so a job never waits on pool availability. A worker exception now degrades the *item* (slot keeps its pre-initialized miss/fail value) instead of escaping the thread entry and calling `std::terminate` — the serial path propagated, the parallel path killed the process.
2. **Per-item oversize (non-SG batch)**: `CacheFrom`/`RangeInto` filled the WHOLE same-node batch with `kInvalid` when any one item exceeded the per-op bound — every sibling lost its cache write/hit. Now the oversized item fails only itself (the multi variants already ship this fail-soft). New regression: `BatchPutOversizedFailsOnlyOffender`.
3. **Local reg-failure attribution**: a local `ibv_reg_mr` failure returned `kIOError` for the remainder, which made the caller `MarkBad` (cooldown) a healthy peer for the client's own MR pressure. Now `kInvalid` (already ignored by health accounting).

Validation: B200 real-HW: targeted suites green, kv_client_test 9/9, full ctest 347/349 (2 = pre-existing, fixed in #150). TSan job exercises the pool sync.