### PR TITLE
perf(cache): shard the RAM tier + thread-local uring rings — saturated 64K PUT +32%, p99 -74%

### DIFF
--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -58,6 +58,14 @@ bool PreadAll(int fd, void* buf, size_t n, uint64_t off) {
   }
   return true;
 }
+
+#ifdef DFKV_WITH_URING
+// Per-thread batched-write submission ring (see the long comment at the use
+// site in CacheDirectBatch). Store-agnostic: fds ride in the SQEs. Leaked at
+// thread exit by design (flush workers are process-lifetime; retiring on the
+// hygiene path recreates it lazily).
+thread_local io_uring* tls_uring_w = nullptr;
+#endif
 }  // namespace
 
 DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
@@ -137,13 +145,6 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
 }
 
 DiskSlabStore::~DiskSlabStore() {
-#ifdef DFKV_WITH_URING
-  if (uring_w_) {
-    io_uring_queue_exit(static_cast<io_uring*>(uring_w_));
-    delete static_cast<io_uring*>(uring_w_);
-    uring_w_ = nullptr;
-  }
-#endif
   if (reclaim_thread_.joinable()) {
     { std::lock_guard<std::mutex> lk(reclaim_mu_); reclaim_stop_ = true; }
     reclaim_cv_.notify_all();
@@ -437,13 +438,22 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
 #ifdef DFKV_WITH_URING
   bool did_uring = false;
   if (uring_write_enabled_ && direct_n >= 2) {
-    std::lock_guard<std::mutex> ulk(uring_w_mu_);
-    if (!uring_w_) {
+    // One submission ring PER THREAD: the previous single shared ring + mutex
+    // serialized every flush worker behind one lock held ACROSS the blocking
+    // CQE wait — at any instant only one worker was doing uring IO, which
+    // capped the batched path's gain over plain pwrite at ~10% (measured
+    // 45.0k -> 50.6k ops/s saturated 64 KiB PUT, 16 workers, B200 3xNVMe). A
+    // ring is only a submission channel (the fds ride in each SQE), so it can
+    // be thread-local and store-agnostic: no lock, no cross-worker convoy.
+    // The batch-hygiene invariant is per-ring and unchanged (a batch fully
+    // reaps its completions or the ring is retired). Rings leak at thread
+    // exit by design — flush workers live for the process.
+    if (!tls_uring_w) {
       auto* r = new io_uring;
-      if (io_uring_queue_init(256, r, 0) == 0) uring_w_ = r; else delete r;
+      if (io_uring_queue_init(256, r, 0) == 0) tls_uring_w = r; else delete r;
     }
-    if (uring_w_) {
-      auto* ring = static_cast<io_uring*>(uring_w_);
+    if (tls_uring_w) {
+      auto* ring = tls_uring_w;
       size_t submitted = 0;
       for (size_t i = 0; i < N; ++i) {
         if (!st[i].active || !st[i].direct) continue;
@@ -491,13 +501,13 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
         }
         if (!reap_ok || expect != submitted) {
           // Unreaped CQEs or unsubmitted SQEs remain: retire the ring so they
-          // die with it; the next batch re-inits a fresh one. The affected
-          // items keep io_ok=false and are rewritten by the sequential path
-          // below (their slots are exclusively owned by this flush, so the
-          // rewrite is idempotent).
+          // die with it; this thread's next batch re-inits a fresh one. The
+          // affected items keep io_ok=false and are rewritten by the
+          // sequential path below (their slots are exclusively owned by this
+          // flush, so the rewrite is idempotent).
           io_uring_queue_exit(ring);
           delete ring;
-          uring_w_ = nullptr;
+          tls_uring_w = nullptr;
         }
         did_uring = true;
         size_t batch_ok = 0;

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -215,8 +215,8 @@ class DiskSlabStore : public StoreEngine {
   std::atomic<uint64_t> batched_writes_{0};
   std::atomic<uint64_t> uring_write_batches_{0};
   bool uring_write_enabled_ = false;   // DFKV_SLAB_URING_WRITE (needs DFKV_WITH_URING build)
-  void* uring_w_ = nullptr;            // io_uring* (lazily created, guarded by uring_w_mu_)
-  std::mutex uring_w_mu_;
+  // The batched-write submission ring is thread_local (see disk_slab_store.cc):
+  // one per flush worker, no shared lock across the blocking CQE wait.
   std::vector<uint64_t> reclaim_last_puts_;  // reclaim-thread-local puts snapshot
   std::thread reclaim_thread_;
   std::condition_variable reclaim_cv_;

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -75,16 +75,46 @@ RamTier::RamTier(Options opt, FlushFn flush)
   }
   if (ext > opt_.bytes) ext = opt_.bytes;
   extent_bytes_ = ext;
-  SlabAllocator::Options ao;
-  ao.extent_bytes = ext;
-  ao.num_extents = static_cast<uint32_t>(std::max<uint64_t>(1, opt_.bytes / ext));
-  ao.align = opt_.slot_granularity;
-  ao.max_waste = 0.25;
-  alloc_ = std::make_unique<SlabAllocator>(ao);
-  const uint32_t nf = opt_.flush_threads ? opt_.flush_threads : 1;
+  const uint64_t total_extents = std::max<uint64_t>(1, opt_.bytes / ext);
+
+  // Shard count: enough shards to take the single lock off the hot path, few
+  // enough that every shard keeps a deep extent pool for class coexistence
+  // (>= 32 extents per shard). Small/test arenas degrade to 1 shard (identical
+  // to the pre-sharding behavior).
+  size_t nshards = 8;
+  if (const char* s = std::getenv("DFKV_RAM_TIER_SHARDS")) {
+    long v = std::strtol(s, nullptr, 10);
+    if (v >= 1 && v <= static_cast<long>(kMaxShards)) nshards = static_cast<size_t>(v);
+  }
+  nshards = std::min(nshards, kMaxShards);
+  while (nshards > 1 && total_extents / nshards < 32) nshards /= 2;
+  if (nshards < 1) nshards = 1;
+
+  const uint64_t ext_per_shard = total_extents / nshards;  // remainder unused (<1 extent/shard)
+  shards_.reserve(nshards);
+  for (size_t s = 0; s < nshards; ++s) {
+    auto sh = std::make_unique<Shard>();
+    sh->base_off = static_cast<uint64_t>(s) * ext_per_shard * ext;
+    SlabAllocator::Options ao;
+    ao.extent_bytes = ext;
+    ao.num_extents = static_cast<uint32_t>(ext_per_shard);
+    ao.align = opt_.slot_granularity;
+    ao.max_waste = 0.25;
+    sh->alloc = std::make_unique<SlabAllocator>(ao);
+    shards_.push_back(std::move(sh));
+  }
+  if (nshards > 1)
+    DFKV_LOG_INFO("ram tier sharded: " + std::to_string(nshards) + " shards x " +
+                  std::to_string(ext_per_shard) + " extents");
+
+  // Flush workers: distribute round-robin over shards, at least one per shard.
+  const uint32_t nf = std::max<uint32_t>(opt_.flush_threads ? opt_.flush_threads : 1,
+                                         static_cast<uint32_t>(nshards));
   flushers_.reserve(nf);
-  for (uint32_t i = 0; i < nf; ++i)
-    flushers_.emplace_back([this] { FlushLoop(); });
+  for (uint32_t i = 0; i < nf; ++i) {
+    Shard& s = *shards_[i % nshards];
+    flushers_.emplace_back([this, &s] { FlushLoop(s); });
+  }
   if (opt_.reclaim_interval_ms > 0) {
     reclaim_thread_ = std::thread([this] {
       std::unique_lock<std::mutex> lk(reclaim_mu_);
@@ -93,7 +123,7 @@ RamTier::RamTier(Options opt, FlushFn flush)
                              [this] { return reclaim_stop_; });
         if (reclaim_stop_) return;
         lk.unlock();
-        ReclaimTick();
+        for (size_t s = 0; s < shards_.size(); ++s) ReclaimTick(*shards_[s], s);
         lk.lock();
       }
     });
@@ -106,44 +136,42 @@ RamTier::~RamTier() {
     reclaim_cv_.notify_all();
     reclaim_thread_.join();
   }
-  {
-    std::lock_guard<std::mutex> lk(mu_);
-    stop_ = true;
+  for (auto& sh : shards_) {
+    std::lock_guard<std::mutex> lk(sh->mu);
+    sh->stop = true;
   }
-  flush_cv_.notify_all();
+  for (auto& sh : shards_) sh->cv.notify_all();
   for (auto& f : flushers_) if (f.joinable()) f.join();
   if (arena_) std::free(arena_);
 }
 
-// One reclaimer pass (mirror of DiskSlabStore::ReclaimTick, arena flavor): for
-// every class with new inserts since the last pass, top its free slots up to a
-// demand-driven watermark, in small batches per mu_ hold. Victims are unpinned
-// (== durable, no send in flight), so dropping them from index_ is the same
-// operation Put performs for its own inline evictions. This keeps Put's
-// allocator call on the pop-free-slot fast path; without it a full arena runs
-// the CLOCK sweep inline under mu_ on every admission.
-void RamTier::ReclaimTick() {
-  const auto classes = alloc_->Classes();
-  if (reclaim_last_puts_.size() < classes.size())
-    reclaim_last_puts_.resize(classes.size(), 0);
+// One reclaimer pass over one shard (mirror of DiskSlabStore::ReclaimTick,
+// arena flavor): for every class with new inserts since the last pass, top its
+// free slots up to a demand-driven watermark, in small batches per lock hold.
+// Victims are unpinned (== durable, no send in flight), so dropping them from
+// the index is the same operation Put performs for its own inline evictions.
+void RamTier::ReclaimTick(Shard& s, size_t /*shard_idx*/) {
+  const auto classes = s.alloc->Classes();
+  if (s.reclaim_last_puts.size() < classes.size())
+    s.reclaim_last_puts.resize(classes.size(), 0);
   std::vector<uint64_t> delta(classes.size(), 0);
   std::vector<uint32_t> extents(classes.size(), 0);
   for (size_t i = 0; i < classes.size(); ++i) {
-    delta[i] = classes[i].puts - reclaim_last_puts_[i];
-    reclaim_last_puts_[i] = classes[i].puts;
+    delta[i] = classes[i].puts - s.reclaim_last_puts[i];
+    s.reclaim_last_puts[i] = classes[i].puts;
     extents[i] = classes[i].extents;
   }
   // -- GROW -- (mirror of DiskSlabStore::ReclaimTick; see its comment)
   // Runs even while flush-gated, ON PURPOSE: a cold donor's extents hold
   // DURABLE residents, so moving them to the hot class frees admission
-  // capacity precisely when the flusher can't -- the arena's pinned mass is
+  // capacity precisely when the flusher can't -- the shard's pinned mass is
   // the hot class's own unflushed writes, not the donors'.
   for (size_t i = 0; i < classes.size(); ++i) {
     if (delta[i] == 0) continue;
     const auto& c = classes[i];
     size_t free_now = c.free_slots;
     const size_t want = std::max<size_t>(64, static_cast<size_t>(2 * delta[i]));
-    if (free_now >= want || c.slots_per_extent == 0 || alloc_->PoolExtents() > 0)
+    if (free_now >= want || c.slots_per_extent == 0 || s.alloc->PoolExtents() > 0)
       continue;
     size_t need_ext =
         (want - free_now + c.slots_per_extent - 1) / c.slots_per_extent;
@@ -162,9 +190,9 @@ void RamTier::ReclaimTick() {
       std::vector<std::string> evicted;
       bool ok;
       {
-        std::lock_guard<std::mutex> lk(mu_);
-        ok = alloc_->StealFrom(donor, i, &evicted);
-        for (const auto& ev : evicted) index_.erase(ev);
+        std::lock_guard<std::mutex> lk(s.mu);
+        ok = s.alloc->StealFrom(donor, i, &evicted);
+        for (const auto& ev : evicted) s.index.erase(ev);
       }
       if (!ok) { extents[donor] = 0; continue; }  // donor all pinned: try next
       extents[donor]--;
@@ -172,15 +200,14 @@ void RamTier::ReclaimTick() {
       --need_ext;
     }
   }
-  // Flush-gated regime: when the flush queue is deep, the arena is mostly
+  // Flush-gated regime: when the flush queue is deep, the shard is mostly
   // PINNED (not-yet-durable) slots -- free slots are not the admission
   // constraint, and a CLOCK sweep over a pinned-heavy ring just burns lock
   // time skipping entries. Skip the self-eviction phase; it resumes as the
-  // flusher catches up. 4096 = the per-tick eviction budget: below it one
-  // pass could plausibly matter, above it admission is flusher-bound.
+  // flusher catches up. The 4096 budget is per shard.
   {
-    std::lock_guard<std::mutex> lk(mu_);
-    if (flushq_.size() > 4096) return;
+    std::lock_guard<std::mutex> lk(s.mu);
+    if (s.flushq.size() > 4096) return;
   }
   // -- RECLAIM --
   for (size_t i = 0; i < classes.size(); ++i) {
@@ -196,9 +223,9 @@ void RamTier::ReclaimTick() {
       const size_t batch = std::min<size_t>(64, budget);
       size_t got;
       {
-        std::lock_guard<std::mutex> lk(mu_);
-        got = alloc_->ReclaimClass(i, target, batch, &evicted);
-        for (const auto& ev : evicted) index_.erase(ev);
+        std::lock_guard<std::mutex> lk(s.mu);
+        got = s.alloc->ReclaimClass(i, target, batch, &evicted);
+        for (const auto& ev : evicted) s.index.erase(ev);
       }
       if (got > 0) reclaimed_.fetch_add(got, std::memory_order_relaxed);
       budget -= std::min(budget, got);
@@ -210,131 +237,142 @@ void RamTier::ReclaimTick() {
 }
 
 void RamTier::SetArenaMr(void* mr) {
-  std::lock_guard<std::mutex> lk(mu_);
-  arena_mr_ = mr;
+  arena_mr_.store(mr, std::memory_order_release);
 }
 
 bool RamTier::Put(const BlockKey& key, const void* data, size_t len) {
   if (!arena_) return false;
   if (data == nullptr && len != 0) return false;
   const std::string fn = key.Filename();
+  Shard& s = ShardFor(fn);
 
   uint64_t offset = 0;
   uint32_t cap = 0;
   {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::lock_guard<std::mutex> lk(s.mu);
     // Resident, or another thread is mid-copy on this same (content-addressed)
     // key -> dedup. The in-progress writer produces identical bytes, so returning
     // "accepted" here is correct read-after-write for this key.
-    if (index_.count(fn) || writing_.count(fn)) return true;
+    if (s.index.count(fn) || s.writing.count(fn)) return true;
     SlabAllocator::SlotRef ref;
     std::vector<std::string> evicted;
-    if (!alloc_->Put(fn, len, &ref, &evicted)) {
-      // Backpressure (gap 10.3): arena full of non-evictable (flushing / in-
+    if (!s.alloc->Put(fn, len, &ref, &evicted)) {
+      // Backpressure (gap 10.3): shard full of non-evictable (flushing / in-
       // flight) slots. Decline -> caller does the normal synchronous disk write.
       put_bypass_.fetch_add(1, std::memory_order_relaxed);
       return false;
     }
-    for (const auto& ev : evicted) index_.erase(ev);  // evicted are durable+idle
+    for (const auto& ev : evicted) s.index.erase(ev);  // evicted are durable+idle
     // Flush-pin the slot: RAM_ONLY, not evictable until the async flush lands.
-    alloc_->Pin(fn);
-    writing_.insert(fn);  // reserve the key so a concurrent same-key Put dedups
-    offset = ref.extent * extent_bytes_ + ref.offset;  // global arena offset
-    cap = ref.slot_size;                               // (ref.offset is within-extent)
-    // NOT visible yet: index_ install is deferred until after the copy, so a
+    s.alloc->Pin(fn);
+    s.writing.insert(fn);  // reserve the key so a concurrent same-key Put dedups
+    offset = s.base_off + ref.extent * extent_bytes_ + ref.offset;  // global offset
+    cap = ref.slot_size;                                            // (within-extent)
+    // NOT visible yet: index install is deferred until after the copy, so a
     // concurrent GetPrep can't read the slot mid-copy.
   }
 
   std::memcpy(arena_ + offset, data, len);  // copy outside the lock (MB-scale)
 
   {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::lock_guard<std::mutex> lk(s.mu);
     Entry e;
     e.offset = offset;
     e.len = static_cast<uint32_t>(len);
     e.cap = cap;
     e.durable = false;
-    index_[fn] = e;
-    writing_.erase(fn);  // copy done -> now visible to GetPrep
-    flushq_.push_back(QItem{fn, key, 0});
+    s.index[fn] = e;
+    s.writing.erase(fn);  // copy done -> now visible to GetPrep
+    s.flushq.push_back(QItem{fn, key, 0});
   }
-  flush_cv_.notify_one();
+  s.cv.notify_one();
   puts_.fetch_add(1, std::memory_order_relaxed);
   return true;
 }
 
 bool RamTier::GetPrep(const BlockKey& key, uint64_t offset, uint64_t length,
                       Hit* out) {
+  if (shards_.empty()) return false;  // failed-construction guard (ok()==false)
   const std::string fn = key.Filename();
-  std::lock_guard<std::mutex> lk(mu_);
-  auto it = index_.find(fn);
-  if (it == index_.end()) {
+  const size_t sidx = std::hash<std::string>{}(fn) % shards_.size();
+  Shard& s = *shards_[sidx];
+  std::lock_guard<std::mutex> lk(s.mu);
+  auto it = s.index.find(fn);
+  if (it == s.index.end()) {
     misses_.fetch_add(1, std::memory_order_relaxed);
     return false;
   }
   const Entry& e = it->second;
   // Send-pin: the RDMA send reads the shared arena in place; the slot must not
   // be evicted/reused until the send completes (gap 10.1).
-  alloc_->Pin(fn);
+  s.alloc->Pin(fn);
   const uint64_t start = std::min<uint64_t>(offset, e.len);
   const uint64_t avail = e.len - start;
   const uint64_t n = std::min(length ? length : avail, avail);
   if (out) {
     out->ptr = arena_ + e.offset + start;
     out->len = static_cast<size_t>(n);
-    out->mr = arena_mr_;
-    out->token = next_token_++;
-    pinned_[out->token] = fn;
+    out->mr = arena_mr_.load(std::memory_order_acquire);
+    // Token encodes the shard so Release() routes without a global map.
+    out->token = (s.next_token++ << kTokenShardBits) | sidx;
+    s.pinned[out->token] = fn;
   }
   hits_.fetch_add(1, std::memory_order_relaxed);
   return true;
 }
 
 void RamTier::Release(uint64_t token) {
-  std::lock_guard<std::mutex> lk(mu_);
-  auto it = pinned_.find(token);
-  if (it == pinned_.end()) return;
-  alloc_->Unpin(it->second);  // release the send-pin
-  pinned_.erase(it);
+  if (shards_.empty()) return;
+  Shard& s = *shards_[(token & (kMaxShards - 1)) % shards_.size()];
+  std::lock_guard<std::mutex> lk(s.mu);
+  auto it = s.pinned.find(token);
+  if (it == s.pinned.end()) return;
+  s.alloc->Unpin(it->second);  // release the send-pin
+  s.pinned.erase(it);
 }
 
 bool RamTier::Contains(const BlockKey& key) const {
-  std::lock_guard<std::mutex> lk(mu_);
-  return index_.find(key.Filename()) != index_.end();
+  if (shards_.empty()) return false;
+  const std::string fn = key.Filename();
+  const Shard& s = ShardFor(fn);
+  std::lock_guard<std::mutex> lk(s.mu);
+  return s.index.find(fn) != s.index.end();
 }
 
 bool RamTier::Remove(const BlockKey& key) {
+  if (shards_.empty()) return false;
   const std::string fn = key.Filename();
-  std::lock_guard<std::mutex> lk(mu_);
-  auto it = index_.find(fn);
-  if (it == index_.end()) return false;
+  Shard& s = ShardFor(fn);
+  std::lock_guard<std::mutex> lk(s.mu);
+  auto it = s.index.find(fn);
+  if (it == s.index.end()) return false;
   // Best-effort for a cache: only a DURABLE, not-in-flight slot can be freed
   // safely. A still-flushing slot holds the flush-pin (the flusher owns it); an
   // in-flight slot holds a send-pin. Either way, decline -- the caller retries.
   if (!it->second.durable) return false;
   bool in_flight = false;
-  for (const auto& kv : pinned_) if (kv.second == fn) { in_flight = true; break; }
+  for (const auto& kv : s.pinned) if (kv.second == fn) { in_flight = true; break; }
   if (in_flight) return false;
-  DropLocked(fn);
+  DropLocked(s, fn);
   return true;
 }
 
-void RamTier::DropLocked(const std::string& fn) {
-  alloc_->Remove(fn);   // frees the slot (must be unpinned)
-  index_.erase(fn);
+void RamTier::DropLocked(Shard& s, const std::string& fn) {
+  s.alloc->Remove(fn);   // frees the slot (must be unpinned)
+  s.index.erase(fn);
 }
 
-void RamTier::FlushLoop() {
+void RamTier::FlushLoop(Shard& s) {
   for (;;) {
     // Drain up to kFlushBatchMax queued items in one pass (one worker's batch).
     std::vector<QItem> batch;
     {
-      std::unique_lock<std::mutex> lk(mu_);
-      flush_cv_.wait(lk, [this] { return stop_ || !flushq_.empty(); });
-      if (stop_ && flushq_.empty()) return;
-      while (!flushq_.empty() && batch.size() < kFlushBatchMax) {
-        batch.push_back(std::move(flushq_.front()));
-        flushq_.pop_front();
+      std::unique_lock<std::mutex> lk(s.mu);
+      s.cv.wait(lk, [&s] { return s.stop || !s.flushq.empty(); });
+      if (s.stop && s.flushq.empty()) return;
+      while (!s.flushq.empty() && batch.size() < kFlushBatchMax) {
+        batch.push_back(std::move(s.flushq.front()));
+        s.flushq.pop_front();
       }
     }
 
@@ -344,10 +382,10 @@ void RamTier::FlushLoop() {
     std::vector<FlushItem> items(B);
     std::vector<char> live(B, 0);
     {
-      std::lock_guard<std::mutex> lk(mu_);
+      std::lock_guard<std::mutex> lk(s.mu);
       for (size_t i = 0; i < B; ++i) {
-        auto it = index_.find(batch[i].fn);
-        if (it == index_.end() || it->second.durable) continue;  // gone/already done
+        auto it = s.index.find(batch[i].fn);
+        if (it == s.index.end() || it->second.durable) continue;  // gone/already done
         items[i] = FlushItem{batch[i].key, arena_ + it->second.offset,
                              it->second.len, it->second.cap};
         live[i] = 1;
@@ -374,23 +412,23 @@ void RamTier::FlushLoop() {
     if (!flush_ && !flush_batch_) for (size_t i = 0; i < B; ++i) ok[i] = live[i];
 
     {
-      std::lock_guard<std::mutex> lk(mu_);
+      std::lock_guard<std::mutex> lk(s.mu);
       for (size_t i = 0; i < B; ++i) {
         if (!live[i]) continue;
-        auto it = index_.find(batch[i].fn);
-        if (it == index_.end()) continue;  // defensive
+        auto it = s.index.find(batch[i].fn);
+        if (it == s.index.end()) continue;  // defensive
         if (ok[i]) {
           it->second.durable = true;
-          alloc_->Unpin(batch[i].fn);  // release the flush-pin -> now evictable
+          s.alloc->Unpin(batch[i].fn);  // release the flush-pin -> now evictable
           flushed_.fetch_add(1, std::memory_order_relaxed);
         } else if (++batch[i].tries < opt_.flush_retries) {
-          flushq_.push_back(std::move(batch[i]));  // retry later
-          flush_cv_.notify_one();
+          s.flushq.push_back(std::move(batch[i]));  // retry later
+          s.cv.notify_one();
         } else {
           // Give up: drop from RAM (releases flush-pin + frees slot). GET falls
           // back to a miss (recompute) -- correct cache semantics, no arena leak.
-          alloc_->Unpin(batch[i].fn);
-          DropLocked(batch[i].fn);
+          s.alloc->Unpin(batch[i].fn);
+          DropLocked(s, batch[i].fn);
           flush_dropped_.fetch_add(1, std::memory_order_relaxed);
         }
       }
@@ -398,14 +436,34 @@ void RamTier::FlushLoop() {
   }
 }
 
+uint64_t RamTier::Evictions() const {
+  uint64_t n = 0;
+  for (const auto& sh : shards_) n += sh->alloc->Evictions();
+  return n;
+}
+
+uint64_t RamTier::UsedBytes() const {
+  uint64_t n = 0;
+  for (const auto& sh : shards_) n += sh->alloc->UsedBytes();
+  return n;
+}
+
 size_t RamTier::Count() const {
-  std::lock_guard<std::mutex> lk(mu_);
-  return index_.size();
+  size_t n = 0;
+  for (const auto& sh : shards_) {
+    std::lock_guard<std::mutex> lk(sh->mu);
+    n += sh->index.size();
+  }
+  return n;
 }
 
 size_t RamTier::FlushBacklog() const {
-  std::lock_guard<std::mutex> lk(mu_);
-  return flushq_.size();
+  size_t n = 0;
+  for (const auto& sh : shards_) {
+    std::lock_guard<std::mutex> lk(sh->mu);
+    n += sh->flushq.size();
+  }
+  return n;
 }
 
 }  // namespace dfkv

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -23,6 +23,16 @@
  * Alignment (gap 10.4): the arena base is posix_memalign(4096) and slot sizes
  * are 4096-multiples, so a slot address is O_DIRECT-aligned for the flusher.
  *
+ * SHARDING: every op used to funnel through ONE mutex (index/alloc/flushq/pins)
+ * — with 16 serve threads + 16 flush workers the single lock was the measured
+ * write-path serialization point (each RAM op also took the allocator's lock
+ * UNDER it: two locks per op). The arena is still one allocation (one reg_mr),
+ * but it is partitioned into DFKV_RAM_TIER_SHARDS (default 8) independent
+ * shards — own SlabAllocator, mutex, index, flush queue and flush workers —
+ * routed by hash(key) so a key's whole lifecycle stays on one shard. Hot paths
+ * only contend within a shard. Backpressure is per shard (a full shard
+ * declines while others admit); the hash keeps that rare and unbiased.
+ *
  * Off by default (DFKV_RAM_TIER=0); this class is the standalone core, wired in
  * by later PRs. RDMA MR registration is deferred (SetArenaMr) so this stays
  * hermetically testable without libibverbs. */
@@ -53,20 +63,16 @@ class RamTier {
     uint64_t bytes = (4ull << 30);       // arena size (DFKV_RAM_TIER_BYTES)
     uint32_t slot_granularity = 4096;    // slot quantum (>= O_DIRECT align)
     uint32_t flush_retries = 3;          // per-item flush attempts before drop
-    // Flush worker threads draining the shared queue. One DIO stream sustains
-    // only ~1.6-3 GB/s -- far below the arena's ingest -- so the drain rate,
-    // not the arena size, decides when Put backpressure kicks in. The server
-    // defaults this to 4x the disk count, capped at 16 (small objects are
-    // IOPS-bound: one sync write per worker leaves NVMe queues nearly idle;
-    // 3 -> 16 workers measured +73% on 64 KiB saturated writes once the ingest
-    // lock contention was fixed). Same-key flushes can't run concurrently (one
-    // queued item per key at a time), so workers need no extra ordering.
+    // Flush worker threads draining the shard queues (distributed round-robin
+    // over the shards, at least one per shard). One DIO stream sustains only
+    // ~1.6-3 GB/s -- far below the arena's ingest -- so the drain rate, not
+    // the arena size, decides when Put backpressure kicks in. The server
+    // defaults this to 4x the disk count, capped at 16.
     uint32_t flush_threads = 1;
     // Background free-slot reclaimer cadence (ms; 0 = off). Keeps demand-driven
     // free-slot headroom per class so Put's allocator call stays pop-free-slot;
-    // without it a full arena runs the CLOCK eviction sweep inline under mu_ on
-    // every admission -- with tens of ingest threads that sweep is the measured
-    // write-path serialization point.
+    // without it a full arena runs the CLOCK eviction sweep inline under the
+    // shard lock on every admission.
     uint32_t reclaim_interval_ms = 10;
   };
 
@@ -97,7 +103,7 @@ class RamTier {
   };
 
   RamTier(Options opt, FlushFn flush);
-  ~RamTier();                // stops the flusher, joins
+  ~RamTier();                // stops the flushers, joins
 
   RamTier(const RamTier&) = delete;
   RamTier& operator=(const RamTier&) = delete;
@@ -106,8 +112,8 @@ class RamTier {
 
   // Write-through: copy into a RAM slot + make visible + enqueue flush. Returns
   // true if accepted into RAM (caller may skip the sync disk write; the flusher
-  // will persist). Returns false on backpressure (arena full of non-evictable
-  // slots) or if len exceeds the arena -- caller then does the normal disk write.
+  // will persist). Returns false on backpressure (shard full of non-evictable
+  // slots) or if len exceeds the shard -- caller then does the normal disk write.
   bool Put(const BlockKey& key, const void* data, size_t len);
 
   // On hit, pins the slot (send-pin) and returns its arena location. The caller
@@ -122,6 +128,7 @@ class RamTier {
   void SetArenaMr(void* mr);
   char* arena() const { return arena_; }
   uint64_t arena_bytes() const { return opt_.bytes; }
+  size_t shards() const { return shards_.size(); }  // test/diagnostic
 
   // metrics (relaxed)
   uint64_t Hits() const { return hits_.load(std::memory_order_relaxed); }
@@ -132,55 +139,71 @@ class RamTier {
   uint64_t FlushDropped() const { return flush_dropped_.load(std::memory_order_relaxed); }
   uint64_t Reclaimed() const { return reclaimed_.load(std::memory_order_relaxed); }
   uint64_t Rebalanced() const { return rebalanced_.load(std::memory_order_relaxed); }
-  uint64_t Evictions() const { return alloc_->Evictions(); }
-  uint64_t UsedBytes() const { return alloc_->UsedBytes(); }  // resident slot bytes
+  uint64_t Evictions() const;
+  uint64_t UsedBytes() const;   // resident slot bytes
   size_t Count() const;
   size_t FlushBacklog() const;  // queued, not-yet-durable items
 
  private:
   struct Entry {
-    uint64_t offset = 0;   // byte offset into arena_
+    uint64_t offset = 0;   // byte offset into arena_ (GLOBAL, not shard-local)
     uint32_t len = 0;      // payload length
     uint32_t cap = 0;      // slot size (>= len, 4 KiB multiple) -- flusher's DIO cap
     bool durable = false;  // flushed to disk (metrics; eviction uses alloc pin)
   };
   struct QItem { std::string fn; BlockKey key; uint32_t tries = 0; };
 
-  void FlushLoop();
+  // One independent slice of the tier. All state a key's lifecycle touches
+  // (allocator, index, writing set, send-pins, flush queue) lives here, under
+  // this shard's mutex only. base_off is the shard's byte offset into arena_.
+  struct Shard {
+    uint64_t base_off = 0;
+    std::unique_ptr<SlabAllocator> alloc;
+    mutable std::mutex mu;
+    std::unordered_map<std::string, Entry> index;
+    std::unordered_set<std::string> writing;
+    std::unordered_map<uint64_t, std::string> pinned;  // token -> fn (send-pins)
+    uint64_t next_token = 1;
+    std::deque<QItem> flushq;
+    std::condition_variable cv;
+    bool stop = false;
+    std::vector<uint64_t> reclaim_last_puts;  // reclaim-thread-local snapshot
+  };
+
+  Shard& ShardFor(const std::string& fn) {
+    return *shards_[std::hash<std::string>{}(fn) % shards_.size()];
+  }
+  const Shard& ShardFor(const std::string& fn) const {
+    return *shards_[std::hash<std::string>{}(fn) % shards_.size()];
+  }
+
+  void FlushLoop(Shard& s);
   // Max items one flush worker drains per store visit. Big enough to amortize
   // the two store-lock hops + reach a useful uring submit width, small enough
   // that a batch's slots stay flush-pinned only briefly.
   static constexpr size_t kFlushBatchMax = 16;
-  void ReclaimTick();  // one background grow + free-slot top-up pass (see Options)
+  // Send-pin tokens encode their shard in the low bits so Release() can route
+  // without a global map. 4 bits = up to 16 shards.
+  static constexpr int kTokenShardBits = 4;
+  static constexpr size_t kMaxShards = 1u << kTokenShardBits;
+  void ReclaimTick(Shard& s, size_t shard_idx);
   // Rebalance rate cap: extents moved per tick per hot class (32 MiB default
   // extents; converges in well under a second at the 10 ms tick).
   static constexpr size_t kGrowExtentsPerTick = 8;
-  void DropLocked(const std::string& fn);  // remove key from index_ + alloc + unpin
+  static void DropLocked(Shard& s, const std::string& fn);  // s.mu held
 
   Options opt_;
   FlushFn flush_;
   FlushBatchFn flush_batch_;
   char* arena_ = nullptr;
-  void* arena_mr_ = nullptr;
+  std::atomic<void*> arena_mr_{nullptr};
   uint64_t extent_bytes_ = 0;   // SlabAllocator extent size; global arena offset
-                                // of a slot = ref.extent * extent_bytes_ + ref.offset
-  std::unique_ptr<SlabAllocator> alloc_;
-
-  mutable std::mutex mu_;
-  std::unordered_map<std::string, Entry> index_;         // fn -> arena entry (visible)
-  // Keys whose slot is reserved+pinned but whose arena copy is still in progress
-  // (memcpy runs outside the lock so a GET never blocks on a PUT). A concurrent
-  // same-key Put sees this and dedups instead of copying the same slot twice.
-  std::unordered_set<std::string> writing_;
-  std::unordered_map<uint64_t, std::string> pinned_;     // token -> fn (send-pins)
-  uint64_t next_token_ = 1;
-  std::deque<QItem> flushq_;
-  std::condition_variable flush_cv_;
-  bool stop_ = false;
+                                // of a slot = shard.base_off + ref.extent *
+                                // extent_bytes_ + ref.offset
+  std::vector<std::unique_ptr<Shard>> shards_;
   std::vector<std::thread> flushers_;
   // Background free-slot reclaimer (own cv/mutex so shutdown never races the
-  // flushers' flush_cv_ protocol).
-  std::vector<uint64_t> reclaim_last_puts_;  // reclaim-thread-local puts snapshot
+  // flushers' cv protocol). One thread sweeps all shards.
   std::thread reclaim_thread_;
   std::condition_variable reclaim_cv_;
   std::mutex reclaim_mu_;

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -336,3 +336,42 @@ TEST(RamTier, BatchFlushDrainsQueueAndRetriesPerItem) {
   EXPECT_FALSE(rt.Contains(K(900))) << "dropped after retries";
   EXPECT_TRUE(rt.Contains(K(901)));
 }
+
+// Sharded tier: keys route by hash to independent shards; the whole lifecycle
+// (put -> visible -> flush -> durable -> get/pin/release -> remove) must hold
+// with shards > 1 exactly as with the single-lock layout.
+TEST(RamTier, ShardedLifecycleAcrossShards) {
+  ::setenv("DFKV_RAM_TIER_EXTENT_BYTES", "1048576", 1);  // 1 MiB extents
+  ::setenv("DFKV_RAM_TIER_SHARDS", "8", 1);
+  FlushSink sink;  // gate open by default
+  RamTier::Options o;
+  o.bytes = 256ull << 20;  // 256 extents -> 32/shard, keeps 8 shards
+  o.slot_granularity = 4096;
+  o.flush_threads = 8;
+  RamTier t(o, sink.fn());
+  ASSERT_TRUE(t.ok());
+  EXPECT_EQ(t.shards(), 8u);
+
+  const int N = 512;  // hash spreads these across all shards
+  std::string v(8000, 'x');
+  for (int i = 0; i < N; ++i) ASSERT_TRUE(t.Put(K(1000 + i), v.data(), v.size())) << i;
+  EXPECT_EQ(t.Count(), static_cast<size_t>(N));
+  // Wait for every shard's flushers to drain.
+  for (int spin = 0; spin < 500 && t.Flushed() < static_cast<uint64_t>(N); ++spin)
+    std::this_thread::sleep_for(10ms);
+  EXPECT_EQ(t.Flushed(), static_cast<uint64_t>(N));
+  EXPECT_EQ(t.FlushBacklog(), 0u);
+
+  // Every key readable; tokens (shard-encoded) release correctly.
+  for (int i = 0; i < N; ++i) {
+    RamTier::Hit h;
+    ASSERT_TRUE(t.GetPrep(K(1000 + i), 0, 0, &h)) << i;
+    EXPECT_EQ(h.len, v.size());
+    EXPECT_EQ(std::string(h.ptr, 16), v.substr(0, 16));
+    t.Release(h.token);
+  }
+  // Durable + idle -> removable, on whichever shard the key lives.
+  for (int i = 0; i < N; i += 7) EXPECT_TRUE(t.Remove(K(1000 + i))) << i;
+  ::unsetenv("DFKV_RAM_TIER_SHARDS");
+  ::unsetenv("DFKV_RAM_TIER_EXTENT_BYTES");
+}


### PR DESCRIPTION
Phase-4 batch 2 — the two serialization points left after v1.18-1.20, shipped together because the canary matrix shows they only win TOGETHER.

## Canary matrix (B200, 3xNVMe, saturated 196 GB 64 KiB PUT t16, same store state)

| build | ops/s | p99 |
|---|---|---|
| v1.20.0 (shared ring, single RamTier lock) | 46.7k | 1.31 ms |
| thread-local rings alone | 40.9k ⚠️ | 1.36 ms |
| **sharded RamTier + thread-local rings** | **61.7k (+32%)** | **0.34 ms (-74%)** |
| sharded RamTier, uring off | 59.7k | 0.35 ms |

The shared write ring's mutex (held across the blocking CQE wait) was accidentally *throttling* concurrency into the single RamTier lock — removing it alone made contention worse. Sharding the tier is the real lever; the lock-free rings then add their margin back and remove the convoy structurally.

## Changes

- **RamTier sharding**: arena stays ONE allocation (one `ibv_reg_mr`, RDMA wiring unchanged), partitioned into `DFKV_RAM_TIER_SHARDS` (default 8; small arenas degrade to 1 = the old layout exactly) independent shards — own SlabAllocator, mutex, index, writing set, send-pin map, flush queue and workers. A key's lifecycle stays on `hash(key)`'s shard. Send-pin tokens carry the shard in the low 4 bits so `Release()` routes without a global map. Reclaimer sweeps shards sequentially; backpressure/class-rebalance turn per-shard (each shard keeps ≥32 extents).
- **Thread-local uring rings**: a ring is only a submission channel (fds ride in the SQEs), so it needn't be shared — one per flush thread, no lock, batch-hygiene invariant (#151) unchanged and now per-ring.

## No-regression checks (warm, matched conditions)

2.75 MB PUT 38.9 GB/s (baseline 36.8) / GET 50.5 (49.7); 16 MB PUT p99 5.4 ms (20.3), fails=0; 64 KiB both PUT 67.8k / GET 150k (66k/147k). Full ctest **361/361** incl. new `ShardedLifecycleAcrossShards`; TSan green (concurrent lifecycle test).