### PR TITLE
fix(rdma-server): anchor pool MRs for the server's lifetime — kill the ~5 s first-op stall

### DIFF
--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -74,6 +74,24 @@ Status RdmaServer::Start(int port) {
   socklen_t sl = sizeof(sa);
   ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&sa), &sl);
   port_ = ntohs(sa.sin_port);
+  // Anchor the pool regions' MRs for the server's lifetime. The shared-device
+  // registry is refcounted by live endpoints: without an anchor, the moment
+  // the LAST client connection is torn down (disconnect or idle reclaim) the
+  // device closes and the pool MRs — arena-scale, seconds to pin — are
+  // deregistered, so the NEXT client's first op stalls ~5 s re-registering
+  // 128 GiB (observed on B200). The anchor endpoint holds one device ref and
+  // performs the registration once, HERE, where the cost is expected and
+  // reported. Only the configured device is anchored; a client requesting a
+  // different rail still pays that rail's first registration
+  // (SharedAddPoolMr logs slow ones).
+  if (!user_regions_.empty()) {
+    anchor_ep_ = std::make_unique<rdma::RcEndpoint>();
+    if (anchor_ep_->Open(dev_name_.empty() ? nullptr : dev_name_.c_str(), 4096, 1)) {
+      anchor_ep_->EnsurePoolMrs(user_regions_);
+    } else {
+      anchor_ep_.reset();  // no usable device: Serve would fail the same way
+    }
+  }
   running_ = true;
   accept_thread_ = std::thread([this] { AcceptLoop(); });
   return Status::kOk;
@@ -93,6 +111,7 @@ void RdmaServer::Stop() {
     conns.swap(conns_);
   }
   for (auto& c : conns) if (c.th.joinable()) c.th.join();
+  anchor_ep_.reset();  // drop the lifetime device ref (frees pool MRs last)
 }
 
 // Join and drop any Serve threads that have already finished. Called from

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -186,6 +186,8 @@ class RdmaServer {
   std::mutex conn_mu_;
   std::vector<Conn> conns_;
   std::unordered_set<rdma::RcEndpoint*> live_eps_;
+  // Lifetime device ref + one-time pool-MR registration (see Start()).
+  std::unique_ptr<rdma::RcEndpoint> anchor_ep_;
   std::atomic<uint64_t> uring_reads_{0}, uring_init_fallbacks_{0};
   std::atomic<uint64_t> completions_{0}, completion_errors_{0}, active_conns_{0},
       idle_reclaims_{0};

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -5,15 +5,17 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
-#include <atomic>
 #include <mutex>
 #include <random>
 #include <string>
 #include <unordered_map>
 #include <utility>
 
+#include "utils/log.h"        // slow pool-MR registration report
 #include "utils/net_util.h"   // PutU32/GetU32/PutU64 host-endian codec
 #include "utils/numa_util.h"  // best-effort NUMA buffer placement
 
@@ -109,8 +111,18 @@ ibv_mr* SharedAddPoolMr(ibv_context* ctx, ibv_pd* pd, void* base, size_t size) {
     if (d.second.ctx != ctx) continue;
     for (const auto& p : d.second.pool_mrs)
       if (p.base == b && p.size >= size) return p.mr;  // already registered on this PD
+    const auto t0 = std::chrono::steady_clock::now();
     ibv_mr* mr = ibv_reg_mr(pd, base, size, IBV_ACCESS_LOCAL_WRITE);
     if (!mr) return nullptr;
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - t0).count();
+    // Registering a huge (arena-scale) region pins every page: seconds of
+    // wall time. That must happen at startup (anchor endpoint), never on a
+    // connection's first op — a slow registration HERE at serve time means
+    // the anchor is missing or the region appeared late. Always log slow ones.
+    if (ms > 100)
+      DFKV_LOG_INFO("pool MR registered: " + std::to_string(size >> 20) +
+                    " MiB in " + std::to_string(ms) + " ms");
     g_pool_mr_regs.fetch_add(1, std::memory_order_relaxed);  // one actual registration
     d.second.pool_mrs.push_back(SharedPoolMr{b, size, mr});
     return mr;


### PR DESCRIPTION
Phase-4 investigation closed with a smoking gun.

**Symptom**: the first op of a new client connection stalled 4.9–5.2 s — after every server restart AND after idle gaps — while p50/p99 stayed sub-ms. Reproduced 6× on B200 canary benches; engine-independent (uring on/off identical).

**Root cause**: the shared-device registry is refcounted by live endpoints. When the last client connection died (process exit, or `DFKV_RDMA_IDLE_MS` reclaim), the device closed and the pool MRs were deregistered — the next client's first op re-registered the whole 128 GiB arena. With the fix's new timing log the cost is now visible: `pool MR registered: 131072 MiB in 4703 ms` — exactly the observed stall.

**Fix**: `RdmaServer::Start` opens a tiny anchor endpoint on the configured device and registers the pool regions once at startup (where the cost belongs and is reported). The anchor holds one device ref for the server's lifetime, so the refcount can never hit zero while serving. `SharedAddPoolMr` logs any registration over 100 ms — a slow line at serve time now means a missing anchor or a late region.

**Canary verification (B200)**: startup log shows the 4.7 s registration; first bench after restart: `max=325 ms` (previously 4874–5177 ms across 5 restarts). Long-lived inference connectors were never affected; new client processes and reconnect storms were, per occurrence.

Full ctest 360/360.