### PR TITLE
fix(rdma): client-side pool-MR anchor — register at declaration, not first op

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -222,12 +222,36 @@ RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, bool* from_
 
 void RdmaTransport::RegisterMemory(void* base, size_t size) {
   if (!base || size == 0) return;
-  std::lock_guard<std::mutex> lk(mu_);
-  for (const auto& p : pools_) if (p.first == base) return;  // dedup by base
-  pools_.push_back({base, size});
-  mr_regions_.fetch_add(1, std::memory_order_relaxed);
-  // Connections register this lazily on their next Acquire (EnsurePoolMrs); call
-  // before traffic so every connection's PD has the whole pool registered once.
+  std::vector<std::pair<void*, size_t>> pools;
+  std::vector<rdma::RcEndpoint*> anchor_ptrs;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    for (const auto& p : pools_) if (p.first == base) return;  // dedup by base
+    pools_.push_back({base, size});
+    mr_regions_.fetch_add(1, std::memory_order_relaxed);
+    // Anchor each configured rail: hold a lifetime device ref and register the
+    // pool MRs NOW, at declaration time (inference engines call this during
+    // startup), not on the first connection's first op. Registering a
+    // hundred-GB host KV pool pins every page (~4 s measured for 141 GB) —
+    // without the anchor that cost sat in the first lookup after every client
+    // process start, and the client mirror of the server-side dereg-on-idle
+    // cycle (fixed by the server anchor) could re-charge it. Mirrors
+    // RdmaServer::Start's anchor.
+    if (anchors_.empty()) {
+      for (const auto& d : devs_) {
+        auto ep = std::make_unique<rdma::RcEndpoint>();
+        if (ep->Open(d.empty() ? nullptr : d.c_str(), 4096, 1))
+          anchors_.push_back(std::move(ep));
+      }
+    }
+    pools = pools_;
+    for (auto& ep : anchors_) anchor_ptrs.push_back(ep.get());
+  }
+  // The actual (seconds-scale for huge pools) registration runs outside mu_;
+  // anchors_ itself is only ever filled once under mu_, so the snapshot of raw
+  // pointers stays valid for the transport's lifetime.
+  for (auto* ep : anchor_ptrs) ep->EnsurePoolMrs(pools);
+  // Connections still EnsurePoolMrs on Acquire (no-op once anchored here).
 }
 
 std::string RdmaTransport::MetricsText() const {

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -22,6 +22,7 @@
 #include "transport/transport.h"
 
 namespace dfkv {
+namespace rdma { class RcEndpoint; }
 
 class RdmaTransport : public Transport {
  public:
@@ -90,6 +91,9 @@ class RdmaTransport : public Transport {
   // Caller memory regions to register on every connection (the host KV pool).
   // Guarded by mu_; snapshotted in Acquire and registered on the connection.
   std::vector<std::pair<void*, size_t>> pools_;
+  // Lifetime per-rail device refs holding the pool MRs registered at
+  // RegisterMemory time (client-side anchor; see RegisterMemory). Filled once.
+  std::vector<std::unique_ptr<rdma::RcEndpoint>> anchors_;
   size_t max_payload_;
   // DCP1 declared max block bytes (DFKV_RDMA_MAX_BLOCK_BYTES, clamped to
   // max_payload_). 0 = undeclared: worst-case buffers both sides, old wire

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -338,6 +338,20 @@ TEST(RdmaLoopback, UserMrCapTracksDepth) {
       << "cap below depth*max_sge -> in-window MR eviction risk on SG batches";
 }
 
+// Client-side anchor: RegisterMemory must register the pool MRs at
+// DECLARATION time (holding a lifetime device ref), not on the first
+// connection's first op — a 141 GB host pool costs ~4 s to pin, which
+// belongs in engine startup, not the first lookup.
+TEST(RdmaLoopback, RegisterMemoryAnchorsPoolMrBeforeFirstConn) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  const uint64_t before = rdma::RcEndpoint::PoolMrRegistrations();
+  RdmaTransport rt(kMaxMsg);
+  std::vector<char> pool(256 * 1024);
+  rt.RegisterMemory(pool.data(), pool.size());
+  EXPECT_GT(rdma::RcEndpoint::PoolMrRegistrations(), before)
+      << "pool MR not registered at declaration time (anchor missing)";
+}
+
 TEST(RdmaLoopback, PoolMrSharedAcrossBuffers) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   rdma::RcEndpoint ep;


### PR DESCRIPTION
Phase-5, client mirror of the server anchor (#158).

Pool MRs were registered lazily on a connection's first `Acquire`, so an inference engine's **first lookup after process start** sat behind pinning its whole host KV pool — measured **4.32 s** for SGLang's 141 GB pool (phase-4 access log: the first `batch_exists` carried the entire registration).

`RegisterMemory` now opens one anchor endpoint per configured rail (lifetime device ref — the shared-device registry can never dereg the pool MRs while the client lives) and registers the declared regions immediately. Engines call `RegisterMemory` during startup, where seconds-scale pinning belongs; connections' `EnsurePoolMrs` becomes a no-op cache hit. The seconds-scale registration runs outside the transport mutex.

New test: `RegisterMemoryAnchorsPoolMrBeforeFirstConn` (pool MR count rises before any connection exists).

Validation: B200 real-HW full ctest **363/363**.