### PR TITLE
feat(client): same-host GET rendezvous over POSIX shm — dedup TP-replicated L3 loads

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -235,6 +235,13 @@ class DfkvHiCache(HiCacheStorage):
                       "rail selection in the client.", file=_sys.stderr, flush=True)
             if cfg.get("rdma_numa"):
                 os.environ.setdefault("DFKV_RDMA_NUMA", "1")
+            # Same-host GET rendezvous (phase 5): dedups TP-replicated L3 loads
+            # across the rank processes of one node. SAFE here because the
+            # HiCache pools are HOST memory (this connector's destinations are
+            # host KV pool pages); GPUDirect connectors must NOT enable it.
+            if _truthy(cfg.get("node_dedup",
+                               os.environ.get("DFKV_CLIENT_NODE_DEDUP", "0"))):
+                os.environ["DFKV_CLIENT_NODE_DEDUP"] = "1"
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -155,6 +155,9 @@ KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
     t_ = owned_.get();
     DFKV_LOG_INFO("dfkv client transport=" + transport_reason_);
   }
+  // Same-host GET rendezvous (phase 5). Off unless DFKV_CLIENT_NODE_DEDUP=1;
+  // namespaced by model_hash so distinct keyspaces never share entries.
+  dedup_ = NodeDedup::FromEnv(self_hdr_.model_hash);
   // Batch fan-out workers override (0/unset = auto; see set_batch_concurrency).
   if (const char* bc = std::getenv("DFKV_BATCH_CONCURRENCY")) {
     long x = std::strtol(bc, nullptr, 10);
@@ -594,6 +597,53 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
 }
 
 std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
+  if (!dedup_) return BatchGetDirect(items);
+  // Same-host rendezvous (phase 5): first arrival fetches a key, peers copy
+  // the published payload from shm — TP-replicated KV otherwise multiplies
+  // every load by the rank count. Every dedup outcome degrades to the plain
+  // remote path, so correctness never depends on the shm state.
+  const size_t N = items.size();
+  std::vector<bool> res(N, false);
+  std::vector<BlockKey> bks(N);
+  std::vector<KvGetItem> fetch_items;
+  std::vector<size_t> fetch_map, wait_list;
+  fetch_items.reserve(N);
+  for (size_t i = 0; i < N; ++i) {
+    bks[i] = ToBlockKey(items[i].key, self_hdr_.model_hash);
+    switch (dedup_->Claim(bks[i], items[i].n, static_cast<char*>(items[i].out))) {
+      case NodeDedup::Role::kHit:
+        res[i] = true;
+        break;
+      case NodeDedup::Role::kFetch:
+        fetch_map.push_back(i);
+        fetch_items.push_back(items[i]);
+        break;
+      case NodeDedup::Role::kWait:
+        wait_list.push_back(i);
+        break;
+    }
+  }
+  if (!fetch_items.empty()) {
+    auto r = BatchGetDirect(fetch_items);
+    for (size_t m = 0; m < fetch_map.size(); ++m) {
+      const size_t i = fetch_map[m];
+      res[i] = r[m];
+      if (r[m])
+        dedup_->Publish(bks[i], static_cast<const char*>(items[i].out), items[i].n);
+      else
+        dedup_->Abort(bks[i], items[i].n);
+    }
+  }
+  for (size_t i : wait_list) {
+    if (dedup_->WaitCopy(bks[i], items[i].n, static_cast<char*>(items[i].out)))
+      res[i] = true;
+    else  // fetcher failed/slow: bounded fallback to a direct read
+      res[i] = Get(items[i].key, items[i].out, items[i].n);
+  }
+  return res;
+}
+
+std::vector<bool> KVClient::BatchGetDirect(const std::vector<KvGetItem>& items) {
   auto t0 = std::chrono::steady_clock::now();
   const size_t N = items.size();
   std::vector<char> hit(N, 0);

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "utils/con_hash.h"
+#include "client/node_dedup.h"
 #include "common/membership.h"
 #include "mds/mds_member_poller.h"
 #include "mds/mds_registrar.h"
@@ -179,6 +180,9 @@ class KVClient {
   std::string Route(const std::string& key) const;
   uint64_t NowMs() const;
   void ProbeLoop();
+  // The plain (no-dedup) BatchGet body; BatchGet wraps it with the same-host
+  // rendezvous when DFKV_CLIENT_NODE_DEDUP=1 (see node_dedup.h).
+  std::vector<bool> BatchGetDirect(const std::vector<KvGetItem>& items);
   // Record a batch op (hits = count of true flags) into op_stats_ and return the
   // per-item result vector. Called at each batch method's return point.
   std::vector<bool> RecordBatch(OpMetrics::Op op,
@@ -198,6 +202,9 @@ class KVClient {
     return AutoBatchWorkers(batch_concurrency_.load(std::memory_order_relaxed), groups);
   }
   std::unique_ptr<MdsMemberPoller> poller_;
+  // Same-host GET rendezvous (phase 5, DFKV_CLIENT_NODE_DEDUP=1; host-memory
+  // destinations only). nullptr = feature off.
+  std::unique_ptr<NodeDedup> dedup_;
   std::unique_ptr<MdsRegistrar> client_registrar_;  // consumer identity lease (best-effort)
   PeerHealth health_;
   OpMetrics op_stats_;  // per-op (put/get/exist) counters + latency, snapshot'd

--- a/src/client/node_dedup.cc
+++ b/src/client/node_dedup.cc
@@ -1,0 +1,304 @@
+#include "client/node_dedup.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+#include "utils/log.h"
+
+namespace dfkv {
+
+namespace {
+constexpr uint32_t kMagic = 0x44445631u;  // "DDV1"
+constexpr uint32_t kStateEmpty = 0;
+constexpr uint32_t kStateFetching = 1;
+constexpr uint32_t kStateReady = 2;
+
+uint64_t EnvU64(const char* name, uint64_t dflt) {
+  const char* v = std::getenv(name);
+  if (!v || !*v) return dflt;
+  unsigned long long x = std::strtoull(v, nullptr, 10);
+  return x > 0 ? static_cast<uint64_t>(x) : dflt;
+}
+
+uint32_t Pow2AtLeast(uint32_t v) {
+  uint32_t p = 1024;
+  while (p < v && p < (1u << 24)) p <<= 1;
+  return p;
+}
+}  // namespace
+
+// 64-byte slot. gen is a seqlock over {key identity, payload location}: odd
+// while a writer mutates, +1 to even when coherent. state transitions are CAS
+// (only EMPTY->FETCHING, expired-READY->FETCHING, FETCHING->READY/EMPTY).
+struct NodeDedup::Slot {
+  std::atomic<uint64_t> gen;
+  std::atomic<uint32_t> state;
+  uint32_t len;                        // payload byte count (== every peer's n)
+  uint64_t key_id;
+  uint32_t key_index;
+  uint32_t pad0;
+  std::atomic<uint64_t> fetch_start_ms;
+  uint64_t payload_off;                // absolute offset into the arena
+  uint64_t alloc_seq;                  // arena cursor value at allocation (lap check)
+  uint64_t pad1;                       // -> 64 B (cache-line / cross-process ABI)
+};
+
+struct NodeDedup::Header {
+  uint32_t magic;
+  uint32_t nslots;
+  uint64_t arena_bytes;
+  std::atomic<uint64_t> alloc_cursor;  // monotonic bytes allocated (ring = mod arena)
+  std::atomic<uint32_t> init_done;     // 1 once the creator finished laying out
+  uint32_t pad;
+};
+
+uint64_t NodeDedup::NowMs() {
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+std::unique_ptr<NodeDedup> NodeDedup::FromEnv(uint64_t model_hash) {
+  const char* on = std::getenv("DFKV_CLIENT_NODE_DEDUP");
+  if (!on || std::strcmp(on, "1") != 0) return nullptr;
+  Options o;
+  o.arena_bytes = EnvU64("DFKV_NODE_DEDUP_ARENA_MB", 512) << 20;
+  o.slots = static_cast<uint32_t>(EnvU64("DFKV_NODE_DEDUP_SLOTS", 65536));
+  o.wait_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_WAIT_MS", 500));
+  o.takeover_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TAKEOVER_MS", 2000));
+  o.ttl_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TTL_MS", 5000));
+  char name[128];
+  // uid-scoped so unrelated users on one host can't share (or collide on) a
+  // segment; model_hash separates keyspaces (same salting as the block keys).
+  std::snprintf(name, sizeof(name), "/dfkv-dedup-%u-%016llx", ::getuid(),
+                static_cast<unsigned long long>(model_hash));
+  o.name = name;
+  return Open(o);
+}
+
+std::unique_ptr<NodeDedup> NodeDedup::Open(const Options& opt) {
+  static_assert(sizeof(Slot) == 64, "shm slot layout is cross-process ABI");
+  const uint32_t nslots = Pow2AtLeast(opt.slots);
+  const size_t len = sizeof(Header) + static_cast<size_t>(nslots) * sizeof(Slot) +
+                     opt.arena_bytes;
+  int fd = ::shm_open(opt.name.c_str(), O_RDWR | O_CREAT, 0600);
+  if (fd < 0) return nullptr;
+  // Every opener ftruncates to ITS computed size; a config mismatch is caught
+  // by the header check below (first writer wins the layout).
+  struct stat st{};
+  if (::fstat(fd, &st) != 0) { ::close(fd); return nullptr; }
+  const bool creator = (st.st_size == 0);
+  if (creator && ::ftruncate(fd, static_cast<off_t>(len)) != 0) {
+    ::close(fd);
+    return nullptr;
+  }
+  if (!creator && static_cast<size_t>(st.st_size) != len) {
+    DFKV_LOG_INFO("node-dedup: existing segment layout mismatch, running without");
+    ::close(fd);
+    return nullptr;
+  }
+  void* base = ::mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  ::close(fd);
+  if (base == MAP_FAILED) return nullptr;
+
+  auto d = std::unique_ptr<NodeDedup>(new NodeDedup());
+  d->map_base_ = base;
+  d->map_len_ = len;
+  d->hdr_ = static_cast<Header*>(base);
+  d->slots_ = reinterpret_cast<Slot*>(static_cast<char*>(base) + sizeof(Header));
+  d->arena_ = reinterpret_cast<char*>(d->slots_) + static_cast<size_t>(nslots) * sizeof(Slot);
+  d->arena_bytes_ = opt.arena_bytes;
+  d->nslots_ = nslots;
+  d->wait_ms_ = opt.wait_ms;
+  d->takeover_ms_ = opt.takeover_ms;
+  d->ttl_ms_ = opt.ttl_ms;
+
+  if (creator) {
+    // Fresh (ftruncate zero-fills): stamp the header last so concurrent
+    // openers either see a zero magic (spin briefly) or a finished layout.
+    d->hdr_->nslots = nslots;
+    d->hdr_->arena_bytes = opt.arena_bytes;
+    d->hdr_->alloc_cursor.store(0, std::memory_order_relaxed);
+    d->hdr_->magic = kMagic;
+    d->hdr_->init_done.store(1, std::memory_order_release);
+  } else {
+    for (int spin = 0; spin < 1000 && d->hdr_->init_done.load(std::memory_order_acquire) != 1; ++spin)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    if (d->hdr_->magic != kMagic || d->hdr_->nslots != nslots ||
+        d->hdr_->arena_bytes != opt.arena_bytes) {
+      DFKV_LOG_INFO("node-dedup: segment header mismatch, running without");
+      return nullptr;  // unique_ptr dtor munmaps
+    }
+  }
+  DFKV_LOG_INFO("node-dedup: attached " + opt.name + " (slots=" +
+                std::to_string(nslots) + ", arena=" +
+                std::to_string(opt.arena_bytes >> 20) + " MiB)");
+  return d;
+}
+
+NodeDedup::~NodeDedup() {
+  if (map_base_) ::munmap(map_base_, map_len_);
+  // The segment itself is intentionally left in place: peers may still use it,
+  // and a later process re-attaches. Bounded size; no growth over time.
+}
+
+NodeDedup::Slot* NodeDedup::Find(const BlockKey& key, size_t n) const {
+  const uint32_t mask = nslots_ - 1;
+  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index) & mask;
+  for (int probe = 0; probe < 8; ++probe, idx = (idx + 1) & mask) {
+    Slot& s = slots_[idx];
+    if (s.state.load(std::memory_order_acquire) == kStateEmpty) continue;
+    if (s.key_id == key.id && s.key_index == key.index && s.len == n) return &s;
+  }
+  return nullptr;
+}
+
+NodeDedup::Slot* NodeDedup::Reserve(const BlockKey& key, size_t n) {
+  const uint64_t now = NowMs();
+  const uint32_t mask = nslots_ - 1;
+  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index) & mask;
+  for (int probe = 0; probe < 8; ++probe, idx = (idx + 1) & mask) {
+    Slot& s = slots_[idx];
+    uint32_t st = s.state.load(std::memory_order_acquire);
+    bool claim = false;
+    if (st == kStateEmpty) {
+      claim = s.state.compare_exchange_strong(st, kStateFetching,
+                                              std::memory_order_acq_rel);
+    } else if (st == kStateReady &&
+               now - s.fetch_start_ms.load(std::memory_order_relaxed) >
+                   static_cast<uint64_t>(ttl_ms_)) {
+      claim = s.state.compare_exchange_strong(st, kStateFetching,
+                                              std::memory_order_acq_rel);
+    }
+    if (!claim) continue;
+    // Slot reserved: mutate identity under an odd generation so a concurrent
+    // Find/CopyOut on the OLD occupant tears predictably (gen mismatch).
+    s.gen.fetch_add(1, std::memory_order_acq_rel);  // -> odd
+    s.key_id = key.id;
+    s.key_index = key.index;
+    s.len = static_cast<uint32_t>(n);
+    s.payload_off = 0;
+    s.alloc_seq = 0;
+    s.fetch_start_ms.store(now, std::memory_order_relaxed);
+    s.gen.fetch_add(1, std::memory_order_release);  // -> even, coherent
+    return &s;
+  }
+  return nullptr;  // probe window full: run without dedup for this key
+}
+
+bool NodeDedup::CopyOut(Slot* s, size_t n, char* dst) const {
+  const uint64_t g0 = s->gen.load(std::memory_order_acquire);
+  if (g0 & 1) return false;  // writer active
+  if (s->state.load(std::memory_order_acquire) != kStateReady) return false;
+  if (s->len != n) return false;
+  const uint64_t off = s->payload_off;
+  const uint64_t seq = s->alloc_seq;
+  if (off + n > arena_bytes_) return false;  // torn metadata: bail
+  // Lap check BEFORE the copy: if the ring cursor has advanced more than one
+  // lap past this allocation, the payload bytes may already be overwritten.
+  if (hdr_->alloc_cursor.load(std::memory_order_acquire) - seq > arena_bytes_ - n)
+    return false;
+  std::memcpy(dst, arena_ + off, n);
+  // ... and AFTER: the copy is only valid if the payload stayed un-lapped and
+  // the slot generation did not move during the copy.
+  if (hdr_->alloc_cursor.load(std::memory_order_acquire) - seq > arena_bytes_ - n)
+    return false;
+  return s->gen.load(std::memory_order_acquire) == g0;
+}
+
+NodeDedup::Role NodeDedup::Claim(const BlockKey& key, size_t n, char* dst) {
+  if (n == 0 || n > arena_bytes_ / 2) return Role::kFetch;  // oversize: no dedup
+  const uint64_t now = NowMs();
+  if (Slot* s = Find(key, n)) {
+    const uint32_t st = s->state.load(std::memory_order_acquire);
+    if (st == kStateReady) {
+      if (now - s->fetch_start_ms.load(std::memory_order_relaxed) <=
+              static_cast<uint64_t>(ttl_ms_) &&
+          CopyOut(s, n, dst)) {
+        hits_.fetch_add(1, std::memory_order_relaxed);
+        return Role::kHit;
+      }
+      // Expired/torn: fall through to Reserve (may recycle this very slot).
+    } else if (st == kStateFetching) {
+      const uint64_t started = s->fetch_start_ms.load(std::memory_order_relaxed);
+      if (now - started <= static_cast<uint64_t>(takeover_ms_)) return Role::kWait;
+      // Fetcher looks dead: take the fetch over (CAS on fetch_start_ms so
+      // exactly one waiter wins; the loser just waits on the winner).
+      uint64_t expect = started;
+      if (s->fetch_start_ms.compare_exchange_strong(expect, now,
+                                                    std::memory_order_acq_rel)) {
+        fetches_.fetch_add(1, std::memory_order_relaxed);
+        return Role::kFetch;
+      }
+      return Role::kWait;
+    }
+  }
+  if (Reserve(key, n)) {
+    fetches_.fetch_add(1, std::memory_order_relaxed);
+    return Role::kFetch;
+  }
+  return Role::kFetch;  // no slot available: plain fetch, nothing to publish
+}
+
+void NodeDedup::Publish(const BlockKey& key, const char* data, size_t n) {
+  Slot* s = Find(key, n);
+  if (!s || s->state.load(std::memory_order_acquire) != kStateFetching) return;
+  // Ring-allocate: reserve [cur, cur+n) contiguously; skip the tail remainder
+  // when a lap boundary would split the payload.
+  uint64_t cur = hdr_->alloc_cursor.load(std::memory_order_relaxed);
+  uint64_t off, seq;
+  for (;;) {
+    const uint64_t in_lap = cur % arena_bytes_;
+    const uint64_t need = (in_lap + n > arena_bytes_) ? (arena_bytes_ - in_lap) + n : n;
+    if (hdr_->alloc_cursor.compare_exchange_weak(cur, cur + need,
+                                                 std::memory_order_acq_rel)) {
+      seq = cur + need;              // cursor AFTER this allocation
+      off = (cur + need - n) % arena_bytes_;  // payload sits at the end of the grab
+      break;
+    }
+  }
+  std::memcpy(arena_ + off, data, n);
+  s->gen.fetch_add(1, std::memory_order_acq_rel);   // odd: mutating
+  s->payload_off = off;
+  s->alloc_seq = seq;
+  s->fetch_start_ms.store(NowMs(), std::memory_order_relaxed);  // TTL from publish
+  s->gen.fetch_add(1, std::memory_order_release);   // even: coherent
+  s->state.store(kStateReady, std::memory_order_release);
+}
+
+void NodeDedup::Abort(const BlockKey& key, size_t n) {
+  Slot* s = Find(key, n);
+  if (!s) return;
+  // Only the fetcher aborts. Freeing the slot immediately (instead of letting
+  // it age into a takeover) lets a waiter that falls back re-claim at once;
+  // CAS so a concurrent takeover winner isn't clobbered.
+  uint32_t st = kStateFetching;
+  s->state.compare_exchange_strong(st, kStateEmpty, std::memory_order_acq_rel);
+}
+
+bool NodeDedup::WaitCopy(const BlockKey& key, size_t n, char* dst) {
+  const uint64_t deadline = NowMs() + static_cast<uint64_t>(wait_ms_);
+  int backoff_us = 50;
+  for (;;) {
+    Slot* s = Find(key, n);
+    if (s && s->state.load(std::memory_order_acquire) == kStateReady &&
+        CopyOut(s, n, dst)) {
+      wait_hits_.fetch_add(1, std::memory_order_relaxed);
+      return true;
+    }
+    if (NowMs() >= deadline) {
+      wait_timeouts_.fetch_add(1, std::memory_order_relaxed);
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(backoff_us));
+    if (backoff_us < 1000) backoff_us *= 2;
+  }
+}
+
+}  // namespace dfkv

--- a/src/client/node_dedup.h
+++ b/src/client/node_dedup.h
@@ -1,0 +1,118 @@
+/* NodeDedup — same-host GET rendezvous over POSIX shared memory.
+ *
+ * Motivation (phase 5): TP-replicated KV (MLA/DSA latent) is written by one
+ * rank but read back by EVERY rank — 8x fabric traffic and 8x server read
+ * load per L3 prefix load (measured on GLM-5.2 TP8). The ranks are same-host
+ * processes requesting the SAME key set within milliseconds (measured 12 ms
+ * spread vs ~44 ms per fetch batch), so a plain look-aside cache misses: by
+ * the time rank N checks, rank 0's fetch is still in flight. What dedups the
+ * fetch is a RENDEZVOUS: the first arrival claims a key (FETCHING), fetches
+ * it remotely and publishes the payload; the others wait briefly and copy —
+ * with a hard deadline that falls back to a direct fetch, so no failure mode
+ * is worse than today's 8x behavior.
+ *
+ * Correctness model (lock-free, crash-robust):
+ *  - Index slot state machine EMPTY -> FETCHING -> READY guarded by CAS; a
+ *    FETCHING older than takeover_ms (fetcher died/hung) can be re-claimed.
+ *  - Payload arena is a ring with a MONOTONIC allocation cursor; readers
+ *    validate "my payload's lap has not been overwritten" (cursor - alloc_seq
+ *    <= arena - len) before AND after the copy, plus a per-slot seqlock
+ *    generation for slot reuse. A failed validation is just a miss.
+ *  - Nothing here is load-bearing for correctness of the cache itself: every
+ *    exit path (no slot, timeout, torn read, size mismatch) degrades to the
+ *    caller's normal remote fetch.
+ *
+ * SCOPE: host-memory destinations only (the SGLang HiCache path). GPUDirect
+ * destinations (vLLM connector) must NOT enable this — memcpy to a device VA
+ * is invalid; that path needs CUDA IPC and stays with the Phase-2b design.
+ * Off by default (DFKV_CLIENT_NODE_DEDUP=1 opts in). */
+#ifndef DFKV_NODE_DEDUP_H_
+#define DFKV_NODE_DEDUP_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "common/kv_types.h"
+
+namespace dfkv {
+
+class NodeDedup {
+ public:
+  struct Options {
+    std::string name;              // shm name (leading '/'); see MakeName()
+    uint64_t arena_bytes = 512ull << 20;   // DFKV_NODE_DEDUP_ARENA_MB
+    uint32_t slots = 65536;                // DFKV_NODE_DEDUP_SLOTS (pow2 forced)
+    int wait_ms = 500;                     // DFKV_NODE_DEDUP_WAIT_MS
+    int takeover_ms = 2000;                // DFKV_NODE_DEDUP_TAKEOVER_MS
+    int ttl_ms = 5000;                     // DFKV_NODE_DEDUP_TTL_MS
+  };
+
+  // Builds Options from the environment; returns nullptr (feature off) unless
+  // DFKV_CLIENT_NODE_DEDUP=1. model_hash namespaces the segment so distinct
+  // keyspaces on one host never share entries.
+  static std::unique_ptr<NodeDedup> FromEnv(uint64_t model_hash);
+  // Opens (or creates) the shm segment. Returns nullptr on any failure — the
+  // caller just runs without dedup. A parameter mismatch with an existing
+  // segment also returns nullptr (never reinterpret another config's layout).
+  static std::unique_ptr<NodeDedup> Open(const Options& opt);
+  ~NodeDedup();
+
+  NodeDedup(const NodeDedup&) = delete;
+  NodeDedup& operator=(const NodeDedup&) = delete;
+
+  // Per-key verdict for a batch pass.
+  enum class Role {
+    kHit,    // payload copied into dst (done — skip the remote fetch)
+    kFetch,  // caller owns the fetch; MUST call Publish or Abort afterwards
+    kWait,   // someone else is fetching; call WaitCopy after issuing own batch
+  };
+
+  // Classify one key. n = the exact byte count this caller will read; only a
+  // published payload of exactly n bytes is a hit (lockstep peers request the
+  // same n; anything else falls back to a direct fetch).
+  Role Claim(const BlockKey& key, size_t n, char* dst);
+
+  // Fetch outcomes for keys claimed as kFetch.
+  void Publish(const BlockKey& key, const char* data, size_t n);
+  void Abort(const BlockKey& key, size_t n);
+
+  // Wait (poll, bounded by wait_ms) for a kWait key and copy it into dst.
+  // false = timeout/torn/mismatch — caller fetches directly.
+  bool WaitCopy(const BlockKey& key, size_t n, char* dst);
+
+  // diagnostics (relaxed; process-local)
+  uint64_t hits() const { return hits_.load(std::memory_order_relaxed); }
+  uint64_t fetches() const { return fetches_.load(std::memory_order_relaxed); }
+  uint64_t wait_hits() const { return wait_hits_.load(std::memory_order_relaxed); }
+  uint64_t wait_timeouts() const { return wait_timeouts_.load(std::memory_order_relaxed); }
+
+ private:
+  struct Slot;    // 64-byte shm index slot
+  struct Header;  // shm header
+  NodeDedup() = default;
+
+  Slot* Find(const BlockKey& key, size_t n) const;      // matching live slot or null
+  Slot* Reserve(const BlockKey& key, size_t n);         // claim a slot as FETCHING
+  bool CopyOut(Slot* s, size_t n, char* dst) const;     // seqlock+lap validated copy
+  static uint64_t NowMs();
+
+  Header* hdr_ = nullptr;
+  Slot* slots_ = nullptr;
+  char* arena_ = nullptr;
+  uint64_t arena_bytes_ = 0;
+  uint32_t nslots_ = 0;       // power of two
+  int wait_ms_ = 500;
+  int takeover_ms_ = 2000;
+  int ttl_ms_ = 5000;
+  void* map_base_ = nullptr;
+  size_t map_len_ = 0;
+
+  std::atomic<uint64_t> hits_{0}, fetches_{0}, wait_hits_{0}, wait_timeouts_{0};
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_NODE_DEDUP_H_

--- a/test/client/node_dedup_test.cc
+++ b/test/client/node_dedup_test.cc
@@ -1,0 +1,184 @@
+// NodeDedup: same-host GET rendezvous over POSIX shm. Hermetic (no RDMA/etcd);
+// cross-process behavior via fork. Every test uses its own uniquely-named
+// segment and unlinks it, so runs never interfere.
+#include "client/node_dedup.h"
+
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+using dfkv::BlockKey;
+using dfkv::NodeDedup;
+using namespace std::chrono_literals;
+
+namespace {
+
+struct ShmGuard {
+  std::string name;
+  explicit ShmGuard(const std::string& tag)
+      : name("/dfkv-dedup-test-" + std::to_string(::getpid()) + "-" + tag) {
+    ::shm_unlink(name.c_str());
+  }
+  ~ShmGuard() { ::shm_unlink(name.c_str()); }
+};
+
+NodeDedup::Options Opts(const std::string& name, uint64_t arena = 4 << 20) {
+  NodeDedup::Options o;
+  o.name = name;
+  o.arena_bytes = arena;
+  o.slots = 1024;
+  o.wait_ms = 300;
+  o.takeover_ms = 200;
+  o.ttl_ms = 1000;
+  return o;
+}
+
+BlockKey K(uint64_t id) { return BlockKey{id, 0, 1}; }
+
+std::string Val(uint64_t id, size_t n) {
+  std::string v(n, '\0');
+  for (size_t i = 0; i < n; ++i) v[i] = static_cast<char>((id * 131 + i) & 0xFF);
+  return v;
+}
+
+}  // namespace
+
+TEST(NodeDedup, FetchPublishThenPeersHit) {
+  ShmGuard g("basic");
+  auto a = NodeDedup::Open(Opts(g.name));
+  auto b = NodeDedup::Open(Opts(g.name));  // second attach (peer)
+  ASSERT_TRUE(a && b);
+  const std::string v = Val(1, 8192);
+  std::string dst(v.size(), '\0');
+
+  ASSERT_EQ(a->Claim(K(1), v.size(), &dst[0]), NodeDedup::Role::kFetch);
+  a->Publish(K(1), v.data(), v.size());
+  ASSERT_EQ(b->Claim(K(1), v.size(), &dst[0]), NodeDedup::Role::kHit);
+  EXPECT_EQ(dst, v);
+  EXPECT_EQ(b->hits(), 1u);
+}
+
+TEST(NodeDedup, WaiterCopiesAfterPublish) {
+  ShmGuard g("wait");
+  auto a = NodeDedup::Open(Opts(g.name));
+  auto b = NodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a && b);
+  const std::string v = Val(2, 65536);
+  std::string dst_a(v.size(), '\0'), dst_b(v.size(), '\0');
+
+  ASSERT_EQ(a->Claim(K(2), v.size(), &dst_a[0]), NodeDedup::Role::kFetch);
+  ASSERT_EQ(b->Claim(K(2), v.size(), &dst_b[0]), NodeDedup::Role::kWait);
+  std::thread pub([&] {
+    std::this_thread::sleep_for(50ms);
+    a->Publish(K(2), v.data(), v.size());
+  });
+  EXPECT_TRUE(b->WaitCopy(K(2), v.size(), &dst_b[0]));
+  pub.join();
+  EXPECT_EQ(dst_b, v);
+  EXPECT_EQ(b->wait_hits(), 1u);
+}
+
+TEST(NodeDedup, AbortLetsWaiterFallBack) {
+  ShmGuard g("abort");
+  auto a = NodeDedup::Open(Opts(g.name));
+  auto b = NodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a && b);
+  std::string dst(4096, '\0');
+  ASSERT_EQ(a->Claim(K(3), dst.size(), &dst[0]), NodeDedup::Role::kFetch);
+  ASSERT_EQ(b->Claim(K(3), dst.size(), &dst[0]), NodeDedup::Role::kWait);
+  a->Abort(K(3), dst.size());
+  // The waiter's bounded poll must return false (fall back to a direct fetch),
+  // never hang.
+  EXPECT_FALSE(b->WaitCopy(K(3), dst.size(), &dst[0]));
+  EXPECT_EQ(b->wait_timeouts(), 1u);
+}
+
+TEST(NodeDedup, DeadFetcherIsTakenOver) {
+  ShmGuard g("takeover");
+  auto a = NodeDedup::Open(Opts(g.name));
+  auto b = NodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a && b);
+  std::string dst(4096, '\0');
+  ASSERT_EQ(a->Claim(K(4), dst.size(), &dst[0]), NodeDedup::Role::kFetch);
+  // a never publishes (simulated crash). After takeover_ms a peer claims the
+  // fetch instead of waiting forever.
+  std::this_thread::sleep_for(250ms);  // > takeover_ms(200)
+  EXPECT_EQ(b->Claim(K(4), dst.size(), &dst[0]), NodeDedup::Role::kFetch);
+}
+
+TEST(NodeDedup, TtlExpiryRecyclesEntry) {
+  ShmGuard g("ttl");
+  auto o = Opts(g.name);
+  o.ttl_ms = 100;
+  auto a = NodeDedup::Open(o);
+  ASSERT_TRUE(a);
+  const std::string v = Val(5, 4096);
+  std::string dst(v.size(), '\0');
+  ASSERT_EQ(a->Claim(K(5), v.size(), &dst[0]), NodeDedup::Role::kFetch);
+  a->Publish(K(5), v.data(), v.size());
+  ASSERT_EQ(a->Claim(K(5), v.size(), &dst[0]), NodeDedup::Role::kHit);
+  std::this_thread::sleep_for(150ms);  // > ttl
+  // Expired: a new arrival re-fetches instead of serving stale bytes.
+  EXPECT_EQ(a->Claim(K(5), v.size(), &dst[0]), NodeDedup::Role::kFetch);
+}
+
+TEST(NodeDedup, LappedArenaNeverServesOverwrittenBytes) {
+  ShmGuard g("lap");
+  auto a = NodeDedup::Open(Opts(g.name, /*arena=*/1 << 20));  // 1 MiB ring
+  ASSERT_TRUE(a);
+  const std::string v = Val(6, 128 * 1024);
+  std::string dst(v.size(), '\0');
+  ASSERT_EQ(a->Claim(K(6), v.size(), &dst[0]), NodeDedup::Role::kFetch);
+  a->Publish(K(6), v.data(), v.size());
+  // Lap the ring: publish > arena_bytes of other payloads.
+  for (uint64_t i = 100; i < 100 + 12; ++i) {
+    const std::string w = Val(i, 128 * 1024);
+    std::string tmp(w.size(), '\0');
+    if (a->Claim(K(i), w.size(), &tmp[0]) == NodeDedup::Role::kFetch)
+      a->Publish(K(i), w.data(), w.size());
+  }
+  // K(6)'s payload region has been overwritten: the entry must NOT hit with
+  // stale bytes — any non-kHit outcome (re-fetch) is correct; a kHit MUST
+  // still carry the exact original value (possible if the slot was recycled
+  // and republished, which this workload doesn't do).
+  std::string out(v.size(), '\1');
+  if (a->Claim(K(6), v.size(), &out[0]) == NodeDedup::Role::kHit)
+    EXPECT_EQ(out, v);
+}
+
+TEST(NodeDedup, CrossProcessRendezvous) {
+  ShmGuard g("fork");
+  const std::string v = Val(7, 32768);
+  auto parent = NodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(parent);
+  std::string dst(v.size(), '\0');
+  ASSERT_EQ(parent->Claim(K(7), v.size(), &dst[0]), NodeDedup::Role::kFetch);
+  parent->Publish(K(7), v.data(), v.size());
+
+  pid_t pid = ::fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0) {  // child: attach and hit
+    auto child = NodeDedup::Open(Opts(g.name));
+    if (!child) ::_exit(2);
+    std::string cdst(v.size(), '\0');
+    if (child->Claim(K(7), v.size(), &cdst[0]) != NodeDedup::Role::kHit) ::_exit(3);
+    if (cdst != v) ::_exit(4);
+    ::_exit(0);
+  }
+  int status = 0;
+  ASSERT_EQ(::waitpid(pid, &status, 0), pid);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0) << "child exit code";
+}
+
+TEST(NodeDedup, DisabledByDefaultFromEnv) {
+  ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
+  EXPECT_EQ(NodeDedup::FromEnv(0x51), nullptr);
+}

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -13,6 +13,8 @@
 #include "common/value_header.h"
 
 #include <gtest/gtest.h>
+#include <sys/mman.h>  // shm_unlink (node-dedup test)
+#include <unistd.h>
 
 #include <chrono>
 #include <cstdlib>
@@ -182,6 +184,54 @@ TEST(RdmaLoopback, BatchPutOversizedFailsOnlyOffender) {
   EXPECT_TRUE(c.Exist("bpo_a"));
   EXPECT_FALSE(c.Exist("bpo_big"));
   EXPECT_TRUE(c.Exist("bpo_c"));
+}
+
+// Same-host GET rendezvous (phase 5): with DFKV_CLIENT_NODE_DEDUP=1, a second
+// client reading the SAME keys must be served from the shm rendezvous, not the
+// server — server-side completions stay ~flat while the data stays correct.
+TEST(RdmaLoopback, NodeDedupCollapsesSameHostGets) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  char nm[128];
+  std::snprintf(nm, sizeof(nm), "/dfkv-dedup-%u-%016llx",
+                ::getuid(), static_cast<unsigned long long>(SelfHdr().model_hash));
+  ::shm_unlink(nm);
+  ::setenv("DFKV_CLIENT_NODE_DEDUP", "1", 1);
+  {
+    RdmaNode node("ndd");
+    RdmaTransport rt1(kMaxMsg), rt2(kMaxMsg);
+    KVClient c1({{"n", node.addr}}, SelfHdr(), &rt1);
+    KVClient c2({{"n", node.addr}}, SelfHdr(), &rt2);
+
+    const int N = 32;
+    std::vector<std::string> vals(N);
+    for (int i = 0; i < N; ++i) {
+      vals[i].assign(8192, '\0');
+      for (size_t b = 0; b < vals[i].size(); ++b)
+        vals[i][b] = static_cast<char>((i * 131 + b * 7) & 0xFF);
+      ASSERT_TRUE(c1.Put("ndd" + std::to_string(i), vals[i].data(), vals[i].size())) << i;
+    }
+
+    auto get_all = [&](KVClient& c, std::vector<std::string>* out) {
+      std::vector<KvGetItem> items(N);
+      out->assign(N, std::string(8192, '\0'));
+      for (int i = 0; i < N; ++i)
+        items[i] = {"ndd" + std::to_string(i), &(*out)[i][0], 8192};
+      return c.BatchGet(items);
+    };
+
+    std::vector<std::string> o1, o2;
+    auto r1 = get_all(c1, &o1);  // first reader: remote fetch + publish
+    for (int i = 0; i < N; ++i) { ASSERT_TRUE(r1[i]) << i; EXPECT_EQ(o1[i], vals[i]); }
+    const long mid = CounterVal(node.rsrv->MetricsText(), "dfkv_rdma_completions_total");
+    auto r2 = get_all(c2, &o2);  // peer: rendezvous hits, no server traffic
+    for (int i = 0; i < N; ++i) { ASSERT_TRUE(r2[i]) << i; EXPECT_EQ(o2[i], vals[i]); }
+    const long after = CounterVal(node.rsrv->MetricsText(), "dfkv_rdma_completions_total");
+    EXPECT_LE(after - mid, N / 4)
+        << "peer reads reached the server (" << (after - mid)
+        << " completions); rendezvous not deduplicating";
+  }
+  ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
+  ::shm_unlink(nm);
 }
 
 TEST(RdmaLoopback, PutGetExistMissOverRdma) {


### PR DESCRIPTION
Phase-5 main course: TP-replicated KV (MLA/DSA latent) is written once but read back by EVERY rank — **8× fabric traffic and 8× server read load** per L3 prefix load (measured on GLM-5.2 TP8: 1.12 GB written, 8.94 GB read back). The ranks request the SAME key set within **12 ms** while one fetch batch takes ~44 ms, so a look-aside cache misses — only a **rendezvous** dedups: first arrival claims the key (CAS EMPTY→FETCHING), fetches remotely, publishes to shm; peers wait (bounded 500 ms) and copy.

## Design (lock-free, crash-robust)

- `NodeDedup`: uid+model_hash-namespaced shm segment — CAS-claimed index slots (seqlock generations) over a monotonic-cursor **ring arena with lap validation** (reader checks `cursor − alloc_seq ≤ arena − len` before AND after the copy).
- Dead fetcher → takeover after 2 s; READY entries expire after 5 s (non-lockstep arrivals still hit); torn/lapped/mismatched reads are just misses.
- **Every exit path degrades to the plain remote fetch** — the shm state is never load-bearing for correctness.

## Scope

- Wired into `KVClient::BatchGet` (the SGLang HiCache read path, where the 8× was measured).
- **Host-memory destinations only.** GPUDirect connectors (vLLM) must not enable it — that path stays with the Phase-2b design (CUDA IPC).
- **Off by default**: `DFKV_CLIENT_NODE_DEDUP=1`, or hicache `extra_config.node_dedup=true`.

## Tests

8 hermetic NodeDedup cases (rendezvous, waiter-copy, abort-fallback, dead-fetcher takeover, TTL recycle, ring-lap safety, **fork cross-process**, env-off) + loopback integration: a second client reading the same 32 keys leaves server RDMA completions flat while data stays byte-correct.

Validation: B200 real-HW full ctest **371/371**. Canary SGLang 8-rank measurement follows in the release notes.