### PR TITLE
feat(client): extend the same-host rendezvous to BatchGetAuto and BatchExist; export dedup metrics

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -284,6 +284,20 @@ std::string KVClient::MetricsSnapshot() const {
   s += health_.Render();
   s += peer_lat_.Render();
   s += op_stats_.Render();
+  if (dedup_) {
+    s += "# HELP dfkv_client_dedup_hits_total Rendezvous results served from shm\n";
+    s += "# TYPE dfkv_client_dedup_hits_total counter\n";
+    s += "dfkv_client_dedup_hits_total " + std::to_string(dedup_->hits()) + "\n";
+    s += "# HELP dfkv_client_dedup_fetches_total Keys this process fetched for the rendezvous\n";
+    s += "# TYPE dfkv_client_dedup_fetches_total counter\n";
+    s += "dfkv_client_dedup_fetches_total " + std::to_string(dedup_->fetches()) + "\n";
+    s += "# HELP dfkv_client_dedup_wait_hits_total Waits resolved by a peer's publish\n";
+    s += "# TYPE dfkv_client_dedup_wait_hits_total counter\n";
+    s += "dfkv_client_dedup_wait_hits_total " + std::to_string(dedup_->wait_hits()) + "\n";
+    s += "# HELP dfkv_client_dedup_wait_timeouts_total Waits that fell back to a direct fetch\n";
+    s += "# TYPE dfkv_client_dedup_wait_timeouts_total counter\n";
+    s += "dfkv_client_dedup_wait_timeouts_total " + std::to_string(dedup_->wait_timeouts()) + "\n";
+  }
   if (t_) s += t_->MetricsText();
   return s;
 }
@@ -629,9 +643,10 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
       const size_t i = fetch_map[m];
       res[i] = r[m];
       if (r[m])
-        dedup_->Publish(bks[i], static_cast<const char*>(items[i].out), items[i].n);
+        dedup_->Publish(bks[i], NodeDedup::Kind::kData,
+                        static_cast<const char*>(items[i].out), items[i].n);
       else
-        dedup_->Abort(bks[i], items[i].n);
+        dedup_->Abort(bks[i], NodeDedup::Kind::kData);
     }
   }
   for (size_t i : wait_list) {
@@ -703,6 +718,65 @@ std::vector<bool> KVClient::BatchGetDirect(const std::vector<KvGetItem>& items) 
 
 std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
                                          std::vector<size_t>* out_lens) {
+  if (!dedup_) return BatchGetAutoDirect(items, out_lens);
+  // Same-host rendezvous, variable-size flavor: identity is the key; a
+  // published payload hits any reader whose cap fits it (see node_dedup.h).
+  const size_t N = items.size();
+  std::vector<bool> res(N, false);
+  std::vector<size_t> lens(N, 0);
+  std::vector<BlockKey> bks(N);
+  std::vector<KvGetItem> fetch_items;
+  std::vector<size_t> fetch_map, wait_list;
+  fetch_items.reserve(N);
+  for (size_t i = 0; i < N; ++i) {
+    bks[i] = ToBlockKey(items[i].key, self_hdr_.model_hash);
+    size_t got = 0;
+    switch (dedup_->ClaimAuto(bks[i], items[i].n, static_cast<char*>(items[i].out), &got)) {
+      case NodeDedup::Role::kHit:
+        res[i] = true;
+        lens[i] = got;
+        break;
+      case NodeDedup::Role::kFetch:
+        fetch_map.push_back(i);
+        fetch_items.push_back(items[i]);
+        break;
+      case NodeDedup::Role::kWait:
+        wait_list.push_back(i);
+        break;
+    }
+  }
+  if (!fetch_items.empty()) {
+    std::vector<size_t> flens;
+    auto r = BatchGetAutoDirect(fetch_items, &flens);
+    for (size_t m = 0; m < fetch_map.size(); ++m) {
+      const size_t i = fetch_map[m];
+      res[i] = r[m];
+      if (r[m]) {
+        lens[i] = flens[m];
+        dedup_->Publish(bks[i], NodeDedup::Kind::kData,
+                        static_cast<const char*>(items[i].out), flens[m]);
+      } else {
+        dedup_->Abort(bks[i], NodeDedup::Kind::kData);
+      }
+    }
+  }
+  for (size_t i : wait_list) {
+    size_t got = 0;
+    if (dedup_->WaitCopyAuto(bks[i], items[i].n, static_cast<char*>(items[i].out), &got)) {
+      res[i] = true;
+      lens[i] = got;
+    } else {  // fetcher failed/slow: bounded fallback to a direct read
+      size_t got2 = 0;
+      res[i] = GetAuto(items[i].key, items[i].out, items[i].n, &got2);
+      if (res[i]) lens[i] = got2;
+    }
+  }
+  if (out_lens) *out_lens = std::move(lens);
+  return res;
+}
+
+std::vector<bool> KVClient::BatchGetAutoDirect(const std::vector<KvGetItem>& items,
+                                         std::vector<size_t>* out_lens) {
   auto t0 = std::chrono::steady_clock::now();
   const size_t N = items.size();
   std::vector<char> hit(N, 0);
@@ -766,6 +840,51 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
 }
 
 std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
+  if (!dedup_) return BatchExistDirect(keys);
+  // Exist probes ride the rendezvous with a 1-byte answer. NEGATIVE answers
+  // are published too (a valid result, unlike a failed GET); staleness is
+  // bounded by the TTL and safe both ways (stale absent -> recompute, stale
+  // present -> the GET misses and recomputes).
+  const size_t N = keys.size();
+  std::vector<bool> res(N, false);
+  std::vector<BlockKey> bks(N);
+  std::vector<std::string> fetch_keys;
+  std::vector<size_t> fetch_map, wait_list;
+  fetch_keys.reserve(N);
+  for (size_t i = 0; i < N; ++i) {
+    bks[i] = ToBlockKey(keys[i], self_hdr_.model_hash);
+    bool val = false;
+    switch (dedup_->ClaimExist(bks[i], &val)) {
+      case NodeDedup::Role::kHit:
+        res[i] = val;
+        break;
+      case NodeDedup::Role::kFetch:
+        fetch_map.push_back(i);
+        fetch_keys.push_back(keys[i]);
+        break;
+      case NodeDedup::Role::kWait:
+        wait_list.push_back(i);
+        break;
+    }
+  }
+  if (!fetch_keys.empty()) {
+    auto r = BatchExistDirect(fetch_keys);
+    for (size_t m = 0; m < fetch_map.size(); ++m) {
+      const size_t i = fetch_map[m];
+      res[i] = r[m];
+      const char b = r[m] ? 1 : 0;
+      dedup_->Publish(bks[i], NodeDedup::Kind::kExist, &b, 1);
+    }
+  }
+  for (size_t i : wait_list) {
+    bool val = false;
+    if (dedup_->WaitExist(bks[i], &val)) res[i] = val;
+    else res[i] = Exist(keys[i]);  // bounded fallback
+  }
+  return res;
+}
+
+std::vector<bool> KVClient::BatchExistDirect(const std::vector<std::string>& keys) {
   auto t0 = std::chrono::steady_clock::now();
   const size_t N = keys.size();
   std::vector<char> e(N, 0);

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -180,9 +180,12 @@ class KVClient {
   std::string Route(const std::string& key) const;
   uint64_t NowMs() const;
   void ProbeLoop();
-  // The plain (no-dedup) BatchGet body; BatchGet wraps it with the same-host
-  // rendezvous when DFKV_CLIENT_NODE_DEDUP=1 (see node_dedup.h).
+  // The plain (no-dedup) batch bodies; the public methods wrap them with the
+  // same-host rendezvous when DFKV_CLIENT_NODE_DEDUP=1 (see node_dedup.h).
   std::vector<bool> BatchGetDirect(const std::vector<KvGetItem>& items);
+  std::vector<bool> BatchGetAutoDirect(const std::vector<KvGetItem>& items,
+                                       std::vector<size_t>* out_lens);
+  std::vector<bool> BatchExistDirect(const std::vector<std::string>& keys);
   // Record a batch op (hits = count of true flags) into op_stats_ and return the
   // per-item result vector. Called at each batch method's return point.
   std::vector<bool> RecordBatch(OpMetrics::Op op,

--- a/src/client/node_dedup.cc
+++ b/src/client/node_dedup.cc
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <thread>
@@ -15,10 +16,11 @@
 namespace dfkv {
 
 namespace {
-constexpr uint32_t kMagic = 0x44445631u;  // "DDV1"
+constexpr uint32_t kMagic = 0x44445632u;  // "DDV2" (v2: identity = key+kind)
 constexpr uint32_t kStateEmpty = 0;
 constexpr uint32_t kStateFetching = 1;
 constexpr uint32_t kStateReady = 2;
+constexpr size_t kAnyLen = SIZE_MAX;  // CopyOut strict_n wildcard
 
 uint64_t EnvU64(const char* name, uint64_t dflt) {
   const char* v = std::getenv(name);
@@ -34,20 +36,20 @@ uint32_t Pow2AtLeast(uint32_t v) {
 }
 }  // namespace
 
-// 64-byte slot. gen is a seqlock over {key identity, payload location}: odd
-// while a writer mutates, +1 to even when coherent. state transitions are CAS
-// (only EMPTY->FETCHING, expired-READY->FETCHING, FETCHING->READY/EMPTY).
+// 64-byte slot. gen is a seqlock over {identity, payload location}: odd while
+// a writer mutates, +1 to even when coherent. state transitions are CAS-only
+// (EMPTY->FETCHING, expired-READY->FETCHING, FETCHING->READY/EMPTY).
 struct NodeDedup::Slot {
   std::atomic<uint64_t> gen;
   std::atomic<uint32_t> state;
-  uint32_t len;                        // payload byte count (== every peer's n)
+  uint32_t len;                        // payload byte count (attribute, not identity)
   uint64_t key_id;
   uint32_t key_index;
-  uint32_t pad0;
+  uint32_t kind;                       // Kind: data vs exist namespace
   std::atomic<uint64_t> fetch_start_ms;
   uint64_t payload_off;                // absolute offset into the arena
   uint64_t alloc_seq;                  // arena cursor value at allocation (lap check)
-  uint64_t pad1;                       // -> 64 B (cache-line / cross-process ABI)
+  uint64_t pad1;                       // -> 64 B (cache line / cross-process ABI)
 };
 
 struct NodeDedup::Header {
@@ -89,8 +91,6 @@ std::unique_ptr<NodeDedup> NodeDedup::Open(const Options& opt) {
                      opt.arena_bytes;
   int fd = ::shm_open(opt.name.c_str(), O_RDWR | O_CREAT, 0600);
   if (fd < 0) return nullptr;
-  // Every opener ftruncates to ITS computed size; a config mismatch is caught
-  // by the header check below (first writer wins the layout).
   struct stat st{};
   if (::fstat(fd, &st) != 0) { ::close(fd); return nullptr; }
   const bool creator = (st.st_size == 0);
@@ -121,7 +121,7 @@ std::unique_ptr<NodeDedup> NodeDedup::Open(const Options& opt) {
 
   if (creator) {
     // Fresh (ftruncate zero-fills): stamp the header last so concurrent
-    // openers either see a zero magic (spin briefly) or a finished layout.
+    // openers either spin briefly on init_done or see a finished layout.
     d->hdr_->nslots = nslots;
     d->hdr_->arena_bytes = opt.arena_bytes;
     d->hdr_->alloc_cursor.store(0, std::memory_order_relaxed);
@@ -148,21 +148,25 @@ NodeDedup::~NodeDedup() {
   // and a later process re-attaches. Bounded size; no growth over time.
 }
 
-NodeDedup::Slot* NodeDedup::Find(const BlockKey& key, size_t n) const {
+NodeDedup::Slot* NodeDedup::Find(const BlockKey& key, Kind kind) const {
   const uint32_t mask = nslots_ - 1;
-  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index) & mask;
+  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index ^
+                                       (static_cast<uint32_t>(kind) << 13)) & mask;
   for (int probe = 0; probe < 8; ++probe, idx = (idx + 1) & mask) {
     Slot& s = slots_[idx];
     if (s.state.load(std::memory_order_acquire) == kStateEmpty) continue;
-    if (s.key_id == key.id && s.key_index == key.index && s.len == n) return &s;
+    if (s.key_id == key.id && s.key_index == key.index &&
+        s.kind == static_cast<uint32_t>(kind))
+      return &s;
   }
   return nullptr;
 }
 
-NodeDedup::Slot* NodeDedup::Reserve(const BlockKey& key, size_t n) {
+NodeDedup::Slot* NodeDedup::Reserve(const BlockKey& key, Kind kind) {
   const uint64_t now = NowMs();
   const uint32_t mask = nslots_ - 1;
-  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index) & mask;
+  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index ^
+                                       (static_cast<uint32_t>(kind) << 13)) & mask;
   for (int probe = 0; probe < 8; ++probe, idx = (idx + 1) & mask) {
     Slot& s = slots_[idx];
     uint32_t st = s.state.load(std::memory_order_acquire);
@@ -182,7 +186,8 @@ NodeDedup::Slot* NodeDedup::Reserve(const BlockKey& key, size_t n) {
     s.gen.fetch_add(1, std::memory_order_acq_rel);  // -> odd
     s.key_id = key.id;
     s.key_index = key.index;
-    s.len = static_cast<uint32_t>(n);
+    s.kind = static_cast<uint32_t>(kind);
+    s.len = 0;
     s.payload_off = 0;
     s.alloc_seq = 0;
     s.fetch_start_ms.store(now, std::memory_order_relaxed);
@@ -192,11 +197,14 @@ NodeDedup::Slot* NodeDedup::Reserve(const BlockKey& key, size_t n) {
   return nullptr;  // probe window full: run without dedup for this key
 }
 
-bool NodeDedup::CopyOut(Slot* s, size_t n, char* dst) const {
+bool NodeDedup::CopyOut(Slot* s, size_t cap, size_t strict_n, char* dst,
+                        size_t* got) const {
   const uint64_t g0 = s->gen.load(std::memory_order_acquire);
   if (g0 & 1) return false;  // writer active
   if (s->state.load(std::memory_order_acquire) != kStateReady) return false;
-  if (s->len != n) return false;
+  const size_t n = s->len;
+  if (strict_n != kAnyLen && n != strict_n) return false;
+  if (n > cap) return false;
   const uint64_t off = s->payload_off;
   const uint64_t seq = s->alloc_seq;
   if (off + n > arena_bytes_) return false;  // torn metadata: bail
@@ -209,27 +217,30 @@ bool NodeDedup::CopyOut(Slot* s, size_t n, char* dst) const {
   // the slot generation did not move during the copy.
   if (hdr_->alloc_cursor.load(std::memory_order_acquire) - seq > arena_bytes_ - n)
     return false;
-  return s->gen.load(std::memory_order_acquire) == g0;
+  if (s->gen.load(std::memory_order_acquire) != g0) return false;
+  if (got) *got = n;
+  return true;
 }
 
-NodeDedup::Role NodeDedup::Claim(const BlockKey& key, size_t n, char* dst) {
-  if (n == 0 || n > arena_bytes_ / 2) return Role::kFetch;  // oversize: no dedup
+NodeDedup::Role NodeDedup::ClaimImpl(const BlockKey& key, Kind kind, size_t cap,
+                                     size_t strict_n, char* dst, size_t* got) {
+  if (cap == 0 || cap > arena_bytes_ / 2) return Role::kFetch;  // oversize: no dedup
   const uint64_t now = NowMs();
-  if (Slot* s = Find(key, n)) {
+  if (Slot* s = Find(key, kind)) {
     const uint32_t st = s->state.load(std::memory_order_acquire);
     if (st == kStateReady) {
       if (now - s->fetch_start_ms.load(std::memory_order_relaxed) <=
               static_cast<uint64_t>(ttl_ms_) &&
-          CopyOut(s, n, dst)) {
+          CopyOut(s, cap, strict_n, dst, got)) {
         hits_.fetch_add(1, std::memory_order_relaxed);
         return Role::kHit;
       }
-      // Expired/torn: fall through to Reserve (may recycle this very slot).
+      // Expired/torn/size-mismatch: fall through to Reserve (may recycle it).
     } else if (st == kStateFetching) {
       const uint64_t started = s->fetch_start_ms.load(std::memory_order_relaxed);
       if (now - started <= static_cast<uint64_t>(takeover_ms_)) return Role::kWait;
       // Fetcher looks dead: take the fetch over (CAS on fetch_start_ms so
-      // exactly one waiter wins; the loser just waits on the winner).
+      // exactly one waiter wins; the losers keep waiting on the winner).
       uint64_t expect = started;
       if (s->fetch_start_ms.compare_exchange_strong(expect, now,
                                                     std::memory_order_acq_rel)) {
@@ -239,15 +250,31 @@ NodeDedup::Role NodeDedup::Claim(const BlockKey& key, size_t n, char* dst) {
       return Role::kWait;
     }
   }
-  if (Reserve(key, n)) {
+  if (Reserve(key, kind)) {
     fetches_.fetch_add(1, std::memory_order_relaxed);
     return Role::kFetch;
   }
   return Role::kFetch;  // no slot available: plain fetch, nothing to publish
 }
 
-void NodeDedup::Publish(const BlockKey& key, const char* data, size_t n) {
-  Slot* s = Find(key, n);
+NodeDedup::Role NodeDedup::Claim(const BlockKey& key, size_t n, char* dst) {
+  return ClaimImpl(key, Kind::kData, n, n, dst, nullptr);
+}
+
+NodeDedup::Role NodeDedup::ClaimAuto(const BlockKey& key, size_t cap, char* dst,
+                                     size_t* got) {
+  return ClaimImpl(key, Kind::kData, cap, kAnyLen, dst, got);
+}
+
+NodeDedup::Role NodeDedup::ClaimExist(const BlockKey& key, bool* val) {
+  char b = 0;
+  const Role r = ClaimImpl(key, Kind::kExist, 1, 1, &b, nullptr);
+  if (r == Role::kHit && val) *val = (b != 0);
+  return r;
+}
+
+void NodeDedup::Publish(const BlockKey& key, Kind kind, const char* data, size_t n) {
+  Slot* s = Find(key, kind);
   if (!s || s->state.load(std::memory_order_acquire) != kStateFetching) return;
   // Ring-allocate: reserve [cur, cur+n) contiguously; skip the tail remainder
   // when a lap boundary would split the payload.
@@ -258,13 +285,14 @@ void NodeDedup::Publish(const BlockKey& key, const char* data, size_t n) {
     const uint64_t need = (in_lap + n > arena_bytes_) ? (arena_bytes_ - in_lap) + n : n;
     if (hdr_->alloc_cursor.compare_exchange_weak(cur, cur + need,
                                                  std::memory_order_acq_rel)) {
-      seq = cur + need;              // cursor AFTER this allocation
+      seq = cur + need;                       // cursor AFTER this allocation
       off = (cur + need - n) % arena_bytes_;  // payload sits at the end of the grab
       break;
     }
   }
   std::memcpy(arena_ + off, data, n);
   s->gen.fetch_add(1, std::memory_order_acq_rel);   // odd: mutating
+  s->len = static_cast<uint32_t>(n);
   s->payload_off = off;
   s->alloc_seq = seq;
   s->fetch_start_ms.store(NowMs(), std::memory_order_relaxed);  // TTL from publish
@@ -272,23 +300,24 @@ void NodeDedup::Publish(const BlockKey& key, const char* data, size_t n) {
   s->state.store(kStateReady, std::memory_order_release);
 }
 
-void NodeDedup::Abort(const BlockKey& key, size_t n) {
-  Slot* s = Find(key, n);
+void NodeDedup::Abort(const BlockKey& key, Kind kind) {
+  Slot* s = Find(key, kind);
   if (!s) return;
   // Only the fetcher aborts. Freeing the slot immediately (instead of letting
-  // it age into a takeover) lets a waiter that falls back re-claim at once;
-  // CAS so a concurrent takeover winner isn't clobbered.
+  // it age into a takeover) lets a falling-back waiter re-claim at once; CAS
+  // so a concurrent takeover winner isn't clobbered.
   uint32_t st = kStateFetching;
   s->state.compare_exchange_strong(st, kStateEmpty, std::memory_order_acq_rel);
 }
 
-bool NodeDedup::WaitCopy(const BlockKey& key, size_t n, char* dst) {
+bool NodeDedup::WaitImpl(const BlockKey& key, Kind kind, size_t cap,
+                         size_t strict_n, char* dst, size_t* got) {
   const uint64_t deadline = NowMs() + static_cast<uint64_t>(wait_ms_);
   int backoff_us = 50;
   for (;;) {
-    Slot* s = Find(key, n);
+    Slot* s = Find(key, kind);
     if (s && s->state.load(std::memory_order_acquire) == kStateReady &&
-        CopyOut(s, n, dst)) {
+        CopyOut(s, cap, strict_n, dst, got)) {
       wait_hits_.fetch_add(1, std::memory_order_relaxed);
       return true;
     }
@@ -299,6 +328,21 @@ bool NodeDedup::WaitCopy(const BlockKey& key, size_t n, char* dst) {
     std::this_thread::sleep_for(std::chrono::microseconds(backoff_us));
     if (backoff_us < 1000) backoff_us *= 2;
   }
+}
+
+bool NodeDedup::WaitCopy(const BlockKey& key, size_t n, char* dst) {
+  return WaitImpl(key, Kind::kData, n, n, dst, nullptr);
+}
+
+bool NodeDedup::WaitCopyAuto(const BlockKey& key, size_t cap, char* dst, size_t* got) {
+  return WaitImpl(key, Kind::kData, cap, kAnyLen, dst, got);
+}
+
+bool NodeDedup::WaitExist(const BlockKey& key, bool* val) {
+  char b = 0;
+  if (!WaitImpl(key, Kind::kExist, 1, 1, &b, nullptr)) return false;
+  if (val) *val = (b != 0);
+  return true;
 }
 
 }  // namespace dfkv

--- a/src/client/node_dedup.h
+++ b/src/client/node_dedup.h
@@ -1,26 +1,29 @@
-/* NodeDedup — same-host GET rendezvous over POSIX shared memory.
+/* NodeDedup — same-host GET/EXIST rendezvous over POSIX shared memory.
  *
- * Motivation (phase 5): TP-replicated KV (MLA/DSA latent) is written by one
+ * Motivation (phase 5/6): TP-replicated KV (MLA/DSA latent) is written by one
  * rank but read back by EVERY rank — 8x fabric traffic and 8x server read
  * load per L3 prefix load (measured on GLM-5.2 TP8). The ranks are same-host
  * processes requesting the SAME key set within milliseconds (measured 12 ms
  * spread vs ~44 ms per fetch batch), so a plain look-aside cache misses: by
  * the time rank N checks, rank 0's fetch is still in flight. What dedups the
  * fetch is a RENDEZVOUS: the first arrival claims a key (FETCHING), fetches
- * it remotely and publishes the payload; the others wait briefly and copy —
- * with a hard deadline that falls back to a direct fetch, so no failure mode
- * is worse than today's 8x behavior.
+ * it remotely and publishes; the others wait briefly and copy — with a hard
+ * deadline that falls back to a direct fetch, so no failure mode is worse
+ * than today's 8x behavior. EXIST probes (2 per page per rank) ride the same
+ * machinery with a 1-byte payload; a stale exist answer is safe either way
+ * (stale absent -> recompute, stale present -> GET miss -> recompute).
  *
  * Correctness model (lock-free, crash-robust):
- *  - Index slot state machine EMPTY -> FETCHING -> READY guarded by CAS; a
- *    FETCHING older than takeover_ms (fetcher died/hung) can be re-claimed.
+ *  - Index slot identity is (key, kind); the payload length is an attribute
+ *    (strict readers require len == n, auto readers accept len <= cap).
+ *  - State machine EMPTY -> FETCHING -> READY guarded by CAS; a FETCHING
+ *    older than takeover_ms (fetcher died/hung) can be re-claimed.
  *  - Payload arena is a ring with a MONOTONIC allocation cursor; readers
  *    validate "my payload's lap has not been overwritten" (cursor - alloc_seq
  *    <= arena - len) before AND after the copy, plus a per-slot seqlock
  *    generation for slot reuse. A failed validation is just a miss.
- *  - Nothing here is load-bearing for correctness of the cache itself: every
- *    exit path (no slot, timeout, torn read, size mismatch) degrades to the
- *    caller's normal remote fetch.
+ *  - Nothing here is load-bearing: every exit path (no slot, timeout, torn
+ *    read, size mismatch) degrades to the caller's normal remote op.
  *
  * SCOPE: host-memory destinations only (the SGLang HiCache path). GPUDirect
  * destinations (vLLM connector) must NOT enable this — memcpy to a device VA
@@ -42,13 +45,17 @@ namespace dfkv {
 class NodeDedup {
  public:
   struct Options {
-    std::string name;              // shm name (leading '/'); see MakeName()
+    std::string name;              // shm name (leading '/'); see FromEnv()
     uint64_t arena_bytes = 512ull << 20;   // DFKV_NODE_DEDUP_ARENA_MB
     uint32_t slots = 65536;                // DFKV_NODE_DEDUP_SLOTS (pow2 forced)
     int wait_ms = 500;                     // DFKV_NODE_DEDUP_WAIT_MS
     int takeover_ms = 2000;                // DFKV_NODE_DEDUP_TAKEOVER_MS
     int ttl_ms = 5000;                     // DFKV_NODE_DEDUP_TTL_MS
   };
+
+  // Entry namespaces sharing one index: a key's data payload and its exist
+  // answer are distinct entries.
+  enum class Kind : uint32_t { kData = 1, kExist = 2 };
 
   // Builds Options from the environment; returns nullptr (feature off) unless
   // DFKV_CLIENT_NODE_DEDUP=1. model_hash namespaces the segment so distinct
@@ -65,23 +72,30 @@ class NodeDedup {
 
   // Per-key verdict for a batch pass.
   enum class Role {
-    kHit,    // payload copied into dst (done — skip the remote fetch)
-    kFetch,  // caller owns the fetch; MUST call Publish or Abort afterwards
-    kWait,   // someone else is fetching; call WaitCopy after issuing own batch
+    kHit,    // result delivered (skip the remote op)
+    kFetch,  // caller owns the remote op; MUST call Publish or Abort afterwards
+    kWait,   // someone else is fetching; call the matching Wait* afterwards
   };
 
-  // Classify one key. n = the exact byte count this caller will read; only a
-  // published payload of exactly n bytes is a hit (lockstep peers request the
-  // same n; anything else falls back to a direct fetch).
+  // Strict GET (BatchGet semantics: exact n bytes). A published payload of a
+  // different length is not a hit (lockstep peers request the same n).
   Role Claim(const BlockKey& key, size_t n, char* dst);
-
-  // Fetch outcomes for keys claimed as kFetch.
-  void Publish(const BlockKey& key, const char* data, size_t n);
-  void Abort(const BlockKey& key, size_t n);
-
-  // Wait (poll, bounded by wait_ms) for a kWait key and copy it into dst.
-  // false = timeout/torn/mismatch — caller fetches directly.
   bool WaitCopy(const BlockKey& key, size_t n, char* dst);
+
+  // Variable-size GET (BatchGetAuto semantics): hit iff published len <= cap;
+  // *got receives the payload length.
+  Role ClaimAuto(const BlockKey& key, size_t cap, char* dst, size_t* got);
+  bool WaitCopyAuto(const BlockKey& key, size_t cap, char* dst, size_t* got);
+
+  // EXIST probe (1-byte answer). Stale answers are bounded by ttl_ms and safe
+  // in both directions (miss -> recompute; false present -> GET miss).
+  Role ClaimExist(const BlockKey& key, bool* val);
+  bool WaitExist(const BlockKey& key, bool* val);
+
+  // Fetch outcomes for keys claimed as kFetch (kind selects the namespace;
+  // exist publishes a 1-byte payload).
+  void Publish(const BlockKey& key, Kind kind, const char* data, size_t n);
+  void Abort(const BlockKey& key, Kind kind);
 
   // diagnostics (relaxed; process-local)
   uint64_t hits() const { return hits_.load(std::memory_order_relaxed); }
@@ -94,9 +108,15 @@ class NodeDedup {
   struct Header;  // shm header
   NodeDedup() = default;
 
-  Slot* Find(const BlockKey& key, size_t n) const;      // matching live slot or null
-  Slot* Reserve(const BlockKey& key, size_t n);         // claim a slot as FETCHING
-  bool CopyOut(Slot* s, size_t n, char* dst) const;     // seqlock+lap validated copy
+  Slot* Find(const BlockKey& key, Kind kind) const;
+  Slot* Reserve(const BlockKey& key, Kind kind);
+  // Validated copy. strict_n: exact length required (SIZE_MAX = any <= cap).
+  // Returns payload length via *got on success.
+  bool CopyOut(Slot* s, size_t cap, size_t strict_n, char* dst, size_t* got) const;
+  Role ClaimImpl(const BlockKey& key, Kind kind, size_t cap, size_t strict_n,
+                 char* dst, size_t* got);
+  bool WaitImpl(const BlockKey& key, Kind kind, size_t cap, size_t strict_n,
+                char* dst, size_t* got);
   static uint64_t NowMs();
 
   Header* hdr_ = nullptr;

--- a/test/client/node_dedup_test.cc
+++ b/test/client/node_dedup_test.cc
@@ -59,7 +59,7 @@ TEST(NodeDedup, FetchPublishThenPeersHit) {
   std::string dst(v.size(), '\0');
 
   ASSERT_EQ(a->Claim(K(1), v.size(), &dst[0]), NodeDedup::Role::kFetch);
-  a->Publish(K(1), v.data(), v.size());
+  a->Publish(K(1), NodeDedup::Kind::kData, v.data(), v.size());
   ASSERT_EQ(b->Claim(K(1), v.size(), &dst[0]), NodeDedup::Role::kHit);
   EXPECT_EQ(dst, v);
   EXPECT_EQ(b->hits(), 1u);
@@ -77,7 +77,7 @@ TEST(NodeDedup, WaiterCopiesAfterPublish) {
   ASSERT_EQ(b->Claim(K(2), v.size(), &dst_b[0]), NodeDedup::Role::kWait);
   std::thread pub([&] {
     std::this_thread::sleep_for(50ms);
-    a->Publish(K(2), v.data(), v.size());
+    a->Publish(K(2), NodeDedup::Kind::kData, v.data(), v.size());
   });
   EXPECT_TRUE(b->WaitCopy(K(2), v.size(), &dst_b[0]));
   pub.join();
@@ -93,7 +93,7 @@ TEST(NodeDedup, AbortLetsWaiterFallBack) {
   std::string dst(4096, '\0');
   ASSERT_EQ(a->Claim(K(3), dst.size(), &dst[0]), NodeDedup::Role::kFetch);
   ASSERT_EQ(b->Claim(K(3), dst.size(), &dst[0]), NodeDedup::Role::kWait);
-  a->Abort(K(3), dst.size());
+  a->Abort(K(3), NodeDedup::Kind::kData);
   // The waiter's bounded poll must return false (fall back to a direct fetch),
   // never hang.
   EXPECT_FALSE(b->WaitCopy(K(3), dst.size(), &dst[0]));
@@ -122,7 +122,7 @@ TEST(NodeDedup, TtlExpiryRecyclesEntry) {
   const std::string v = Val(5, 4096);
   std::string dst(v.size(), '\0');
   ASSERT_EQ(a->Claim(K(5), v.size(), &dst[0]), NodeDedup::Role::kFetch);
-  a->Publish(K(5), v.data(), v.size());
+  a->Publish(K(5), NodeDedup::Kind::kData, v.data(), v.size());
   ASSERT_EQ(a->Claim(K(5), v.size(), &dst[0]), NodeDedup::Role::kHit);
   std::this_thread::sleep_for(150ms);  // > ttl
   // Expired: a new arrival re-fetches instead of serving stale bytes.
@@ -136,13 +136,13 @@ TEST(NodeDedup, LappedArenaNeverServesOverwrittenBytes) {
   const std::string v = Val(6, 128 * 1024);
   std::string dst(v.size(), '\0');
   ASSERT_EQ(a->Claim(K(6), v.size(), &dst[0]), NodeDedup::Role::kFetch);
-  a->Publish(K(6), v.data(), v.size());
+  a->Publish(K(6), NodeDedup::Kind::kData, v.data(), v.size());
   // Lap the ring: publish > arena_bytes of other payloads.
   for (uint64_t i = 100; i < 100 + 12; ++i) {
     const std::string w = Val(i, 128 * 1024);
     std::string tmp(w.size(), '\0');
     if (a->Claim(K(i), w.size(), &tmp[0]) == NodeDedup::Role::kFetch)
-      a->Publish(K(i), w.data(), w.size());
+      a->Publish(K(i), NodeDedup::Kind::kData, w.data(), w.size());
   }
   // K(6)'s payload region has been overwritten: the entry must NOT hit with
   // stale bytes — any non-kHit outcome (re-fetch) is correct; a kHit MUST
@@ -160,7 +160,7 @@ TEST(NodeDedup, CrossProcessRendezvous) {
   ASSERT_TRUE(parent);
   std::string dst(v.size(), '\0');
   ASSERT_EQ(parent->Claim(K(7), v.size(), &dst[0]), NodeDedup::Role::kFetch);
-  parent->Publish(K(7), v.data(), v.size());
+  parent->Publish(K(7), NodeDedup::Kind::kData, v.data(), v.size());
 
   pid_t pid = ::fork();
   ASSERT_GE(pid, 0);
@@ -181,4 +181,46 @@ TEST(NodeDedup, CrossProcessRendezvous) {
 TEST(NodeDedup, DisabledByDefaultFromEnv) {
   ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
   EXPECT_EQ(NodeDedup::FromEnv(0x51), nullptr);
+}
+
+TEST(NodeDedup, AutoAcceptsFittingPayloadStrictDoesNot) {
+  ShmGuard g("auto");
+  auto a = NodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a);
+  const std::string v = Val(8, 5000);  // "unfull" payload
+  std::string dst(8192, '\0');
+  ASSERT_EQ(a->Claim(K(8), v.size(), &dst[0]), NodeDedup::Role::kFetch);
+  a->Publish(K(8), NodeDedup::Kind::kData, v.data(), v.size());
+  // Auto with a larger cap hits and reports the true length.
+  size_t got = 0;
+  ASSERT_EQ(a->ClaimAuto(K(8), 8192, &dst[0], &got), NodeDedup::Role::kHit);
+  EXPECT_EQ(got, v.size());
+  EXPECT_EQ(std::string(dst.data(), got), v);
+  // Auto with a too-small cap must NOT hit (falls back to fetch/reserve path).
+  std::string small(1024, '\0');
+  EXPECT_NE(a->ClaimAuto(K(8), 1024, &small[0], &got), NodeDedup::Role::kHit);
+  // Strict with a different n must NOT hit either.
+  EXPECT_NE(a->Claim(K(8), 8192, &dst[0]), NodeDedup::Role::kHit);
+}
+
+TEST(NodeDedup, ExistRendezvousBothAnswers) {
+  ShmGuard g("exist");
+  auto a = NodeDedup::Open(Opts(g.name));
+  auto b = NodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a && b);
+  bool val = false;
+  ASSERT_EQ(a->ClaimExist(K(9), &val), NodeDedup::Role::kFetch);
+  const char yes = 1;
+  a->Publish(K(9), NodeDedup::Kind::kExist, &yes, 1);
+  ASSERT_EQ(b->ClaimExist(K(9), &val), NodeDedup::Role::kHit);
+  EXPECT_TRUE(val);
+  // Negative answers are published too (valid result, unlike a failed GET).
+  ASSERT_EQ(a->ClaimExist(K(10), &val), NodeDedup::Role::kFetch);
+  const char no = 0;
+  a->Publish(K(10), NodeDedup::Kind::kExist, &no, 1);
+  ASSERT_EQ(b->ClaimExist(K(10), &val), NodeDedup::Role::kHit);
+  EXPECT_FALSE(val);
+  // The exist namespace never collides with the data namespace of the same key.
+  std::string dst(4096, '\0');
+  EXPECT_EQ(a->Claim(K(9), dst.size(), &dst[0]), NodeDedup::Role::kFetch);
 }


### PR DESCRIPTION
Phase-6 completion of the phase-5 rendezvous (#161 covered only strict `BatchGet`):

- **Identity becomes (key, kind)** — payload length is an attribute, so variable-size readers share entries: strict requires `len == n`, auto accepts `len <= cap` and learns the true length. Segment magic bumps to DDV2 (mixed old/new hosts run unshared — safe).
- **BatchGetAuto** rides the rendezvous (unfull/variable chunks), per-key `GetAuto` fallback on wait timeout.
- **BatchExist** rides it with a 1-byte answer in the `kExist` namespace (exist probes are 2/page/rank — 8× replicated too). **Negative answers are published as well** — a valid result, unlike a failed GET; staleness is TTL-bounded and safe both ways.
- **Metrics**: `dfkv_client_dedup_{hits,fetches,wait_hits,wait_timeouts}` in the client snapshot — production soak becomes observable.

Tests: 10 hermetic NodeDedup cases (new: auto-fit vs strict-mismatch, exist both answers + namespace isolation). B200 real-HW full ctest **374/374**.