### PR TITLE
feat(server): /readyz readiness gate — alive is not servable

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <string>
 
+#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -282,6 +283,11 @@ int main(int argc, char** argv) {
 
   // Start /metrics now that the (optional) RDMA server exists: the render
   // callback combines the cache-node metrics with the RDMA server counters.
+  // ready_flag flips once EVERY startup stage below has finished (RDMA
+  // listener + MR anchor are already up at this point; MDS registration is
+  // still ahead) — /readyz answers 503 until then so rolling upgrades wait
+  // for a servable node, not merely an open metrics port.
+  auto ready_flag = std::make_shared<std::atomic<bool>>(false);
   if (metrics_port >= 0) {
     mhttp = std::make_unique<dfkv::MetricsHttpServer>([&] {
       std::string s = srv.MetricsText();
@@ -290,6 +296,7 @@ int main(int argc, char** argv) {
 #endif
       return s;
     });
+    mhttp->set_ready_check([ready_flag] { return ready_flag->load(std::memory_order_acquire); });
     if (mhttp->Start(metrics_port, metrics_bind) == Status::kOk)
       DFKV_LOG_INFO("dfkv_server /metrics on port " + std::to_string(mhttp->port()));
     else
@@ -364,6 +371,9 @@ int main(int argc, char** argv) {
     DFKV_LOG_INFO("dfkv_server registered with MDS group=" + group + " id=" + node_id +
                   " advertise=" + advertise);
   }
+
+  ready_flag->store(true, std::memory_order_release);
+  DFKV_LOG_INFO("dfkv_server ready (all startup stages complete)");
 
   while (!g_stop) { struct timespec ts{0, 50 * 1000 * 1000}; nanosleep(&ts, nullptr); }
   DFKV_LOG_INFO("dfkv_server shutting down");

--- a/src/utils/metrics_http.cc
+++ b/src/utils/metrics_http.cc
@@ -135,6 +135,13 @@ void MetricsHttpServer::Handle(int fd) {
       out = Resp("200 OK", "text/plain", "ok\n");
     else
       out = Resp("503 Service Unavailable", "text/plain", "unavailable\n");
+  } else if (path == "/readyz") {
+    // Readiness (serving-capable), not liveness: 503 while startup work
+    // (arena pre-fault, MR anchor, listeners, MDS registration) is running.
+    if (!ready_ || ready_())
+      out = Resp("200 OK", "text/plain", "ready\n");
+    else
+      out = Resp("503 Service Unavailable", "text/plain", "starting\n");
   } else {
     out = Resp("404 Not Found", "text/plain", "not found\n");
   }

--- a/src/utils/metrics_http.h
+++ b/src/utils/metrics_http.h
@@ -33,6 +33,12 @@ class MetricsHttpServer {
   // answers 503 (e.g. MDS reporting etcd unreachable) instead of a blanket
   // 200 "ok"; unset keeps the always-200 behavior. Called on the HTTP thread.
   void set_health_check(std::function<bool()> fn) { health_ = std::move(fn); }
+  // Optional /readyz predicate — READINESS, distinct from liveness: the
+  // process is alive (healthz 200) long before it can serve (arena pre-fault,
+  // pool-MR anchor, RDMA listener, MDS registration: tens of seconds on big
+  // arenas). Rolling upgrades must gate on THIS, not on the port being open.
+  // Unset => mirrors the always-200 behavior.
+  void set_ready_check(std::function<bool()> fn) { ready_ = std::move(fn); }
 
   // port 0 => ephemeral (query with port()). bind_addr empty => all interfaces
   // (back-compat); pass e.g. "127.0.0.1" to restrict /metrics to loopback.
@@ -59,6 +65,7 @@ class MetricsHttpServer {
 
   std::function<std::string()> render_;
   std::function<bool()> health_;  // optional /healthz predicate (null => always ok)
+  std::function<bool()> ready_;   // optional /readyz predicate (null => always ok)
   int listen_fd_ = -1;
   int port_ = 0;
   std::atomic<bool> running_{false};

--- a/test/utils/metrics_http_test.cc
+++ b/test/utils/metrics_http_test.cc
@@ -109,3 +109,32 @@ TEST(MetricsHttp, HealthCheckPredicateGates503) {
 
   srv.Stop();
 }
+
+TEST(MetricsHttp, ReadyCheckPredicateGates503) {
+  std::atomic<bool> ready{false};
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  srv.set_ready_check([&] { return ready.load(); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int port = srv.port();
+
+  // Startup window: alive (healthz 200) but NOT ready (readyz 503) — rolling
+  // upgrades gate on readiness, not on the port being open.
+  std::string h = HttpGet(port, "/healthz");
+  EXPECT_NE(h.find("200"), std::string::npos) << h;
+  std::string starting = HttpGet(port, "/readyz");
+  EXPECT_NE(starting.find("503"), std::string::npos) << starting;
+  EXPECT_NE(starting.find("starting"), std::string::npos) << starting;
+
+  ready.store(true);
+  std::string ok = HttpGet(port, "/readyz");
+  EXPECT_NE(ok.find("200"), std::string::npos) << ok;
+  EXPECT_NE(ok.find("ready"), std::string::npos) << ok;
+
+  // Unset predicate mirrors the always-200 behavior.
+  MetricsHttpServer plain([] { return std::string(); });
+  ASSERT_EQ(plain.Start(0), Status::kOk);
+  std::string dflt = HttpGet(plain.port(), "/readyz");
+  EXPECT_NE(dflt.find("200"), std::string::npos) << dflt;
+  plain.Stop();
+  srv.Stop();
+}


### PR DESCRIPTION
Phase-6 ops item. The metrics port comes up long before the server can serve: arena pre-fault (13–67 s on 128 GiB), pool-MR anchor (~5 s), RDMA listener, MDS registration all follow it. Anything gating on the port being open (rolling upgrades; this campaign's own release smoke) hits the gap as spurious failures.

`/readyz` answers **503 "starting"** until every startup stage in `dfkv_server_main` completes, then **200 "ready"** — distinct from `/healthz` (liveness, 200 throughout). Unset predicate keeps always-200, so other embedders are unaffected; the ready flip is logged.

Test: `ReadyCheckPredicateGates503` (alive-but-not-ready window, flip, unset default). B200 full ctest 373/373. Rollout tooling change (wait on /readyz) lands in dfkv-rollout separately.