### PR TITLE
fix(client): version the rendezvous segment NAME — a layout bump must not self-disable

### DIFF
--- a/src/client/node_dedup.cc
+++ b/src/client/node_dedup.cc
@@ -66,6 +66,19 @@ uint64_t NodeDedup::NowMs() {
       std::chrono::steady_clock::now().time_since_epoch()).count());
 }
 
+std::string NodeDedup::EnvSegmentName(uint64_t model_hash) {
+  char name[128];
+  // Layout version FIRST: a layout bump gets a fresh name and can never be
+  // silently disabled by (or corrupt) a segment an older lib left behind —
+  // old and new processes each rendezvous within their own generation during
+  // a rolling upgrade, then the old segment ages out with its processes.
+  // uid-scoped so unrelated users on one host can't share (or collide on) a
+  // segment; model_hash separates keyspaces (same salting as the block keys).
+  std::snprintf(name, sizeof(name), "/dfkv-dedup-v2-%u-%016llx", ::getuid(),
+                static_cast<unsigned long long>(model_hash));
+  return name;
+}
+
 std::unique_ptr<NodeDedup> NodeDedup::FromEnv(uint64_t model_hash) {
   const char* on = std::getenv("DFKV_CLIENT_NODE_DEDUP");
   if (!on || std::strcmp(on, "1") != 0) return nullptr;
@@ -75,12 +88,7 @@ std::unique_ptr<NodeDedup> NodeDedup::FromEnv(uint64_t model_hash) {
   o.wait_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_WAIT_MS", 500));
   o.takeover_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TAKEOVER_MS", 2000));
   o.ttl_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TTL_MS", 5000));
-  char name[128];
-  // uid-scoped so unrelated users on one host can't share (or collide on) a
-  // segment; model_hash separates keyspaces (same salting as the block keys).
-  std::snprintf(name, sizeof(name), "/dfkv-dedup-%u-%016llx", ::getuid(),
-                static_cast<unsigned long long>(model_hash));
-  o.name = name;
+  o.name = EnvSegmentName(model_hash);
   return Open(o);
 }
 

--- a/src/client/node_dedup.h
+++ b/src/client/node_dedup.h
@@ -61,6 +61,14 @@ class NodeDedup {
   // DFKV_CLIENT_NODE_DEDUP=1. model_hash namespaces the segment so distinct
   // keyspaces on one host never share entries.
   static std::unique_ptr<NodeDedup> FromEnv(uint64_t model_hash);
+  // The env-derived segment name. The shm LAYOUT VERSION is part of the name:
+  // a layout change must never collide with a segment an older lib left
+  // behind — v1.23.0 shipped a layout bump behind the same name, the header
+  // check "safely" refused the stale segment, and the feature silently
+  // disabled itself across the whole upgrade (canary re-measured 8x). The
+  // header magic stays as a backstop only. Exposed so tests clean up the
+  // exact segment FromEnv would use.
+  static std::string EnvSegmentName(uint64_t model_hash);
   // Opens (or creates) the shm segment. Returns nullptr on any failure — the
   // caller just runs without dedup. A parameter mismatch with an existing
   // segment also returns nullptr (never reinterpret another config's layout).

--- a/test/client/node_dedup_test.cc
+++ b/test/client/node_dedup_test.cc
@@ -224,3 +224,12 @@ TEST(NodeDedup, ExistRendezvousBothAnswers) {
   std::string dst(4096, '\0');
   EXPECT_EQ(a->Claim(K(9), dst.size(), &dst[0]), NodeDedup::Role::kFetch);
 }
+
+TEST(NodeDedup, EnvSegmentNameCarriesLayoutVersion) {
+  // A layout bump must land in a FRESH segment name: v1.23.0 bumped the header
+  // magic behind the same name, the mismatch check refused the stale v1.22
+  // segment, and the feature silently disabled itself fleet-wide on upgrade.
+  const std::string nm = NodeDedup::EnvSegmentName(0xABCD);
+  EXPECT_NE(nm.find("/dfkv-dedup-v2-"), std::string::npos) << nm;
+  EXPECT_NE(nm.find("000000000000abcd"), std::string::npos) << nm;
+}

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -5,6 +5,7 @@
 // no RDMA device is present. Built only when DFKV_WITH_RDMA is defined. Run under
 // ThreadSanitizer to exercise the worker-pool / QP concurrency.
 #include "client/kv_client.h"
+#include "client/node_dedup.h"
 #include "client/key_map.h"
 #include "cache/kv_node_server.h"
 #include "cache/rdma_server.h"
@@ -191,10 +192,8 @@ TEST(RdmaLoopback, BatchPutOversizedFailsOnlyOffender) {
 // server — server-side completions stay ~flat while the data stays correct.
 TEST(RdmaLoopback, NodeDedupCollapsesSameHostGets) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
-  char nm[128];
-  std::snprintf(nm, sizeof(nm), "/dfkv-dedup-%u-%016llx",
-                ::getuid(), static_cast<unsigned long long>(SelfHdr().model_hash));
-  ::shm_unlink(nm);
+  const std::string nm = NodeDedup::EnvSegmentName(SelfHdr().model_hash);
+  ::shm_unlink(nm.c_str());
   ::setenv("DFKV_CLIENT_NODE_DEDUP", "1", 1);
   {
     RdmaNode node("ndd");
@@ -231,7 +230,7 @@ TEST(RdmaLoopback, NodeDedupCollapsesSameHostGets) {
         << " completions); rendezvous not deduplicating";
   }
   ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
-  ::shm_unlink(nm);
+  ::shm_unlink(nm.c_str());
 }
 
 TEST(RdmaLoopback, PutGetExistMissOverRdma) {


### PR DESCRIPTION
**v1.23.0 known defect** (caught by the canary full-stack re-validation): #163 bumped the shm layout (magic DDV1→DDV2) behind the SAME segment name. On any host upgraded from v1.22.0 the stale segment survives in /dev/shm, the header check refuses it *as designed* ('running without'), and the rendezvous silently disables itself for every process — canary re-measured the full **8× read amplification** on the v1.23.0 stack, with only an INFO log to show why.

**Fix**: the layout version is part of the segment name (`/dfkv-dedup-v2-<uid>-<model_hash>`). A layout change gets a fresh segment; during a rolling upgrade old and new processes each rendezvous within their own generation, and the old segment ages out with its processes. Header magic stays as a backstop. `EnvSegmentName()` exposed for tests.

Lesson: *refuse and degrade* is only safe when the degradation is loud or temporary — a permanent silent feature-off after an upgrade is a defect, not safety.

Validation: B200 full ctest **376/376**; canary re-measurement on the patched stack follows in v1.23.1 notes.