### PR TITLE
feat(obs): role-name every background thread (pthread_setname)

### DIFF
--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -13,7 +13,8 @@
 #include <filesystem>
 #include <vector>
 
-#include "utils/net_util.h"  // PutU32/PutU64/GetU32/GetU64 (host-endian codec)
+#include "utils/net_util.h"
+#include "utils/thread_name.h"  // PutU32/PutU64/GetU32/GetU64 (host-endian codec)
 
 namespace fs = std::filesystem;
 
@@ -105,6 +106,7 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
   if (ok_) Rebuild();
   if (ok_ && opt_.table_sync_ms > 0) {
     sync_thread_ = std::thread([this] {
+      NameThisThread("slab-sync");
       std::unique_lock<std::mutex> lk(sync_mu_);
       for (;;) {
         sync_cv_.wait_for(lk, std::chrono::milliseconds(opt_.table_sync_ms),
@@ -130,6 +132,7 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
 #endif
   if (ok_ && opt_.reclaim_interval_ms > 0) {
     reclaim_thread_ = std::thread([this] {
+      NameThisThread("slab-reclaim");
       std::unique_lock<std::mutex> lk(reclaim_mu_);
       for (;;) {
         reclaim_cv_.wait_for(lk, std::chrono::milliseconds(opt_.reclaim_interval_ms),

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "utils/net_util.h"
+#include "utils/thread_name.h"
 #include "utils/wire_limits.h"
 #include "utils/prom_escape.h"
 #include "transport/transport.h"
@@ -118,7 +119,7 @@ Status KvNodeServer::Start(int port) {
   ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&sa), &sl);
   port_ = ntohs(sa.sin_port);
   running_ = true;
-  accept_thread_ = std::thread([this] { AcceptLoop(); });
+  accept_thread_ = std::thread([this] { NameThisThread("kv-accept"); AcceptLoop(); });
   return Status::kOk;
 }
 
@@ -320,6 +321,7 @@ void KvNodeServer::AcceptLoop() {
     conn_fds_.insert(fd);
     auto done = std::make_shared<std::atomic<bool>>(false);
     conns_.push_back({std::thread([this, fd, done] {
+                        NameThisThread("kv-serve");
                         Handle(fd);
                         open_connections_.fetch_sub(1, std::memory_order_relaxed);
                         { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "utils/log.h"
+#include "utils/thread_name.h"
 #include "utils/numa_util.h"
 
 namespace dfkv {
@@ -113,10 +114,11 @@ RamTier::RamTier(Options opt, FlushFn flush)
   flushers_.reserve(nf);
   for (uint32_t i = 0; i < nf; ++i) {
     Shard& s = *shards_[i % nshards];
-    flushers_.emplace_back([this, &s] { FlushLoop(s); });
+    flushers_.emplace_back([this, &s, i] { NameThisThread("rt-flush-", i); FlushLoop(s); });
   }
   if (opt_.reclaim_interval_ms > 0) {
     reclaim_thread_ = std::thread([this] {
+      NameThisThread("rt-reclaim");
       std::unique_lock<std::mutex> lk(reclaim_mu_);
       for (;;) {
         reclaim_cv_.wait_for(lk, std::chrono::milliseconds(opt_.reclaim_interval_ms),

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -17,6 +17,7 @@
 
 #include "utils/log.h"          // DFKV_LOG_WARN (uring init fallback)
 #include "utils/net_util.h"     // ReadAll / WriteAll / Get*/Put*
+#include "utils/thread_name.h"
 #include "utils/numa_util.h"    // pin serve thread to the device's NUMA node
 #include "utils/wire_limits.h"  // ResolveMaxPayload (shared with the TCP path)
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
@@ -93,7 +94,7 @@ Status RdmaServer::Start(int port) {
     }
   }
   running_ = true;
-  accept_thread_ = std::thread([this] { AcceptLoop(); });
+  accept_thread_ = std::thread([this] { NameThisThread("rdma-accept"); AcceptLoop(); });
   return Status::kOk;
 }
 
@@ -151,6 +152,7 @@ void RdmaServer::AcceptLoop() {
     ReapDoneLocked();  // reap connections that finished since the last accept
     auto done = std::make_shared<std::atomic<bool>>(false);
     conns_.push_back({std::thread([this, fd, done] {
+                        NameThisThread("rdma-serve");
                         Serve(fd);
                         done->store(true, std::memory_order_release);  // last act
                       }),

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -16,6 +16,7 @@
 
 #include "client/key_map.h"
 #include "utils/log.h"
+#include "utils/thread_name.h"
 #include "transport/transport_factory.h"
 
 namespace dfkv {
@@ -105,7 +106,7 @@ class FanoutPool {
   void EnsureThreads(size_t want) {
     std::lock_guard<std::mutex> lk(mu_);
     while (threads_ < want && threads_ < kMaxThreads) {
-      std::thread([this] { Loop(); }).detach();
+      std::thread([this, i = threads_] { NameThisThread("kv-fan-", i); Loop(); }).detach();
       ++threads_;
     }
   }
@@ -233,7 +234,7 @@ void KVClient::StartProbe(int interval_ms) {
   if (interval_ms <= 0 || probe_running_.load(std::memory_order_relaxed)) return;
   probe_interval_ms_ = interval_ms;
   probe_running_.store(true, std::memory_order_relaxed);
-  probe_th_ = std::thread([this] { ProbeLoop(); });
+  probe_th_ = std::thread([this] { NameThisThread("kv-probe"); ProbeLoop(); });
 }
 
 void KVClient::StopProbe() {

--- a/src/mds/mds_member_poller.cc
+++ b/src/mds/mds_member_poller.cc
@@ -8,6 +8,7 @@
 
 #include "common/status.h"
 #include "utils/net_util.h"
+#include "utils/thread_name.h"
 #include "utils/wire_limits.h"
 #include "transport/wire.h"
 
@@ -107,7 +108,7 @@ void MdsMemberPoller::Loop() {
 
 void MdsMemberPoller::Start() {
   if (running_.exchange(true)) return;
-  th_ = std::thread([this] { Loop(); });
+  th_ = std::thread([this] { NameThisThread("mds-poll"); Loop(); });
 }
 
 void MdsMemberPoller::Stop() {

--- a/src/mds/mds_registrar.cc
+++ b/src/mds/mds_registrar.cc
@@ -9,6 +9,7 @@
 #include "common/status.h"
 #include "mds/mds_proto.h"
 #include "utils/net_util.h"
+#include "utils/thread_name.h"
 #include "utils/wire_limits.h"
 #include "transport/wire.h"
 
@@ -96,7 +97,7 @@ void MdsRegistrar::Loop() {
 
 void MdsRegistrar::Start() {
   if (running_.exchange(true)) return;
-  th_ = std::thread([this] { Loop(); });
+  th_ = std::thread([this] { NameThisThread(is_client_ ? "mds-reg-cli" : "mds-reg"); Loop(); });
 }
 
 void MdsRegistrar::Stop() {

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -11,6 +11,7 @@
 #include "common/membership.h"
 #include "mds/mds_proto.h"
 #include "utils/net_util.h"
+#include "utils/thread_name.h"
 #include "utils/wire_limits.h"
 #include "transport/wire.h"
 
@@ -45,7 +46,7 @@ Status MdsServer::Start(int port) {
   ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&sa), &sl);
   port_ = ntohs(sa.sin_port);
   running_ = true;
-  accept_thread_ = std::thread([this] { AcceptLoop(); });
+  accept_thread_ = std::thread([this] { NameThisThread("mds-accept"); AcceptLoop(); });
   return Status::kOk;
 }
 
@@ -116,6 +117,7 @@ void MdsServer::AcceptLoop() {
     conn_fds_.push_back(fd);
     auto done = std::make_shared<std::atomic<bool>>(false);
     conns_.push_back({std::thread([this, fd, done] {
+                        NameThisThread("mds-conn");
                         Handle(fd);
                         {
                           std::lock_guard<std::mutex> lk(conn_mu_);

--- a/src/utils/metrics_http.cc
+++ b/src/utils/metrics_http.cc
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "utils/net_util.h"
+#include "utils/thread_name.h"
 
 namespace dfkv {
 
@@ -36,7 +37,7 @@ Status MetricsHttpServer::Start(int port, const std::string& bind_addr) {
   ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&sa), &sl);
   port_ = ntohs(sa.sin_port);
   running_ = true;
-  accept_thread_ = std::thread([this] { AcceptLoop(); });
+  accept_thread_ = std::thread([this] { NameThisThread("met-accept"); AcceptLoop(); });
   return Status::kOk;
 }
 
@@ -87,6 +88,7 @@ void MetricsHttpServer::AcceptLoop() {
     conn_fds_.insert(fd);
     auto done = std::make_shared<std::atomic<bool>>(false);
     conns_.push_back({std::thread([this, fd, done] {
+                        NameThisThread("met-conn");
                         Handle(fd);
                         { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
                         ::close(fd);

--- a/src/utils/thread_name.h
+++ b/src/utils/thread_name.h
@@ -1,0 +1,36 @@
+/* NameThisThread — role-name the calling thread for observability.
+ *
+ * Every background thread used to show up as "dfkv_server"/"python3" in
+ * /proc, perf, eBPF and gdb: the phase-7 write-path investigation could not
+ * even attribute CPU between serve/flush/reclaim roles. Called first thing
+ * inside each thread body. Kernel limit is 15 chars + NUL; longer names are
+ * truncated by pthread_setname_np, so keep them short and stable — they are
+ * an observability ABI of sorts (dashboards/bpftrace scripts match on them). */
+#ifndef DFKV_THREAD_NAME_H_
+#define DFKV_THREAD_NAME_H_
+
+#include <pthread.h>
+
+#include <cstdio>
+
+namespace dfkv {
+
+inline void NameThisThread(const char* name) {
+#ifdef __linux__
+  ::pthread_setname_np(::pthread_self(), name);
+#else
+  (void)name;
+#endif
+}
+
+// Indexed flavor for worker pools: "<prefix><idx>", truncated to the kernel's
+// 15-char limit ("rt-flush-12", "kv-fan-7").
+inline void NameThisThread(const char* prefix, size_t idx) {
+  char buf[16];
+  std::snprintf(buf, sizeof(buf), "%s%zu", prefix, idx);
+  NameThisThread(buf);
+}
+
+}  // namespace dfkv
+
+#endif  // DFKV_THREAD_NAME_H_


### PR DESCRIPTION
Phase-7 observability prerequisite: the write-path ceiling investigation could not attribute CPU between roles — /proc, perf and eBPF showed one wall of `dfkv_server`. Every background thread now names itself first thing in its body (`rdma-serve`, `rt-flush-N`, `slab-reclaim`, `mds-conn`, `kv-fan-N`, …; 15-char kernel limit respected). Names are a soft observability ABI — dashboards/bpftrace scripts will match on them. B200 full ctest 376/376.