### PR TITLE
fix(client): eagerly back the rendezvous segment (posix_fallocate) — ENOSPC beats SIGBUS

### DIFF
--- a/src/client/node_dedup.cc
+++ b/src/client/node_dedup.cc
@@ -106,6 +106,23 @@ std::unique_ptr<NodeDedup> NodeDedup::Open(const Options& opt) {
     ::close(fd);
     return nullptr;
   }
+  if (creator) {
+    // Eagerly back the whole segment with pages. tmpfs allocates lazily on
+    // first write: with /dev/shm full (other tenants), ftruncate+mmap succeed
+    // and the process later takes a SIGBUS on a page fault mid-publish —
+    // a crash, not a degrade. posix_fallocate converts that into a clean
+    // ENOSPC HERE, where returning nullptr just runs without dedup. Cost:
+    // the segment occupies its full size from creation (bounded, documented).
+    const int frc = ::posix_fallocate(fd, 0, static_cast<off_t>(len));
+    if (frc != 0) {
+      DFKV_LOG_INFO("node-dedup: cannot pre-reserve " +
+                    std::to_string(len >> 20) + " MiB in /dev/shm (" +
+                    std::to_string(frc) + "), running without");
+      ::close(fd);
+      ::shm_unlink(opt.name.c_str());  // don't leave a half-backed segment
+      return nullptr;
+    }
+  }
   if (!creator && static_cast<size_t>(st.st_size) != len) {
     DFKV_LOG_INFO("node-dedup: existing segment layout mismatch, running without");
     ::close(fd);

--- a/test/client/node_dedup_test.cc
+++ b/test/client/node_dedup_test.cc
@@ -4,7 +4,9 @@
 #include "client/node_dedup.h"
 
 #include <gtest/gtest.h>
+#include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -232,4 +234,21 @@ TEST(NodeDedup, EnvSegmentNameCarriesLayoutVersion) {
   const std::string nm = NodeDedup::EnvSegmentName(0xABCD);
   EXPECT_NE(nm.find("/dfkv-dedup-v2-"), std::string::npos) << nm;
   EXPECT_NE(nm.find("000000000000abcd"), std::string::npos) << nm;
+}
+
+TEST(NodeDedup, SegmentIsEagerlyBackedNotSparse) {
+  // tmpfs allocates lazily on write: a full /dev/shm would SIGBUS a publisher
+  // mid-copy instead of degrading. Open() posix_fallocates the whole segment
+  // at creation, converting that into a clean attach-time ENOSPC (nullptr).
+  // Verify the backing is real: allocated blocks cover the full length.
+  ShmGuard g("backed");
+  auto a = NodeDedup::Open(Opts(g.name, /*arena=*/4 << 20));
+  ASSERT_TRUE(a);
+  int fd = ::shm_open(g.name.c_str(), O_RDONLY, 0600);
+  ASSERT_GE(fd, 0);
+  struct stat st{};
+  ASSERT_EQ(::fstat(fd, &st), 0);
+  ::close(fd);
+  EXPECT_GE(static_cast<uint64_t>(st.st_blocks) * 512, static_cast<uint64_t>(st.st_size))
+      << "segment is sparse: a full tmpfs would SIGBUS at publish time";
 }


### PR DESCRIPTION
Phase-7 hardening. tmpfs allocates pages lazily on first write: with /dev/shm full (other tenants), `shm_open`/`ftruncate`/`mmap` all succeed and the process later takes a **SIGBUS mid-publish** — a crash, where every other rendezvous failure mode degrades to running without dedup. The creator now `posix_fallocate`s the whole segment: the failure becomes a clean attach-time ENOSPC (logged, nullptr, feature off, half-backed segment unlinked). Cost: the segment occupies its full bounded size from creation. Test pins the eager backing via `st_blocks`. B200 full ctest 377/377.