### PR TITLE
Phase 2b: GPU-destination rendezvous (CUDA IPC) + live max_sge SG sizing + B200 HW CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,4 +265,10 @@ jobs:
       - name: Build
         run: cmake --build build -j 48
       - name: Full ctest on real hardware
+        # Tests place their stores under fs::temp_directory_path()/<fixed name>,
+        # which honors TMPDIR. Point it at the per-run runner temp so CI runs
+        # never collide with root-owned residue from manual ctest runs on the
+        # box (Permission denied on remove_all) or with each other.
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: ctest --test-dir build --output-on-failure -j 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,3 +237,32 @@ jobs:
         with:
           name: dfkv-linux-x86_64
           path: dfkv-*-linux-x86_64.tar.gz
+
+  b200-hw-gate:
+    name: B200 real-HW full ctest
+    # Self-hosted runner on the xb01 B200 dev box: real ConnectX RDMA rails and
+    # CUDA devices, so the RDMA datapath and GPU-rendezvous suites actually run
+    # (the hosted runners' Soft-RoCE cannot round-trip RC traffic — the
+    # rdma-loopback job above degrades to its probe there).
+    # SECURITY (public repo + self-hosted runner): run ONLY same-repo refs —
+    # pushes to main, same-repo PRs, manual dispatch. Fork PRs never reach this
+    # runner: the branch filter above plus the repo-level "require approval for
+    # all outside collaborators" Actions policy gate them.
+    if: >-
+      github.repository == 'dingodb/dfkv' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository))
+    runs-on: [self-hosted, b200]
+    concurrency:
+      group: b200-hw-gate   # one build+ctest on the box at a time
+      cancel-in-progress: false
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDFKV_WITH_RDMA=ON
+      - name: Build
+        run: cmake --build build -j 48
+      - name: Full ctest on real hardware
+        run: ctest --test-dir build --output-on-failure -j 8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,11 @@ target_link_libraries(dfkv_bench PRIVATE dfkv_core)
 add_executable(dfkv_discover_smoke ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_discover_smoke_main.cc)
 target_link_libraries(dfkv_discover_smoke PRIVATE dfkv_core)
 
+# Real-HW lockstep repro for the GPU rendezvous (needs CUDA devices at
+# runtime; builds everywhere — CUDA is dlopen'd).
+add_executable(dfkv_gpu_dedup_repro ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_gpu_dedup_repro_main.cc)
+target_link_libraries(dfkv_gpu_dedup_repro PRIVATE dfkv_core)
+
 include(GNUInstallDirs)
 install(TARGETS dfkv dfkv_server dfkv_mds dfkv_smoke dfkvctl dfkv_bench dfkv_discover_smoke dfkv_core
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/integration/vllm/src/dfkv_vllm/_cabi.py
+++ b/integration/vllm/src/dfkv_vllm/_cabi.py
@@ -64,6 +64,14 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_register_memory.restype = c_int
     lib.dfkv_register_memory.argtypes = [c_void_p, c_void_p, c_uint64]
 
+    # Live SG width (negotiated max_sge - 1). Older libs lack the symbol;
+    # callers must tolerate AttributeError and fall back to 29.
+    try:
+        lib.dfkv_max_sg_segs.restype = c_uint32
+        lib.dfkv_max_sg_segs.argtypes = [c_void_p]
+    except AttributeError:
+        pass
+
     # Batch primitives (raw void** pointers -> may be GPU device pointers).
     lib.dfkv_batch_put.restype = c_int
     lib.dfkv_batch_put.argtypes = [

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -137,6 +137,13 @@ class DfkvDeviceClient:
     def transport_mode(self) -> str:
         return self._lib.dfkv_transport_mode(self._h).decode()
 
+    def max_sg_segs(self) -> int:
+        """Max payload segments one scatter-gather key may carry on the live
+        transport (RDMA: negotiated max_sge - 1; TCP: 29). Raises
+        AttributeError on an older libdfkv without the export — callers fall
+        back to the historical 29 (see worker._sg_segs_of)."""
+        return int(self._lib.dfkv_max_sg_segs(self._h))
+
     def register_memory(self, base: int, size: int) -> None:
         """Register a (host or GPU device) region as an RDMA MR. One call per
         contiguous KV-cache storage region; later put/get reference offsets."""

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -351,7 +351,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             save_exists_start = time.perf_counter()
             try:
                 exists_states = self.client.batch_exist(
-                    [f"{k}@sg0" for k in keys]
+                    [_sg_group_key(k, 0, _sg_segs_of(self.client)) for k in keys]
                 )
             except Exception:
                 self._record_operation(
@@ -429,7 +429,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
             # suffixed "@sg{n}" -- one RDMA multi-SGE op + one server blob per key
             # instead of one tiny key per segment. This cuts the key count ~20x
             # (25392 -> ~1242) so the load is bandwidth-bound, not per-key-bound.
-            sg_keys, sg_ptrs, sg_sizes, _ = _group_segments_sg(keys, addrs, sizes)
+            sg_keys, sg_ptrs, sg_sizes, _ = _group_segments_sg(
+                keys, addrs, sizes, _sg_segs_of(self.client)
+            )
             batch_bytes = sum(sum(s) for s in sg_sizes)
             put_start = time.perf_counter()
             try:
@@ -577,8 +579,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             # Flatten per-key scatter-gather to one (ptr, cap) per dfkv key, then
             # map each flattened result back to its originating block id for error
             # reporting (see _group_segments_sg / seg_owner).
+            # Resolve the client BEFORE grouping: the SG width (and with it the
+            # on-wire key names) comes from the live transport.
+            client = self.client
+            if client is None and self.client_provider is not None:
+                client = self.client_provider()  # lazy un-elide
+                if client is not None:
+                    self.client = client
             sg_keys, sg_ptrs, sg_caps, sg_owner = _group_segments_sg(
-                key_list_c, addr_list_c, size_list_c
+                key_list_c, addr_list_c, size_list_c, _sg_segs_of(client)
             )
             sg_totals = [sum(c) for c in sg_caps]
             batch_bytes = sum(sg_totals)
@@ -590,11 +599,6 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 # into this chunk's per-layer segments. hit == 1 + len == sum(caps)
                 # means the chunk loaded; a miss or short read marks the originating
                 # block as a load error so vLLM recomputes that span (never fatal).
-                client = self.client
-                if client is None and self.client_provider is not None:
-                    client = self.client_provider()  # lazy un-elide
-                    if client is not None:
-                        self.client = client
                 if client is None:  # no client (un-elide failed): miss -> recompute
                     hits, lens = [False] * len(sg_keys), [0] * len(sg_keys)
                 else:
@@ -660,12 +664,42 @@ class KVCacheStoreRecvingThread(KVTransferThread):
 
 
 # dfkv: max payload segments gathered into one scatter-gather key. The HCA
-# max_sge is 30; SGE[0] is the request/value header, leaving 29 for payload.
+# Historical/default SG width: ConnectX-era max_sge=30, SGE[0] is the
+# request/value header, leaving 29 for payload. The LIVE width comes from
+# dfkv_max_sg_segs (negotiated per HCA); this constant is the fallback and the
+# compatibility anchor for key naming (see _sg_group_key).
 SG_MAX_SEGS = 29
 
 
+# Live SG width of a client's transport, cached on the client object (device
+# caps don't change under a running process). None / old libs => the default.
+def _sg_segs_of(client: Any) -> int:
+    if client is None:
+        return SG_MAX_SEGS
+    v = getattr(client, "_sg_segs_cache", None)
+    if v is None:
+        try:
+            v = int(client.max_sg_segs()) or SG_MAX_SEGS
+        except Exception:  # older libdfkv without dfkv_max_sg_segs
+            v = SG_MAX_SEGS
+        client._sg_segs_cache = v
+    return v
+
+
+# SG group key name. The grouping WIDTH is part of a key's identity: the same
+# "@sg1" under different widths would carry different segment spans, and a
+# variable-size GET whose total cap happens to fit would scatter the WRONG
+# bytes without any error. Non-default widths therefore get their own key
+# namespace ("@sgw{W}.{n}"); the default width keeps the historical "@sg{n}"
+# so existing cached data stays reachable across this upgrade.
+def _sg_group_key(key: str, grp: int, max_segs: int) -> str:
+    if max_segs == SG_MAX_SEGS:
+        return f"{key}@sg{grp}"
+    return f"{key}@sgw{max_segs}.{grp}"
+
+
 # dfkv scatter-gather grouping: coalesce each chunk's per-layer segments
-# (addrs[i]/sizes[i]) into "<key>@sg{n}" groups of <= SG_MAX_SEGS segments. Each
+# (addrs[i]/sizes[i]) into "<key>@sg{n}" groups of <= max_segs segments. Each
 # group is ONE dfkv key carrying all its segments via a single RDMA multi-SGE op
 # (one @sg key per chunk). owner[i] maps each @sg key back to
 # its originating chunk index for per-block load-error attribution.
@@ -673,6 +707,7 @@ def _group_segments_sg(
     keys: list[str],
     addrs: list[list[int]],
     sizes: list[list[int]],
+    max_segs: int = SG_MAX_SEGS,
 ) -> tuple[list[str], list[list[int]], list[list[int]], list[int]]:
     sg_keys: list[str] = []
     sg_ptrs: list[list[int]] = []
@@ -680,10 +715,10 @@ def _group_segments_sg(
     sg_owner: list[int] = []
     for key_idx, (key, addr, size) in enumerate(zip(keys, addrs, sizes, strict=True)):
         grp = 0
-        for off in range(0, len(addr), SG_MAX_SEGS):
-            sg_keys.append(f"{key}@sg{grp}")
-            sg_ptrs.append(list(addr[off:off + SG_MAX_SEGS]))
-            sg_sizes.append(list(size[off:off + SG_MAX_SEGS]))
+        for off in range(0, len(addr), max_segs):
+            sg_keys.append(_sg_group_key(key, grp, max_segs))
+            sg_ptrs.append(list(addr[off:off + max_segs]))
+            sg_sizes.append(list(size[off:off + max_segs]))
             sg_owner.append(key_idx)
             grp += 1
     return sg_keys, sg_ptrs, sg_sizes, sg_owner
@@ -1337,7 +1372,8 @@ class DfkvStoreWorker:
                         # block-present proxy so the lookup agrees with the
                         # SAVE/LOAD on-wire key.
                         candidate_keys.append(
-                            PoolKey(md, h.hex()).to_string() + "@sg0"
+                            _sg_group_key(PoolKey(md, h.hex()).to_string(), 0,
+                                          _sg_segs_of(self.client))
                         )
                         candidate_meta.append((g_idx, bytes(h)))
 

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -33,6 +33,15 @@ bool CudaLib::Resolve() {
       SymV2(h, "cuMemFree_v2", "cuMemFree"));
   Memcpy = reinterpret_cast<CUresult (*)(CUdeviceptr, CUdeviceptr, size_t)>(
       ::dlsym(h, "cuMemcpy"));
+  MemcpyAsync = reinterpret_cast<CUresult (*)(CUdeviceptr, CUdeviceptr, size_t,
+                                              CUstream)>(
+      ::dlsym(h, "cuMemcpyAsync"));
+  StreamCreate = reinterpret_cast<CUresult (*)(CUstream*, unsigned)>(
+      ::dlsym(h, "cuStreamCreate"));
+  StreamSynchronize = reinterpret_cast<CUresult (*)(CUstream)>(
+      ::dlsym(h, "cuStreamSynchronize"));
+  StreamDestroy = reinterpret_cast<CUresult (*)(CUstream)>(
+      SymV2(h, "cuStreamDestroy_v2", "cuStreamDestroy"));
   IpcGetMemHandle = reinterpret_cast<CUresult (*)(CUipcMemHandle*, CUdeviceptr)>(
       ::dlsym(h, "cuIpcGetMemHandle"));
   IpcOpenMemHandle = reinterpret_cast<CUresult (*)(CUdeviceptr*, CUipcMemHandle,
@@ -50,10 +59,11 @@ bool CudaLib::Resolve() {
       ::dlsym(h, "cuDevicePrimaryCtxRetain"));
   pointer_get_attribute_ = reinterpret_cast<CUresult (*)(void*, int, CUdeviceptr)>(
       ::dlsym(h, "cuPointerGetAttribute"));
-  if (!init || !MemAlloc || !MemFree || !Memcpy || !IpcGetMemHandle ||
-      !IpcOpenMemHandle || !IpcCloseMemHandle || !ctx_get_current_ ||
-      !ctx_set_current_ || !ctx_get_device_ || !primary_ctx_retain_ ||
-      !pointer_get_attribute_)
+  if (!init || !MemAlloc || !MemFree || !Memcpy || !MemcpyAsync ||
+      !StreamCreate || !StreamSynchronize || !StreamDestroy ||
+      !IpcGetMemHandle || !IpcOpenMemHandle || !IpcCloseMemHandle ||
+      !ctx_get_current_ || !ctx_set_current_ || !ctx_get_device_ ||
+      !primary_ctx_retain_ || !pointer_get_attribute_)
     return false;
   // cuInit is idempotent; the host framework normally beat us to it. A
   // failure here (no device, driver/library mismatch) disables the surface.

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -1,0 +1,82 @@
+#include "client/cuda_ipc.h"
+
+#include <dlfcn.h>
+
+#include <mutex>
+
+#include "utils/log.h"
+
+namespace dfkv {
+
+namespace {
+// Prefer the versioned symbol (what cuda.h binds since CUDA 3.2/11); fall
+// back to the legacy name so ancient drivers still resolve.
+void* SymV2(void* h, const char* v2, const char* legacy) {
+  if (void* p = ::dlsym(h, v2)) return p;
+  return ::dlsym(h, legacy);
+}
+}  // namespace
+
+bool CudaLib::Resolve() {
+  void* h = ::dlopen("libcuda.so.1", RTLD_NOW | RTLD_GLOBAL);
+  if (!h) return false;
+  using F = void*;
+  F init = ::dlsym(h, "cuInit");
+  MemAlloc = reinterpret_cast<CUresult (*)(CUdeviceptr*, size_t)>(
+      SymV2(h, "cuMemAlloc_v2", "cuMemAlloc"));
+  MemFree = reinterpret_cast<CUresult (*)(CUdeviceptr)>(
+      SymV2(h, "cuMemFree_v2", "cuMemFree"));
+  Memcpy = reinterpret_cast<CUresult (*)(CUdeviceptr, CUdeviceptr, size_t)>(
+      ::dlsym(h, "cuMemcpy"));
+  IpcGetMemHandle = reinterpret_cast<CUresult (*)(CUipcMemHandle*, CUdeviceptr)>(
+      ::dlsym(h, "cuIpcGetMemHandle"));
+  IpcOpenMemHandle = reinterpret_cast<CUresult (*)(CUdeviceptr*, CUipcMemHandle,
+                                                   unsigned)>(
+      SymV2(h, "cuIpcOpenMemHandle_v2", "cuIpcOpenMemHandle"));
+  IpcCloseMemHandle = reinterpret_cast<CUresult (*)(CUdeviceptr)>(
+      ::dlsym(h, "cuIpcCloseMemHandle"));
+  ctx_get_current_ = reinterpret_cast<CUresult (*)(CUcontext*)>(
+      SymV2(h, "cuCtxGetCurrent_v2", "cuCtxGetCurrent"));
+  ctx_get_device_ = reinterpret_cast<CUresult (*)(int*)>(
+      SymV2(h, "cuCtxGetDevice_v2", "cuCtxGetDevice"));
+  pointer_get_attribute_ = reinterpret_cast<CUresult (*)(void*, int, CUdeviceptr)>(
+      ::dlsym(h, "cuPointerGetAttribute"));
+  if (!init || !MemAlloc || !MemFree || !Memcpy || !IpcGetMemHandle ||
+      !IpcOpenMemHandle || !IpcCloseMemHandle || !ctx_get_current_ ||
+      !ctx_get_device_ || !pointer_get_attribute_)
+    return false;
+  // cuInit is idempotent; the host framework normally beat us to it. A
+  // failure here (no device, driver/library mismatch) disables the surface.
+  return reinterpret_cast<CUresult (*)(unsigned)>(init)(0) == kCudaSuccess;
+}
+
+const CudaLib* CudaLib::Get() {
+  static CudaLib* lib = [] {
+    auto* l = new CudaLib();
+    if (l->Resolve()) return l;
+    delete l;
+    return static_cast<CudaLib*>(nullptr);
+  }();
+  return lib;
+}
+
+bool CudaLib::IsDevicePtr(const void* p) const {
+  unsigned type = 0;
+  if (pointer_get_attribute_(&type, kCuPointerAttributeMemoryType,
+                             reinterpret_cast<CUdeviceptr>(p)) != kCudaSuccess)
+    return false;  // unregistered host memory: attribute query fails
+  return type == kCuMemoryTypeDevice;
+}
+
+bool CudaLib::HasCurrentCtx() const {
+  CUcontext c = nullptr;
+  return ctx_get_current_(&c) == kCudaSuccess && c != nullptr;
+}
+
+int CudaLib::CurrentDevice() const {
+  int dev = -1;
+  if (ctx_get_device_(&dev) != kCudaSuccess) return -1;
+  return dev;
+}
+
+}  // namespace dfkv

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -37,13 +37,18 @@ bool CudaLib::Resolve() {
       ::dlsym(h, "cuIpcCloseMemHandle"));
   ctx_get_current_ = reinterpret_cast<CUresult (*)(CUcontext*)>(
       SymV2(h, "cuCtxGetCurrent_v2", "cuCtxGetCurrent"));
+  ctx_set_current_ = reinterpret_cast<CUresult (*)(CUcontext)>(
+      SymV2(h, "cuCtxSetCurrent_v2", "cuCtxSetCurrent"));
   ctx_get_device_ = reinterpret_cast<CUresult (*)(int*)>(
       SymV2(h, "cuCtxGetDevice_v2", "cuCtxGetDevice"));
+  primary_ctx_retain_ = reinterpret_cast<CUresult (*)(CUcontext*, int)>(
+      SymV2(h, "cuDevicePrimaryCtxRetain_v2", "cuDevicePrimaryCtxRetain"));
   pointer_get_attribute_ = reinterpret_cast<CUresult (*)(void*, int, CUdeviceptr)>(
       ::dlsym(h, "cuPointerGetAttribute"));
   if (!init || !MemAlloc || !MemFree || !Memcpy || !IpcGetMemHandle ||
       !IpcOpenMemHandle || !IpcCloseMemHandle || !ctx_get_current_ ||
-      !ctx_get_device_ || !pointer_get_attribute_)
+      !ctx_set_current_ || !ctx_get_device_ || !primary_ctx_retain_ ||
+      !pointer_get_attribute_)
     return false;
   // cuInit is idempotent; the host framework normally beat us to it. A
   // failure here (no device, driver/library mismatch) disables the surface.
@@ -77,6 +82,21 @@ int CudaLib::CurrentDevice() const {
   int dev = -1;
   if (ctx_get_device_(&dev) != kCudaSuccess) return -1;
   return dev;
+}
+
+int CudaLib::DeviceOf(const void* p) const {
+  int dev = -1;
+  if (pointer_get_attribute_(&dev, kCuPointerAttributeDeviceOrdinal,
+                             reinterpret_cast<CUdeviceptr>(p)) != kCudaSuccess)
+    return -1;
+  return dev;
+}
+
+bool CudaLib::BindPrimaryCtx(int dev) const {
+  if (dev < 0) return false;
+  CUcontext ctx = nullptr;
+  if (primary_ctx_retain_(&ctx, dev) != kCudaSuccess || !ctx) return false;
+  return ctx_set_current_(ctx) == kCudaSuccess;
 }
 
 }  // namespace dfkv

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -9,8 +9,13 @@
 namespace dfkv {
 
 namespace {
-// Prefer the versioned symbol (what cuda.h binds since CUDA 3.2/11); fall
-// back to the legacy name so ancient drivers still resolve.
+// Prefer the versioned symbol ONLY where cuda.h itself binds it (the classic
+// 32->64-bit _v2 set: cuMemAlloc/cuMemFree/cuIpcOpenMemHandle) — there the
+// _v2 signature is the one we declare. NEVER guess _v2 for other entry
+// points: drivers export e.g. cuCtxGetDevice_v2 with a DIFFERENT signature
+// (an extra CUcontext parameter), and calling it through the plain prototype
+// reads a garbage register — a segfault that only fires on some threads
+// (found live: one of four vLLM workers died in exactly that call).
 void* SymV2(void* h, const char* v2, const char* legacy) {
   if (void* p = ::dlsym(h, v2)) return p;
   return ::dlsym(h, legacy);
@@ -36,13 +41,13 @@ bool CudaLib::Resolve() {
   IpcCloseMemHandle = reinterpret_cast<CUresult (*)(CUdeviceptr)>(
       ::dlsym(h, "cuIpcCloseMemHandle"));
   ctx_get_current_ = reinterpret_cast<CUresult (*)(CUcontext*)>(
-      SymV2(h, "cuCtxGetCurrent_v2", "cuCtxGetCurrent"));
+      ::dlsym(h, "cuCtxGetCurrent"));
   ctx_set_current_ = reinterpret_cast<CUresult (*)(CUcontext)>(
-      SymV2(h, "cuCtxSetCurrent_v2", "cuCtxSetCurrent"));
+      ::dlsym(h, "cuCtxSetCurrent"));
   ctx_get_device_ = reinterpret_cast<CUresult (*)(int*)>(
-      SymV2(h, "cuCtxGetDevice_v2", "cuCtxGetDevice"));
+      ::dlsym(h, "cuCtxGetDevice"));
   primary_ctx_retain_ = reinterpret_cast<CUresult (*)(CUcontext*, int)>(
-      SymV2(h, "cuDevicePrimaryCtxRetain_v2", "cuDevicePrimaryCtxRetain"));
+      ::dlsym(h, "cuDevicePrimaryCtxRetain"));
   pointer_get_attribute_ = reinterpret_cast<CUresult (*)(void*, int, CUdeviceptr)>(
       ::dlsym(h, "cuPointerGetAttribute"));
   if (!init || !MemAlloc || !MemFree || !Memcpy || !IpcGetMemHandle ||

--- a/src/client/cuda_ipc.h
+++ b/src/client/cuda_ipc.h
@@ -1,0 +1,64 @@
+/* CudaLib — dlopen'd CUDA *driver* API surface for the GPU rendezvous path.
+ *
+ * libdfkv.so must not link CUDA: SGLang hosts and CPU-only tools load the
+ * same library. Everything here resolves from libcuda.so.1 at first use; if
+ * the driver (or any required symbol) is absent, Get() returns nullptr and
+ * callers run without GPU dedup — the same "nothing here is load-bearing"
+ * rule as NodeDedup. The declarations below intentionally mirror cuda.h so
+ * no CUDA toolkit is needed at build time; they are ABI, not API (the driver
+ * exports them with C linkage and fixed layouts).
+ */
+#ifndef DFKV_CUDA_IPC_H_
+#define DFKV_CUDA_IPC_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace dfkv {
+
+// Minimal cuda.h mirror (ABI-stable driver types).
+using CUresult = int;
+using CUdeviceptr = unsigned long long;
+using CUcontext = void*;
+struct CUipcMemHandle {
+  char reserved[64];
+};
+constexpr CUresult kCudaSuccess = 0;
+constexpr unsigned kCuIpcMemLazyEnablePeerAccess = 0x1;
+constexpr int kCuPointerAttributeMemoryType = 2;  // CU_POINTER_ATTRIBUTE_MEMORY_TYPE
+constexpr unsigned kCuMemoryTypeDevice = 2;       // CU_MEMORYTYPE_DEVICE
+
+class CudaLib {
+ public:
+  // dlopens libcuda.so.1 and resolves the surface exactly once per process.
+  // nullptr => no usable driver; callers must degrade silently.
+  static const CudaLib* Get();
+
+  // True iff p is a CUDA device pointer (UVA query; host/unknown => false).
+  bool IsDevicePtr(const void* p) const;
+  // True iff the calling thread has a current CUDA context (GPU dedup runs on
+  // the caller's context — vLLM worker threads always carry one; we never
+  // create contexts behind a framework's back).
+  bool HasCurrentCtx() const;
+  int CurrentDevice() const;  // -1 without a context
+
+  CUresult (*MemAlloc)(CUdeviceptr*, size_t) = nullptr;
+  CUresult (*MemFree)(CUdeviceptr) = nullptr;
+  // Unified-addressing copy: any host/device src/dst combination.
+  CUresult (*Memcpy)(CUdeviceptr, CUdeviceptr, size_t) = nullptr;
+  CUresult (*IpcGetMemHandle)(CUipcMemHandle*, CUdeviceptr) = nullptr;
+  CUresult (*IpcOpenMemHandle)(CUdeviceptr*, CUipcMemHandle, unsigned) = nullptr;
+  CUresult (*IpcCloseMemHandle)(CUdeviceptr) = nullptr;
+
+ private:
+  CudaLib() = default;
+  bool Resolve();
+
+  CUresult (*ctx_get_current_)(CUcontext*) = nullptr;
+  CUresult (*ctx_get_device_)(int*) = nullptr;
+  CUresult (*pointer_get_attribute_)(void*, int, CUdeviceptr) = nullptr;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_CUDA_IPC_H_

--- a/src/client/cuda_ipc.h
+++ b/src/client/cuda_ipc.h
@@ -25,8 +25,9 @@ struct CUipcMemHandle {
 };
 constexpr CUresult kCudaSuccess = 0;
 constexpr unsigned kCuIpcMemLazyEnablePeerAccess = 0x1;
-constexpr int kCuPointerAttributeMemoryType = 2;  // CU_POINTER_ATTRIBUTE_MEMORY_TYPE
-constexpr unsigned kCuMemoryTypeDevice = 2;       // CU_MEMORYTYPE_DEVICE
+constexpr int kCuPointerAttributeMemoryType = 2;    // CU_POINTER_ATTRIBUTE_MEMORY_TYPE
+constexpr int kCuPointerAttributeDeviceOrdinal = 9; // CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL
+constexpr unsigned kCuMemoryTypeDevice = 2;         // CU_MEMORYTYPE_DEVICE
 
 class CudaLib {
  public:
@@ -36,11 +37,17 @@ class CudaLib {
 
   // True iff p is a CUDA device pointer (UVA query; host/unknown => false).
   bool IsDevicePtr(const void* p) const;
-  // True iff the calling thread has a current CUDA context (GPU dedup runs on
-  // the caller's context — vLLM worker threads always carry one; we never
-  // create contexts behind a framework's back).
+  // Device ordinal owning device pointer p; -1 on failure.
+  int DeviceOf(const void* p) const;
+  // True iff the calling thread has a current CUDA context. Framework compute
+  // threads always do; the connectors' pure-Python transfer threads (ctypes ->
+  // C ABI, never touched CUDA) do NOT — those must BindPrimaryCtx first.
   bool HasCurrentCtx() const;
   int CurrentDevice() const;  // -1 without a context
+  // Make device dev's PRIMARY context current on the calling thread (retains
+  // it once per process — the framework already holds it; this only bumps a
+  // refcount, it never creates a fresh context behind the framework's back).
+  bool BindPrimaryCtx(int dev) const;
 
   CUresult (*MemAlloc)(CUdeviceptr*, size_t) = nullptr;
   CUresult (*MemFree)(CUdeviceptr) = nullptr;
@@ -55,7 +62,9 @@ class CudaLib {
   bool Resolve();
 
   CUresult (*ctx_get_current_)(CUcontext*) = nullptr;
+  CUresult (*ctx_set_current_)(CUcontext) = nullptr;
   CUresult (*ctx_get_device_)(int*) = nullptr;
+  CUresult (*primary_ctx_retain_)(CUcontext*, int) = nullptr;
   CUresult (*pointer_get_attribute_)(void*, int, CUdeviceptr) = nullptr;
 };
 

--- a/src/client/cuda_ipc.h
+++ b/src/client/cuda_ipc.h
@@ -20,6 +20,7 @@ namespace dfkv {
 using CUresult = int;
 using CUdeviceptr = unsigned long long;
 using CUcontext = void*;
+using CUstream = void*;
 struct CUipcMemHandle {
   char reserved[64];
 };
@@ -28,6 +29,7 @@ constexpr unsigned kCuIpcMemLazyEnablePeerAccess = 0x1;
 constexpr int kCuPointerAttributeMemoryType = 2;    // CU_POINTER_ATTRIBUTE_MEMORY_TYPE
 constexpr int kCuPointerAttributeDeviceOrdinal = 9; // CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL
 constexpr unsigned kCuMemoryTypeDevice = 2;         // CU_MEMORYTYPE_DEVICE
+constexpr unsigned kCuStreamNonBlocking = 1;        // CU_STREAM_NON_BLOCKING
 
 class CudaLib {
  public:
@@ -52,7 +54,16 @@ class CudaLib {
   CUresult (*MemAlloc)(CUdeviceptr*, size_t) = nullptr;
   CUresult (*MemFree)(CUdeviceptr) = nullptr;
   // Unified-addressing copy: any host/device src/dst combination.
+  // NOTE (learned live): the synchronous cuMemcpy runs on the LEGACY default
+  // stream — it falsely serializes with every compute kernel the framework
+  // has in flight (100x slowdowns under load) AND returns before D2D copies
+  // complete. The rendezvous therefore uses MemcpyAsync on its own
+  // non-blocking stream + StreamSynchronize; plain Memcpy stays for tests.
   CUresult (*Memcpy)(CUdeviceptr, CUdeviceptr, size_t) = nullptr;
+  CUresult (*MemcpyAsync)(CUdeviceptr, CUdeviceptr, size_t, CUstream) = nullptr;
+  CUresult (*StreamCreate)(CUstream*, unsigned) = nullptr;
+  CUresult (*StreamSynchronize)(CUstream) = nullptr;
+  CUresult (*StreamDestroy)(CUstream) = nullptr;
   CUresult (*IpcGetMemHandle)(CUipcMemHandle*, CUdeviceptr) = nullptr;
   CUresult (*IpcOpenMemHandle)(CUdeviceptr*, CUipcMemHandle, unsigned) = nullptr;
   CUresult (*IpcCloseMemHandle)(CUdeviceptr) = nullptr;

--- a/src/client/dfkv_c_api.cc
+++ b/src/client/dfkv_c_api.cc
@@ -93,6 +93,11 @@ int dfkv_register_memory(dfkv_client_t c, const void* base, uint64_t size) {
   return 0;
 }
 
+uint32_t dfkv_max_sg_segs(dfkv_client_t c) {
+  if (!c) return 0;
+  return static_cast<uint32_t>(static_cast<KVClient*>(c)->MaxSgPayloadSegs());
+}
+
 // The batch entrypoints take caller-owned C arrays. We validate the array
 // pointers up front (null with n>0 => bad call) and tolerate a null element:
 // a null keys[i] is substituted with an empty item so BatchPut/Get stays index-

--- a/src/client/dfkv_c_api.h
+++ b/src/client/dfkv_c_api.h
@@ -38,6 +38,11 @@ int dfkv_remove(dfkv_client_t c, const char* key);                           // 
 // region is registered once per connection. No-op on the TCP transport. Call once
 // at startup after the pool is allocated, before traffic. Returns 0 on success.
 int dfkv_register_memory(dfkv_client_t c, const void* base, uint64_t size);
+// Max payload segments one scatter-gather key may carry on this client's live
+// transport (RDMA: negotiated max_sge - 1; TCP: 29). Size batch_put_sg /
+// batch_get_auto_sg grouping from this instead of assuming 29. Returns 0 on a
+// null client.
+uint32_t dfkv_max_sg_segs(dfkv_client_t c);
 // Hot-swap cluster membership ("n1=ip:port,n2=ip:port"). Returns 0 on success.
 int dfkv_set_members(dfkv_client_t c, const char* members);
 // Discovery: query seed ("ip:port") for the cluster member list and apply it.

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -299,6 +299,20 @@ std::string KVClient::MetricsSnapshot() const {
     s += "# TYPE dfkv_client_dedup_wait_timeouts_total counter\n";
     s += "dfkv_client_dedup_wait_timeouts_total " + std::to_string(dedup_->wait_timeouts()) + "\n";
   }
+  if (const GpuNodeDedup* gd = gpu_dedup_raw_.load(std::memory_order_acquire)) {
+    s += "# HELP dfkv_client_gpu_dedup_hits_total GPU rendezvous results served via CUDA IPC\n";
+    s += "# TYPE dfkv_client_gpu_dedup_hits_total counter\n";
+    s += "dfkv_client_gpu_dedup_hits_total " + std::to_string(gd->hits()) + "\n";
+    s += "# HELP dfkv_client_gpu_dedup_fetches_total Keys this process fetched for the GPU rendezvous\n";
+    s += "# TYPE dfkv_client_gpu_dedup_fetches_total counter\n";
+    s += "dfkv_client_gpu_dedup_fetches_total " + std::to_string(gd->fetches()) + "\n";
+    s += "# HELP dfkv_client_gpu_dedup_wait_hits_total Waits resolved by a peer's publish\n";
+    s += "# TYPE dfkv_client_gpu_dedup_wait_hits_total counter\n";
+    s += "dfkv_client_gpu_dedup_wait_hits_total " + std::to_string(gd->wait_hits()) + "\n";
+    s += "# HELP dfkv_client_gpu_dedup_wait_timeouts_total Waits that fell back to a direct fetch\n";
+    s += "# TYPE dfkv_client_gpu_dedup_wait_timeouts_total counter\n";
+    s += "dfkv_client_gpu_dedup_wait_timeouts_total " + std::to_string(gd->wait_timeouts()) + "\n";
+  }
   if (t_) s += t_->MetricsText();
   return s;
 }
@@ -622,8 +636,19 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
   std::vector<BlockKey> bks(N);
   std::vector<KvGetItem> fetch_items;
   std::vector<size_t> fetch_map, wait_list;
+  std::vector<char> fetch_claimed;  // 1 = we own a FETCHING slot
   fetch_items.reserve(N);
+  // Host rendezvous can't serve device destinations (memcpy to a device VA);
+  // route those straight to the fetch list unclaimed instead of crashing when
+  // the env switch is set in a GPUDirect process. cu is null on CPU-only hosts.
+  const CudaLib* cu = CudaLib::Get();
   for (size_t i = 0; i < N; ++i) {
+    if (cu && cu->IsDevicePtr(items[i].out)) {
+      fetch_map.push_back(i);
+      fetch_items.push_back(items[i]);
+      fetch_claimed.push_back(0);
+      continue;
+    }
     bks[i] = ToBlockKey(items[i].key, self_hdr_.model_hash);
     switch (dedup_->Claim(bks[i], items[i].n, static_cast<char*>(items[i].out))) {
       case NodeDedup::Role::kHit:
@@ -632,6 +657,7 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
       case NodeDedup::Role::kFetch:
         fetch_map.push_back(i);
         fetch_items.push_back(items[i]);
+        fetch_claimed.push_back(1);
         break;
       case NodeDedup::Role::kWait:
         wait_list.push_back(i);
@@ -643,6 +669,7 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
     for (size_t m = 0; m < fetch_map.size(); ++m) {
       const size_t i = fetch_map[m];
       res[i] = r[m];
+      if (!fetch_claimed[m]) continue;
       if (r[m])
         dedup_->Publish(bks[i], NodeDedup::Kind::kData,
                         static_cast<const char*>(items[i].out), items[i].n);
@@ -728,8 +755,16 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
   std::vector<BlockKey> bks(N);
   std::vector<KvGetItem> fetch_items;
   std::vector<size_t> fetch_map, wait_list;
+  std::vector<char> fetch_claimed;  // 1 = we own a FETCHING slot
   fetch_items.reserve(N);
+  const CudaLib* cu = CudaLib::Get();  // device destinations bypass (see BatchGet)
   for (size_t i = 0; i < N; ++i) {
+    if (cu && cu->IsDevicePtr(items[i].out)) {
+      fetch_map.push_back(i);
+      fetch_items.push_back(items[i]);
+      fetch_claimed.push_back(0);
+      continue;
+    }
     bks[i] = ToBlockKey(items[i].key, self_hdr_.model_hash);
     size_t got = 0;
     switch (dedup_->ClaimAuto(bks[i], items[i].n, static_cast<char*>(items[i].out), &got)) {
@@ -740,6 +775,7 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
       case NodeDedup::Role::kFetch:
         fetch_map.push_back(i);
         fetch_items.push_back(items[i]);
+        fetch_claimed.push_back(1);
         break;
       case NodeDedup::Role::kWait:
         wait_list.push_back(i);
@@ -752,8 +788,9 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
     for (size_t m = 0; m < fetch_map.size(); ++m) {
       const size_t i = fetch_map[m];
       res[i] = r[m];
+      if (r[m]) lens[i] = flens[m];
+      if (!fetch_claimed[m]) continue;
       if (r[m]) {
-        lens[i] = flens[m];
         dedup_->Publish(bks[i], NodeDedup::Kind::kData,
                         static_cast<const char*>(items[i].out), flens[m]);
       } else {
@@ -1036,8 +1073,110 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   return RecordBatch(OpMetrics::kPut, t0, ok, bytes);
 }
 
+GpuNodeDedup* KVClient::GpuDedup() {
+  std::call_once(gpu_dedup_once_, [this] {
+    gpu_dedup_ = GpuNodeDedup::FromEnv(self_hdr_.model_hash);
+    gpu_dedup_raw_.store(gpu_dedup_.get(), std::memory_order_release);
+  });
+  return gpu_dedup_.get();
+}
+
 std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items,
                                            std::vector<size_t>* out_lens) {
+  GpuNodeDedup* gd = GpuDedup();
+  if (!gd || items.empty()) return BatchGetAutoSgDirect(items, out_lens);
+  // Same-host rendezvous for GPU destinations (phase 2b, see node_dedup_gpu.h):
+  // the vLLM connector's SG gets land in device memory, where lockstep TP
+  // ranks re-fetch identical TP-replicated KV. Payloads rendezvous through
+  // per-process GPU staging arenas (CUDA IPC + NVLink D2D); every outcome
+  // degrades to the plain remote path.
+  const CudaLib* cu = CudaLib::Get();  // non-null: gd exists
+  const size_t N = items.size();
+  std::vector<bool> res(N, false);
+  std::vector<size_t> lens(N, 0);
+  std::vector<BlockKey> bks(N);
+  std::vector<KvGetItemSg> fetch_items;
+  std::vector<size_t> fetch_map, wait_list;
+  std::vector<char> fetch_claimed;  // 1 = we own a FETCHING slot (must publish/abort)
+  std::vector<GpuNodeDedup::Seg> segs;
+  auto segs_of = [&segs](const KvGetItemSg& it) {
+    segs.clear();
+    segs.reserve(it.dsts.size());
+    for (size_t j = 0; j < it.dsts.size(); ++j)
+      segs.push_back(GpuNodeDedup::Seg{it.dsts[j], it.caps[j]});
+  };
+  auto total_cap = [](const KvGetItemSg& it) {
+    size_t c = 0;
+    for (size_t x : it.caps) c += x;
+    return c;
+  };
+  for (size_t i = 0; i < N; ++i) {
+    // Eligible = well-shaped AND device-memory destination. Host-destination
+    // SG items (or malformed ones the Direct guard rejects) skip the
+    // rendezvous entirely — an unclaimed fetch has no publish obligation.
+    const bool eligible = !items[i].key.empty() && !items[i].dsts.empty() &&
+                          items[i].dsts.size() == items[i].caps.size() &&
+                          cu->IsDevicePtr(items[i].dsts[0]);
+    if (!eligible) {
+      fetch_map.push_back(i);
+      fetch_items.push_back(items[i]);
+      fetch_claimed.push_back(0);
+      continue;
+    }
+    bks[i] = ToBlockKey(items[i].key, self_hdr_.model_hash);
+    segs_of(items[i]);
+    size_t got = 0;
+    switch (gd->ClaimSg(bks[i], segs.data(), segs.size(), total_cap(items[i]), &got)) {
+      case GpuNodeDedup::Role::kHit:
+        res[i] = true;
+        lens[i] = got;
+        break;
+      case GpuNodeDedup::Role::kFetch:
+        fetch_map.push_back(i);
+        fetch_items.push_back(items[i]);
+        fetch_claimed.push_back(1);
+        break;
+      case GpuNodeDedup::Role::kWait:
+        wait_list.push_back(i);
+        break;
+    }
+  }
+  if (!fetch_items.empty()) {
+    std::vector<size_t> flens;
+    auto r = BatchGetAutoSgDirect(fetch_items, &flens);
+    for (size_t m = 0; m < fetch_map.size(); ++m) {
+      const size_t i = fetch_map[m];
+      res[i] = r[m];
+      if (r[m]) lens[i] = flens[m];
+      if (!fetch_claimed[m]) continue;
+      if (r[m]) {
+        segs_of(items[i]);
+        gd->PublishSg(bks[i], segs.data(), segs.size(), flens[m]);
+      } else {
+        gd->Abort(bks[i]);
+      }
+    }
+  }
+  for (size_t i : wait_list) {
+    segs_of(items[i]);
+    size_t got = 0;
+    if (gd->WaitSg(bks[i], segs.data(), segs.size(), total_cap(items[i]), &got)) {
+      res[i] = true;
+      lens[i] = got;
+    } else {  // fetcher failed/slow: bounded fallback to a direct read
+      std::vector<KvGetItemSg> one(1, items[i]);
+      std::vector<size_t> ol;
+      auto rr = BatchGetAutoSgDirect(one, &ol);
+      res[i] = rr[0];
+      if (rr[0]) lens[i] = ol[0];
+    }
+  }
+  if (out_lens) *out_lens = std::move(lens);
+  return res;
+}
+
+std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>& items,
+                                                 std::vector<size_t>* out_lens) {
   auto t0 = std::chrono::steady_clock::now();
   const size_t N = items.size();
   std::vector<char> hit(N, 0);

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1157,18 +1157,35 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
       }
     }
   }
+  // Waits are sequential with a per-key deadline; a batch-level budget stops
+  // a slow/failed fetcher from stacking those deadlines (1554 keys x 500 ms
+  // was a 7-minute request, observed live). Everything unresolved when the
+  // budget runs out — and every individual wait miss — falls back through
+  // ONE direct batch, not per-key singles.
+  std::vector<size_t> fb;
+  const uint64_t wait_deadline =
+      NowMs() + 2ull * static_cast<uint64_t>(gd->wait_ms());
   for (size_t i : wait_list) {
-    segs_of(items[i]);
     size_t got = 0;
-    if (gd->WaitSg(bks[i], segs.data(), segs.size(), total_cap(items[i]), &got)) {
-      res[i] = true;
-      lens[i] = got;
-    } else {  // fetcher failed/slow: bounded fallback to a direct read
-      std::vector<KvGetItemSg> one(1, items[i]);
-      std::vector<size_t> ol;
-      auto rr = BatchGetAutoSgDirect(one, &ol);
-      res[i] = rr[0];
-      if (rr[0]) lens[i] = ol[0];
+    if (NowMs() < wait_deadline) {
+      segs_of(items[i]);
+      if (gd->WaitSg(bks[i], segs.data(), segs.size(), total_cap(items[i]), &got)) {
+        res[i] = true;
+        lens[i] = got;
+        continue;
+      }
+    }
+    fb.push_back(i);
+  }
+  if (!fb.empty()) {
+    std::vector<KvGetItemSg> rest;
+    rest.reserve(fb.size());
+    for (size_t i : fb) rest.push_back(items[i]);
+    std::vector<size_t> rl;
+    auto rr = BatchGetAutoSgDirect(rest, &rl);
+    for (size_t m = 0; m < fb.size(); ++m) {
+      res[fb[m]] = rr[m];
+      if (rr[m]) lens[fb[m]] = rl[m];
     }
   }
   if (out_lens) *out_lens = std::move(lens);

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1064,9 +1064,9 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   return RecordBatch(OpMetrics::kPut, t0, ok, bytes);
 }
 
-GpuNodeDedup* KVClient::GpuDedup() {
-  std::call_once(gpu_dedup_once_, [this] {
-    gpu_dedup_ = GpuNodeDedup::FromEnv(self_hdr_.model_hash);
+GpuNodeDedup* KVClient::GpuDedup(const void* device_dst_hint) {
+  std::call_once(gpu_dedup_once_, [this, device_dst_hint] {
+    gpu_dedup_ = GpuNodeDedup::FromEnv(self_hdr_.model_hash, device_dst_hint);
     gpu_dedup_raw_.store(gpu_dedup_.get(), std::memory_order_release);
   });
   return gpu_dedup_.get();
@@ -1074,7 +1074,16 @@ GpuNodeDedup* KVClient::GpuDedup() {
 
 std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items,
                                            std::vector<size_t>* out_lens) {
-  GpuNodeDedup* gd = GpuDedup();
+  // Init the GPU rendezvous only once a DEVICE destination shows up: its
+  // pointer picks the primary context to bind when this (transfer) thread
+  // has none, and host-only callers never pay for an arena.
+  GpuNodeDedup* gd = nullptr;
+  if (const CudaLib* cu0 = CudaLib::Get()) {
+    const void* hint = nullptr;
+    for (const auto& it : items)
+      if (!it.dsts.empty() && cu0->IsDevicePtr(it.dsts[0])) { hint = it.dsts[0]; break; }
+    if (hint) gd = GpuDedup(hint);
+  }
   if (!gd || items.empty()) return BatchGetAutoSgDirect(items, out_lens);
   // Same-host rendezvous for GPU destinations (phase 2b, see node_dedup_gpu.h):
   // the vLLM connector's SG gets land in device memory, where lockstep TP

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1157,25 +1157,32 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
       }
     }
   }
-  // Waits are sequential with a per-key deadline; a batch-level budget stops
-  // a slow/failed fetcher from stacking those deadlines (1554 keys x 500 ms
-  // was a 7-minute request, observed live). Everything unresolved when the
-  // budget runs out — and every individual wait miss — falls back through
-  // ONE direct batch, not per-key singles.
+  // One amortized-sync wait for the WHOLE wait list (WaitManySg): copies are
+  // enqueued as keys turn READY and the stream synchronizes per round, not
+  // per key — per-key syncs cost ~ms under load and burned any wait budget
+  // long before the list was through (the dedup win leaked back out through
+  // fallback re-fetches; measured live in the PD A/B). Failures fall back
+  // through ONE direct batch.
   std::vector<size_t> fb;
-  const uint64_t wait_deadline =
-      NowMs() + 2ull * static_cast<uint64_t>(gd->wait_ms());
-  for (size_t i : wait_list) {
-    size_t got = 0;
-    if (NowMs() < wait_deadline) {
-      segs_of(items[i]);
-      if (gd->WaitSg(bks[i], segs.data(), segs.size(), total_cap(items[i]), &got)) {
-        res[i] = true;
-        lens[i] = got;
-        continue;
-      }
+  std::vector<GpuNodeDedup::WaitItem> wits(wait_list.size());
+  std::vector<std::vector<GpuNodeDedup::Seg>> wsegs(wait_list.size());
+  for (size_t m = 0; m < wait_list.size(); ++m) {
+    const size_t i = wait_list[m];
+    wsegs[m].reserve(items[i].dsts.size());
+    for (size_t j = 0; j < items[i].dsts.size(); ++j)
+      wsegs[m].push_back(GpuNodeDedup::Seg{items[i].dsts[j], items[i].caps[j]});
+    wits[m] = GpuNodeDedup::WaitItem{bks[i], wsegs[m].data(), wsegs[m].size(),
+                                     total_cap(items[i]), false, 0};
+  }
+  gd->WaitManySg(wits.data(), wits.size());
+  for (size_t m = 0; m < wait_list.size(); ++m) {
+    const size_t i = wait_list[m];
+    if (wits[m].ok) {
+      res[i] = true;
+      lens[i] = wits[m].got;
+    } else {
+      fb.push_back(i);
     }
-    fb.push_back(i);
   }
   if (!fb.empty()) {
     std::vector<KvGetItemSg> rest;

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1188,6 +1188,27 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
       if (rr[m]) lens[fb[m]] = rl[m];
     }
   }
+  // Per-batch split, opt-in (DFKV_CLIENT_NODE_DEDUP_LOG=1): the one line that
+  // distinguishes "waits time out" from "claims never dedup" when the server
+  // counters look wrong — cheap enough to leave on in a canary.
+  static const bool log_split = [] {
+    const char* v = std::getenv("DFKV_CLIENT_NODE_DEDUP_LOG");
+    return v && std::strcmp(v, "1") == 0;
+  }();
+  if (log_split) {
+    size_t hits0 = 0;
+    for (bool b : res) hits0 += b;
+    DFKV_LOG_INFO("gpu-dedup batch: n=" + std::to_string(N) +
+                  " claim_hit=" + std::to_string(N - fetch_map.size() - wait_list.size()) +
+                  " fetched=" + std::to_string(fetch_map.size()) +
+                  " waited=" + std::to_string(wait_list.size()) +
+                  " fallback=" + std::to_string(fb.size()) +
+                  " ok=" + std::to_string(hits0) +
+                  " cum(h=" + std::to_string(gd->hits()) +
+                  ",f=" + std::to_string(gd->fetches()) +
+                  ",wh=" + std::to_string(gd->wait_hits()) +
+                  ",wt=" + std::to_string(gd->wait_timeouts()) + ")");
+  }
   if (out_lens) *out_lens = std::move(lens);
   return res;
 }

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -22,22 +22,13 @@
 namespace dfkv {
 
 namespace {
-// Max payload segments per scatter-gather key. The RDMA QP carries max_sge SGEs
-// per work request; SGE0 is the header, leaving max_sge-1 payload SGEs. The
-// device cap on hd04 ConnectX is 30 -> 29 payload segments. The connector
-// guarantees <=29; a key over this is reported failed instead of corrupted.
-//
-// KNOWN LIMITATION (heterogeneous hardware): this is a fixed 29, not the live
-// negotiated ep.max_sge()-1. On an HCA reporting max_sge < 30, a key whose seg
-// count is between (max_sge-1) and 29 passes this client guard but trips the
-// transport's per-window check (CacheFromMulti/RangeIntoMulti). That now fails
-// only the OFFENDING item (per-item kInvalid), not the whole node batch, so it
-// is graceful fail-soft (the connector recomputes just those blocks; siblings
-// still hit; no data corruption) — it only costs the cache benefit for the
-// oversized keys on small-max_sge devices. Remaining TODO for full cross-HCA
-// efficiency: derive the SG chunk size from the live max_sge instead of this
-// constant so even those keys cache.
-constexpr size_t kSgMaxPayloadSegs = 29;
+// Max payload segments per scatter-gather key: the guards below use the LIVE
+// Transport::MaxSgPayloadSegs() (negotiated max_sge - 1 on RDMA; 29 on TCP),
+// and the connector reads the same value through dfkv_max_sg_segs, so its
+// chunking matches whatever HCA the client actually opened. A key exceeding
+// the guard is reported failed up front instead of corrupted; a stale caller
+// still hard-coding 29 on a smaller-max_sge device degrades per-item (the
+// transport's window check fails only the offending key), never per-batch.
 
 // Shared fan-out pool for the Batch* paths. The old RunParallel created and
 // joined up to 32 std::threads PER CALL; a connector issuing batches at high
@@ -1020,7 +1011,7 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   for (size_t i = 0; i < N; ++i) {
     if (items[i].key.empty() ||  // null/empty key: skip (no header-only blob written)
         items[i].ptrs.size() != items[i].sizes.size() ||
-        items[i].ptrs.size() > kSgMaxPayloadSegs)
+        items[i].ptrs.size() > t_->MaxSgPayloadSegs())
       over[i] = 1;
   }
 
@@ -1188,7 +1179,7 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
   for (size_t i = 0; i < N; ++i) {
     if (items[i].key.empty() ||  // null/empty key: skip (no wasted GET issued)
         items[i].dsts.size() != items[i].caps.size() ||
-        items[i].dsts.size() > kSgMaxPayloadSegs)
+        items[i].dsts.size() > t_->MaxSgPayloadSegs())
       over[i] = 1;
   }
 

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -23,6 +23,7 @@
 
 #include "utils/con_hash.h"
 #include "client/node_dedup.h"
+#include "client/node_dedup_gpu.h"
 #include "common/membership.h"
 #include "mds/mds_member_poller.h"
 #include "mds/mds_registrar.h"
@@ -185,7 +186,13 @@ class KVClient {
   std::vector<bool> BatchGetDirect(const std::vector<KvGetItem>& items);
   std::vector<bool> BatchGetAutoDirect(const std::vector<KvGetItem>& items,
                                        std::vector<size_t>* out_lens);
+  std::vector<bool> BatchGetAutoSgDirect(const std::vector<KvGetItemSg>& items,
+                                         std::vector<size_t>* out_lens);
   std::vector<bool> BatchExistDirect(const std::vector<std::string>& keys);
+  // Lazily opens the GPU rendezvous on the FIRST SG batch (the ctor thread may
+  // not hold a CUDA context yet; the data-path caller always does). nullptr =
+  // feature off. Init is once-only; metrics readers use gpu_dedup_raw_.
+  GpuNodeDedup* GpuDedup();
   // Record a batch op (hits = count of true flags) into op_stats_ and return the
   // per-item result vector. Called at each batch method's return point.
   std::vector<bool> RecordBatch(OpMetrics::Op op,
@@ -208,6 +215,11 @@ class KVClient {
   // Same-host GET rendezvous (phase 5, DFKV_CLIENT_NODE_DEDUP=1; host-memory
   // destinations only). nullptr = feature off.
   std::unique_ptr<NodeDedup> dedup_;
+  // Same-host GET rendezvous for GPU destinations (phase 2b; vLLM SG path).
+  // Lazy-init via GpuDedup(); raw pointer published for lock-free metrics.
+  std::once_flag gpu_dedup_once_;
+  std::unique_ptr<GpuNodeDedup> gpu_dedup_;
+  std::atomic<GpuNodeDedup*> gpu_dedup_raw_{nullptr};
   std::unique_ptr<MdsRegistrar> client_registrar_;  // consumer identity lease (best-effort)
   PeerHealth health_;
   OpMetrics op_stats_;  // per-op (put/get/exist) counters + latency, snapshot'd

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -194,10 +194,11 @@ class KVClient {
   std::vector<bool> BatchGetAutoSgDirect(const std::vector<KvGetItemSg>& items,
                                          std::vector<size_t>* out_lens);
   std::vector<bool> BatchExistDirect(const std::vector<std::string>& keys);
-  // Lazily opens the GPU rendezvous on the FIRST SG batch (the ctor thread may
-  // not hold a CUDA context yet; the data-path caller always does). nullptr =
-  // feature off. Init is once-only; metrics readers use gpu_dedup_raw_.
-  GpuNodeDedup* GpuDedup();
+  // Lazily opens the GPU rendezvous on the first SG batch carrying a device
+  // destination; the hint pointer selects the primary context to bind when
+  // the calling (transfer) thread has none. nullptr = feature off. Init is
+  // once-only; metrics readers use gpu_dedup_raw_.
+  GpuNodeDedup* GpuDedup(const void* device_dst_hint);
   // Record a batch op (hits = count of true flags) into op_stats_ and return the
   // per-item result vector. Called at each batch method's return point.
   std::vector<bool> RecordBatch(OpMetrics::Op op,

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -134,6 +134,11 @@ class KVClient {
   // Call once at startup (after the pool is allocated) before traffic.
   void RegisterMemory(void* base, size_t size) { t_->RegisterMemory(base, size); }
 
+  // Max payload segments per scatter-gather key on the LIVE transport (RDMA:
+  // negotiated max_sge - 1; TCP: 29). Connectors size their SG chunking from
+  // this (via dfkv_max_sg_segs) instead of hard-coding the ConnectX-era 29.
+  size_t MaxSgPayloadSegs() const { return t_->MaxSgPayloadSegs(); }
+
   // Hot-swap the cluster membership (rebuilds the consistent-hash ring).
   // Thread-safe vs concurrent Put/Get/Exist.
   void SetMembers(std::vector<std::pair<std::string, std::string>> members);

--- a/src/client/node_dedup.cc
+++ b/src/client/node_dedup.cc
@@ -279,14 +279,19 @@ NodeDedup::Role NodeDedup::ClaimImpl(const BlockKey& key, Kind kind, size_t cap,
     // Concurrent claimers can reserve TWO slots for one key when the second
     // claimer's Find() races the first's identity write (near-synchronous
     // claim loops hit that window almost every key; found live on the GPU
-    // flavor as exactly-2x server reads). Lowest probe position is canonical;
-    // a non-canonical winner releases and waits.
-    Slot* first = Find(key, kind);
-    if (first && first != mine) {
-      uint32_t st = kStateFetching;
-      mine->state.compare_exchange_strong(st, kStateEmpty,
-                                          std::memory_order_acq_rel);
-      return Role::kWait;
+    // flavor as exactly-2x server reads). Re-scan twice — immediately and
+    // after a ~1 us settle spin — and keep only the LOWEST probe position
+    // (what every waiter's Find returns); other winners release and wait.
+    for (int pass = 0; pass < 2; ++pass) {
+      Slot* first = Find(key, kind);
+      if (first && first != mine) {
+        uint32_t st = kStateFetching;
+        mine->state.compare_exchange_strong(st, kStateEmpty,
+                                            std::memory_order_acq_rel);
+        return Role::kWait;
+      }
+      if (pass == 0)
+        for (volatile int spin = 0; spin < 2000; ++spin) {}
     }
     fetches_.fetch_add(1, std::memory_order_relaxed);
     return Role::kFetch;

--- a/src/client/node_dedup.cc
+++ b/src/client/node_dedup.cc
@@ -275,7 +275,19 @@ NodeDedup::Role NodeDedup::ClaimImpl(const BlockKey& key, Kind kind, size_t cap,
       return Role::kWait;
     }
   }
-  if (Reserve(key, kind)) {
+  if (Slot* mine = Reserve(key, kind)) {
+    // Concurrent claimers can reserve TWO slots for one key when the second
+    // claimer's Find() races the first's identity write (near-synchronous
+    // claim loops hit that window almost every key; found live on the GPU
+    // flavor as exactly-2x server reads). Lowest probe position is canonical;
+    // a non-canonical winner releases and waits.
+    Slot* first = Find(key, kind);
+    if (first && first != mine) {
+      uint32_t st = kStateFetching;
+      mine->state.compare_exchange_strong(st, kStateEmpty,
+                                          std::memory_order_acq_rel);
+      return Role::kWait;
+    }
     fetches_.fetch_add(1, std::memory_order_relaxed);
     return Role::kFetch;
   }

--- a/src/client/node_dedup.h
+++ b/src/client/node_dedup.h
@@ -25,9 +25,10 @@
  *  - Nothing here is load-bearing: every exit path (no slot, timeout, torn
  *    read, size mismatch) degrades to the caller's normal remote op.
  *
- * SCOPE: host-memory destinations only (the SGLang HiCache path). GPUDirect
- * destinations (vLLM connector) must NOT enable this — memcpy to a device VA
- * is invalid; that path needs CUDA IPC and stays with the Phase-2b design.
+ * SCOPE: host-memory destinations (the SGLang HiCache path). GPUDirect
+ * destinations are ROUTED AWAY from this class by the batch wrappers (a
+ * memcpy to a device VA is invalid) and served by the CUDA-IPC flavor in
+ * node_dedup_gpu.h (phase 2b, DFKV_CLIENT_NODE_DEDUP_GPU=1 opts in on top).
  * Off by default (DFKV_CLIENT_NODE_DEDUP=1 opts in). */
 #ifndef DFKV_NODE_DEDUP_H_
 #define DFKV_NODE_DEDUP_H_

--- a/src/client/node_dedup_gpu.cc
+++ b/src/client/node_dedup_gpu.cc
@@ -1,0 +1,471 @@
+#include "client/node_dedup_gpu.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+#include "utils/log.h"
+
+namespace dfkv {
+
+namespace {
+constexpr uint32_t kMagic = 0x44444731u;  // "DDG1"
+constexpr uint32_t kStateEmpty = 0;
+constexpr uint32_t kStateFetching = 1;
+constexpr uint32_t kStateReady = 2;
+constexpr uint32_t kKindData = 1;  // single namespace (exist rides the host segment)
+
+uint64_t EnvU64(const char* name, uint64_t dflt) {
+  const char* v = std::getenv(name);
+  if (!v || !*v) return dflt;
+  unsigned long long x = std::strtoull(v, nullptr, 10);
+  return x > 0 ? static_cast<uint64_t>(x) : dflt;
+}
+
+uint32_t Pow2AtLeast(uint32_t v) {
+  uint32_t p = 1024;
+  while (p < v && p < (1u << 24)) p <<= 1;
+  return p;
+}
+
+bool PidDead(uint32_t pid) {
+  return ::kill(static_cast<pid_t>(pid), 0) != 0 && errno == ESRCH;
+}
+}  // namespace
+
+// Same 64-byte seqlock slot as the host flavor, but the payload location is a
+// DESCRIPTOR into a peer's GPU arena: (owner registry index, owner generation,
+// arena offset, arena cursor at allocation).
+struct GpuNodeDedup::Slot {
+  std::atomic<uint64_t> gen;
+  std::atomic<uint32_t> state;
+  uint32_t len;
+  uint64_t key_id;
+  uint32_t key_index;
+  uint32_t kind;
+  std::atomic<uint64_t> fetch_start_ms;
+  uint64_t payload_off;   // offset into the OWNER's GPU arena
+  uint64_t alloc_seq;     // owner's arena cursor value at allocation (lap check)
+  uint32_t owner_idx;     // registry entry of the publishing process
+  uint32_t owner_gen32;   // truncated entry generation at publish time
+};
+
+// One per participating process. pid claims the entry (CAS, dead pids are
+// reclaimable); generation counts claims so descriptors and cached IPC
+// mappings against a previous occupant are detectable. The arena allocation
+// cursor lives HERE (per arena), not in the header.
+struct GpuNodeDedup::ProcEntry {
+  std::atomic<uint32_t> pid;         // 0 = free
+  std::atomic<uint32_t> ready;       // 1 once handle/device/arena_bytes valid
+  std::atomic<uint64_t> generation;  // bumped on every claim
+  std::atomic<uint64_t> alloc_cursor;
+  uint64_t arena_bytes;
+  int32_t device;
+  uint32_t pad0;
+  CUipcMemHandle handle;
+  uint64_t pad1[3];  // -> 128 B (cross-process ABI)
+};
+
+struct GpuNodeDedup::Header {
+  uint32_t magic;
+  uint32_t nslots;
+  uint64_t arena_bytes;  // configured per-process arena size (must match)
+  std::atomic<uint32_t> init_done;
+  uint32_t pad;
+};
+
+uint64_t GpuNodeDedup::NowMs() {
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+std::string GpuNodeDedup::EnvSegmentName(uint64_t model_hash) {
+  char name[128];
+  // Layout version FIRST in the name (v1.23.0 lesson, see node_dedup.h):
+  // a layout bump must never meet a segment an older lib left behind.
+  std::snprintf(name, sizeof(name), "/dfkv-dedup-gpuv1-%u-%016llx", ::getuid(),
+                static_cast<unsigned long long>(model_hash));
+  return name;
+}
+
+std::unique_ptr<GpuNodeDedup> GpuNodeDedup::FromEnv(uint64_t model_hash) {
+  const char* on = std::getenv("DFKV_CLIENT_NODE_DEDUP");
+  if (!on || std::strcmp(on, "1") != 0) return nullptr;
+  const char* gpu = std::getenv("DFKV_CLIENT_NODE_DEDUP_GPU");
+  if (!gpu || std::strcmp(gpu, "1") != 0) return nullptr;
+  const CudaLib* cu = CudaLib::Get();
+  if (!cu) {
+    DFKV_LOG_INFO("gpu-dedup: no usable CUDA driver, running without");
+    return nullptr;
+  }
+  if (!cu->HasCurrentCtx()) {
+    DFKV_LOG_INFO("gpu-dedup: no current CUDA context on this thread, running without");
+    return nullptr;
+  }
+  Options o;
+  o.arena_bytes = EnvU64("DFKV_NODE_DEDUP_GPU_ARENA_MB", 512) << 20;
+  o.slots = static_cast<uint32_t>(EnvU64("DFKV_NODE_DEDUP_GPU_SLOTS", 16384));
+  o.wait_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_WAIT_MS", 500));
+  o.takeover_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TAKEOVER_MS", 2000));
+  o.ttl_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TTL_MS", 5000));
+  o.name = EnvSegmentName(model_hash);
+  return Open(o);
+}
+
+std::unique_ptr<GpuNodeDedup> GpuNodeDedup::Open(const Options& opt) {
+  static_assert(sizeof(Slot) == 64, "shm slot layout is cross-process ABI");
+  static_assert(sizeof(ProcEntry) == 128, "shm registry layout is cross-process ABI");
+  const CudaLib* cu = CudaLib::Get();
+  if (!cu || !cu->HasCurrentCtx()) return nullptr;
+
+  const uint32_t nslots = Pow2AtLeast(opt.slots);
+  const size_t len = sizeof(Header) + sizeof(ProcEntry) * kMaxProcs +
+                     static_cast<size_t>(nslots) * sizeof(Slot);
+  int fd = ::shm_open(opt.name.c_str(), O_RDWR | O_CREAT, 0600);
+  if (fd < 0) return nullptr;
+  struct stat st{};
+  if (::fstat(fd, &st) != 0) { ::close(fd); return nullptr; }
+  const bool creator = (st.st_size == 0);
+  if (creator) {
+    // Small segment (~1-2 MiB: descriptors only, payloads live in GPU
+    // memory), but the eager-backing rule from the host flavor still holds:
+    // ENOSPC here beats a SIGBUS mid-publish.
+    if (::ftruncate(fd, static_cast<off_t>(len)) != 0 ||
+        ::posix_fallocate(fd, 0, static_cast<off_t>(len)) != 0) {
+      ::close(fd);
+      ::shm_unlink(opt.name.c_str());
+      return nullptr;
+    }
+  } else if (static_cast<size_t>(st.st_size) != len) {
+    DFKV_LOG_INFO("gpu-dedup: existing segment layout mismatch, running without");
+    ::close(fd);
+    return nullptr;
+  }
+  void* base = ::mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  ::close(fd);
+  if (base == MAP_FAILED) return nullptr;
+
+  auto d = std::unique_ptr<GpuNodeDedup>(new GpuNodeDedup());
+  d->cu_ = cu;
+  d->map_base_ = base;
+  d->map_len_ = len;
+  d->hdr_ = static_cast<Header*>(base);
+  d->reg_ = reinterpret_cast<ProcEntry*>(static_cast<char*>(base) + sizeof(Header));
+  d->slots_ = reinterpret_cast<Slot*>(reinterpret_cast<char*>(d->reg_) +
+                                      sizeof(ProcEntry) * kMaxProcs);
+  d->nslots_ = nslots;
+  d->arena_bytes_ = opt.arena_bytes;
+  d->wait_ms_ = opt.wait_ms;
+  d->takeover_ms_ = opt.takeover_ms;
+  d->ttl_ms_ = opt.ttl_ms;
+
+  if (creator) {
+    d->hdr_->nslots = nslots;
+    d->hdr_->arena_bytes = opt.arena_bytes;
+    d->hdr_->magic = kMagic;
+    d->hdr_->init_done.store(1, std::memory_order_release);
+  } else {
+    for (int spin = 0; spin < 1000 && d->hdr_->init_done.load(std::memory_order_acquire) != 1; ++spin)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    if (d->hdr_->magic != kMagic || d->hdr_->nslots != nslots ||
+        d->hdr_->arena_bytes != opt.arena_bytes) {
+      DFKV_LOG_INFO("gpu-dedup: segment header mismatch, running without");
+      return nullptr;
+    }
+  }
+
+  // Allocate this process' staging arena on the caller's device and export it.
+  if (cu->MemAlloc(&d->arena_base_, opt.arena_bytes) != kCudaSuccess) {
+    DFKV_LOG_INFO("gpu-dedup: cannot allocate " +
+                  std::to_string(opt.arena_bytes >> 20) +
+                  " MiB GPU staging arena, running without");
+    return nullptr;
+  }
+  CUipcMemHandle handle{};
+  if (cu->IpcGetMemHandle(&handle, d->arena_base_) != kCudaSuccess) {
+    DFKV_LOG_INFO("gpu-dedup: cuIpcGetMemHandle failed, running without");
+    return nullptr;  // dtor frees the arena
+  }
+
+  // Claim a registry entry: a free one, or one whose owner died.
+  const uint32_t mypid = static_cast<uint32_t>(::getpid());
+  for (uint32_t i = 0; i < kMaxProcs && d->self_idx_ == kMaxProcs; ++i) {
+    ProcEntry& e = d->reg_[i];
+    uint32_t cur = e.pid.load(std::memory_order_acquire);
+    if (cur == mypid) continue;  // stale self entry from an exec'd ancestor: skip
+    if (cur != 0 && !PidDead(cur)) continue;
+    if (!e.pid.compare_exchange_strong(cur, mypid, std::memory_order_acq_rel))
+      continue;
+    e.ready.store(0, std::memory_order_release);
+    d->self_gen_ = e.generation.fetch_add(1, std::memory_order_acq_rel) + 1;
+    e.alloc_cursor.store(0, std::memory_order_relaxed);
+    e.arena_bytes = opt.arena_bytes;
+    e.device = cu->CurrentDevice();
+    std::memcpy(&e.handle, &handle, sizeof(handle));
+    e.ready.store(1, std::memory_order_release);
+    d->self_idx_ = i;
+  }
+  if (d->self_idx_ == kMaxProcs) {
+    DFKV_LOG_INFO("gpu-dedup: registry full (" + std::to_string(kMaxProcs) +
+                  " live processes), running without");
+    return nullptr;
+  }
+  DFKV_LOG_INFO("gpu-dedup: attached " + opt.name + " (slots=" +
+                std::to_string(nslots) + ", arena=" +
+                std::to_string(opt.arena_bytes >> 20) + " MiB on device " +
+                std::to_string(d->reg_[d->self_idx_].device) + ", entry " +
+                std::to_string(d->self_idx_) + ")");
+  return d;
+}
+
+GpuNodeDedup::~GpuNodeDedup() {
+  if (self_idx_ < kMaxProcs && reg_) {
+    ProcEntry& e = reg_[self_idx_];
+    // Invalidate before the arena goes away: readers check generation before
+    // AND after the copy, so a mid-copy free degrades to a miss (the driver
+    // rejects the unmapped VA range; it does not corrupt).
+    e.ready.store(0, std::memory_order_release);
+    e.generation.fetch_add(1, std::memory_order_acq_rel);
+    e.pid.store(0, std::memory_order_release);
+  }
+  if (cu_) {
+    for (auto& pm : peer_map_)
+      if (pm.base) cu_->IpcCloseMemHandle(pm.base);  // best-effort at teardown
+    if (arena_base_) cu_->MemFree(arena_base_);
+  }
+  if (map_base_) ::munmap(map_base_, map_len_);
+}
+
+GpuNodeDedup::Slot* GpuNodeDedup::Find(const BlockKey& key) const {
+  const uint32_t mask = nslots_ - 1;
+  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index) & mask;
+  for (int probe = 0; probe < 8; ++probe, idx = (idx + 1) & mask) {
+    Slot& s = slots_[idx];
+    if (s.state.load(std::memory_order_acquire) == kStateEmpty) continue;
+    if (s.key_id == key.id && s.key_index == key.index && s.kind == kKindData)
+      return &s;
+  }
+  return nullptr;
+}
+
+GpuNodeDedup::Slot* GpuNodeDedup::Reserve(const BlockKey& key) {
+  const uint64_t now = NowMs();
+  const uint32_t mask = nslots_ - 1;
+  uint32_t idx = static_cast<uint32_t>(key.id ^ (key.id >> 32) ^ key.index) & mask;
+  for (int probe = 0; probe < 8; ++probe, idx = (idx + 1) & mask) {
+    Slot& s = slots_[idx];
+    uint32_t st = s.state.load(std::memory_order_acquire);
+    bool claim = false;
+    if (st == kStateEmpty) {
+      claim = s.state.compare_exchange_strong(st, kStateFetching,
+                                              std::memory_order_acq_rel);
+    } else if (st == kStateReady &&
+               now - s.fetch_start_ms.load(std::memory_order_relaxed) >
+                   static_cast<uint64_t>(ttl_ms_)) {
+      claim = s.state.compare_exchange_strong(st, kStateFetching,
+                                              std::memory_order_acq_rel);
+    }
+    if (!claim) continue;
+    s.gen.fetch_add(1, std::memory_order_acq_rel);  // odd: mutating identity
+    s.key_id = key.id;
+    s.key_index = key.index;
+    s.kind = kKindData;
+    s.len = 0;
+    s.payload_off = 0;
+    s.alloc_seq = 0;
+    s.owner_idx = kMaxProcs;
+    s.owner_gen32 = 0;
+    s.fetch_start_ms.store(now, std::memory_order_relaxed);
+    s.gen.fetch_add(1, std::memory_order_release);  // even: coherent
+    return &s;
+  }
+  return nullptr;
+}
+
+CUdeviceptr GpuNodeDedup::PeerBase(uint32_t idx, uint64_t gen) {
+  if (idx == self_idx_)
+    return gen == self_gen_ ? arena_base_ : 0;  // own publishes: no IPC open
+  std::lock_guard<std::mutex> lk(peer_mu_);
+  PeerMap& pm = peer_map_[idx];
+  if (pm.base && pm.gen == gen) return pm.base;
+  if (pm.base) {  // stale mapping of a previous occupant
+    cu_->IpcCloseMemHandle(pm.base);
+    pm.base = 0;
+  }
+  ProcEntry& e = reg_[idx];
+  CUipcMemHandle h;
+  std::memcpy(&h, &e.handle, sizeof(h));
+  // Re-check the generation AFTER snapshotting the handle: a concurrent
+  // re-claim can't have half-written the handle we just validated.
+  if (e.ready.load(std::memory_order_acquire) != 1 ||
+      e.generation.load(std::memory_order_acquire) != gen)
+    return 0;
+  CUdeviceptr base = 0;
+  if (cu_->IpcOpenMemHandle(&base, h, kCuIpcMemLazyEnablePeerAccess) != kCudaSuccess)
+    return 0;
+  pm.gen = gen;
+  pm.base = base;
+  return base;
+}
+
+bool GpuNodeDedup::CopyOutSg(Slot* s, const Seg* segs, size_t nsegs,
+                             size_t total_cap, size_t* got) {
+  const uint64_t g0 = s->gen.load(std::memory_order_acquire);
+  if (g0 & 1) return false;
+  if (s->state.load(std::memory_order_acquire) != kStateReady) return false;
+  const size_t n = s->len;
+  if (n == 0 || n > total_cap) return false;
+  const uint32_t oi = s->owner_idx;
+  const uint32_t og = s->owner_gen32;
+  const uint64_t off = s->payload_off;
+  const uint64_t seq = s->alloc_seq;
+  if (oi >= kMaxProcs) return false;
+  ProcEntry& e = reg_[oi];
+  const uint64_t egen = e.generation.load(std::memory_order_acquire);
+  if (e.ready.load(std::memory_order_acquire) != 1 ||
+      static_cast<uint32_t>(egen) != og)
+    return false;
+  if (off + n > e.arena_bytes) return false;  // torn metadata: bail
+  // Lap check BEFORE the copy (owner's cursor lives in its registry entry).
+  if (e.alloc_cursor.load(std::memory_order_acquire) - seq > e.arena_bytes - n)
+    return false;
+  CUdeviceptr base = PeerBase(oi, egen);
+  if (!base) return false;
+  size_t done = 0;
+  for (size_t j = 0; j < nsegs && done < n; ++j) {
+    const size_t m = std::min(n - done, segs[j].cap);
+    if (m == 0) continue;
+    if (cu_->Memcpy(reinterpret_cast<CUdeviceptr>(segs[j].ptr),
+                    base + off + done, m) != kCudaSuccess)
+      return false;  // unmapped/raced VA: the driver rejects, we miss
+    done += m;
+  }
+  if (done != n) return false;
+  // ... and AFTER: un-lapped payload, same entry generation (arena still the
+  // one we copied from), untouched slot.
+  if (e.alloc_cursor.load(std::memory_order_acquire) - seq > e.arena_bytes - n)
+    return false;
+  if (e.generation.load(std::memory_order_acquire) != egen) return false;
+  if (s->gen.load(std::memory_order_acquire) != g0) return false;
+  if (got) *got = n;
+  return true;
+}
+
+GpuNodeDedup::Role GpuNodeDedup::ClaimSg(const BlockKey& key, const Seg* segs,
+                                         size_t nsegs, size_t total_cap,
+                                         size_t* got) {
+  if (total_cap == 0 || total_cap > arena_bytes_ / 2) return Role::kFetch;
+  const uint64_t now = NowMs();
+  if (Slot* s = Find(key)) {
+    const uint32_t st = s->state.load(std::memory_order_acquire);
+    if (st == kStateReady) {
+      if (now - s->fetch_start_ms.load(std::memory_order_relaxed) <=
+              static_cast<uint64_t>(ttl_ms_) &&
+          CopyOutSg(s, segs, nsegs, total_cap, got)) {
+        hits_.fetch_add(1, std::memory_order_relaxed);
+        return Role::kHit;
+      }
+    } else if (st == kStateFetching) {
+      const uint64_t started = s->fetch_start_ms.load(std::memory_order_relaxed);
+      if (now - started <= static_cast<uint64_t>(takeover_ms_)) return Role::kWait;
+      uint64_t expect = started;
+      if (s->fetch_start_ms.compare_exchange_strong(expect, now,
+                                                    std::memory_order_acq_rel)) {
+        fetches_.fetch_add(1, std::memory_order_relaxed);
+        return Role::kFetch;
+      }
+      return Role::kWait;
+    }
+  }
+  if (Reserve(key)) {
+    fetches_.fetch_add(1, std::memory_order_relaxed);
+    return Role::kFetch;
+  }
+  return Role::kFetch;  // probe window full: plain fetch, nothing to publish
+}
+
+void GpuNodeDedup::PublishSg(const BlockKey& key, const Seg* segs, size_t nsegs,
+                             size_t len) {
+  Slot* s = Find(key);
+  if (!s || s->state.load(std::memory_order_acquire) != kStateFetching) return;
+  const size_t n = len;
+  auto abandon = [&] {  // free the slot so a falling-back waiter can re-claim
+    uint32_t st = kStateFetching;
+    s->state.compare_exchange_strong(st, kStateEmpty, std::memory_order_acq_rel);
+  };
+  if (n == 0 || n > arena_bytes_ / 2) return abandon();
+  ProcEntry& e = reg_[self_idx_];
+  // Ring-allocate on OUR arena cursor; skip the tail remainder when a lap
+  // boundary would split the payload (same scheme as the host flavor).
+  uint64_t cur = e.alloc_cursor.load(std::memory_order_relaxed);
+  uint64_t off, seq;
+  for (;;) {
+    const uint64_t in_lap = cur % arena_bytes_;
+    const uint64_t need = (in_lap + n > arena_bytes_) ? (arena_bytes_ - in_lap) + n : n;
+    if (e.alloc_cursor.compare_exchange_weak(cur, cur + need,
+                                             std::memory_order_acq_rel)) {
+      seq = cur + need;
+      off = (cur + need - n) % arena_bytes_;
+      break;
+    }
+  }
+  // Gather the caller's segments (device VAs, D2D) into the arena.
+  size_t done = 0;
+  for (size_t j = 0; j < nsegs && done < n; ++j) {
+    const size_t m = std::min(n - done, segs[j].cap);
+    if (m == 0) continue;
+    if (cu_->Memcpy(arena_base_ + off + done,
+                    reinterpret_cast<CUdeviceptr>(segs[j].ptr), m) != kCudaSuccess)
+      return abandon();
+    done += m;
+  }
+  if (done != n) return abandon();
+  s->gen.fetch_add(1, std::memory_order_acq_rel);
+  s->len = static_cast<uint32_t>(n);
+  s->payload_off = off;
+  s->alloc_seq = seq;
+  s->owner_idx = self_idx_;
+  s->owner_gen32 = static_cast<uint32_t>(self_gen_);
+  s->fetch_start_ms.store(NowMs(), std::memory_order_relaxed);  // TTL from publish
+  s->gen.fetch_add(1, std::memory_order_release);
+  s->state.store(kStateReady, std::memory_order_release);
+}
+
+void GpuNodeDedup::Abort(const BlockKey& key) {
+  Slot* s = Find(key);
+  if (!s) return;
+  uint32_t st = kStateFetching;
+  s->state.compare_exchange_strong(st, kStateEmpty, std::memory_order_acq_rel);
+}
+
+bool GpuNodeDedup::WaitSg(const BlockKey& key, const Seg* segs, size_t nsegs,
+                          size_t total_cap, size_t* got) {
+  const uint64_t deadline = NowMs() + static_cast<uint64_t>(wait_ms_);
+  int backoff_us = 50;
+  for (;;) {
+    Slot* s = Find(key);
+    if (s && s->state.load(std::memory_order_acquire) == kStateReady &&
+        CopyOutSg(s, segs, nsegs, total_cap, got)) {
+      wait_hits_.fetch_add(1, std::memory_order_relaxed);
+      return true;
+    }
+    if (NowMs() >= deadline) {
+      wait_timeouts_.fetch_add(1, std::memory_order_relaxed);
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(backoff_us));
+    if (backoff_us < 1000) backoff_us *= 2;
+  }
+}
+
+}  // namespace dfkv

--- a/src/client/node_dedup_gpu.cc
+++ b/src/client/node_dedup_gpu.cc
@@ -517,14 +517,20 @@ GpuNodeDedup::Role GpuNodeDedup::ClaimSg(const BlockKey& key, const Seg* segs,
     // second claimer's Find() raced the first's identity write (a ~100 ns
     // window that near-synchronous claim loops hit almost every key —
     // observed live as server reads of exactly 2x the uniques). Re-scan the
-    // probe window: the LOWEST probe position is canonical (Find returns it
-    // for every waiter); a non-canonical winner releases its slot and waits.
-    Slot* first = Find(key);
-    if (first && first != mine) {
-      uint32_t st = kStateFetching;
-      mine->state.compare_exchange_strong(st, kStateEmpty,
-                                          std::memory_order_acq_rel);
-      return Role::kWait;
+    // probe window TWICE — immediately, and after a ~1 us settle spin so a
+    // truly simultaneous peer's identity write has landed. The LOWEST probe
+    // position is canonical (it is what every waiter's Find returns); a
+    // non-canonical winner releases its slot and waits.
+    for (int pass = 0; pass < 2; ++pass) {
+      Slot* first = Find(key);
+      if (first && first != mine) {
+        uint32_t st = kStateFetching;
+        mine->state.compare_exchange_strong(st, kStateEmpty,
+                                            std::memory_order_acq_rel);
+        return Role::kWait;
+      }
+      if (pass == 0)
+        for (volatile int spin = 0; spin < 2000; ++spin) {}
     }
     fetches_.fetch_add(1, std::memory_order_relaxed);
     return Role::kFetch;

--- a/src/client/node_dedup_gpu.cc
+++ b/src/client/node_dedup_gpu.cc
@@ -253,6 +253,7 @@ GpuNodeDedup::~GpuNodeDedup() {
   if (cu_) {
     for (auto& pm : peer_map_)
       if (pm.base) cu_->IpcCloseMemHandle(pm.base);  // best-effort at teardown
+    if (stream_) cu_->StreamDestroy(stream_);
     if (arena_base_) cu_->MemFree(arena_base_);
   }
   if (map_base_) ::munmap(map_base_, map_len_);
@@ -262,6 +263,14 @@ void GpuNodeDedup::EnsureThreadCtx() const {
   // First bind on a thread retains the primary ctx once (bounded by thread
   // count); afterwards HasCurrentCtx short-circuits.
   if (!cu_->HasCurrentCtx()) cu_->BindPrimaryCtx(self_device_);
+}
+
+CUstream GpuNodeDedup::Stream() {
+  std::lock_guard<std::mutex> lk(stream_mu_);
+  if (!stream_ &&
+      cu_->StreamCreate(&stream_, kCuStreamNonBlocking) != kCudaSuccess)
+    stream_ = nullptr;
+  return stream_;
 }
 
 GpuNodeDedup::Slot* GpuNodeDedup::Find(const BlockKey& key) const {
@@ -371,16 +380,21 @@ bool GpuNodeDedup::CopyOutSg(Slot* s, const Seg* segs, size_t nsegs,
     return false;
   CUdeviceptr base = PeerBase(oi, egen);
   if (!base) return false;
+  CUstream st = Stream();
+  if (!st) return false;
   size_t done = 0;
   for (size_t j = 0; j < nsegs && done < n; ++j) {
     const size_t m = std::min(n - done, segs[j].cap);
     if (m == 0) continue;
-    if (cu_->Memcpy(reinterpret_cast<CUdeviceptr>(segs[j].ptr),
-                    base + off + done, m) != kCudaSuccess)
+    if (cu_->MemcpyAsync(reinterpret_cast<CUdeviceptr>(segs[j].ptr),
+                         base + off + done, m, st) != kCudaSuccess)
       return false;  // unmapped/raced VA: the driver rejects, we miss
     done += m;
   }
-  if (done != n) return false;
+  // The scatter must be ON the device before we declare a hit — async D2D
+  // "returns" immediately; the framework would otherwise consume the blocks
+  // before the bytes land.
+  if (done != n || cu_->StreamSynchronize(st) != kCudaSuccess) return false;
   // ... and AFTER: un-lapped payload, same entry generation (arena still the
   // one we copied from), untouched slot.
   if (e.alloc_cursor.load(std::memory_order_acquire) - seq > e.arena_bytes - n)
@@ -451,17 +465,22 @@ void GpuNodeDedup::PublishSg(const BlockKey& key, const Seg* segs, size_t nsegs,
       break;
     }
   }
-  // Gather the caller's segments (device VAs, D2D) into the arena.
+  // Gather the caller's segments (device VAs, D2D) into the arena on our own
+  // stream, and SYNC before flipping READY: an unsynchronized gather let
+  // peers copy stale arena bytes (garbage KV, observed live).
+  CUstream st = Stream();
+  if (!st) return abandon();
   size_t done = 0;
   for (size_t j = 0; j < nsegs && done < n; ++j) {
     const size_t m = std::min(n - done, segs[j].cap);
     if (m == 0) continue;
-    if (cu_->Memcpy(arena_base_ + off + done,
-                    reinterpret_cast<CUdeviceptr>(segs[j].ptr), m) != kCudaSuccess)
+    if (cu_->MemcpyAsync(arena_base_ + off + done,
+                         reinterpret_cast<CUdeviceptr>(segs[j].ptr), m,
+                         st) != kCudaSuccess)
       return abandon();
     done += m;
   }
-  if (done != n) return abandon();
+  if (done != n || cu_->StreamSynchronize(st) != kCudaSuccess) return abandon();
   s->gen.fetch_add(1, std::memory_order_acq_rel);
   s->len = static_cast<uint32_t>(n);
   s->payload_off = off;

--- a/src/client/node_dedup_gpu.cc
+++ b/src/client/node_dedup_gpu.cc
@@ -102,7 +102,8 @@ std::string GpuNodeDedup::EnvSegmentName(uint64_t model_hash) {
   return name;
 }
 
-std::unique_ptr<GpuNodeDedup> GpuNodeDedup::FromEnv(uint64_t model_hash) {
+std::unique_ptr<GpuNodeDedup> GpuNodeDedup::FromEnv(uint64_t model_hash,
+                                                    const void* device_dst_hint) {
   const char* on = std::getenv("DFKV_CLIENT_NODE_DEDUP");
   if (!on || std::strcmp(on, "1") != 0) return nullptr;
   const char* gpu = std::getenv("DFKV_CLIENT_NODE_DEDUP_GPU");
@@ -113,8 +114,13 @@ std::unique_ptr<GpuNodeDedup> GpuNodeDedup::FromEnv(uint64_t model_hash) {
     return nullptr;
   }
   if (!cu->HasCurrentCtx()) {
-    DFKV_LOG_INFO("gpu-dedup: no current CUDA context on this thread, running without");
-    return nullptr;
+    // The connectors' transfer threads are fresh pthreads that never touched
+    // CUDA: bind the primary context of the device the caller is about to
+    // scatter into (already alive — the framework holds it).
+    if (!device_dst_hint || !cu->BindPrimaryCtx(cu->DeviceOf(device_dst_hint))) {
+      DFKV_LOG_INFO("gpu-dedup: no CUDA context and no bindable device, running without");
+      return nullptr;
+    }
   }
   Options o;
   o.arena_bytes = EnvU64("DFKV_NODE_DEDUP_GPU_ARENA_MB", 512) << 20;
@@ -215,6 +221,7 @@ std::unique_ptr<GpuNodeDedup> GpuNodeDedup::Open(const Options& opt) {
     e.alloc_cursor.store(0, std::memory_order_relaxed);
     e.arena_bytes = opt.arena_bytes;
     e.device = cu->CurrentDevice();
+    d->self_device_ = e.device;
     std::memcpy(&e.handle, &handle, sizeof(handle));
     e.owner_va = static_cast<uint64_t>(d->arena_base_);
     e.ready.store(1, std::memory_order_release);
@@ -249,6 +256,12 @@ GpuNodeDedup::~GpuNodeDedup() {
     if (arena_base_) cu_->MemFree(arena_base_);
   }
   if (map_base_) ::munmap(map_base_, map_len_);
+}
+
+void GpuNodeDedup::EnsureThreadCtx() const {
+  // First bind on a thread retains the primary ctx once (bounded by thread
+  // count); afterwards HasCurrentCtx short-circuits.
+  if (!cu_->HasCurrentCtx()) cu_->BindPrimaryCtx(self_device_);
 }
 
 GpuNodeDedup::Slot* GpuNodeDedup::Find(const BlockKey& key) const {
@@ -382,6 +395,7 @@ GpuNodeDedup::Role GpuNodeDedup::ClaimSg(const BlockKey& key, const Seg* segs,
                                          size_t nsegs, size_t total_cap,
                                          size_t* got) {
   if (total_cap == 0 || total_cap > arena_bytes_ / 2) return Role::kFetch;
+  EnsureThreadCtx();
   const uint64_t now = NowMs();
   if (Slot* s = Find(key)) {
     const uint32_t st = s->state.load(std::memory_order_acquire);
@@ -413,6 +427,7 @@ GpuNodeDedup::Role GpuNodeDedup::ClaimSg(const BlockKey& key, const Seg* segs,
 
 void GpuNodeDedup::PublishSg(const BlockKey& key, const Seg* segs, size_t nsegs,
                              size_t len) {
+  EnsureThreadCtx();
   Slot* s = Find(key);
   if (!s || s->state.load(std::memory_order_acquire) != kStateFetching) return;
   const size_t n = len;
@@ -467,6 +482,7 @@ void GpuNodeDedup::Abort(const BlockKey& key) {
 
 bool GpuNodeDedup::WaitSg(const BlockKey& key, const Seg* segs, size_t nsegs,
                           size_t total_cap, size_t* got) {
+  EnsureThreadCtx();
   const uint64_t deadline = NowMs() + static_cast<uint64_t>(wait_ms_);
   int backoff_us = 50;
   for (;;) {

--- a/src/client/node_dedup_gpu.cc
+++ b/src/client/node_dedup_gpu.cc
@@ -73,7 +73,11 @@ struct GpuNodeDedup::ProcEntry {
   int32_t device;
   uint32_t pad0;
   CUipcMemHandle handle;
-  uint64_t pad1[3];  // -> 128 B (cross-process ABI)
+  // The exporter's own arena VA: cuIpcOpenMemHandle refuses handles from the
+  // EXPORTING process, so a second instance in the same process (same address
+  // space) reads through this pointer directly. Only trusted when pid matches.
+  uint64_t owner_va;
+  uint64_t pad1[2];  // -> 128 B (cross-process ABI)
 };
 
 struct GpuNodeDedup::Header {
@@ -212,6 +216,7 @@ std::unique_ptr<GpuNodeDedup> GpuNodeDedup::Open(const Options& opt) {
     e.arena_bytes = opt.arena_bytes;
     e.device = cu->CurrentDevice();
     std::memcpy(&e.handle, &handle, sizeof(handle));
+    e.owner_va = static_cast<uint64_t>(d->arena_base_);
     e.ready.store(1, std::memory_order_release);
     d->self_idx_ = i;
   }
@@ -295,6 +300,18 @@ GpuNodeDedup::Slot* GpuNodeDedup::Reserve(const BlockKey& key) {
 CUdeviceptr GpuNodeDedup::PeerBase(uint32_t idx, uint64_t gen) {
   if (idx == self_idx_)
     return gen == self_gen_ ? arena_base_ : 0;  // own publishes: no IPC open
+  {
+    // Another instance in THIS process: cuIpcOpenMemHandle refuses handles
+    // the process itself exported, but its arena VA is directly valid here.
+    ProcEntry& e = reg_[idx];
+    if (e.pid.load(std::memory_order_acquire) ==
+        static_cast<uint32_t>(::getpid())) {
+      if (e.ready.load(std::memory_order_acquire) != 1 ||
+          e.generation.load(std::memory_order_acquire) != gen)
+        return 0;
+      return static_cast<CUdeviceptr>(e.owner_va);
+    }
+  }
   std::lock_guard<std::mutex> lk(peer_mu_);
   PeerMap& pm = peer_map_[idx];
   if (pm.base && pm.gen == gen) return pm.base;

--- a/src/client/node_dedup_gpu.cc
+++ b/src/client/node_dedup_gpu.cc
@@ -512,7 +512,20 @@ GpuNodeDedup::Role GpuNodeDedup::ClaimSg(const BlockKey& key, const Seg* segs,
       return Role::kWait;
     }
   }
-  if (Reserve(key)) {
+  if (Slot* mine = Reserve(key)) {
+    // Concurrent lockstep claimers can reserve TWO slots for one key: the
+    // second claimer's Find() raced the first's identity write (a ~100 ns
+    // window that near-synchronous claim loops hit almost every key —
+    // observed live as server reads of exactly 2x the uniques). Re-scan the
+    // probe window: the LOWEST probe position is canonical (Find returns it
+    // for every waiter); a non-canonical winner releases its slot and waits.
+    Slot* first = Find(key);
+    if (first && first != mine) {
+      uint32_t st = kStateFetching;
+      mine->state.compare_exchange_strong(st, kStateEmpty,
+                                          std::memory_order_acq_rel);
+      return Role::kWait;
+    }
     fetches_.fetch_add(1, std::memory_order_relaxed);
     return Role::kFetch;
   }

--- a/src/client/node_dedup_gpu.cc
+++ b/src/client/node_dedup_gpu.cc
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <thread>
+#include <vector>
 
 #include "utils/log.h"
 
@@ -357,8 +358,8 @@ CUdeviceptr GpuNodeDedup::PeerBase(uint32_t idx, uint64_t gen) {
   return base;
 }
 
-bool GpuNodeDedup::CopyOutSg(Slot* s, const Seg* segs, size_t nsegs,
-                             size_t total_cap, size_t* got) {
+bool GpuNodeDedup::IssueCopySg(Slot* s, const Seg* segs, size_t nsegs,
+                               size_t total_cap, CUstream st, CopySnap* snap) {
   const uint64_t g0 = s->gen.load(std::memory_order_acquire);
   if (g0 & 1) return false;
   if (s->state.load(std::memory_order_acquire) != kStateReady) return false;
@@ -380,8 +381,6 @@ bool GpuNodeDedup::CopyOutSg(Slot* s, const Seg* segs, size_t nsegs,
     return false;
   CUdeviceptr base = PeerBase(oi, egen);
   if (!base) return false;
-  CUstream st = Stream();
-  if (!st) return false;
   size_t done = 0;
   for (size_t j = 0; j < nsegs && done < n; ++j) {
     const size_t m = std::min(n - done, segs[j].cap);
@@ -391,18 +390,99 @@ bool GpuNodeDedup::CopyOutSg(Slot* s, const Seg* segs, size_t nsegs,
       return false;  // unmapped/raced VA: the driver rejects, we miss
     done += m;
   }
+  if (done != n) return false;
+  *snap = CopySnap{s, g0, oi, egen, seq, n};
+  return true;
+}
+
+bool GpuNodeDedup::ValidateCopy(const CopySnap& snap) const {
+  // AFTER the sync: un-lapped payload, same entry generation (arena still the
+  // one we copied from), untouched slot.
+  ProcEntry& e = reg_[snap.oi];
+  if (e.alloc_cursor.load(std::memory_order_acquire) - snap.seq >
+      e.arena_bytes - snap.n)
+    return false;
+  if (e.generation.load(std::memory_order_acquire) != snap.egen) return false;
+  if (snap.s->gen.load(std::memory_order_acquire) != snap.g0) return false;
+  return true;
+}
+
+bool GpuNodeDedup::CopyOutSg(Slot* s, const Seg* segs, size_t nsegs,
+                             size_t total_cap, size_t* got) {
+  CUstream st = Stream();
+  if (!st) return false;
+  CopySnap snap{};
+  if (!IssueCopySg(s, segs, nsegs, total_cap, st, &snap)) return false;
   // The scatter must be ON the device before we declare a hit — async D2D
   // "returns" immediately; the framework would otherwise consume the blocks
   // before the bytes land.
-  if (done != n || cu_->StreamSynchronize(st) != kCudaSuccess) return false;
-  // ... and AFTER: un-lapped payload, same entry generation (arena still the
-  // one we copied from), untouched slot.
-  if (e.alloc_cursor.load(std::memory_order_acquire) - seq > e.arena_bytes - n)
-    return false;
-  if (e.generation.load(std::memory_order_acquire) != egen) return false;
-  if (s->gen.load(std::memory_order_acquire) != g0) return false;
-  if (got) *got = n;
+  if (cu_->StreamSynchronize(st) != kCudaSuccess) return false;
+  if (!ValidateCopy(snap)) return false;
+  if (got) *got = snap.n;
   return true;
+}
+
+void GpuNodeDedup::WaitManySg(WaitItem* items, size_t n) {
+  for (size_t i = 0; i < n; ++i) {
+    items[i].ok = false;
+    items[i].got = 0;
+  }
+  if (n == 0) return;
+  EnsureThreadCtx();
+  CUstream st = Stream();
+  if (!st) {
+    wait_timeouts_.fetch_add(n, std::memory_order_relaxed);
+    return;
+  }
+  std::vector<size_t> pending(n);
+  for (size_t i = 0; i < n; ++i) pending[i] = i;
+  struct InFlight {
+    size_t idx;
+    CopySnap snap;
+  };
+  std::vector<InFlight> inflight;
+  inflight.reserve(n);
+  const uint64_t deadline = NowMs() + static_cast<uint64_t>(wait_ms_);
+  int backoff_us = 50;
+  size_t failed_final = 0;
+  while (!pending.empty()) {
+    // Issue round: enqueue every key that is READY right now.
+    size_t w = 0;
+    for (size_t r = 0; r < pending.size(); ++r) {
+      const size_t idx = pending[r];
+      WaitItem& it = items[idx];
+      Slot* s = Find(it.key);
+      CopySnap snap{};
+      if (s && s->state.load(std::memory_order_acquire) == kStateReady &&
+          IssueCopySg(s, it.segs, it.nsegs, it.total_cap, st, &snap)) {
+        inflight.push_back(InFlight{idx, snap});
+      } else {
+        pending[w++] = idx;  // not published yet (or torn): retry next round
+      }
+    }
+    pending.resize(w);
+    if (!inflight.empty()) {
+      // ONE sync amortized over the whole round, then post-validation.
+      const bool synced = cu_->StreamSynchronize(st) == kCudaSuccess;
+      for (const InFlight& f : inflight) {
+        if (synced && ValidateCopy(f.snap)) {
+          items[f.idx].ok = true;
+          items[f.idx].got = f.snap.n;
+          wait_hits_.fetch_add(1, std::memory_order_relaxed);
+        } else {
+          ++failed_final;  // lapped mid-copy: it will not heal — re-fetch
+        }
+      }
+      inflight.clear();
+      backoff_us = 50;  // publishes are flowing; poll eagerly
+      continue;
+    }
+    if (NowMs() >= deadline) break;
+    std::this_thread::sleep_for(std::chrono::microseconds(backoff_us));
+    if (backoff_us < 1000) backoff_us *= 2;
+  }
+  wait_timeouts_.fetch_add(pending.size() + failed_final,
+                           std::memory_order_relaxed);
 }
 
 GpuNodeDedup::Role GpuNodeDedup::ClaimSg(const BlockKey& key, const Seg* segs,

--- a/src/client/node_dedup_gpu.h
+++ b/src/client/node_dedup_gpu.h
@@ -91,6 +91,8 @@ class GpuNodeDedup {
   void PublishSg(const BlockKey& key, const Seg* segs, size_t nsegs, size_t len);
   void Abort(const BlockKey& key);
 
+  int wait_ms() const { return wait_ms_; }
+
   // diagnostics (relaxed; process-local)
   uint64_t hits() const { return hits_.load(std::memory_order_relaxed); }
   uint64_t fetches() const { return fetches_.load(std::memory_order_relaxed); }
@@ -109,6 +111,11 @@ class GpuNodeDedup {
   // bind our device's primary context on demand so every entry point works
   // from any caller thread.
   void EnsureThreadCtx() const;
+  // The rendezvous' own non-blocking stream (lazy; guarded by stream_mu_).
+  // Copies must NOT ride the legacy default stream: that falsely serializes
+  // them with the framework's in-flight kernels, and unsynchronized D2D
+  // "completions" published stale arena bytes (both observed live).
+  CUstream Stream();
   Slot* Find(const BlockKey& key) const;
   Slot* Reserve(const BlockKey& key);
   bool CopyOutSg(Slot* s, const Seg* segs, size_t nsegs, size_t total_cap,
@@ -134,6 +141,8 @@ class GpuNodeDedup {
   uint32_t self_idx_ = kMaxProcs;
   uint64_t self_gen_ = 0;
   int self_device_ = -1;  // arena's device (EnsureThreadCtx re-binds to it)
+  std::mutex stream_mu_;
+  CUstream stream_ = nullptr;
 
   std::mutex peer_mu_;  // guards peer_map_
   struct PeerMap {

--- a/src/client/node_dedup_gpu.h
+++ b/src/client/node_dedup_gpu.h
@@ -1,0 +1,141 @@
+/* GpuNodeDedup — same-host GET rendezvous for GPU (device-memory) destinations.
+ *
+ * Phase 2b of the NodeDedup design (see node_dedup.h for the host flavor and
+ * the full correctness model): the vLLM connector's GETs land via GPUDirect
+ * straight in device memory, so the host rendezvous' memcpy-through-shm can
+ * not serve them. Same lockstep pattern though — TP ranks re-fetch identical
+ * TP-replicated KV within milliseconds — so the same slot machinery applies;
+ * only the payload channel changes:
+ *
+ *  - Every participating process owns a private GPU STAGING ARENA (cuMemAlloc
+ *    on its current device) and exports it once via a CUDA IPC handle kept in
+ *    a small shm registry. A publisher gathers its fetched segments into its
+ *    own arena (D2D); a waiter opens the publisher's arena (cached handle,
+ *    lazy peer access = NVLink) and scatters straight into its destination
+ *    segments — the copy never touches host memory.
+ *  - The index slots and per-arena allocation cursors live in shm exactly
+ *    like the host flavor: monotonic cursor ring + before/after lap check +
+ *    per-slot seqlock. The cursor of arena X lives in X's registry entry.
+ *  - Registry entries are pid-claimed; a claim bumps the entry generation, so
+ *    a slot published against a died-and-replaced arena fails its generation
+ *    check and degrades to a direct fetch. The driver validates VA ranges on
+ *    cuMemcpy, so a racing unmap yields an error, not corruption.
+ *
+ * CUDA is a dlopen'd soft dependency (cuda_ipc.h); no driver, no current
+ * context, or any CUDA error on the copy path => the caller just fetches
+ * directly. Nothing here is load-bearing.
+ *
+ * Off by default: DFKV_CLIENT_NODE_DEDUP=1 (master) plus
+ * DFKV_CLIENT_NODE_DEDUP_GPU=1 opt in. */
+#ifndef DFKV_NODE_DEDUP_GPU_H_
+#define DFKV_NODE_DEDUP_GPU_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "client/cuda_ipc.h"
+#include "common/kv_types.h"
+
+namespace dfkv {
+
+class GpuNodeDedup {
+ public:
+  struct Options {
+    std::string name;                       // shm name; see FromEnv()
+    uint64_t arena_bytes = 512ull << 20;    // per-PROCESS GPU staging arena
+                                            // (DFKV_NODE_DEDUP_GPU_ARENA_MB)
+    uint32_t slots = 16384;                 // DFKV_NODE_DEDUP_GPU_SLOTS (pow2)
+    int wait_ms = 500;                      // shared with the host flavor:
+    int takeover_ms = 2000;                 //   DFKV_NODE_DEDUP_WAIT_MS /
+    int ttl_ms = 5000;                      //   _TAKEOVER_MS / _TTL_MS
+  };
+
+  // One destination (or source) segment of a scatter-gather item. ptr may be
+  // device or host — cuMemcpy is unified-addressing — but the feature is only
+  // routed to when the first segment is device memory.
+  struct Seg {
+    void* ptr;
+    size_t cap;
+  };
+
+  enum class Role { kHit, kFetch, kWait };  // same contract as NodeDedup::Role
+
+  // nullptr unless BOTH env switches are set AND the CUDA driver resolves AND
+  // the calling thread holds a CUDA context (the arena must live on the
+  // caller's device — never create contexts behind the framework's back).
+  static std::unique_ptr<GpuNodeDedup> FromEnv(uint64_t model_hash);
+  static std::string EnvSegmentName(uint64_t model_hash);
+  static std::unique_ptr<GpuNodeDedup> Open(const Options& opt);
+  ~GpuNodeDedup();
+
+  GpuNodeDedup(const GpuNodeDedup&) = delete;
+  GpuNodeDedup& operator=(const GpuNodeDedup&) = delete;
+
+  // Variable-size SG semantics (BatchGetAutoSg): a published payload hits iff
+  // its length fits sum(caps); it is scattered across segs in order. *got
+  // receives the payload length. kFetch obliges PublishSg or Abort.
+  Role ClaimSg(const BlockKey& key, const Seg* segs, size_t nsegs,
+               size_t total_cap, size_t* got);
+  bool WaitSg(const BlockKey& key, const Seg* segs, size_t nsegs,
+              size_t total_cap, size_t* got);
+  // Gathers the fetched segments (total payload = len bytes) into this
+  // process' arena and flips the slot READY.
+  void PublishSg(const BlockKey& key, const Seg* segs, size_t nsegs, size_t len);
+  void Abort(const BlockKey& key);
+
+  // diagnostics (relaxed; process-local)
+  uint64_t hits() const { return hits_.load(std::memory_order_relaxed); }
+  uint64_t fetches() const { return fetches_.load(std::memory_order_relaxed); }
+  uint64_t wait_hits() const { return wait_hits_.load(std::memory_order_relaxed); }
+  uint64_t wait_timeouts() const { return wait_timeouts_.load(std::memory_order_relaxed); }
+
+  static constexpr uint32_t kMaxProcs = 64;
+
+ private:
+  struct Slot;       // 64-byte shm index slot (owner-descriptor flavor)
+  struct ProcEntry;  // 128-byte shm registry entry (one per process)
+  struct Header;
+  GpuNodeDedup() = default;
+
+  Slot* Find(const BlockKey& key) const;
+  Slot* Reserve(const BlockKey& key);
+  bool CopyOutSg(Slot* s, const Seg* segs, size_t nsegs, size_t total_cap,
+                 size_t* got);
+  // Cached cuIpcOpenMemHandle of registry entry idx at generation gen;
+  // 0 on any failure. Self resolves to arena_base_ without an IPC open.
+  CUdeviceptr PeerBase(uint32_t idx, uint64_t gen);
+  static uint64_t NowMs();
+
+  const CudaLib* cu_ = nullptr;
+  Header* hdr_ = nullptr;
+  ProcEntry* reg_ = nullptr;
+  Slot* slots_ = nullptr;
+  uint32_t nslots_ = 0;
+  uint64_t arena_bytes_ = 0;
+  int wait_ms_ = 500;
+  int takeover_ms_ = 2000;
+  int ttl_ms_ = 5000;
+  void* map_base_ = nullptr;
+  size_t map_len_ = 0;
+
+  CUdeviceptr arena_base_ = 0;  // this process' staging arena (device memory)
+  uint32_t self_idx_ = kMaxProcs;
+  uint64_t self_gen_ = 0;
+
+  std::mutex peer_mu_;  // guards peer_map_
+  struct PeerMap {
+    uint64_t gen = 0;
+    CUdeviceptr base = 0;
+  };
+  PeerMap peer_map_[kMaxProcs];
+
+  std::atomic<uint64_t> hits_{0}, fetches_{0}, wait_hits_{0}, wait_timeouts_{0};
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_NODE_DEDUP_GPU_H_

--- a/src/client/node_dedup_gpu.h
+++ b/src/client/node_dedup_gpu.h
@@ -64,10 +64,14 @@ class GpuNodeDedup {
 
   enum class Role { kHit, kFetch, kWait };  // same contract as NodeDedup::Role
 
-  // nullptr unless BOTH env switches are set AND the CUDA driver resolves AND
-  // the calling thread holds a CUDA context (the arena must live on the
-  // caller's device — never create contexts behind the framework's back).
-  static std::unique_ptr<GpuNodeDedup> FromEnv(uint64_t model_hash);
+  // nullptr unless BOTH env switches are set AND the CUDA driver resolves.
+  // device_dst_hint is a device pointer the caller is about to scatter into:
+  // when the calling thread has no current CUDA context (the connectors'
+  // pure-Python transfer threads never touched CUDA), the hint's device
+  // selects which PRIMARY context to bind — the framework already holds it,
+  // so this never creates a context, only makes it current here.
+  static std::unique_ptr<GpuNodeDedup> FromEnv(uint64_t model_hash,
+                                               const void* device_dst_hint);
   static std::string EnvSegmentName(uint64_t model_hash);
   static std::unique_ptr<GpuNodeDedup> Open(const Options& opt);
   ~GpuNodeDedup();
@@ -101,6 +105,10 @@ class GpuNodeDedup {
   struct Header;
   GpuNodeDedup() = default;
 
+  // Threads that never touched CUDA (fresh pthreads) lack a current context;
+  // bind our device's primary context on demand so every entry point works
+  // from any caller thread.
+  void EnsureThreadCtx() const;
   Slot* Find(const BlockKey& key) const;
   Slot* Reserve(const BlockKey& key);
   bool CopyOutSg(Slot* s, const Seg* segs, size_t nsegs, size_t total_cap,
@@ -125,6 +133,7 @@ class GpuNodeDedup {
   CUdeviceptr arena_base_ = 0;  // this process' staging arena (device memory)
   uint32_t self_idx_ = kMaxProcs;
   uint64_t self_gen_ = 0;
+  int self_device_ = -1;  // arena's device (EnsureThreadCtx re-binds to it)
 
   std::mutex peer_mu_;  // guards peer_map_
   struct PeerMap {

--- a/src/client/node_dedup_gpu.h
+++ b/src/client/node_dedup_gpu.h
@@ -86,6 +86,26 @@ class GpuNodeDedup {
                size_t total_cap, size_t* got);
   bool WaitSg(const BlockKey& key, const Seg* segs, size_t nsegs,
               size_t total_cap, size_t* got);
+
+  // One wait-item of a WaitManySg batch. segs/nsegs/total_cap mirror the
+  // per-key API; ok/got are outputs (ok=false => caller re-fetches the key).
+  struct WaitItem {
+    BlockKey key;
+    const Seg* segs;
+    size_t nsegs;
+    size_t total_cap;
+    bool ok;
+    size_t got;
+  };
+  // Waits for MANY keys with amortized synchronization: copies are issued
+  // asynchronously the moment each key turns READY, and the stream is
+  // synchronized ONCE per issue round, with post-validation (lap/seqlock)
+  // after the sync. The per-key WaitSg costs a StreamSynchronize per payload
+  // (~ms under load); a lockstep batch of >1000 keys blew straight through
+  // any reasonable wait budget that way (measured 2.3 ms/key in the PD A/B —
+  // the dedup win leaked back out through the fallback re-fetches). wait_ms
+  // bounds how long the batch waits for publishes as a whole.
+  void WaitManySg(WaitItem* items, size_t n);
   // Gathers the fetched segments (total payload = len bytes) into this
   // process' arena and flips the slot READY.
   void PublishSg(const BlockKey& key, const Seg* segs, size_t nsegs, size_t len);
@@ -118,6 +138,21 @@ class GpuNodeDedup {
   CUstream Stream();
   Slot* Find(const BlockKey& key) const;
   Slot* Reserve(const BlockKey& key);
+  // Split copy-out: Issue pre-validates and ENQUEUES the scatter on st (no
+  // sync); Validate re-checks lap/generation AFTER the caller synchronized.
+  // CopyOutSg composes them for the single-key path; WaitManySg amortizes one
+  // sync over a whole issue round.
+  struct CopySnap {
+    Slot* s;
+    uint64_t g0;
+    uint32_t oi;
+    uint64_t egen;
+    uint64_t seq;
+    size_t n;
+  };
+  bool IssueCopySg(Slot* s, const Seg* segs, size_t nsegs, size_t total_cap,
+                   CUstream st, CopySnap* snap);
+  bool ValidateCopy(const CopySnap& snap) const;
   bool CopyOutSg(Slot* s, const Seg* segs, size_t nsegs, size_t total_cap,
                  size_t* got);
   // Cached cuIpcOpenMemHandle of registry entry idx at generation gen;

--- a/src/tools/dfkv_gpu_dedup_repro_main.cc
+++ b/src/tools/dfkv_gpu_dedup_repro_main.cc
@@ -1,0 +1,211 @@
+/* dfkv_gpu_dedup_repro — same-host lockstep GET repro against a LIVE server.
+ *
+ * Reproduces the vLLM PD decode pattern without vLLM: N ranks (separate
+ * processes, one CUDA device each) issue the SAME key batch with device
+ * destinations at the same instant. With DFKV_CLIENT_NODE_DEDUP=1 +
+ * DFKV_CLIENT_NODE_DEDUP_GPU=1 in the environment the ranks rendezvous over
+ * CUDA IPC; the tool prints the per-rank dedup split so the server-side read
+ * counters can be reconciled key by key. Payloads are content-checked, so a
+ * wrong-bytes rendezvous fails loudly here rather than as garbage KV.
+ *
+ *   dfkv_gpu_dedup_repro --members node=ip:port [--keys 1024] [--size 1048576]
+ *                        [--ranks 4] [--model-hash 999001]
+ *
+ * Master PUTs the keys (host buffers), then forks+execs one child per rank
+ * (CUDA does not survive fork). Children barrier on a shared file so their
+ * batches truly overlap. Exit code 0 = every rank saw every key with the
+ * right bytes.
+ */
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "client/cuda_ipc.h"
+#include "client/kv_client.h"
+#include "common/value_header.h"
+
+using namespace dfkv;
+
+namespace {
+
+struct Args {
+  std::string members;
+  size_t keys = 1024;
+  size_t size = 1 << 20;
+  int ranks = 4;
+  uint64_t model_hash = 999001;
+  int rank = -1;  // >=0: child mode
+  std::string barrier;
+};
+
+std::string KeyName(size_t i) { return "gpudedup-repro-" + std::to_string(i); }
+
+char PatByte(size_t key, size_t off) {
+  return static_cast<char>((key * 131 + off * 7 + 3) & 0xFF);
+}
+
+ValueHeader Hdr(uint64_t mh) {
+  ValueHeader h{};
+  h.model_hash = mh;
+  h.page_size = 1;
+  h.dtype_tag = 1;
+  h.tp_size = 1;
+  h.tp_rank = 0;
+  h.layer_num = 1;
+  return h;
+}
+
+int Child(const Args& a) {
+  const CudaLib* cu = CudaLib::Get();
+  if (!cu || !cu->BindPrimaryCtx(a.rank)) {
+    std::fprintf(stderr, "rank %d: no CUDA ctx on device %d\n", a.rank, a.rank);
+    return 2;
+  }
+  CUdeviceptr pool = 0;
+  const size_t pool_bytes = a.keys * a.size;
+  if (cu->MemAlloc(&pool, pool_bytes) != kCudaSuccess) {
+    std::fprintf(stderr, "rank %d: cuMemAlloc(%zu) failed\n", a.rank, pool_bytes);
+    return 2;
+  }
+  std::vector<std::pair<std::string, std::string>> members;
+  {
+    const std::string& m = a.members;
+    size_t eq = m.find('=');
+    members.emplace_back(m.substr(0, eq), m.substr(eq + 1));
+  }
+  KVClient c(members, Hdr(a.model_hash));
+  c.RegisterMemory(reinterpret_cast<void*>(pool), pool_bytes);
+
+  std::vector<KvGetItemSg> items(a.keys);
+  for (size_t i = 0; i < a.keys; ++i) {
+    items[i].key = KeyName(i);
+    items[i].dsts = {reinterpret_cast<void*>(pool + i * a.size)};
+    items[i].caps = {a.size};
+  }
+
+  // Barrier: every rank touches the file, then waits for `ranks` lines.
+  {
+    FILE* f = std::fopen(a.barrier.c_str(), "a");
+    std::fprintf(f, "%d\n", a.rank);
+    std::fclose(f);
+    for (;;) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      FILE* r = std::fopen(a.barrier.c_str(), "r");
+      int lines = 0, ch;
+      while ((ch = std::fgetc(r)) != EOF)
+        if (ch == '\n') ++lines;
+      std::fclose(r);
+      if (lines >= a.ranks) break;
+    }
+  }
+
+  auto t0 = std::chrono::steady_clock::now();
+  std::vector<size_t> lens;
+  auto res = c.BatchGetAutoSg(items, &lens);
+  const double dt = std::chrono::duration<double>(
+      std::chrono::steady_clock::now() - t0).count();
+
+  size_t ok = 0, bad_bytes = 0;
+  std::vector<char> host(a.size);
+  for (size_t i = 0; i < a.keys; ++i) {
+    if (!res[i] || lens[i] != a.size) continue;
+    // Verify content (spot-check whole payload; D2H via UVA copy).
+    if (cu->Memcpy(reinterpret_cast<CUdeviceptr>(host.data()),
+                   pool + i * a.size, a.size) != kCudaSuccess)
+      continue;
+    bool good = true;
+    for (size_t off = 0; off < a.size; off += 4099)
+      if (host[off] != PatByte(i, off)) { good = false; break; }
+    if (good) ++ok; else ++bad_bytes;
+  }
+  std::printf("rank %d: ok=%zu/%zu bad_bytes=%zu dt=%.3fs  %s\n", a.rank, ok,
+              a.keys, bad_bytes, dt, c.MetricsSnapshot().find("gpu_dedup") !=
+              std::string::npos ? "gpu-dedup-active" : "gpu-dedup-INACTIVE");
+  // The split lands via DFKV_CLIENT_NODE_DEDUP_LOG=1 (kv_client INFO line).
+  std::fflush(stdout);
+  return (ok == a.keys && bad_bytes == 0) ? 0 : 3;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  Args a;
+  std::vector<char*> rest;
+  for (int i = 1; i < argc; ++i) {
+    std::string s = argv[i];
+    auto next = [&] { return std::string(argv[++i]); };
+    if (s == "--members") a.members = next();
+    else if (s == "--keys") a.keys = std::stoull(next());
+    else if (s == "--size") a.size = std::stoull(next());
+    else if (s == "--ranks") a.ranks = std::stoi(next());
+    else if (s == "--model-hash") a.model_hash = std::stoull(next());
+    else if (s == "--rank") a.rank = std::stoi(next());
+    else if (s == "--barrier") a.barrier = next();
+  }
+  if (a.members.empty()) {
+    std::fprintf(stderr, "usage: %s --members node=ip:port [--keys N] [--size B] [--ranks R]\n",
+                 argv[0]);
+    return 1;
+  }
+  if (a.rank >= 0) return Child(a);
+
+  // Master: PUT the dataset (host buffers), then launch the lockstep ranks.
+  {
+    std::vector<std::pair<std::string, std::string>> members;
+    size_t eq = a.members.find('=');
+    members.emplace_back(a.members.substr(0, eq), a.members.substr(eq + 1));
+    KVClient c(members, Hdr(a.model_hash));
+    std::vector<std::string> bufs(a.keys);
+    std::vector<KvPutItemSg> puts(a.keys);
+    for (size_t i = 0; i < a.keys; ++i) {
+      bufs[i].resize(a.size);
+      for (size_t off = 0; off < a.size; ++off) bufs[i][off] = PatByte(i, off);
+      puts[i].key = KeyName(i);
+      puts[i].ptrs = {bufs[i].data()};
+      puts[i].sizes = {a.size};
+    }
+    auto pr = c.BatchPutSg(puts);
+    size_t stored = 0;
+    for (bool b : pr) stored += b;
+    std::printf("master: stored %zu/%zu keys (%zu MB)\n", stored, a.keys,
+                stored * a.size >> 20);
+    if (stored != a.keys) return 1;
+  }
+
+  char bar[] = "/tmp/gpudedup-repro-XXXXXX";
+  int bfd = ::mkstemp(bar);
+  if (bfd >= 0) ::close(bfd);
+  std::vector<pid_t> kids;
+  for (int r = 0; r < a.ranks; ++r) {
+    pid_t pid = ::fork();
+    if (pid == 0) {
+      ::execl("/proc/self/exe", argv[0], "--members", a.members.c_str(),
+              "--keys", std::to_string(a.keys).c_str(),
+              "--size", std::to_string(a.size).c_str(),
+              "--ranks", std::to_string(a.ranks).c_str(),
+              "--model-hash", std::to_string(a.model_hash).c_str(),
+              "--rank", std::to_string(r).c_str(),
+              "--barrier", bar, static_cast<char*>(nullptr));
+      _exit(97);
+    }
+    kids.push_back(pid);
+  }
+  int rc = 0;
+  for (pid_t p : kids) {
+    int st = 0;
+    ::waitpid(p, &st, 0);
+    if (!WIFEXITED(st) || WEXITSTATUS(st) != 0) rc = 4;
+  }
+  ::unlink(bar);
+  std::printf("master: %s\n", rc == 0 ? "ALL RANKS OK" : "FAILURES");
+  return rc;
+}

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -115,6 +115,15 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
   if (devs_.empty()) devs_.push_back("");  // first available device
   for (const auto& d : devs_)
     dev_node_.push_back(numa::DeviceNode(d.empty() ? nullptr : d.c_str()));
+  // Live SG width: the tightest rail decides (connections round-robin rails,
+  // and a key must fit whichever rail carries it). Queried once — device caps
+  // don't change under a running process.
+  {
+    size_t msge = rdma::kMaxSge;
+    for (const auto& d : devs_)
+      msge = std::min(msge, rdma::QueryMaxSge(d.empty() ? nullptr : d.c_str()));
+    sg_payload_segs_ = msge - 1;  // SGE0 carries the wire/value header
+  }
   const char* d = std::getenv("DFKV_RDMA_DEPTH");  // pipeline depth (must be <= server's)
   if (d && *d) { long v = std::strtol(d, nullptr, 10); if (v >= 1 && v <= 256) depth_ = (size_t)v; }
   connect_ms_ = EnvInt("DFKV_RDMA_CONNECT_MS", 3000);

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -46,6 +46,7 @@ class RdmaTransport : public Transport {
   std::string MetricsText() const override;  // dfkv_rdma_client_* (conns, per-rail)
 
   bool pipelined() const override { return true; }
+  size_t MaxSgPayloadSegs() const override { return sg_payload_segs_; }
   // Pipelined: up to `depth_` requests in flight on a single connection.
   std::vector<Status> CacheMany(const std::string& node,
                                 const std::vector<CacheItem>& items) override;
@@ -94,6 +95,8 @@ class RdmaTransport : public Transport {
   // Lifetime per-rail device refs holding the pool MRs registered at
   // RegisterMemory time (client-side anchor; see RegisterMemory). Filled once.
   std::vector<std::unique_ptr<rdma::RcEndpoint>> anchors_;
+  // min over rails of (negotiated max_sge) - 1; set once in the ctor.
+  size_t sg_payload_segs_ = 29;
   size_t max_payload_;
   // DCP1 declared max block bytes (DFKV_RDMA_MAX_BLOCK_BYTES, clamped to
   // max_payload_). 0 = undeclared: worst-case buffers both sides, old wire

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -139,6 +139,19 @@ uint64_t RcEndpoint::PoolMrRegistrations() {
   return g_pool_mr_regs.load(std::memory_order_relaxed);
 }
 
+size_t QueryMaxSge(const char* dev_name) {
+  auto shared = AcquireSharedDevice(dev_name);
+  if (!shared.first) return kMaxSge;
+  ibv_device_attr dev_attr{};
+  size_t r = kMaxSge;
+  if (ibv_query_device(shared.first, &dev_attr) == 0 && dev_attr.max_sge > 0) {
+    r = std::min(kMaxSge, static_cast<size_t>(dev_attr.max_sge));
+    if (r < 2) r = 2;  // SGE0 is the header; keep >=1 payload segment
+  }
+  ReleaseSharedDevice(shared.first);
+  return r;
+}
+
 void SerializeQpInfo(const QpInfo& in, char out[kQpInfoBytes]) {
   std::memset(out, 0, kQpInfoBytes);
   net::PutU32(out + 0, in.qpn);

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -69,6 +69,14 @@ QpInfo ParseQpInfo(const char in[kQpInfoBytes]);
 // key may hold up to kMaxSge-1 (=29) non-contiguous buffers. Open() clamps this
 // to the device's reported max_sge (ConnectX-* on hd04 reports 30).
 constexpr size_t kMaxSge = 30;
+
+// The SG width Open() would negotiate on dev_name (min(kMaxSge, device
+// max_sge)) WITHOUT bootstrapping a connection: rides the shared-device cache,
+// so callers can size scatter-gather batches before any peer traffic. Empty
+// dev_name = first device. Returns kMaxSge when no device answers — matching
+// Open()'s "trust the documented cap" fallback keeps the client guard at its
+// historical 29-payload-segs behavior instead of silently shrinking it.
+size_t QueryMaxSge(const char* dev_name);
 // Alignment used for server-side O_DIRECT read buffers. NVMe/xfs are happy with
 // 4096, and it is a safe superset for 512-byte logical-sector devices.
 constexpr size_t kDirectIoAlign = 4096;

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -101,6 +101,13 @@ class Transport {
   // threads instead, since the per-node loop here would be sequential.
   virtual bool pipelined() const { return false; }
 
+  // Max payload segments one scatter-gather key may carry end-to-end. On RDMA
+  // this is the live negotiated max_sge minus the header SGE; the TCP default
+  // keeps the documented ConnectX-era 29 so batches built against it stay
+  // valid everywhere. Callers (connectors, via the C ABI) size their SG
+  // grouping from this instead of hard-coding 29.
+  virtual size_t MaxSgPayloadSegs() const { return 29; }
+
   // Batch variants for one node. Default = sequential loop; RDMA overrides these
   // to pipeline multiple requests in flight on a single connection. All keys in
   // a RangeMany share (offset, length).

--- a/test/client/node_dedup_gpu_test.cc
+++ b/test/client/node_dedup_gpu_test.cc
@@ -112,9 +112,9 @@ TEST(GpuNodeDedup, EnvSegmentNameCarriesLayoutVersion) {
 TEST(GpuNodeDedup, FromEnvNeedsBothSwitches) {
   ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
   ::unsetenv("DFKV_CLIENT_NODE_DEDUP_GPU");
-  EXPECT_EQ(GpuNodeDedup::FromEnv(1), nullptr);
+  EXPECT_EQ(GpuNodeDedup::FromEnv(1, nullptr), nullptr);
   ::setenv("DFKV_CLIENT_NODE_DEDUP", "1", 1);
-  EXPECT_EQ(GpuNodeDedup::FromEnv(1), nullptr);  // GPU flag still off
+  EXPECT_EQ(GpuNodeDedup::FromEnv(1, nullptr), nullptr);  // GPU flag still off
   ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
 }
 
@@ -175,6 +175,31 @@ TEST(GpuNodeDedup, WaiterCopiesAfterPublish) {
   EXPECT_EQ(got, v.size());
   EXPECT_EQ(dst.Down(65536), v);
   EXPECT_EQ(b->wait_hits(), 1u);
+}
+
+// The vLLM transfer threads are fresh pthreads with NO current CUDA context
+// (the phase-8 PD A/B found the feature silently off because of exactly
+// this); every entry point must self-bind the arena device's primary ctx.
+TEST(GpuNodeDedup, ThreadWithoutCtxIsServed) {
+  if (!EnsureCudaCtx()) GTEST_SKIP() << "no CUDA device";
+  ShmGuard g("noctx");
+  auto a = GpuNodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a);
+  const std::string v = Val(9, 32768);
+  DevBuf src(32768), dst(32768);
+  src.Up(v);
+  GpuNodeDedup::Seg ss{reinterpret_cast<void*>(src.p), 32768};
+  GpuNodeDedup::Seg ds{reinterpret_cast<void*>(dst.p), 32768};
+  std::thread t([&] {  // deliberately NO EnsureCudaCtx here
+    size_t got = 0;
+    ASSERT_EQ(a->ClaimSg(K(9), &ss, 1, 32768, &got), GpuNodeDedup::Role::kFetch);
+    a->PublishSg(K(9), &ss, 1, v.size());
+  });
+  t.join();
+  size_t got = 0;
+  ASSERT_EQ(a->ClaimSg(K(9), &ds, 1, 32768, &got), GpuNodeDedup::Role::kHit);
+  EXPECT_EQ(got, v.size());
+  EXPECT_EQ(dst.Down(32768), v);
 }
 
 TEST(GpuNodeDedup, AbortFreesSlotForWaiterFallback) {

--- a/test/client/node_dedup_gpu_test.cc
+++ b/test/client/node_dedup_gpu_test.cc
@@ -1,0 +1,258 @@
+// GpuNodeDedup: same-host GET rendezvous for device-memory destinations over
+// CUDA IPC. Hermetic wrt dfkv (no RDMA/etcd) but NOT wrt hardware: everything
+// past the env/name tests needs a CUDA device and skips cleanly without one
+// (the CI runners have no GPU; the B200 gate runs the full set). Cross-process
+// coverage forks AND EXECS this binary — CUDA does not survive a bare fork —
+// with the segment name in the environment (see GpuDedupChild).
+#include "client/node_dedup_gpu.h"
+
+#include <gtest/gtest.h>
+#include <dlfcn.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "client/cuda_ipc.h"
+
+using dfkv::BlockKey;
+using dfkv::CudaLib;
+using dfkv::CUdeviceptr;
+using dfkv::GpuNodeDedup;
+using dfkv::kCudaSuccess;
+
+namespace {
+
+// The library never creates CUDA contexts (it rides the framework's); the
+// test IS the framework here, so it retains device 0's primary context and
+// makes it current on the calling thread. Safe to call per-thread.
+bool EnsureCudaCtx() {
+  static void* ctx = [] {
+    void* h = ::dlopen("libcuda.so.1", RTLD_NOW | RTLD_GLOBAL);
+    if (!h) return static_cast<void*>(nullptr);
+    auto init = reinterpret_cast<int (*)(unsigned)>(::dlsym(h, "cuInit"));
+    auto devget = reinterpret_cast<int (*)(int*, int)>(::dlsym(h, "cuDeviceGet"));
+    auto retain = reinterpret_cast<int (*)(void**, int)>(
+        ::dlsym(h, "cuDevicePrimaryCtxRetain"));
+    if (!init || !devget || !retain || init(0) != 0) return static_cast<void*>(nullptr);
+    int dev = 0;
+    void* c = nullptr;
+    if (devget(&dev, 0) != 0 || retain(&c, dev) != 0) return static_cast<void*>(nullptr);
+    return c;
+  }();
+  if (!ctx) return false;
+  static auto setcur = reinterpret_cast<int (*)(void*)>(
+      ::dlsym(::dlopen("libcuda.so.1", RTLD_NOW), "cuCtxSetCurrent"));
+  return setcur && setcur(ctx) == 0;
+}
+
+struct ShmGuard {
+  std::string name;
+  explicit ShmGuard(const std::string& tag)
+      : name("/dfkv-dedup-gputest-" + std::to_string(::getpid()) + "-" + tag) {
+    ::shm_unlink(name.c_str());
+  }
+  ~ShmGuard() { ::shm_unlink(name.c_str()); }
+};
+
+GpuNodeDedup::Options Opts(const std::string& name) {
+  GpuNodeDedup::Options o;
+  o.name = name;
+  o.arena_bytes = 32ull << 20;
+  o.slots = 1024;
+  o.wait_ms = 300;
+  o.takeover_ms = 200;
+  o.ttl_ms = 30000;  // outlives a child-process exec in the cross-proc test
+  return o;
+}
+
+BlockKey K(uint64_t id) { return BlockKey{id, 0, 1}; }
+
+std::string Val(uint64_t id, size_t n) {
+  std::string v(n, '\0');
+  for (size_t i = 0; i < n; ++i) v[i] = static_cast<char>((id * 131 + i) & 0xFF);
+  return v;
+}
+
+// Device buffer with RAII; up/down copies ride the UVA cuMemcpy.
+struct DevBuf {
+  CUdeviceptr p = 0;
+  const CudaLib* cu = CudaLib::Get();
+  explicit DevBuf(size_t n) { EXPECT_EQ(cu->MemAlloc(&p, n), kCudaSuccess); }
+  ~DevBuf() { if (p) cu->MemFree(p); }
+  void Up(const std::string& v) {
+    ASSERT_EQ(cu->Memcpy(p, reinterpret_cast<CUdeviceptr>(v.data()), v.size()),
+              kCudaSuccess);
+  }
+  std::string Down(size_t n) {
+    std::string v(n, '\0');
+    EXPECT_EQ(cu->Memcpy(reinterpret_cast<CUdeviceptr>(v.data()), p, n),
+              kCudaSuccess);
+    return v;
+  }
+};
+
+}  // namespace
+
+// ---- no-GPU-required ----
+
+TEST(GpuNodeDedup, EnvSegmentNameCarriesLayoutVersion) {
+  const std::string n = GpuNodeDedup::EnvSegmentName(0xabcdef);
+  EXPECT_NE(n.find("/dfkv-dedup-gpuv1-"), std::string::npos);
+  EXPECT_NE(n.find("0000000000abcdef"), std::string::npos);
+  // distinct from the host segment namespace
+  EXPECT_EQ(n.find("/dfkv-dedup-v2-"), std::string::npos);
+}
+
+TEST(GpuNodeDedup, FromEnvNeedsBothSwitches) {
+  ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
+  ::unsetenv("DFKV_CLIENT_NODE_DEDUP_GPU");
+  EXPECT_EQ(GpuNodeDedup::FromEnv(1), nullptr);
+  ::setenv("DFKV_CLIENT_NODE_DEDUP", "1", 1);
+  EXPECT_EQ(GpuNodeDedup::FromEnv(1), nullptr);  // GPU flag still off
+  ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
+}
+
+// ---- CUDA required below ----
+
+TEST(GpuNodeDedup, FetchPublishThenPeerHitsScattered) {
+  if (!EnsureCudaCtx()) GTEST_SKIP() << "no CUDA device";
+  ShmGuard g("basic");
+  auto a = GpuNodeDedup::Open(Opts(g.name));
+  auto b = GpuNodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a && b);
+  const std::string v = Val(1, 6000);
+
+  // Publisher fetched into TWO device segments (4096 + 4096 caps, 6000 used).
+  DevBuf s0(4096), s1(4096);
+  s0.Up(v.substr(0, 4096));
+  s1.Up(v.substr(4096));
+  GpuNodeDedup::Seg src[2] = {{reinterpret_cast<void*>(s0.p), 4096},
+                              {reinterpret_cast<void*>(s1.p), 4096}};
+  size_t got = 0;
+  ASSERT_EQ(a->ClaimSg(K(1), src, 2, 8192, &got), GpuNodeDedup::Role::kFetch);
+  a->PublishSg(K(1), src, 2, v.size());
+
+  // Peer scatters into a DIFFERENT segment split (3000 + 5192).
+  DevBuf d0(3000), d1(5192);
+  GpuNodeDedup::Seg dst[2] = {{reinterpret_cast<void*>(d0.p), 3000},
+                              {reinterpret_cast<void*>(d1.p), 5192}};
+  got = 0;
+  ASSERT_EQ(b->ClaimSg(K(1), dst, 2, 8192, &got), GpuNodeDedup::Role::kHit);
+  EXPECT_EQ(got, v.size());
+  EXPECT_EQ(d0.Down(3000), v.substr(0, 3000));
+  EXPECT_EQ(d1.Down(3000), v.substr(3000));  // 6000-3000 used of 5192 cap
+  EXPECT_EQ(b->hits(), 1u);
+}
+
+TEST(GpuNodeDedup, WaiterCopiesAfterPublish) {
+  if (!EnsureCudaCtx()) GTEST_SKIP() << "no CUDA device";
+  ShmGuard g("wait");
+  auto a = GpuNodeDedup::Open(Opts(g.name));
+  auto b = GpuNodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a && b);
+  const std::string v = Val(2, 65536);
+  DevBuf src(65536), dst(65536);
+  src.Up(v);
+  GpuNodeDedup::Seg ss{reinterpret_cast<void*>(src.p), 65536};
+  GpuNodeDedup::Seg ds{reinterpret_cast<void*>(dst.p), 65536};
+
+  size_t got = 0;
+  ASSERT_EQ(a->ClaimSg(K(2), &ss, 1, 65536, &got), GpuNodeDedup::Role::kFetch);
+  ASSERT_EQ(b->ClaimSg(K(2), &ds, 1, 65536, &got), GpuNodeDedup::Role::kWait);
+  std::thread pub([&] {
+    ASSERT_TRUE(EnsureCudaCtx());  // publish thread needs its own current ctx
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    a->PublishSg(K(2), &ss, 1, v.size());
+  });
+  EXPECT_TRUE(b->WaitSg(K(2), &ds, 1, 65536, &got));
+  pub.join();
+  EXPECT_EQ(got, v.size());
+  EXPECT_EQ(dst.Down(65536), v);
+  EXPECT_EQ(b->wait_hits(), 1u);
+}
+
+TEST(GpuNodeDedup, AbortFreesSlotForWaiterFallback) {
+  if (!EnsureCudaCtx()) GTEST_SKIP() << "no CUDA device";
+  ShmGuard g("abort");
+  auto a = GpuNodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a);
+  DevBuf d(4096);
+  GpuNodeDedup::Seg s{reinterpret_cast<void*>(d.p), 4096};
+  size_t got = 0;
+  ASSERT_EQ(a->ClaimSg(K(3), &s, 1, 4096, &got), GpuNodeDedup::Role::kFetch);
+  a->Abort(K(3));
+  // Slot freed: the next claimant fetches (no stuck FETCHING until takeover).
+  ASSERT_EQ(a->ClaimSg(K(3), &s, 1, 4096, &got), GpuNodeDedup::Role::kFetch);
+}
+
+TEST(GpuNodeDedup, OversizePayloadSkipsRendezvous) {
+  if (!EnsureCudaCtx()) GTEST_SKIP() << "no CUDA device";
+  ShmGuard g("oversize");
+  auto a = GpuNodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a);
+  DevBuf d(4096);
+  GpuNodeDedup::Seg s{reinterpret_cast<void*>(d.p), 4096};
+  size_t got = 0;
+  // cap > arena/2: no slot is claimed, so no publish obligation either.
+  EXPECT_EQ(a->ClaimSg(K(4), &s, 1, (32ull << 20), &got),
+            GpuNodeDedup::Role::kFetch);
+  a->Abort(K(4));  // must be a harmless no-op (nothing was reserved)
+  EXPECT_EQ(a->ClaimSg(K(4), &s, 1, (32ull << 20), &got),
+            GpuNodeDedup::Role::kFetch);
+}
+
+// Child half of the cross-process test: skipped unless the parent exec'd us
+// with the segment name in the environment. Attaches, expects an immediate
+// IPC hit on the parent's publish, and verifies the payload byte-for-byte.
+TEST(GpuDedupChild, ReadsPeerPublish) {
+  const char* seg = ::getenv("DFKV_GPU_DEDUP_TEST_SEG");
+  if (!seg) GTEST_SKIP() << "not a child process";
+  ASSERT_TRUE(EnsureCudaCtx());
+  auto d = GpuNodeDedup::Open(Opts(seg));
+  ASSERT_TRUE(d);
+  const std::string v = Val(7, 40000);
+  DevBuf d0(20000), d1(20000);
+  GpuNodeDedup::Seg dst[2] = {{reinterpret_cast<void*>(d0.p), 20000},
+                              {reinterpret_cast<void*>(d1.p), 20000}};
+  size_t got = 0;
+  ASSERT_EQ(d->ClaimSg(K(7), dst, 2, 40000, &got), GpuNodeDedup::Role::kHit);
+  ASSERT_EQ(got, v.size());
+  EXPECT_EQ(d0.Down(20000), v.substr(0, 20000));
+  EXPECT_EQ(d1.Down(20000), v.substr(20000));
+}
+
+TEST(GpuNodeDedup, CrossProcessIpcHit) {
+  if (!EnsureCudaCtx()) GTEST_SKIP() << "no CUDA device";
+  ShmGuard g("xproc");
+  auto a = GpuNodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a);
+  const std::string v = Val(7, 40000);
+  DevBuf src(40000);
+  src.Up(v);
+  GpuNodeDedup::Seg s{reinterpret_cast<void*>(src.p), 40000};
+  size_t got = 0;
+  ASSERT_EQ(a->ClaimSg(K(7), &s, 1, 40000, &got), GpuNodeDedup::Role::kFetch);
+  a->PublishSg(K(7), &s, 1, v.size());
+
+  // CUDA does not survive fork; exec this binary so the child initializes its
+  // own driver state and pulls the payload across processes via cuIpc*.
+  pid_t pid = ::fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0) {
+    ::setenv("DFKV_GPU_DEDUP_TEST_SEG", g.name.c_str(), 1);
+    ::execl("/proc/self/exe", "node_dedup_gpu_test",
+            "--gtest_filter=GpuDedupChild.ReadsPeerPublish",
+            static_cast<char*>(nullptr));
+    _exit(97);  // exec failed
+  }
+  int st = 0;
+  ASSERT_EQ(::waitpid(pid, &st, 0), pid);
+  ASSERT_TRUE(WIFEXITED(st));
+  EXPECT_EQ(WEXITSTATUS(st), 0) << "child (IPC reader) failed";
+}

--- a/test/client/node_dedup_gpu_test.cc
+++ b/test/client/node_dedup_gpu_test.cc
@@ -14,6 +14,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
@@ -200,6 +201,48 @@ TEST(GpuNodeDedup, ThreadWithoutCtxIsServed) {
   ASSERT_EQ(a->ClaimSg(K(9), &ds, 1, 32768, &got), GpuNodeDedup::Role::kHit);
   EXPECT_EQ(got, v.size());
   EXPECT_EQ(dst.Down(32768), v);
+}
+
+TEST(GpuNodeDedup, WaitManyAmortizedSync) {
+  if (!EnsureCudaCtx()) GTEST_SKIP() << "no CUDA device";
+  ShmGuard g("waitmany");
+  auto a = GpuNodeDedup::Open(Opts(g.name));
+  auto b = GpuNodeDedup::Open(Opts(g.name));
+  ASSERT_TRUE(a && b);
+  constexpr size_t kN = 16;
+  std::vector<std::string> vals;
+  std::vector<std::unique_ptr<DevBuf>> srcs, dsts;
+  std::vector<GpuNodeDedup::Seg> ssegs(kN), dsegs(kN);
+  std::vector<GpuNodeDedup::WaitItem> wits(kN);
+  size_t got = 0;
+  for (size_t i = 0; i < kN; ++i) {
+    vals.push_back(Val(100 + i, 8192));
+    srcs.push_back(std::make_unique<DevBuf>(8192));
+    dsts.push_back(std::make_unique<DevBuf>(8192));
+    srcs[i]->Up(vals[i]);
+    ssegs[i] = {reinterpret_cast<void*>(srcs[i]->p), 8192};
+    dsegs[i] = {reinterpret_cast<void*>(dsts[i]->p), 8192};
+    ASSERT_EQ(a->ClaimSg(K(100 + i), &ssegs[i], 1, 8192, &got),
+              GpuNodeDedup::Role::kFetch);
+    ASSERT_EQ(b->ClaimSg(K(100 + i), &dsegs[i], 1, 8192, &got),
+              GpuNodeDedup::Role::kWait);
+    wits[i] = GpuNodeDedup::WaitItem{K(100 + i), &dsegs[i], 1, 8192, false, 0};
+  }
+  std::thread pub([&] {  // publishes trickle in while the batch wait runs
+    ASSERT_TRUE(EnsureCudaCtx());
+    for (size_t i = 0; i < kN; ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+      a->PublishSg(K(100 + i), &ssegs[i], 1, vals[i].size());
+    }
+  });
+  b->WaitManySg(wits.data(), kN);
+  pub.join();
+  for (size_t i = 0; i < kN; ++i) {
+    EXPECT_TRUE(wits[i].ok) << "key " << i;
+    EXPECT_EQ(wits[i].got, vals[i].size());
+    EXPECT_EQ(dsts[i]->Down(8192), vals[i]) << "key " << i;
+  }
+  EXPECT_EQ(b->wait_hits(), kN);
 }
 
 TEST(GpuNodeDedup, AbortFreesSlotForWaiterFallback) {


### PR DESCRIPTION
## What

Three additive pieces:

### 1. GPU-destination same-host rendezvous (`node_dedup_gpu`)
The vLLM connector's GPUDirect SG gets are the same lockstep pattern the host rendezvous (phase 5/6) collapses for SGLang — but their destinations are device memory, which the host flavor's shm memcpy cannot serve. New `GpuNodeDedup` mirrors the slot machinery (CAS state machine, monotonic-cursor ring, before/after lap checks, seqlock generations) with the payload channel in GPU memory: each process owns a private staging arena (`cuMemAlloc`, exported once via `cuIpcGetMemHandle` into a pid-claimed shm registry); publishers gather D2D into their arena, waiters open the peer arena (cached, lazy peer access = NVLink) and scatter straight into their destination segments. Host memory is never touched on the copy path.

- CUDA is a **dlopen'd soft dependency** (`cuda_ipc.h` mirrors the driver ABI; no toolkit at build time, no link-time CUDA). No driver / no context / any CUDA error => direct fetch, same "nothing is load-bearing" rule.
- Registry generations invalidate descriptors and cached IPC mappings of dead or replaced processes; the driver rejects unmapped VA ranges, so races degrade to misses, never corruption.
- Same-process peers read through the exporter's VA (cuIpcOpenMemHandle refuses same-process handles).
- Host rendezvous now **routes device destinations away** instead of crashing if misconfigured.
- Opt-in: `DFKV_CLIENT_NODE_DEDUP=1` + `DFKV_CLIENT_NODE_DEDUP_GPU=1`. Segment name carries the layout version (`/dfkv-dedup-gpuv1-…`) per the v1.23.0 lesson.

### 2. SG chunking from the live negotiated max_sge
The 29-payload-segs constant becomes `Transport::MaxSgPayloadSegs()` (min over rails of negotiated max_sge − 1, queried through the shared-device cache without bootstrapping a connection) + `dfkv_max_sg_segs` C ABI export; the vLLM connector sizes `_group_segments_sg` from it. Grouping width is part of key identity — non-default widths key as `@sgw{W}.{n}`; width 29 keeps historical `@sg{n}` names so existing cached data stays reachable. Old libs => AttributeError-tolerant fallback to 29.

### 3. B200 self-hosted CI gate
Registered runner `b200-xb01-0064` (real ConnectX + CUDA; dedicated low-priv user) runs the FULL ctest suite on pushes to main / same-repo PRs / dispatch. Fork PRs are excluded by the job condition and the repo-level outside-collaborator approval policy.

## Verification (B200 real HW)

- 385/385 ctest green (377 baseline + 8 new GPU tests incl. a fork+exec cross-process CUDA IPC hit).
- `dfkv_max_sg_segs` = 29 on the 400G CX rails => production key naming unchanged.
- Single-node vLLM PD (TP4 prefill + TP4 decode, DfkvStoreConnector) A/B in progress; results follow in a PR comment.