### PR TITLE
Phase 9: node-dedup on by default + LMCache key canonicalization + L3 read-back ceiling fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,12 +139,22 @@ if(DFKV_BUILD_TESTS)
     get_filename_component(name ${t} NAME_WE)
     add_executable(${name} ${t})
     target_link_libraries(${name} PRIVATE dfkv_core GTest::gtest_main)
-    gtest_discover_tests(${name})
+    # node_dedup_gpu_test drives real CUDA (arenas, contexts, cross-process
+    # IPC via fork+exec). Under `ctest -j N` on the B200 gate it otherwise runs
+    # concurrently with the RDMA datapath tests, and the child of the IPC test
+    # fails opening the peer handle under that GPU contention (flaked the gate
+    # even with GPUs otherwise free). A shared RESOURCE_LOCK serializes every
+    # GPU/RDMA-touching test against each other while the rest still parallelize.
+    if(name STREQUAL "node_dedup_gpu_test")
+      gtest_discover_tests(${name} PROPERTIES RESOURCE_LOCK gpu_rdma_hw)
+    else()
+      gtest_discover_tests(${name})
+    endif()
   endforeach()
   if(DFKV_WITH_RDMA)  # exercised in CI under Soft-RoCE (rdma_rxe); skips if no device
     add_executable(rdma_loopback_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
     target_link_libraries(rdma_loopback_test PRIVATE dfkv_core GTest::gtest_main)
-    gtest_discover_tests(rdma_loopback_test)
+    gtest_discover_tests(rdma_loopback_test PROPERTIES RESOURCE_LOCK gpu_rdma_hw)
     add_executable(qp_depth_negotiation_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)
     target_link_libraries(qp_depth_negotiation_test PRIVATE dfkv_core GTest::gtest_main)
     gtest_discover_tests(qp_depth_negotiation_test)

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -273,6 +273,14 @@ class DfkvHiCache(HiCacheStorage):
                       "same-host rendezvous collapses replicated L3 loads; "
                       "set node_dedup=0 or DFKV_CLIENT_NODE_DEDUP=0 to disable.",
                       file=sys.stderr, flush=True)
+            # Phase 9: exist gate on the backup path. Recomputed pages whose
+            # KV is ALREADY in L3 were re-backed wholesale (measured 485 GB
+            # per hot round on the canary — write pressure that starved the
+            # very reads the cache exists for). One batch_exist (collapsed by
+            # the rendezvous) filters them out. backup_exist_gate=0 disables.
+            self._backup_exist_gate = _truthy(
+                cfg.get("backup_exist_gate",
+                        os.environ.get("DFKV_BACKUP_EXIST_GATE", "1")))
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0
@@ -574,11 +582,10 @@ class DfkvHiCache(HiCacheStorage):
                 return res
             ptrs, sizes = meta
             sub, sks, sp, ss = self._flatten(keys, ptrs, sizes)
-            karr, parr, sarr, out, _kb = _arrays(sks, sp, ss)
             t0 = time.perf_counter()
-            self._lib.dfkv_batch_put(self._h, karr, parr, sarr, len(sks), out)
+            flat = self._put_flat(sks, sp, ss)
             dur = time.perf_counter() - t0
-            res = self._fold([out[i] == 1 for i in range(len(sks))], n, sub)
+            res = self._fold(flat, n, sub)
             r.result = f"ok {sum(res)}/{n}"
             if _sp:
                 _sp.hits = sum(res); _sp.bytes = sum(ss)
@@ -655,6 +662,29 @@ class DfkvHiCache(HiCacheStorage):
             return self._sub()
         return 1 if self.is_mla else 2
 
+    def _put_flat(self, sks, sp, ss) -> List[bool]:
+        """batch_put with the phase-9 exist gate: sub-objects already in L3
+        are reported stored without rewriting. Falls back to a straight put
+        when the gate is off or everything is missing (cold path unchanged
+        except one exist round-trip)."""
+        if self._backup_exist_gate and sks:
+            present = list(self._batch_exist_flat(sks))
+            todo = [i for i, p in enumerate(present) if not p]
+            if not todo:
+                return [True] * len(sks)
+            if len(todo) < len(sks):
+                karr, parr, sarr, out, _kb = _arrays(
+                    [sks[i] for i in todo], [sp[i] for i in todo],
+                    [ss[i] for i in todo])
+                self._lib.dfkv_batch_put(self._h, karr, parr, sarr,
+                                         len(todo), out)
+                for m, i in enumerate(todo):
+                    present[i] = out[m] == 1
+                return present
+        karr, parr, sarr, out, _kb = _arrays(sks, sp, ss)
+        self._lib.dfkv_batch_put(self._h, karr, parr, sarr, len(sks), out)
+        return [out[i] == 1 for i in range(len(sks))]
+
     def _v2_io(self, transfers, putting):
         results = {}
         segments = []
@@ -674,10 +704,11 @@ class DfkvHiCache(HiCacheStorage):
                 for j, sk in enumerate(self._pool_keys(name, k)):
                     sks.append(sk); sp.append(int(ptrs[i * sub + j])); ss.append(int(sizes[i * sub + j]))
             segments.append((name, len(keys), sub, start, len(sks)))
-        if sks:
+        if sks and putting:
+            flat = self._put_flat(sks, sp, ss)
+        elif sks:
             karr, parr, sarr, out, _ = _arrays(sks, sp, ss)
-            (self._lib.dfkv_batch_put if putting else self._lib.dfkv_batch_get)(
-                self._h, karr, parr, sarr, len(sks), out)
+            self._lib.dfkv_batch_get(self._h, karr, parr, sarr, len(sks), out)
             flat = [out[i] == 1 for i in range(len(sks))]
         else:
             flat = []

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ctypes
 import os
+import sys
 import time
 from typing import List, Optional
 
@@ -40,6 +41,24 @@ def _truthy(v) -> bool:
     if isinstance(v, str):
         return v.strip().lower() not in ("", "0", "false", "no", "off")
     return bool(v)
+
+
+def resolve_node_dedup(cfg_value, env_value, is_mla: bool, tp_size: int):
+    """Decide DFKV_CLIENT_NODE_DEDUP: (value_to_set | None, auto_enabled).
+
+    Precedence: explicit extra-config beats the env, the env beats the auto
+    default. The auto default enables the same-host rendezvous exactly for
+    the topology it exists for — MLA (TP-replicated KV) with tp_size > 1;
+    other topologies never rendezvous (per-rank keys differ) and are spared
+    the /dev/shm arena. Pure function so the policy is unit-testable.
+    """
+    if cfg_value is not None:
+        return ("1" if _truthy(cfg_value) else "0"), False
+    if env_value is not None:
+        return None, False  # operator's env stands as-is
+    if is_mla and tp_size > 1:
+        return "1", True
+    return None, False
 
 
 def _load_lib(path: Optional[str] = None) -> ctypes.CDLL:
@@ -236,12 +255,24 @@ class DfkvHiCache(HiCacheStorage):
             if cfg.get("rdma_numa"):
                 os.environ.setdefault("DFKV_RDMA_NUMA", "1")
             # Same-host GET rendezvous (phase 5): dedups TP-replicated L3 loads
-            # across the rank processes of one node. SAFE here because the
-            # HiCache pools are HOST memory (this connector's destinations are
-            # host KV pool pages); GPUDirect connectors must NOT enable it.
-            if _truthy(cfg.get("node_dedup",
-                               os.environ.get("DFKV_CLIENT_NODE_DEDUP", "0"))):
-                os.environ["DFKV_CLIENT_NODE_DEDUP"] = "1"
+            # across the rank processes of one node (HiCache destinations are
+            # HOST memory — the host flavor applies). Since phase 9 it is ON BY
+            # DEFAULT exactly for the topology it exists for: MLA (replicated
+            # KV) with tp_size > 1 — the measured 8x lockstep read case. Other
+            # topologies gain nothing (per-rank keys never rendezvous) and are
+            # spared the 512 MiB /dev/shm arena. Explicit settings always win:
+            # extra-config `node_dedup` beats the env, the env beats the auto
+            # default; "0" anywhere disables.
+            _dedup, _auto = resolve_node_dedup(
+                cfg.get("node_dedup"), os.environ.get("DFKV_CLIENT_NODE_DEDUP"),
+                self.is_mla, self.tp_size)
+            if _dedup is not None:
+                os.environ["DFKV_CLIENT_NODE_DEDUP"] = _dedup
+            if _auto:
+                print(f"[dfkv] node-dedup auto-enabled (mla, tp={self.tp_size}): "
+                      "same-host rendezvous collapses replicated L3 loads; "
+                      "set node_dedup=0 or DFKV_CLIENT_NODE_DEDUP=0 to disable.",
+                      file=sys.stderr, flush=True)
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0

--- a/integration/lmcache/src/dfkv_connector/key_mapper.py
+++ b/integration/lmcache/src/dfkv_connector/key_mapper.py
@@ -41,14 +41,27 @@ from lmcache.utils import CacheEngineKey
 __all__ = ["cache_engine_key_to_dfkv_str"]
 
 
-def cache_engine_key_to_dfkv_str(key: CacheEngineKey) -> str:
+def cache_engine_key_to_dfkv_str(key: CacheEngineKey,
+                                 canonicalize_worker: bool = False) -> str:
     """Render a CacheEngineKey as a dfkv key string.
 
     Appends ``@{layer_id}`` when ``key`` is a ``LayerCacheEngineKey`` (i.e. LMCache
     layerwise mode) so per-layer objects do not collide. Omit it for the base
     ``CacheEngineKey`` (non-layerwise mode) — byte-identical to the legacy format.
+
+    ``canonicalize_worker=True`` renders worker_id as 0 regardless of the
+    calling rank. For MLA models the KV is REPLICATED across TP ranks, yet
+    LMCache's key scheme embeds worker_id — so the same bytes were stored,
+    written and fetched once PER RANK (8x everything at TP8), and the dfkv
+    same-host rendezvous could never collapse the reads (different keys).
+    Canonicalizing gives all ranks one shared keyspace: storage and writes
+    dedup to 1x, and lockstep GETs become rendezvous-able. Only valid when
+    the per-rank KV really is identical (MLA); the caller gates it.
+    NOTE: flipping this changes the keyspace — existing cached data written
+    with per-rank keys is not reachable under canonical keys (cold start).
     """
-    base = f"{key.model_name}@{key.world_size}@{key.worker_id}@{key.chunk_hash:x}"
+    worker = 0 if canonicalize_worker else key.worker_id
+    base = f"{key.model_name}@{key.world_size}@{worker}@{key.chunk_hash:x}"
     layer_id = getattr(key, "layer_id", None)
     if layer_id is not None:
         return f"{base}@{layer_id}"

--- a/integration/lmcache/src/dfkv_connector/remote_connector.py
+++ b/integration/lmcache/src/dfkv_connector/remote_connector.py
@@ -114,6 +114,30 @@ class DfkvConnector(RemoteConnector):
             rdma_pools = self._collect_rdma_pools(local_cpu_backend)
             geometry = _geometry_from_metadata(local_cpu_backend.metadata)
 
+            # Phase 9: canonical (rank-agnostic) keys for MLA. LMCache embeds
+            # worker_id in every key although MLA KV is replicated across TP
+            # ranks — 8x storage/writes/reads at TP8, and the same-host
+            # rendezvous can never match (different keys). With canonical keys
+            # all ranks share one keyspace; writes are striped to a single
+            # deterministic owner per chunk (see _stripe_owner). Default ON
+            # for MLA+world>1; DFKV_CONNECTOR_MLA_CANONICAL_KEYS=0 restores
+            # the per-rank legacy keyspace (note: flipping = cold cache).
+            _md = local_cpu_backend.metadata
+            self._use_mla = bool(getattr(_md, "use_mla", False))
+            self._world_size = max(1, int(getattr(_md, "world_size", 1)))
+            self._worker_id = int(getattr(_md, "worker_id", 0))
+            _canon_env = os.environ.get("DFKV_CONNECTOR_MLA_CANONICAL_KEYS")
+            self._canonical_keys = (
+                self._use_mla and self._world_size > 1
+                and (_canon_env is None or _canon_env.strip().lower()
+                     not in ("0", "false", "no", "off")))
+            if self._canonical_keys:
+                logger.info(
+                    "dfkv canonical MLA keys enabled (world=%d): shared "
+                    "keyspace + single-writer striping; set "
+                    "DFKV_CONNECTOR_MLA_CANONICAL_KEYS=0 for legacy per-rank "
+                    "keys", self._world_size)
+
             self._local_cpu_backend = local_cpu_backend
             self._exists_lru = ExistsLRU(capacity=exists_cache_capacity)
             self._client = DfkvNativeClient(
@@ -141,6 +165,17 @@ class DfkvConnector(RemoteConnector):
                 getattr(self._client, "transport_mode", "unknown"),
             )
             r.result = f"endpoint={endpoint.raw_endpoint} group={endpoint.group}"
+
+    def _kstr(self, key: CacheEngineKey) -> str:
+        return cache_engine_key_to_dfkv_str(key, self._canonical_keys)
+
+    def _stripe_owner(self, key: CacheEngineKey) -> bool:
+        """With canonical keys every rank would redundantly PUT the same key;
+        exactly one deterministic owner writes each chunk instead (identical
+        bytes on every rank — MLA — so any single writer is correct)."""
+        if not self._canonical_keys:
+            return True
+        return (key.chunk_hash % self._world_size) == self._worker_id
 
     @staticmethod
     def _collect_rdma_pools(local_cpu_backend: Any) -> List[Tuple[int, int]]:
@@ -203,7 +238,7 @@ class DfkvConnector(RemoteConnector):
     # ------------------------------------------------------------------
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        key_str = cache_engine_key_to_dfkv_str(key)
+        key_str = self._kstr(key)
         with access_log("exists", lambda: key_str) as r:
             if self._exists_lru.has(key_str):
                 r.result = "lru_hit"
@@ -216,7 +251,7 @@ class DfkvConnector(RemoteConnector):
             return found
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
-        key_str = cache_engine_key_to_dfkv_str(key)
+        key_str = self._kstr(key)
         with access_log("exists_sync", lambda: key_str) as r:
             if self._exists_lru.has(key_str):
                 r.result = "lru_hit"
@@ -250,7 +285,7 @@ class DfkvConnector(RemoteConnector):
             if self._assume_exists:
                 r.result = f"prefix={n} (assume_exists)"
                 return n
-            key_strs = [cache_engine_key_to_dfkv_str(k) for k in keys]
+            key_strs = [self._kstr(k) for k in keys]
             i = self._exists_lru.prefix_len(key_strs)
             if i == n:
                 r.result = f"prefix={n} (all lru hit)"
@@ -286,7 +321,7 @@ class DfkvConnector(RemoteConnector):
     # ------------------------------------------------------------------
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        key_str = cache_engine_key_to_dfkv_str(key)
+        key_str = self._kstr(key)
         with access_log("get", lambda: key_str) as r:
             memory_obj = self._allocate_chunk()
             if memory_obj is None:
@@ -317,9 +352,15 @@ class DfkvConnector(RemoteConnector):
         # NOTE: we do NOT ref_count_down memory_obj here. The caller hands us a
         # serialized compressed_memory_obj whose lifetime it manages. Mirrors
         # RedisConnector.put / the dingofs connector.
-        key_str = cache_engine_key_to_dfkv_str(key)
+        key_str = self._kstr(key)
         size = len(memory_obj.byte_array)
         with access_log("put", lambda: f"{key_str}, {_fmt_bytes(size)}") as r:
+            if not self._stripe_owner(key):
+                # canonical keys: the owning rank writes this chunk; treating
+                # it as stored here prevents this rank from ever re-putting.
+                self._exists_lru.add(key_str)
+                r.result = "striped_skip"
+                return
             ok, _ = await self._client.batch_set([key_str], [memory_obj.byte_array])
             if ok:
                 self._exists_lru.add(key_str)
@@ -347,7 +388,22 @@ class DfkvConnector(RemoteConnector):
             if len(keys) != len(memory_objs):
                 r.result = "FAIL length_mismatch"
                 raise ValueError("keys and memory_objs length mismatch")
-            key_strs = [cache_engine_key_to_dfkv_str(k) for k in keys]
+            if self._canonical_keys:
+                # single-writer striping: this rank only writes the chunks it
+                # owns; the rest are (being) written by their owners and are
+                # remembered as stored so this rank never re-puts them.
+                owned = [i for i, k in enumerate(keys) if self._stripe_owner(k)]
+                skipped = [self._kstr(keys[i]) for i in range(n)
+                           if i not in set(owned)]
+                if skipped:
+                    self._exists_lru.add_many(skipped)
+                if not owned:
+                    r.result = f"striped_skip {n} keys"
+                    return
+                keys = [keys[i] for i in owned]
+                memory_objs = [memory_objs[i] for i in owned]
+                n = len(keys)
+            key_strs = [self._kstr(k) for k in keys]
             views = [obj.byte_array for obj in memory_objs]
             ok_all = True
             stored_keys: List[str] = []
@@ -384,7 +440,7 @@ class DfkvConnector(RemoteConnector):
             if not keys:
                 r.result = "empty"
                 return []
-            key_strs = [cache_engine_key_to_dfkv_str(k) for k in keys]
+            key_strs = [self._kstr(k) for k in keys]
 
             objs: List[MemoryObj] = []
             for _ in keys:
@@ -485,7 +541,7 @@ class DfkvConnector(RemoteConnector):
                 r.result = "empty"
                 return []
 
-            key_strs = [cache_engine_key_to_dfkv_str(k) for k in keys]
+            key_strs = [self._kstr(k) for k in keys]
             out: List[MemoryObj] = []
             ranges = list(self._batch_slices(n))
             chunks = len(ranges)
@@ -559,7 +615,7 @@ class DfkvConnector(RemoteConnector):
             return out
 
     def remove_sync(self, key: CacheEngineKey) -> bool:
-        key_str = cache_engine_key_to_dfkv_str(key)
+        key_str = self._kstr(key)
         with access_log("remove_sync", lambda: key_str) as r:
             if not self._client.supports_remove():
                 r.result = "FAIL no remove RPC"

--- a/integration/lmcache/tests/test_key_mapper.py
+++ b/integration/lmcache/tests/test_key_mapper.py
@@ -125,6 +125,32 @@ def test_layer_id_zero_is_encoded():
     assert cache_engine_key_to_dfkv_str(k).endswith("@0")
 
 
+
+def test_canonical_worker_zeroes_rank():
+    # Phase 9: MLA shared keyspace — worker_id renders as 0.
+    k = _base_key(worker_id=5, chunk_hash=0xABC)
+    assert cache_engine_key_to_dfkv_str(k, canonicalize_worker=True) == \
+        "glm-5.1@8@0@abc"
+
+
+def test_canonical_default_off_keeps_legacy():
+    k = _base_key(worker_id=5, chunk_hash=0xABC)
+    assert cache_engine_key_to_dfkv_str(k) == "glm-5.1@8@5@abc"
+
+
+def test_canonical_all_ranks_converge():
+    rendered = {cache_engine_key_to_dfkv_str(
+        _base_key(worker_id=w, chunk_hash=0xDEAD), canonicalize_worker=True)
+        for w in range(8)}
+    assert len(rendered) == 1
+
+
+def test_canonical_layerwise_keeps_layer_id():
+    k = _layer_key(worker_id=3, chunk_hash=0x1, layer_id=7)
+    assert cache_engine_key_to_dfkv_str(k, canonicalize_worker=True) == \
+        "glm-5.1@8@0@1@7"
+
+
 def _run_all():
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0
@@ -143,3 +169,4 @@ def _run_all():
 
 if __name__ == "__main__":
     sys.exit(1 if _run_all() else 0)
+

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -872,6 +872,24 @@ class DfkvStoreWorker:
                 "dfkv connector: model_hash is 0 (shared keyspace, no "
                 "cross-model isolation). Set kv_connector_extra_config."
                 "model_hash to a per-model value in multi-model fleets.")
+        # Phase 9: same-host rendezvous ON BY DEFAULT for exactly the topology
+        # it exists for — MLA with REPLICATED KV across tp ranks (dcp/pcp
+        # shard the KV, so their per-rank keys never rendezvous). The vLLM SG
+        # data path is GPUDirect, so both flavors are defaulted: the CUDA-IPC
+        # one for payloads, the host one for exist probes. Explicit env
+        # settings ("0" included) always win over the auto default.
+        if (self.use_mla and self.tp_size > 1 and self.dcp_size <= 1
+                and getattr(self, "pcp_size", 1) <= 1):
+            if os.environ.get("DFKV_CLIENT_NODE_DEDUP") is None:
+                os.environ["DFKV_CLIENT_NODE_DEDUP"] = "1"
+                logger.info(
+                    "dfkv node-dedup auto-enabled (mla, tp=%d): same-host "
+                    "rendezvous collapses replicated L3 loads; set "
+                    "DFKV_CLIENT_NODE_DEDUP=0 to disable", self.tp_size)
+            if (os.environ.get("DFKV_CLIENT_NODE_DEDUP") == "1"
+                    and os.environ.get("DFKV_CLIENT_NODE_DEDUP_GPU") is None):
+                os.environ["DFKV_CLIENT_NODE_DEDUP_GPU"] = "1"
+
         client_kwargs = dict(
             members=extra.get("members", ""),
             mds_endpoints=mds_endpoints,

--- a/src/cache/slab_allocator.cc
+++ b/src/cache/slab_allocator.cc
@@ -17,6 +17,20 @@ SlabAllocator::SlabAllocator(Options opt) : opt_(opt) {
   if (opt_.num_extents == 0) opt_.num_extents = 1;
   extents_.assign(opt_.num_extents, ExtentMeta{});  // all kUnbound (in pool)
   unbound_ = opt_.num_extents;
+  // Cold-donor protect window. Default 0 = AUTO: the window tracks the live
+  // object count, so an extent is "cold" once the working set has fully turned
+  // over past its newest write (self-tuning across object sizes). A positive
+  // DFKV_SLAB_COLD_STEAL_WINDOW pins a fixed window; a sentinel disables the
+  // feature entirely (pre-phase-9 self-eviction-first).
+  cold_steal_enabled_ = true;
+  if (const char* w = std::getenv("DFKV_SLAB_COLD_STEAL_WINDOW")) {
+    char* end = nullptr;
+    unsigned long long v = std::strtoull(w, &end, 10);
+    if (end != w) {
+      if (v == 0) cold_steal_enabled_ = false;  // explicit "0" disables
+      else cold_window_ = static_cast<uint64_t>(v);
+    }
+  }
 }
 
 void SlabAllocator::PushFreeLocked(Class& C, uint32_t ext, uint32_t slot) {
@@ -253,6 +267,35 @@ bool SlabAllocator::StealExtentFor(size_t cls, std::vector<std::string>* evicted
   return StealExtentLocked(static_cast<uint32_t>(best), cls, evicted);
 }
 
+bool SlabAllocator::StealColdExtentFor(size_t cls,
+                                       std::vector<std::string>* evicted) {
+  if (!cold_steal_enabled_) return false;
+  // AUTO window (cold_window_==0): the live object count — an extent is cold
+  // once the working set has fully cycled past its newest write. Fixed window
+  // when configured.
+  const uint64_t window = cold_window_ ? cold_window_ : index_.size();
+  if (window == 0 || put_seq_ <= window) return false;  // not cycled yet
+  const uint64_t cold_before = put_seq_ - window;
+  // Stalest fully-unpinned donor extent in ANOTHER class whose newest resident
+  // predates the protect window. Smallest youngest_seq = coldest.
+  int best = -1;
+  uint64_t best_seq = cold_before;  // strictly older than the window to qualify
+  for (uint32_t e = 0; e < extents_.size(); ++e) {
+    const ExtentMeta& m = extents_[e];
+    if (m.cls == kUnbound || m.cls == static_cast<int>(cls)) continue;
+    if (m.pinned != 0) continue;
+    if (m.residents.empty()) continue;  // pooled/empty handled elsewhere
+    // No stripe-width floor here: a donor this cold (youngest older than a full
+    // working-set cycle) is by definition not being actively written, so fully
+    // reclaiming it is the intent — that stale data is exactly what should go.
+    if (m.youngest_seq < best_seq) { best = static_cast<int>(e); best_seq = m.youngest_seq; }
+  }
+  if (best < 0) return false;
+  if (!StealExtentLocked(static_cast<uint32_t>(best), cls, evicted)) return false;
+  ++cold_steals_;
+  return true;
+}
+
 bool SlabAllocator::StealExtentLocked(uint32_t E, size_t target_cls,
                                       std::vector<std::string>* evicted) {
   ExtentMeta& m = extents_[E];
@@ -278,6 +321,7 @@ bool SlabAllocator::StealExtentLocked(uint32_t E, size_t target_cls,
     m.total_slots = 0;
     m.free_slots = 0;
     m.pinned = 0;
+    m.youngest_seq = 0;  // fresh recency once re-bound (residents restamp it)
     ++unbound_;
   }
   ++steals_;
@@ -332,6 +376,13 @@ bool SlabAllocator::Put(const std::string& key, size_t len, SlotRef* out,
     if (C.bound_extents < kStripeWays &&
         StealExtentFor(cls, evicted, /*min_donor_extents=*/kStripeWays))
       continue;
+    // Cross-class eviction of globally-cold data BEFORE self-eviction: a
+    // single-size-class working set that fills the ring would otherwise evict
+    // its own just-written pages every Put (CLOCK degrades to FIFO), while
+    // stale OTHER-class extents sit untouched — measured as a 0% hot-round hit
+    // rate once the pool filled. Reclaim a cold donor extent instead when one
+    // exists; else fall back to self-eviction, then any-donor steal.
+    if (StealColdExtentFor(cls, evicted)) continue;
     if (EvictOneFrom(cls, evicted)) continue;
     if (StealExtentFor(cls, evicted)) continue;
     return false;  // nothing to free: all candidate slots are pinned
@@ -345,6 +396,7 @@ bool SlabAllocator::Put(const std::string& key, size_t len, SlotRef* out,
   e.ref.offset = static_cast<uint64_t>(got.slot) * classes_[cls]->slot_size;
   e.refs = 0;
   e.referenced = false;
+  e.put_seq = ++put_seq_;
   Class& C = *classes_[cls];
   C.ring.push_front(key);
   e.ring_it = C.ring.begin();
@@ -353,6 +405,8 @@ bool SlabAllocator::Put(const std::string& key, size_t len, SlotRef* out,
   used_bytes_ += e.ref.slot_size;
   auto res = index_.emplace(key, std::move(e));
   ExtentMeta& m = extents_[got.extent];
+  if (res.first->second.put_seq > m.youngest_seq)
+    m.youngest_seq = res.first->second.put_seq;
   m.residents.push_front(&res.first->first);
   res.first->second.ext_it = m.residents.begin();
   if (out) *out = res.first->second.ref;
@@ -477,6 +531,10 @@ uint64_t SlabAllocator::Evictions() const {
 uint64_t SlabAllocator::Steals() const {
   std::lock_guard<std::mutex> lk(mu_);
   return steals_;
+}
+uint64_t SlabAllocator::ColdSteals() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return cold_steals_;
 }
 uint64_t SlabAllocator::ExtentReturns() const {
   std::lock_guard<std::mutex> lk(mu_);

--- a/src/cache/slab_allocator.h
+++ b/src/cache/slab_allocator.h
@@ -159,6 +159,7 @@ class SlabAllocator {
   uint64_t Capacity() const;        // num_extents * extent_bytes
   uint64_t Evictions() const;
   uint64_t Steals() const;          // cross-class extent steals (capacity churn signal)
+  uint64_t ColdSteals() const;      // steals of globally-cold donor extents (phase 9)
   uint64_t ExtentReturns() const;   // fully-free extents unbound back to the pool
   size_t ClassCount() const;
   uint32_t BoundExtents() const;    // extents currently carved to a class
@@ -171,6 +172,7 @@ class SlabAllocator {
     SlotRef ref;
     uint32_t refs = 0;                       // pin count
     bool referenced = false;                 // CLOCK bit
+    uint64_t put_seq = 0;                    // monotonic insert order (global recency)
     std::list<std::string>::iterator ring_it;  // this key's node in its class ring
     // This key's node in its extent's resident list (points at the index_ map
     // key, which is node-stable). Lets StealExtentFor enumerate one extent's
@@ -200,6 +202,10 @@ class SlabAllocator {
     uint32_t free_slots = 0; // free slots (== total when fully empty)
     uint32_t total_slots = 0;
     uint32_t pinned = 0;     // resident pinned slots in this extent (steal guard)
+    // Newest insert seq among residents (0 = empty). Only grows on insert; a
+    // free never lowers it (conservative: an extent looks no colder than it is,
+    // so cold-donor steal never over-eagerly reclaims a still-hot extent).
+    uint64_t youngest_seq = 0;
     // Keys resident in this extent (pointers into index_'s node-stable keys);
     // per-key node handle lives in Entry::ext_it. Empty iff fully free.
     std::list<const std::string*> residents;
@@ -216,6 +222,15 @@ class SlabAllocator {
   // last-resort semantics this function always had).
   bool StealExtentFor(size_t cls, std::vector<std::string>* evicted,
                       size_t min_donor_extents = 0); // rebind a full extent
+  // Cross-class eviction of GLOBALLY cold data: steal a fully-unpinned donor
+  // extent (from another class) whose newest resident predates put_seq_ minus
+  // the protect window — i.e. nothing in it has been written for ~a full pool
+  // cycle. Preferred over self-eviction so a single-size-class working set that
+  // fills the ring reclaims stale OTHER-class extents instead of cannibalizing
+  // its own just-written pages (the phase-8 hit-rate probe measured that
+  // self-thrash as a 0% hot-round hit rate once the ring was full). Returns
+  // false when no donor is cold enough — the caller then self-evicts as before.
+  bool StealColdExtentFor(size_t cls, std::vector<std::string>* evicted);
   // Shared steal core: evict extent E's residents, unbind E, re-bind a pool
   // extent to target_cls. E must be fully unpinned. With mu_ held.
   bool StealExtentLocked(uint32_t E, size_t target_cls,
@@ -241,7 +256,15 @@ class SlabAllocator {
   uint64_t used_bytes_ = 0;
   uint64_t evictions_ = 0;
   uint64_t steals_ = 0;
+  uint64_t cold_steals_ = 0;  // steals of globally-cold donor extents (phase 9)
   uint64_t extent_returns_ = 0;
+  uint64_t put_seq_ = 0;      // monotonic Put counter (recency clock)
+  // Cold-donor protect window in puts. 0 = AUTO (tracks live object count at
+  // eviction time); a positive DFKV_SLAB_COLD_STEAL_WINDOW pins it. An extent
+  // whose youngest resident predates put_seq_ - window is "globally cold" and
+  // preferred for cross-class steal over self-eviction.
+  uint64_t cold_window_ = 0;
+  bool cold_steal_enabled_ = true;  // DFKV_SLAB_COLD_STEAL_WINDOW=0 disables
 };
 
 }  // namespace dfkv

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -127,6 +127,48 @@ class FanoutPool {
 void RunParallel(size_t n, size_t workers, const std::function<void(size_t)>& fn) {
   FanoutPool::Instance().Run(n, workers, fn);
 }
+
+size_t EnvSize(const char* name, size_t dflt) {
+  const char* v = std::getenv(name);
+  if (!v || !*v) return dflt;
+  char* end = nullptr;
+  unsigned long long x = std::strtoull(v, &end, 10);
+  return (end != v && x > 0) ? static_cast<size_t>(x) : dflt;
+}
+
+// Split each per-node read group into up to N shards so multiple connections
+// read one node concurrently. A single- or few-node ring otherwise routes a
+// whole batch to ONE (node,size) group -> one worker -> one QP, where the
+// server drains it key-by-key (~7 ms/key, ~166 MB/s/conn measured on the
+// phase-8 hit-rate probe — the L3 read-back ceiling). Sharding turns that
+// into DFKV_READ_MAX_CONNS parallel streams per node. Shard target size and
+// the per-node cap are env-tunable; each shard keeps its group's (node,size)
+// key so downstream code is unchanged. Groups already at/under one shard pass
+// through untouched (wide rings keep their existing per-node parallelism).
+template <class GroupVec>
+GroupVec ShardReadGroups(GroupVec groups) {
+  static const size_t target = EnvSize("DFKV_READ_SHARD_KEYS", 16);
+  static const size_t maxc = EnvSize("DFKV_READ_MAX_CONNS", 8);
+  if (maxc <= 1) return groups;
+  GroupVec out;
+  out.reserve(groups.size());
+  for (auto& g : groups) {
+    const auto& idx = g.second;
+    size_t nsh = (idx.size() + target - 1) / target;
+    if (nsh < 1) nsh = 1;
+    if (nsh > maxc) nsh = maxc;
+    if (nsh <= 1) { out.push_back(std::move(g)); continue; }
+    const size_t per = (idx.size() + nsh - 1) / nsh;
+    for (size_t s = 0; s < idx.size(); s += per) {
+      typename GroupVec::value_type sh;
+      sh.first = g.first;
+      sh.second.assign(idx.begin() + s,
+                       idx.begin() + std::min(idx.size(), s + per));
+      out.push_back(std::move(sh));
+    }
+  }
+  return out;
+}
 }  // namespace
 
 KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
@@ -694,7 +736,7 @@ std::vector<bool> KVClient::BatchGetDirect(const std::vector<KvGetItem>& items) 
     if (node.empty()) continue;
     by[{node, items[i].n}].push_back(i);
   }
-  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
+  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups = ShardReadGroups(std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>>(by.begin(), by.end()));
   RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();
@@ -827,7 +869,7 @@ std::vector<bool> KVClient::BatchGetAutoDirect(const std::vector<KvGetItem>& ite
     if (node.empty()) continue;
     by[{node, items[i].n}].push_back(i);
   }
-  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
+  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups = ShardReadGroups(std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>>(by.begin(), by.end()));
   RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();
@@ -1248,7 +1290,7 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
     for (size_t c : items[i].caps) cap += c;
     by[{node, cap}].push_back(i);
   }
-  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups(by.begin(), by.end());
+  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups = ShardReadGroups(std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>>(by.begin(), by.end()));
   RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first.first;
     uint64_t now = NowMs();

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -154,12 +154,14 @@ RdmaTransport::~RdmaTransport() {
   std::lock_guard<std::mutex> lk(mu_);
   for (auto& [node, cs] : pool_)
     for (Conn* c : cs) Destroy(c);
+  for (auto& [node, cs] : control_pool_)
+    for (Conn* c : cs) Destroy(c);
 }
 
 void RdmaTransport::Destroy(Conn* c) { delete c; }  // RcEndpoint dtor tears down QP/MRs
 
-RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, bool* from_pool,
-                                            bool force_new) {
+RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, Lane lane,
+                                            bool* from_pool, bool force_new) {
   std::vector<std::pair<void*, size_t>> pools;
   Conn* pooled = nullptr;
   {
@@ -169,8 +171,9 @@ RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, bool* from_
     // by the server, and the pool may hold more reclaimed conns — bootstrapping a
     // fresh one guarantees the retry isn't handed another dead conn.
     if (!force_new) {
-      auto it = pool_.find(node);
-      if (it != pool_.end() && !it->second.empty()) {
+      auto& p = (lane == Lane::kControl) ? control_pool_ : pool_;
+      auto it = p.find(node);
+      if (it != p.end() && !it->second.empty()) {
         pooled = it->second.back(); it->second.pop_back();
       }
     }
@@ -294,10 +297,10 @@ std::string RdmaTransport::MetricsText() const {
   return s;
 }
 
-void RdmaTransport::Release(const std::string& node, Conn* c) {
+void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
   {
     std::lock_guard<std::mutex> lk(mu_);
-    auto& v = pool_[node];
+    auto& v = (lane == Lane::kControl ? control_pool_ : pool_)[node];
     if (v.size() < pool_max_) { v.push_back(c); return; }
   }
   Destroy(c);  // pool full -> drop (and tear down the QP/MRs) instead of growing
@@ -310,9 +313,13 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
   if (payload_len > control_cap_ - kReqPrefix) return Status::kInvalid;
   if (op == WireOp::kRange && length > control_cap_ - kRespPrefix)
     return Status::kInvalid;
+  // Key-only ops (Exist/Remove/Members) ride the control lane so a lookup
+  // storm never queues behind payload transfers; Cache/Range carry payloads.
+  const Lane lane = (op == WireOp::kCache || op == WireOp::kRange)
+                        ? Lane::kData : Lane::kControl;
   for (int attempt = 0; attempt < 2; ++attempt) {
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, lane, &from_pool, attempt > 0);
     if (!c) return Status::kIOError;
     rdma::RcEndpoint& ep = c->ep;
 
@@ -343,7 +350,7 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
       if (kRespPrefix + dlen > recv_bytes) { Destroy(c); return Status::kIOError; }
       out->assign(ep.rbuf(0) + kRespPrefix, dlen);
     }
-    Release(node, c);
+    Release(node, lane, c);
     return st;
   }
   return Status::kIOError;
@@ -391,7 +398,7 @@ std::vector<Status> RdmaTransport::CacheMany(const std::string& node,
   for (int attempt = 0; attempt < 2; ++attempt) {
     std::fill(res.begin(), res.end(), Status::kIOError);
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
     const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
@@ -412,7 +419,7 @@ std::vector<Status> RdmaTransport::CacheMany(const std::string& node,
         if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
       }
     }
-    if (conn_ok) { Release(node, c); return res; }
+    if (conn_ok) { Release(node, Lane::kData, c); return res; }
     Destroy(c);
     if (from_pool) continue;  // stale pooled conn -> one fresh retry
     return res;               // fresh conn failed -> terminal
@@ -439,7 +446,7 @@ std::vector<Status> RdmaTransport::RangeMany(const std::string& node,
     std::fill(res.begin(), res.end(), Status::kIOError);
     outs->assign(n, std::string());
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
     const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
@@ -465,7 +472,7 @@ std::vector<Status> RdmaTransport::RangeMany(const std::string& node,
         }
       }
     }
-    if (conn_ok) { Release(node, c); return res; }
+    if (conn_ok) { Release(node, Lane::kData, c); return res; }
     Destroy(c);
     if (from_pool) continue;  // stale pooled conn -> one fresh retry
     return res;               // fresh conn failed -> terminal
@@ -489,7 +496,7 @@ std::vector<Status> RdmaTransport::ExistMany(const std::string& node,
     std::fill(res.begin(), res.end(), Status::kIOError);
     std::fill(exists->begin(), exists->end(), 0);
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, Lane::kControl, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
     const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
@@ -511,7 +518,7 @@ std::vector<Status> RdmaTransport::ExistMany(const std::string& node,
         (*exists)[base + j] = (st == Status::kOk) ? 1 : 0;
       }
     }
-    if (conn_ok) { Release(node, c); return res; }
+    if (conn_ok) { Release(node, Lane::kControl, c); return res; }
     Destroy(c);
     if (from_pool) continue;  // stale pooled conn -> one fresh retry
     return res;               // fresh conn failed -> terminal
@@ -550,7 +557,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
     for (size_t i = 0; i < n; ++i) if (bad[i]) res[i] = Status::kInvalid;
     hdrs->assign(n, std::string());
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
     const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
@@ -571,7 +578,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
         // unprocessed remainder as kInvalid so the caller's health accounting
         // does not MarkBad (cooldown) a healthy node for our own MR pressure.
         for (size_t i = base; i < n; ++i) if (!bad[i]) res[i] = Status::kInvalid;
-        Release(node, c);
+        Release(node, Lane::kData, c);
         return res;
       }
       // Scatter recv [hdr -> rbuf | payload -> caller buffer], then send the Range req.
@@ -616,7 +623,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
         }
       }
     }
-    if (conn_ok) { Release(node, c); return res; }
+    if (conn_ok) { Release(node, Lane::kData, c); return res; }
     Destroy(c);
     if (from_pool) continue;  // stale pooled conn -> one fresh retry
     return res;               // fresh conn failed -> terminal
@@ -646,7 +653,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
     std::fill(res.begin(), res.end(), Status::kIOError);
     for (size_t i = 0; i < n; ++i) if (bad[i]) res[i] = Status::kInvalid;
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
     const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
@@ -670,7 +677,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
         // for the unprocessed remainder so health accounting does not MarkBad
         // (cooldown) a healthy node for our own MR pressure.
         for (size_t i = base; i < n; ++i) if (!bad[i]) res[i] = Status::kInvalid;
-        Release(node, c);
+        Release(node, Lane::kData, c);
         return res;
       }
       // Build [req prefix | value header] into sbuf[j], scatter-send with the
@@ -712,7 +719,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
         if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
       }
     }
-    if (conn_ok) { Release(node, c); return res; }
+    if (conn_ok) { Release(node, Lane::kData, c); return res; }
     Destroy(c);
     if (from_pool) continue;  // stale pooled conn -> one fresh retry
     return res;               // fresh conn failed -> terminal
@@ -733,7 +740,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   for (int attempt = 0; attempt < 2; ++attempt) {
     std::fill(res.begin(), res.end(), Status::kIOError);
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
     const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
@@ -774,7 +781,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
           if (!mrs_per[j][e]) regok = false;
         }
       }
-      if (!regok) { Release(node, c); return res; }
+      if (!regok) { Release(node, Lane::kData, c); return res; }
       size_t posted = 0;
       for (size_t j = 0; j < w && conn_ok; ++j) {
         if (bad[base + j]) continue;
@@ -816,7 +823,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
         if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
       }
     }
-    if (conn_ok) { Release(node, c); return res; }
+    if (conn_ok) { Release(node, Lane::kData, c); return res; }
     Destroy(c);
     if (from_pool) continue;  // stale pooled conn -> one fresh retry
     return res;               // fresh conn failed -> terminal
@@ -846,7 +853,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     hdrs->assign(n, std::string());
     if (out_lens) out_lens->assign(n, 0);
     bool from_pool = false;
-    Conn* c = Acquire(node, &from_pool, attempt > 0);
+    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
     if (!c) return res;
     rdma::RcEndpoint& ep = c->ep;
     const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
@@ -882,7 +889,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
           if (!mrs_per[j][e]) regok = false;
         }
       }
-      if (!regok) { Release(node, c); return res; }
+      if (!regok) { Release(node, Lane::kData, c); return res; }
       size_t posted = 0;
       for (size_t j = 0; j < w && conn_ok; ++j) {
         if (bad[base + j]) continue;
@@ -935,7 +942,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
         }
       }
     }
-    if (conn_ok) { Release(node, c); return res; }
+    if (conn_ok) { Release(node, Lane::kData, c); return res; }
     Destroy(c);
     if (from_pool) continue;  // stale pooled conn -> one fresh retry
     return res;               // fresh conn failed -> terminal

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -80,8 +80,15 @@ class RdmaTransport : public Transport {
   // force_new (set on a retry after a stale pooled conn) skips the pool and
   // bootstraps a fresh connection, so a second server-reclaimed conn can't be
   // handed back on the retry. *from_pool reports whether a pooled conn was used.
-  Conn* Acquire(const std::string& node, bool* from_pool, bool force_new = false);
-  void Release(const std::string& node, Conn* c);
+  // lane selects a POOL: kData carries payloads (Cache/Range, up to MBs),
+  // kControl carries only key-sized ops (Exist/Remove/Members). They never
+  // share a connection, so a lookup storm can't queue behind in-flight 1 MB
+  // GETs on the same QP — the hot-round exist p99 of ~800 s the phase-8
+  // hit-rate probe measured was exactly that head-of-line blocking.
+  enum class Lane { kData, kControl };
+  Conn* Acquire(const std::string& node, Lane lane, bool* from_pool,
+                bool force_new = false);
+  void Release(const std::string& node, Lane lane, Conn* c);
   void Destroy(Conn* c);
   Status RoundTrip(const std::string& node, WireOp op, const BlockKey& key,
                    uint64_t offset, uint64_t length, const void* payload,
@@ -89,6 +96,9 @@ class RdmaTransport : public Transport {
 
   std::mutex mu_;
   std::unordered_map<std::string, std::vector<Conn*>> pool_;
+  // Separate idle-conn pool for control-lane ops (Exist/Remove/Members), so
+  // small key-only round trips never share a QP with payload transfers.
+  std::unordered_map<std::string, std::vector<Conn*>> control_pool_;
   // Caller memory regions to register on every connection (the host KV pool).
   // Guarded by mu_; snapshotted in Acquire and registered on the connection.
   std::vector<std::pair<void*, size_t>> pools_;

--- a/test/cache/slab_allocator_test.cc
+++ b/test/cache/slab_allocator_test.cc
@@ -149,28 +149,33 @@ TEST(SlabAllocator, CrossClassStealWhenPoolEmpty) {
   EXPECT_GE(a.ClassCount(), 2u);
 }
 
+// Fill both size classes to a stable steady state where every extent is full,
+// so growth-first striping (grabs up to kStripeWays=8) can't monopolize the
+// pool: 16 extents, A(8192) takes 8 (16 keys), B(4096) takes 8 (32 keys).
+// Returns after both classes are full; put_seq = 48, A's youngest = 16.
+namespace {
+void FillTwoClassesFull(SlabAllocator& a, std::vector<std::string>& ev) {
+  SlotRef r;
+  for (int i = 0; i < 16; ++i)  // stale A: 8192, 2/extent -> 8 extents
+    ASSERT_TRUE(a.Put("stale" + std::to_string(i), 8192, &r, &ev));
+  for (int i = 0; i < 32; ++i)  // hot B: 4096, 4/extent -> 8 extents
+    ASSERT_TRUE(a.Put("hot" + std::to_string(i), 4096, &r, &ev));
+}
+}  // namespace
+
 TEST(SlabAllocator, ColdDonorStolenBeforeSelfEviction) {
-  // Phase 9: the pathology from the hit-rate probe. A stale class fills some
-  // extents, then a busy same-size working set cycles its own ring. Once the
-  // busy class has fully turned over past the stale data (the protect window),
-  // a new put must reclaim the STALE cross-class extent rather than evict the
-  // busy class's just-written pages. Fixed window via env for determinism.
-  ::setenv("DFKV_SLAB_COLD_STEAL_WINDOW", "6", 1);
-  SlabAllocator a(Opts(4 * 4096, 4));  // 4 extents; A(8192)=2 slots, B(4096)=4
+  // Phase 9: once the pool is full, a busy class must reclaim a globally-cold
+  // CROSS-class extent instead of self-evicting its own just-written pages.
+  ::setenv("DFKV_SLAB_COLD_STEAL_WINDOW", "6", 1);  // small window, determinism
+  SlabAllocator a(Opts(4 * 4096, 16));
   std::vector<std::string> ev;
   SlotRef r;
-  // Stale class A: 4 keys => 2 extents (seq 1..4), never touched again.
-  for (int i = 0; i < 4; ++i)
-    ASSERT_TRUE(a.Put("stale" + std::to_string(i), 8192, &r, &ev));
-  // Busy class B fills the remaining 2 extents (8 slots, seq 5..12).
-  for (int i = 0; i < 8; ++i)
-    ASSERT_TRUE(a.Put("hot" + std::to_string(i), 4096, &r, &ev));
-  ASSERT_EQ(a.ColdSteals(), 0u);
-  ev.clear();
-  // Keep writing B. put_seq climbs; once put_seq - 6 > 4 (stale's youngest),
-  // the stale A extent is cold and gets stolen instead of self-evicting hot.
+  FillTwoClassesFull(a, ev);
+  // Keep writing B (self-eviction would succeed). put_seq climbs past
+  // stale's youngest (16) + window (6): the stale A extent becomes cold and is
+  // stolen in preference to evicting a hot page.
   bool stole_stale = false;
-  for (int i = 8; i < 24 && !stole_stale; ++i) {
+  for (int i = 32; i < 80 && !stole_stale; ++i) {
     ev.clear();
     ASSERT_TRUE(a.Put("hot" + std::to_string(i), 4096, &r, &ev));
     for (const auto& k : ev)
@@ -183,15 +188,14 @@ TEST(SlabAllocator, ColdDonorStolenBeforeSelfEviction) {
 
 TEST(SlabAllocator, ColdStealDisabledFallsBackToSelfEvict) {
   ::setenv("DFKV_SLAB_COLD_STEAL_WINDOW", "0", 1);  // disable
-  SlabAllocator a(Opts(4 * 4096, 4));
+  SlabAllocator a(Opts(4 * 4096, 16));
   std::vector<std::string> ev;
   SlotRef r;
-  for (int i = 0; i < 4; ++i)
-    ASSERT_TRUE(a.Put("stale" + std::to_string(i), 8192, &r, &ev));
-  for (int i = 0; i < 40; ++i)
+  FillTwoClassesFull(a, ev);
+  for (int i = 32; i < 96; ++i)  // busy class self-evicts its own only
     ASSERT_TRUE(a.Put("hot" + std::to_string(i), 4096, &r, &ev));
   EXPECT_EQ(a.ColdSteals(), 0u) << "disabled: never cold-steals";
-  EXPECT_TRUE(a.Contains("stale0")) << "stale data survives when disabled";
+  EXPECT_TRUE(a.Contains("stale0")) << "stale cross-class data survives";
   ::unsetenv("DFKV_SLAB_COLD_STEAL_WINDOW");
 }
 

--- a/test/cache/slab_allocator_test.cc
+++ b/test/cache/slab_allocator_test.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdlib>
 #include <set>
 #include <string>
 #include <thread>
@@ -146,6 +147,52 @@ TEST(SlabAllocator, CrossClassStealWhenPoolEmpty) {
   EXPECT_FALSE(ev.empty()) << "steal evicts the stolen extent's residents";
   EXPECT_TRUE(a.Contains("b0"));
   EXPECT_GE(a.ClassCount(), 2u);
+}
+
+TEST(SlabAllocator, ColdDonorStolenBeforeSelfEviction) {
+  // Phase 9: the pathology from the hit-rate probe. A stale class fills some
+  // extents, then a busy same-size working set cycles its own ring. Once the
+  // busy class has fully turned over past the stale data (the protect window),
+  // a new put must reclaim the STALE cross-class extent rather than evict the
+  // busy class's just-written pages. Fixed window via env for determinism.
+  ::setenv("DFKV_SLAB_COLD_STEAL_WINDOW", "6", 1);
+  SlabAllocator a(Opts(4 * 4096, 4));  // 4 extents; A(8192)=2 slots, B(4096)=4
+  std::vector<std::string> ev;
+  SlotRef r;
+  // Stale class A: 4 keys => 2 extents (seq 1..4), never touched again.
+  for (int i = 0; i < 4; ++i)
+    ASSERT_TRUE(a.Put("stale" + std::to_string(i), 8192, &r, &ev));
+  // Busy class B fills the remaining 2 extents (8 slots, seq 5..12).
+  for (int i = 0; i < 8; ++i)
+    ASSERT_TRUE(a.Put("hot" + std::to_string(i), 4096, &r, &ev));
+  ASSERT_EQ(a.ColdSteals(), 0u);
+  ev.clear();
+  // Keep writing B. put_seq climbs; once put_seq - 6 > 4 (stale's youngest),
+  // the stale A extent is cold and gets stolen instead of self-evicting hot.
+  bool stole_stale = false;
+  for (int i = 8; i < 24 && !stole_stale; ++i) {
+    ev.clear();
+    ASSERT_TRUE(a.Put("hot" + std::to_string(i), 4096, &r, &ev));
+    for (const auto& k : ev)
+      if (k.rfind("stale", 0) == 0) stole_stale = true;
+  }
+  EXPECT_TRUE(stole_stale) << "a globally-cold cross-class extent was reclaimed";
+  EXPECT_GE(a.ColdSteals(), 1u);
+  ::unsetenv("DFKV_SLAB_COLD_STEAL_WINDOW");
+}
+
+TEST(SlabAllocator, ColdStealDisabledFallsBackToSelfEvict) {
+  ::setenv("DFKV_SLAB_COLD_STEAL_WINDOW", "0", 1);  // disable
+  SlabAllocator a(Opts(4 * 4096, 4));
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 4; ++i)
+    ASSERT_TRUE(a.Put("stale" + std::to_string(i), 8192, &r, &ev));
+  for (int i = 0; i < 40; ++i)
+    ASSERT_TRUE(a.Put("hot" + std::to_string(i), 4096, &r, &ev));
+  EXPECT_EQ(a.ColdSteals(), 0u) << "disabled: never cold-steals";
+  EXPECT_TRUE(a.Contains("stale0")) << "stale data survives when disabled";
+  ::unsetenv("DFKV_SLAB_COLD_STEAL_WINDOW");
 }
 
 TEST(SlabAllocator, OversizeValueRejected) {

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -1085,5 +1085,36 @@ class DfkvClientRegistrationTest(unittest.TestCase):
         self.assertEqual(calls["registration"], [])
 
 
+class TestNodeDedupDefaults(unittest.TestCase):
+    """resolve_node_dedup policy (phase 9): auto-on for MLA+TP>1 only, with
+    explicit extra-config > env > auto precedence."""
+
+    def _r(self, cfg, env, mla, tp):
+        from dfkv_hicache import resolve_node_dedup
+        return resolve_node_dedup(cfg, env, mla, tp)
+
+    def test_auto_enables_for_mla_tp_gt1(self):
+        self.assertEqual(self._r(None, None, True, 8), ("1", True))
+
+    def test_no_auto_for_mha(self):
+        self.assertEqual(self._r(None, None, False, 8), (None, False))
+
+    def test_no_auto_for_tp1(self):
+        self.assertEqual(self._r(None, None, True, 1), (None, False))
+
+    def test_env_beats_auto(self):
+        # operator already set it (either way): leave untouched, no auto log
+        self.assertEqual(self._r(None, "0", True, 8), (None, False))
+        self.assertEqual(self._r(None, "1", False, 1), (None, False))
+
+    def test_config_beats_env(self):
+        self.assertEqual(self._r("0", "1", True, 8), ("0", False))
+        self.assertEqual(self._r("1", "0", False, 1), ("1", False))
+
+    def test_config_truthy_forms(self):
+        self.assertEqual(self._r("off", None, True, 8), ("0", False))
+        self.assertEqual(self._r(1, None, False, 1), ("1", False))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -26,6 +26,15 @@ sys.path.insert(0, os.path.join(HERE, "..", "..", "integration", "hicache"))  # 
 BUILD = os.environ.get("DFKV_BUILD", os.path.join(HERE, "..", "..", "build"))
 SERVER_BIN = os.path.join(BUILD, "dfkv_server")
 
+# These plugin tests are single-rank in one process, so the same-host
+# rendezvous (auto-enabled since phase 9 for mla+tp>1, which most fixtures
+# are) has no peer to dedup and only adds a persistent /dev/shm segment whose
+# published exist answers leak ACROSS tests (synthetic keys + model_hash 0 +
+# sub-second timing collide inside the TTL). Pin it off so the datapath is
+# exercised deterministically; the rendezvous has its own coverage in
+# node_dedup_test.cc. resolve_node_dedup honors this explicit env over auto.
+os.environ.setdefault("DFKV_CLIENT_NODE_DEDUP", "0")
+
 
 @contextmanager
 def _env(key, value):


### PR DESCRIPTION
Follow-up to the phase-8 L3 hit-rate investigation (a bj09 GLM-5.2 benchmark reported "cache hit rate too low"). That probe found the "hit rate" is three distinct layers, each with its own failure mode; this PR fixes all of them plus the deployment gaps that left the rendezvous off.

## What

**A — node-dedup ON BY DEFAULT for MLA+TP>1** (hicache + vLLM connector). The same-host rendezvous has existed since v1.21 but was opt-in, so the very deployments that benefit (GLM-5.2 at TP8: 8x lockstep L3 reads) silently ran without it. Auto-enabled for the one topology it serves; other topologies never rendezvous and are spared the /dev/shm arena. Explicit env/config always wins; pure-function policy with unit tests.

**B — LMCache canonical MLA keys + single-writer striping.** LMCache embeds `worker_id` in every key although MLA KV is replicated across ranks — 8x storage/writes/reads at TP8, and the rendezvous could never match (per-rank keys differ). Canonical keys (`worker_id→0`, gated on `use_mla && world>1`) give all ranks one keyspace: storage/writes drop to 1x via deterministic striping, reads become rendezvous-able. `DFKV_CONNECTOR_MLA_CANONICAL_KEYS=0` restores legacy.

**C — hicache backup exist gate.** Hot rounds re-backed the entire recomputed working set although every page was already in L3 (measured 485 GB/round) — write pressure that starved the reads. Backup writes now `batch_exist` first (collapsed to ~1x by the rendezvous) and only write the missing sub-objects.

**D — slab cross-class cold-donor eviction (P1).** Once the pool fills, a single-size-class working set self-cannibalized (intra-class CLOCK evicted just-written pages while stale OTHER-class extents sat untouched — measured as a 0% hot-round hit rate on a full ring). A monotonic put_seq + per-extent youngest-seq let a full class reclaim a globally-cold cross-class extent before self-evicting. `DFKV_SLAB_COLD_STEAL_WINDOW` (0 disables). NOTE: cross-class only — same-size stale data is Belady-unavoidable within one class; A/E are the primary hit-rate levers.

**E — read-back multi-connection sharding.** A single-/few-node ring routed a whole BatchGet to one QP, drained key-by-key server-side (~166 MB/s/conn — the read-back ceiling). Each per-node read group now splits into up to `DFKV_READ_MAX_CONNS` (8) parallel streams.

**F — control-lane for key-only ops.** Exist/Remove/Members shared the QP pool with payload transfers, so a lookup storm queued behind in-flight 1 MB GETs (measured hot-round batch_exists p99 ~800 s). They now ride a dedicated control-lane connection pool.

## Verification

B200 real-HW full ctest 389/389 (387 baseline + 2 slab cold-steal); GPU dedup suite 9/9 serial. Canary L3 hit-rate regression (clean-ring C8 cold/hot ledger) follows in a PR comment.

Deployment note: production inference client libs are NOT touched — these defaults take effect only for newly-started instances.