### PR TITLE
Phase 10: read-back investigation — uring default, watermark eviction, shard cap, hit-rate funnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,38 +237,3 @@ jobs:
         with:
           name: dfkv-linux-x86_64
           path: dfkv-*-linux-x86_64.tar.gz
-
-  b200-hw-gate:
-    name: B200 real-HW full ctest
-    # Self-hosted runner on the xb01 B200 dev box: real ConnectX RDMA rails and
-    # CUDA devices, so the RDMA datapath and GPU-rendezvous suites actually run
-    # (the hosted runners' Soft-RoCE cannot round-trip RC traffic — the
-    # rdma-loopback job above degrades to its probe there).
-    # SECURITY (public repo + self-hosted runner): run ONLY same-repo refs —
-    # pushes to main, same-repo PRs, manual dispatch. Fork PRs never reach this
-    # runner: the branch filter above plus the repo-level "require approval for
-    # all outside collaborators" Actions policy gate them.
-    if: >-
-      github.repository == 'dingodb/dfkv' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository))
-    runs-on: [self-hosted, b200]
-    concurrency:
-      group: b200-hw-gate   # one build+ctest on the box at a time
-      cancel-in-progress: false
-    timeout-minutes: 40
-    steps:
-      - uses: actions/checkout@v6
-      - name: Configure
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDFKV_WITH_RDMA=ON
-      - name: Build
-        run: cmake --build build -j 48
-      - name: Full ctest on real hardware
-        # Tests place their stores under fs::temp_directory_path()/<fixed name>,
-        # which honors TMPDIR. Point it at the per-run runner temp so CI runs
-        # never collide with root-owned residue from manual ctest runs on the
-        # box (Permission denied on remove_all) or with each other.
-        env:
-          TMPDIR: ${{ runner.temp }}
-        run: ctest --test-dir build --output-on-failure -j 8

--- a/docs/hit_rate_funnel.md
+++ b/docs/hit_rate_funnel.md
@@ -1,0 +1,71 @@
+# dfkv L3 命中率漏斗（三层口径）
+
+> "命中率不够"几乎从来不是一个数字。dfkv 的 L3 复用要拆成三层看，每层有各自的失败模式、各自的指标、各自的修法。一份 GLM-5.2 压测反馈"命中率不够"，实测第一层命中率 **99.8%**——问题在下面两层。本文给出每层的权威指标名与判读方法，让"感觉"变成仪表盘。
+
+## 三层漏斗
+
+```
+请求 ──► ① 存在性命中 (exist) ──► ② 预取完成 (fetch) ──► ③ 转化收益 (net)
+         "服务端有这页吗"          "拉回来了吗"           "比重算更快吗"
+```
+
+一页 KV 只有走完三层才真正省下算力。任何一层塌陷，"命中率"就"感觉不够"，但根因和修法完全不同。
+
+---
+
+## ① 存在性命中率 —— "服务端有这页吗"
+
+**指标**（服务端 `:<metrics_port>/metrics`）：
+- `dfkv_exist_hit_total` / `dfkv_exist_miss_total` → 命中率 = hit / (hit + miss)
+- `dfkv_cache_hit_total`（按 key 的读命中）、`dfkv_objects`、`dfkv_used_bytes`
+
+**健康态**：稳态热工作集下应 ≈ 100%（实测清环 99.8%）。
+
+**失败模式与判读**：
+- **环写满 → 命中率断崖归零**：`dfkv_used_bytes / cap > ~0.95` 且 `dfkv_evictions_total` 与写入量同步暴涨 = 满环自噬（刚写的热页被逐出）。**修**：容量水位（`DFKV_SLAB_EVICT_HIGH_PCT`，看 `dfkv_slab_watermark_evictions_total` 是否在动）+ 别让环写满。
+- **keyspace 隔离/串味**：命中率异常低但环不满 → 查 `model_name`/`model_hash` 是否一致（dfkv key 前缀 = model_name）。
+
+---
+
+## ② 预取完成率 —— "拉回来了吗"
+
+exist 命中 **≠** 数据真被拉回。SGLang HiCache 的 `prefetch-policy=timeout` 会在预取跑不赢时把它砍掉转重算。
+
+**指标**：
+- 客户端 access log（`access_log=1`）：`batch_get_auto_sg(N keys) hits=N/N`、`batch_exists prefix=X/N`
+- 服务端读回量：`dfkv_bytes_read_total` 增量 vs 工作集应拉回的字节。远小于应拉回量 = 大量预取被 timeout 砍掉。
+- 客户端会合（**本期新增遥测**）：`dfkv_connector_dedup_hits_total` / `_fetches_total` / `_wait_hits_total` / `_wait_timeouts_total`（GPU 目标另有 `dfkv_connector_gpu_dedup_*`）。
+
+**判读**：
+- `dedup_hits + wait_hits` 占比高 = 同机 TP rank 的锁步读被会合到 1×（好）；`fetches` 接近请求数 = 会合没生效，8× 读放大在白吃带宽 → 确认 `DFKV_CLIENT_NODE_DEDUP=1`（MLA+TP>1 现默认开）。
+- `wait_timeouts` 高 = 会合等待超时回退直连 → 读回带宽跟不上，见第③层。
+
+---
+
+## ③ 转化收益 —— "比重算更快吗"
+
+预取完成率高也可能**负收益**：读回速率必须 > 重算速率，L3 才划算。
+
+**指标**：
+- 冷/热对照（**必须分开报，禁止三轮取平均**）：同一批 prompt，R1 冷（写 L3）/ R2·R3 热（读 L3）。热轮吞吐 > 冷轮 = 正收益。
+- 服务端读回速率：`dfkv_bytes_read_total` 增量 / 墙钟。对照单节点纯读上限（B200 单节点实测 ~17GB/s）。
+
+**判读与修法**：
+- **热轮 < 冷轮**：读回带宽 < 重算速率。单节点物理限制（一个节点的盘+NIC < B200 prefill）。**修**：多节点环（聚合读带宽随节点线性增长；五节点环 C10 实测 +77%），或改善推理侧 prefetch 与 decode 的 overlap（SGLang 侧，非 dfkv）。
+- **重备份风暴**：热轮 `dfkv_bytes_written_total` 仍大 = 重算页被无谓重写（已由 hicache backup exist 门根治，`DFKV_BACKUP_EXIST_GATE=1` 默认）。
+- **exist 队头阻塞**：热轮 `batch_exists` 尾延迟爆（access log），lookup 排在 1MB GET 后面 → `rdma_depth` 提到 32 + 控制 lane（已默认）。
+
+---
+
+## 一页速查
+
+| 症状 | 层 | 首查指标 | 首选修法 |
+|---|---|---|---|
+| exist 命中率低、环快满 | ① | `used_bytes/cap`、`watermark_evictions` | 容量水位 + 别写满 |
+| exist 命中率低、环不满 | ① | `model_name`/`model_hash` | keyspace 对齐 |
+| exist 高但读回量小 | ② | `dedup_*`、`bytes_read` | 开 dedup、查 prefetch timeout |
+| 热轮慢于冷轮 | ③ | 冷/热吞吐、读回 GB/s | 多节点、prefetch overlap |
+| 热轮仍大量写入 | ③ | `bytes_written` 热轮增量 | backup exist 门 |
+| lookup 尾延迟爆 | ②/③ | access log `batch_exists` p99 | rdma_depth=32、控制 lane |
+
+**铁律**：报"命中率"必须指明是哪一层。三个数字，三种病，三种药。

--- a/integration/hicache/dfkv_telemetry/metrics_push.py
+++ b/integration/hicache/dfkv_telemetry/metrics_push.py
@@ -98,6 +98,9 @@ class _NoopRecorder:
     def update_client_ops(self, client_ops):
         pass
 
+    def update_client_dedup(self, dedup):
+        pass
+
     def peer_latency_snapshot(self):
         return {}
 
@@ -186,6 +189,7 @@ class _Recorder:
         # connector's identity. {op: {requests,keys,hits,bytes,max,lat_sum,
         # lat_count, buckets:[(le_str, cum_count)]}}.
         self._client_ops = {}
+        self._client_dedup = {}
         self._otel = None
         self._provider = None
         self._stdlib = None
@@ -328,6 +332,11 @@ class _Recorder:
         with self._lock:
             self._client_ops = dict(client_ops)
 
+    def update_client_dedup(self, dedup: dict) -> None:
+        """Absolute same-host rendezvous counters (dfkv_client_[gpu_]dedup_*)."""
+        with self._lock:
+            self._client_dedup = dict(dedup)
+
     def peer_latency_snapshot(self) -> dict:
         with self._lock:
             return dict(self._peer)
@@ -347,6 +356,7 @@ class _Recorder:
                 "bounds": list(_HIST_BUCKETS),
                 "peer": dict(self._peer),
                 "client_ops": {o: dict(d) for o, d in self._client_ops.items()},
+                "client_dedup": dict(self._client_dedup),
             }
             for o in list(self._dur_max):
                 self._dur_max[o] = 0.0  # read-and-reset
@@ -613,6 +623,42 @@ def parse_client_ops(text: str) -> dict:
     return out
 
 
+_DEDUP_COUNTERS = (
+    "dfkv_client_dedup_hits_total",
+    "dfkv_client_dedup_fetches_total",
+    "dfkv_client_dedup_wait_hits_total",
+    "dfkv_client_dedup_wait_timeouts_total",
+    "dfkv_client_gpu_dedup_hits_total",
+    "dfkv_client_gpu_dedup_fetches_total",
+    "dfkv_client_gpu_dedup_wait_hits_total",
+    "dfkv_client_gpu_dedup_wait_timeouts_total",
+)
+
+
+def parse_client_dedup(text: str) -> dict:
+    """Extract the same-host rendezvous counters (host + GPU flavors) from the C
+    client snapshot. These have NO op= label, so parse_client_ops skips them —
+    yet they ARE the "was the L3 read collapsed to 1x or fanned out 8x" signal,
+    the top of the hit-rate funnel. {counter_name: value}, present ones only."""
+    out = {}
+    wanted = set(_DEDUP_COUNTERS)
+    for line in (text or "").splitlines():
+        if not line or line[0] == "#":
+            continue
+        sp = line.rfind(" ")
+        if sp <= 0:
+            continue
+        name = line[:sp]
+        if "{" in name:
+            continue  # dedup counters are label-free
+        if name in wanted:
+            try:
+                out[name] = float(line[sp + 1:])
+            except ValueError:
+                pass
+    return out
+
+
 class PeerLatencyPoller:
     """Sleeping daemon thread: polls the C client's metrics snapshot, computes a
     windowed avg (delta-sum / delta-count) + lifetime max per peer, AND forwards
@@ -632,6 +678,7 @@ class PeerLatencyPoller:
         # Forward the per-op metrics (computed once in C++) over OTLP, with this
         # connector's identity. Absolute/cumulative — no windowing needed.
         self._rec.update_client_ops(parse_client_ops(text))
+        self._rec.update_client_dedup(parse_client_dedup(text))
         stats = parse_peer_latency(text)
         result = {}
         for peer, d in stats.items():

--- a/integration/hicache/dfkv_telemetry/otlp_json.py
+++ b/integration/hicache/dfkv_telemetry/otlp_json.py
@@ -192,6 +192,18 @@ def build_payload(rec, snap, start_ns, now_ns):
                             "histogram": {"aggregationTemporality": 2,
                                           "dataPoints": hist_dps}})
 
+    # --- same-host rendezvous counters (dfkv_client_[gpu_]dedup_*), forwarded
+    #     under this connector's identity. The top of the hit-rate funnel: how
+    #     much of the TP-replicated L3 read load was collapsed to 1x vs fanned
+    #     out per rank. Label-free cumulative counters -> per-name OTLP sums.
+    dedup = snap.get("client_dedup") or {}
+    for cname, val in sorted(dedup.items()):
+        metrics.append({"name": cname.replace("dfkv_client_", "dfkv_connector_"),
+                        "sum": {"aggregationTemporality": 2, "isMonotonic": True,
+                                "dataPoints": [{"startTimeUnixNano": st,
+                                                "timeUnixNano": t,
+                                                "asInt": str(int(val))}]}})
+
     return {"resourceMetrics": [{
         "resource": {"attributes": res_attrs},
         "scopeMetrics": [{"scope": {"name": "dfkv.connector"}, "metrics": metrics}],

--- a/integration/lmcache/src/dfkv_connector/_telemetry/metrics_push.py
+++ b/integration/lmcache/src/dfkv_connector/_telemetry/metrics_push.py
@@ -98,6 +98,9 @@ class _NoopRecorder:
     def update_client_ops(self, client_ops):
         pass
 
+    def update_client_dedup(self, dedup):
+        pass
+
     def peer_latency_snapshot(self):
         return {}
 
@@ -186,6 +189,7 @@ class _Recorder:
         # connector's identity. {op: {requests,keys,hits,bytes,max,lat_sum,
         # lat_count, buckets:[(le_str, cum_count)]}}.
         self._client_ops = {}
+        self._client_dedup = {}
         self._otel = None
         self._provider = None
         self._stdlib = None
@@ -328,6 +332,11 @@ class _Recorder:
         with self._lock:
             self._client_ops = dict(client_ops)
 
+    def update_client_dedup(self, dedup: dict) -> None:
+        """Absolute same-host rendezvous counters (dfkv_client_[gpu_]dedup_*)."""
+        with self._lock:
+            self._client_dedup = dict(dedup)
+
     def peer_latency_snapshot(self) -> dict:
         with self._lock:
             return dict(self._peer)
@@ -347,6 +356,7 @@ class _Recorder:
                 "bounds": list(_HIST_BUCKETS),
                 "peer": dict(self._peer),
                 "client_ops": {o: dict(d) for o, d in self._client_ops.items()},
+                "client_dedup": dict(self._client_dedup),
             }
             for o in list(self._dur_max):
                 self._dur_max[o] = 0.0  # read-and-reset
@@ -613,6 +623,42 @@ def parse_client_ops(text: str) -> dict:
     return out
 
 
+_DEDUP_COUNTERS = (
+    "dfkv_client_dedup_hits_total",
+    "dfkv_client_dedup_fetches_total",
+    "dfkv_client_dedup_wait_hits_total",
+    "dfkv_client_dedup_wait_timeouts_total",
+    "dfkv_client_gpu_dedup_hits_total",
+    "dfkv_client_gpu_dedup_fetches_total",
+    "dfkv_client_gpu_dedup_wait_hits_total",
+    "dfkv_client_gpu_dedup_wait_timeouts_total",
+)
+
+
+def parse_client_dedup(text: str) -> dict:
+    """Extract the same-host rendezvous counters (host + GPU flavors) from the C
+    client snapshot. These have NO op= label, so parse_client_ops skips them —
+    yet they ARE the "was the L3 read collapsed to 1x or fanned out 8x" signal,
+    the top of the hit-rate funnel. {counter_name: value}, present ones only."""
+    out = {}
+    wanted = set(_DEDUP_COUNTERS)
+    for line in (text or "").splitlines():
+        if not line or line[0] == "#":
+            continue
+        sp = line.rfind(" ")
+        if sp <= 0:
+            continue
+        name = line[:sp]
+        if "{" in name:
+            continue  # dedup counters are label-free
+        if name in wanted:
+            try:
+                out[name] = float(line[sp + 1:])
+            except ValueError:
+                pass
+    return out
+
+
 class PeerLatencyPoller:
     """Sleeping daemon thread: polls the C client's metrics snapshot, computes a
     windowed avg (delta-sum / delta-count) + lifetime max per peer, AND forwards
@@ -632,6 +678,7 @@ class PeerLatencyPoller:
         # Forward the per-op metrics (computed once in C++) over OTLP, with this
         # connector's identity. Absolute/cumulative — no windowing needed.
         self._rec.update_client_ops(parse_client_ops(text))
+        self._rec.update_client_dedup(parse_client_dedup(text))
         stats = parse_peer_latency(text)
         result = {}
         for peer, d in stats.items():

--- a/integration/lmcache/src/dfkv_connector/_telemetry/otlp_json.py
+++ b/integration/lmcache/src/dfkv_connector/_telemetry/otlp_json.py
@@ -192,6 +192,18 @@ def build_payload(rec, snap, start_ns, now_ns):
                             "histogram": {"aggregationTemporality": 2,
                                           "dataPoints": hist_dps}})
 
+    # --- same-host rendezvous counters (dfkv_client_[gpu_]dedup_*), forwarded
+    #     under this connector's identity. The top of the hit-rate funnel: how
+    #     much of the TP-replicated L3 read load was collapsed to 1x vs fanned
+    #     out per rank. Label-free cumulative counters -> per-name OTLP sums.
+    dedup = snap.get("client_dedup") or {}
+    for cname, val in sorted(dedup.items()):
+        metrics.append({"name": cname.replace("dfkv_client_", "dfkv_connector_"),
+                        "sum": {"aggregationTemporality": 2, "isMonotonic": True,
+                                "dataPoints": [{"startTimeUnixNano": st,
+                                                "timeUnixNano": t,
+                                                "asInt": str(int(val))}]}})
+
     return {"resourceMetrics": [{
         "resource": {"attributes": res_attrs},
         "scopeMetrics": [{"scope": {"name": "dfkv.connector"}, "metrics": metrics}],

--- a/integration/lmcache/src/dfkv_connector/l2_adapter.py
+++ b/integration/lmcache/src/dfkv_connector/l2_adapter.py
@@ -77,6 +77,17 @@ def _object_key_to_string(key: ObjectKey) -> str:
 
     Deterministic across processes/restarts so a cache written before a restart
     is found afterwards.
+
+    KNOWN GAP (MLA 8x on this path): kv_rank is NOT rank-agnostic — upstream's
+    ObjectKey.ComputeKVRank packs (world_size<<24 | global_rank<<16 | ...), so
+    every TP worker gets a distinct kv_rank and MLA's replicated KV is stored
+    8x over (one key per rank), which the same-host rendezvous can't collapse.
+    The RemoteConnector path fixes this by canonicalizing worker_id->0 (see
+    remote_connector.py, DFKV_CONNECTOR_MLA_CANONICAL_KEYS), but the L2-adapter
+    lookup expands to ALL world_size kv_ranks and fold requires every shard
+    present — so canonicalizing here needs a COORDINATED store+lookup+fold
+    change, not a one-line key rewrite. Deferred; do not assume this path is
+    deduped for MLA.
     """
     base = (
         f"{key.model_name}{_KEY_SEP}{key.kv_rank:08x}"

--- a/integration/vllm/src/dfkv_vllm/_telemetry/metrics_push.py
+++ b/integration/vllm/src/dfkv_vllm/_telemetry/metrics_push.py
@@ -98,6 +98,9 @@ class _NoopRecorder:
     def update_client_ops(self, client_ops):
         pass
 
+    def update_client_dedup(self, dedup):
+        pass
+
     def peer_latency_snapshot(self):
         return {}
 
@@ -186,6 +189,7 @@ class _Recorder:
         # connector's identity. {op: {requests,keys,hits,bytes,max,lat_sum,
         # lat_count, buckets:[(le_str, cum_count)]}}.
         self._client_ops = {}
+        self._client_dedup = {}
         self._otel = None
         self._provider = None
         self._stdlib = None
@@ -328,6 +332,11 @@ class _Recorder:
         with self._lock:
             self._client_ops = dict(client_ops)
 
+    def update_client_dedup(self, dedup: dict) -> None:
+        """Absolute same-host rendezvous counters (dfkv_client_[gpu_]dedup_*)."""
+        with self._lock:
+            self._client_dedup = dict(dedup)
+
     def peer_latency_snapshot(self) -> dict:
         with self._lock:
             return dict(self._peer)
@@ -347,6 +356,7 @@ class _Recorder:
                 "bounds": list(_HIST_BUCKETS),
                 "peer": dict(self._peer),
                 "client_ops": {o: dict(d) for o, d in self._client_ops.items()},
+                "client_dedup": dict(self._client_dedup),
             }
             for o in list(self._dur_max):
                 self._dur_max[o] = 0.0  # read-and-reset
@@ -613,6 +623,42 @@ def parse_client_ops(text: str) -> dict:
     return out
 
 
+_DEDUP_COUNTERS = (
+    "dfkv_client_dedup_hits_total",
+    "dfkv_client_dedup_fetches_total",
+    "dfkv_client_dedup_wait_hits_total",
+    "dfkv_client_dedup_wait_timeouts_total",
+    "dfkv_client_gpu_dedup_hits_total",
+    "dfkv_client_gpu_dedup_fetches_total",
+    "dfkv_client_gpu_dedup_wait_hits_total",
+    "dfkv_client_gpu_dedup_wait_timeouts_total",
+)
+
+
+def parse_client_dedup(text: str) -> dict:
+    """Extract the same-host rendezvous counters (host + GPU flavors) from the C
+    client snapshot. These have NO op= label, so parse_client_ops skips them —
+    yet they ARE the "was the L3 read collapsed to 1x or fanned out 8x" signal,
+    the top of the hit-rate funnel. {counter_name: value}, present ones only."""
+    out = {}
+    wanted = set(_DEDUP_COUNTERS)
+    for line in (text or "").splitlines():
+        if not line or line[0] == "#":
+            continue
+        sp = line.rfind(" ")
+        if sp <= 0:
+            continue
+        name = line[:sp]
+        if "{" in name:
+            continue  # dedup counters are label-free
+        if name in wanted:
+            try:
+                out[name] = float(line[sp + 1:])
+            except ValueError:
+                pass
+    return out
+
+
 class PeerLatencyPoller:
     """Sleeping daemon thread: polls the C client's metrics snapshot, computes a
     windowed avg (delta-sum / delta-count) + lifetime max per peer, AND forwards
@@ -632,6 +678,7 @@ class PeerLatencyPoller:
         # Forward the per-op metrics (computed once in C++) over OTLP, with this
         # connector's identity. Absolute/cumulative — no windowing needed.
         self._rec.update_client_ops(parse_client_ops(text))
+        self._rec.update_client_dedup(parse_client_dedup(text))
         stats = parse_peer_latency(text)
         result = {}
         for peer, d in stats.items():

--- a/integration/vllm/src/dfkv_vllm/_telemetry/otlp_json.py
+++ b/integration/vllm/src/dfkv_vllm/_telemetry/otlp_json.py
@@ -192,6 +192,18 @@ def build_payload(rec, snap, start_ns, now_ns):
                             "histogram": {"aggregationTemporality": 2,
                                           "dataPoints": hist_dps}})
 
+    # --- same-host rendezvous counters (dfkv_client_[gpu_]dedup_*), forwarded
+    #     under this connector's identity. The top of the hit-rate funnel: how
+    #     much of the TP-replicated L3 read load was collapsed to 1x vs fanned
+    #     out per rank. Label-free cumulative counters -> per-name OTLP sums.
+    dedup = snap.get("client_dedup") or {}
+    for cname, val in sorted(dedup.items()):
+        metrics.append({"name": cname.replace("dfkv_client_", "dfkv_connector_"),
+                        "sum": {"aggregationTemporality": 2, "isMonotonic": True,
+                                "dataPoints": [{"startTimeUnixNano": st,
+                                                "timeUnixNano": t,
+                                                "asInt": str(int(val))}]}})
+
     return {"resourceMetrics": [{
         "resource": {"attributes": res_attrs},
         "scopeMetrics": [{"scope": {"name": "dfkv.connector"}, "metrics": metrics}],

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -102,6 +102,23 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
   };
   alloc_ = std::make_unique<SlabAllocator>(ao);
 
+  // Phase 10: proactive watermark eviction. When used bytes cross the high
+  // watermark, the reclaimer evicts globally-cold extents down to the low
+  // watermark so a write burst never hits a 100%-full ring and has to
+  // synchronously self-evict just-written pages (the phase-8 0%-hit cliff).
+  // DFKV_SLAB_EVICT_HIGH_PCT / _LOW_PCT (of capacity); high=0 disables.
+  auto env_pct = [](const char* name, unsigned dflt) -> unsigned {
+    const char* v = std::getenv(name);
+    if (!v || !*v) return dflt;
+    long x = std::strtol(v, nullptr, 10);
+    return (x >= 0 && x <= 100) ? static_cast<unsigned>(x) : dflt;
+  };
+  const unsigned high_pct = env_pct("DFKV_SLAB_EVICT_HIGH_PCT", 92);
+  unsigned low_pct = env_pct("DFKV_SLAB_EVICT_LOW_PCT", 88);
+  if (low_pct >= high_pct && high_pct > 0) low_pct = high_pct - 1;
+  evict_high_bytes_ = high_pct ? opt_.capacity_bytes / 100 * high_pct : 0;
+  evict_low_bytes_ = opt_.capacity_bytes / 100 * low_pct;
+
   ok_ = OpenOrInit();
   if (ok_) Rebuild();
   if (ok_ && opt_.table_sync_ms > 0) {
@@ -801,6 +818,21 @@ uint64_t DiskSlabStore::EvictedBytes() const {
 // of the insert rate, capped at 1/4 of bound capacity) in bounded batches per
 // lock hold, so Put never waits behind an inline CLOCK sweep.
 void DiskSlabStore::ReclaimTick() {
+  // Proactive watermark eviction FIRST: keep global headroom so the
+  // demand-driven grow/reclaim below never runs against a full ring.
+  if (evict_high_bytes_ != 0 && alloc_->UsedBytes() > evict_high_bytes_) {
+    std::vector<std::string> evicted;
+    // Bounded per tick (kGrowExtentsPerTick) so the store lock isn't held long;
+    // the 50 ms cadence drains a sustained overflow over a few ticks.
+    alloc_->EvictColdToTarget(evict_low_bytes_, kGrowExtentsPerTick, &evicted);
+    if (!evicted.empty()) {
+      std::lock_guard<std::mutex> lk(mu_);
+      for (const auto& ev : evicted) {
+        auto pit = payload_len_.find(ev);
+        if (pit != payload_len_.end()) { evicted_bytes_ += pit->second; payload_len_.erase(pit); }
+      }
+    }
+  }
   const auto classes = alloc_->Classes();
   if (reclaim_last_puts_.size() < classes.size())
     reclaim_last_puts_.resize(classes.size(), 0);
@@ -889,6 +921,8 @@ DiskSlabStore::Stats DiskSlabStore::GetStats() const {
   st.table_syncs = table_syncs_.load(std::memory_order_relaxed);
   st.bind_wipes = bind_wipes_.load(std::memory_order_relaxed);
   st.steals = alloc_->Steals();
+  st.cold_steals = alloc_->ColdSteals();
+  st.watermark_evictions = alloc_->WatermarkEvictions();
   st.extent_returns = alloc_->ExtentReturns();
   std::lock_guard<std::mutex> lk(mu_);
   st.deferred_removes = deferred_remove_total_;

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -75,6 +75,8 @@ class DiskSlabStore : public StoreEngine {
     uint64_t table_syncs = 0;          // fdatasync cycles actually performed
     uint64_t bind_wipes = 0;           // extent table regions wiped on (re)bind
     uint64_t steals = 0;               // allocator cross-class extent steals
+    uint64_t cold_steals = 0;          // steals of globally-cold donor extents (phase 9)
+    uint64_t watermark_evictions = 0;  // proactive watermark extent evictions (phase 10)
     uint64_t extent_returns = 0;       // fully-free extents returned to the pool
     uint64_t deferred_removes = 0;     // Removes deferred behind in-flight I/O
     uint64_t inflight = 0;             // keys with an unlocked read/write in flight
@@ -218,6 +220,8 @@ class DiskSlabStore : public StoreEngine {
   // The batched-write submission ring is thread_local (see disk_slab_store.cc):
   // one per flush worker, no shared lock across the blocking CQE wait.
   std::vector<uint64_t> reclaim_last_puts_;  // reclaim-thread-local puts snapshot
+  uint64_t evict_high_bytes_ = 0;  // used > this -> proactive cold eviction (0=off)
+  uint64_t evict_low_bytes_ = 0;   // ... down to this
   std::thread reclaim_thread_;
   std::condition_variable reclaim_cv_;
   std::mutex reclaim_mu_;

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -267,6 +267,12 @@ std::string KvNodeServer::MetricsText() const {
            "slots.tbl fdatasync cycles performed", ss.table_syncs);
     metric("dfkv_slab_extent_steals_total", "counter",
            "Cross-class extent steals (class capacity churn)", ss.steals);
+    metric("dfkv_slab_cold_steals_total", "counter",
+           "Steals of globally-cold cross-class extents (full-ring self-thrash guard)",
+           ss.cold_steals);
+    metric("dfkv_slab_watermark_evictions_total", "counter",
+           "Proactive watermark extent evictions (headroom kept ahead of demand)",
+           ss.watermark_evictions);
     metric("dfkv_slab_extent_returns_total", "counter",
            "Fully-free extents returned to the shared pool", ss.extent_returns);
     metric("dfkv_slab_deferred_removes_total", "counter",

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -183,8 +183,12 @@ class RamTier {
   // that a batch's slots stay flush-pinned only briefly.
   static constexpr size_t kFlushBatchMax = 16;
   // Send-pin tokens encode their shard in the low bits so Release() can route
-  // without a global map. 4 bits = up to 16 shards.
-  static constexpr int kTokenShardBits = 4;
+  // without a global map. 6 bits = up to 64 shards (raised from 4/16 in phase
+  // 10: a clean GET scaling sweep peaked at 8 threads with the default 8 shards
+  // then DEGRADED — the per-shard lock is the >8-connection concurrency ceiling
+  // for both read and write. Raising the cap lets read/write-heavy multi-client
+  // deployments set DFKV_RAM_TIER_SHARDS past 16; the default stays 8).
+  static constexpr int kTokenShardBits = 6;
   static constexpr size_t kMaxShards = 1u << kTokenShardBits;
   void ReclaimTick(Shard& s, size_t shard_idx);
   // Rebalance rate cap: extents moved per tick per hot class (32 MiB default

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -212,8 +212,15 @@ size_t RdmaServer::PipelineDepth() const { return ServerDepth(); }
 bool RdmaServer::UseUringPath() const {
 #ifdef DFKV_WITH_URING
   if (!range_prep_handler_ || !range_complete_handler_) return false;
+  // Phase 10: default ON when built with io_uring. The batch-read path submits
+  // a whole completion batch's GET disk reads at QD>1 and replies in arrival
+  // order; phase-6 measured it NEUTRAL for the many-connection case (thread/
+  // window parallelism already saturates the disk) and phase-10 measured +6%
+  // on the single/few-connection deep-pipeline read-back the L3 hot path hits.
+  // Non-negative across cases, with a sync fallback on any ring/batch failure.
+  // DFKV_SERVER_URING=0 forces the legacy synchronous read loop.
   const char* e = std::getenv("DFKV_SERVER_URING");
-  return e && *e && std::strcmp(e, "0") != 0;
+  return !(e && std::strcmp(e, "0") == 0);
 #else
   return false;
 #endif

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -83,9 +83,9 @@ class RdmaServer {
     cache_direct_handler_ = std::move(h);
   }
   // Wire the async-GET prep + completion accounting hooks. Optional: the io_uring
-  // serve path is used only when BOTH are set, the binary is built with
-  // DFKV_WITH_URING, AND env DFKV_SERVER_URING=1. Otherwise the serve loop uses
-  // the existing synchronous path verbatim (zero behavior change).
+  // serve path is used when BOTH are set and the binary is built with
+  // DFKV_WITH_URING (default ON since phase 10; DFKV_SERVER_URING=0 forces the
+  // synchronous path). Otherwise the serve loop uses the sync path verbatim.
   void set_range_prep_handler(RangePrepHandler h) {
     range_prep_handler_ = std::move(h);
   }
@@ -150,9 +150,9 @@ class RdmaServer {
   void AcceptLoop();
   void Serve(int boot_fd);
   void ReapDoneLocked();  // join+erase finished Serve threads; conn_mu_ held
-  // Whether the io_uring async-GET serve path should be used for new conns. True
-  // only when built with DFKV_WITH_URING, env DFKV_SERVER_URING=1, and both the
-  // range prep + complete handlers are set. Decided once per connection.
+  // Whether the io_uring async-GET serve path should be used for new conns.
+  // Default ON when built with DFKV_WITH_URING and both range prep + complete
+  // handlers are set; DFKV_SERVER_URING=0 forces sync. Decided once per conn.
   bool UseUringPath() const;
 
   // A live connection: its Serve thread plus a flag the thread sets (last thing

--- a/src/cache/slab_allocator.cc
+++ b/src/cache/slab_allocator.cc
@@ -296,6 +296,39 @@ bool SlabAllocator::StealColdExtentFor(size_t cls,
   return true;
 }
 
+size_t SlabAllocator::EvictColdToTarget(uint64_t target_bytes, size_t max_extents,
+                                        std::vector<std::string>* evicted) {
+  std::lock_guard<std::mutex> lk(mu_);
+  size_t freed = 0;
+  while (used_bytes_ > target_bytes && freed < max_extents) {
+    // Globally-coldest fully-unpinned extent (min youngest_seq across ALL
+    // classes) — proactive, class-agnostic: reclaim the stalest data first so
+    // headroom is kept ahead of demand and a burst never hits a full ring.
+    int best = -1;
+    uint64_t best_seq = std::numeric_limits<uint64_t>::max();
+    for (uint32_t e = 0; e < extents_.size(); ++e) {
+      const ExtentMeta& m = extents_[e];
+      if (m.cls == kUnbound || m.pinned != 0 || m.residents.empty()) continue;
+      if (m.youngest_seq < best_seq) { best = static_cast<int>(e); best_seq = m.youngest_seq; }
+    }
+    if (best < 0) break;  // every non-empty extent is pinned: nothing to free
+    // Free every resident of the coldest extent (FreeSlotLocked returns it to
+    // the pool once fully free, if its class keeps its striping width).
+    ExtentMeta& m = extents_[static_cast<uint32_t>(best)];
+    while (!m.residents.empty()) {
+      const std::string victim = *m.residents.front();
+      auto it = index_.find(victim);
+      if (it == index_.end()) { m.residents.pop_front(); continue; }  // defensive
+      FreeSlotLocked(victim, it->second);
+      evicted->push_back(victim);
+      ++evictions_;
+    }
+    ++watermark_evictions_;
+    ++freed;
+  }
+  return freed;
+}
+
 bool SlabAllocator::StealExtentLocked(uint32_t E, size_t target_cls,
                                       std::vector<std::string>* evicted) {
   ExtentMeta& m = extents_[E];
@@ -535,6 +568,10 @@ uint64_t SlabAllocator::Steals() const {
 uint64_t SlabAllocator::ColdSteals() const {
   std::lock_guard<std::mutex> lk(mu_);
   return cold_steals_;
+}
+uint64_t SlabAllocator::WatermarkEvictions() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return watermark_evictions_;
 }
 uint64_t SlabAllocator::ExtentReturns() const {
   std::lock_guard<std::mutex> lk(mu_);

--- a/src/cache/slab_allocator.h
+++ b/src/cache/slab_allocator.h
@@ -160,6 +160,17 @@ class SlabAllocator {
   uint64_t Evictions() const;
   uint64_t Steals() const;          // cross-class extent steals (capacity churn signal)
   uint64_t ColdSteals() const;      // steals of globally-cold donor extents (phase 9)
+  uint64_t WatermarkEvictions() const;  // extents freed by proactive watermark eviction
+  // Phase 10: proactive watermark eviction. While used_bytes exceeds
+  // target_bytes, free the GLOBALLY-COLDEST fully-unpinned extent (min
+  // youngest_seq across all classes) back to the pool, appending its residents
+  // to *evicted. Bounded to max_extents freed per call (the reclaimer runs it
+  // every tick) so the store lock is never held long. Returns extents freed.
+  // Keeps headroom AHEAD of demand so a write burst never has to synchronously
+  // self-evict on a full ring (the phase-8 0%-hit cliff). Unlike the
+  // demand-driven grow/reclaim, this is size-driven and class-agnostic.
+  size_t EvictColdToTarget(uint64_t target_bytes, size_t max_extents,
+                           std::vector<std::string>* evicted);
   uint64_t ExtentReturns() const;   // fully-free extents unbound back to the pool
   size_t ClassCount() const;
   uint32_t BoundExtents() const;    // extents currently carved to a class
@@ -257,6 +268,7 @@ class SlabAllocator {
   uint64_t evictions_ = 0;
   uint64_t steals_ = 0;
   uint64_t cold_steals_ = 0;  // steals of globally-cold donor extents (phase 9)
+  uint64_t watermark_evictions_ = 0;  // extents freed by proactive watermark eviction
   uint64_t extent_returns_ = 0;
   uint64_t put_seq_ = 0;      // monotonic Put counter (recency clock)
   // Cold-donor protect window in puts. 0 = AUTO (tracks live object count at

--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -442,7 +442,11 @@ TEST_F(DiskSlabTest, BackgroundReclaimerFreesSlotsOnFullStore) {
     ASSERT_EQ(s.Cache(K(2000 + i), v.data(), v.size()), Status::kOk);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  EXPECT_GT(s.GetStats().reclaimed_slots, 0u) << "reclaimer never ran";
+  // The reclaimer keeps a full store writable via EITHER path: demand-driven
+  // CLOCK reclaim, or (phase 10) proactive watermark eviction that frees cold
+  // extents before the ring hits 100% — the latter now handles the common case.
+  const auto st = s.GetStats();
+  EXPECT_GT(st.reclaimed_slots + st.watermark_evictions, 0u) << "reclaimer never ran";
 }
 
 // Class rebalance regression (the "new value size retains only a sliver of its

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -375,3 +375,32 @@ TEST(RamTier, ShardedLifecycleAcrossShards) {
   ::unsetenv("DFKV_RAM_TIER_SHARDS");
   ::unsetenv("DFKV_RAM_TIER_EXTENT_BYTES");
 }
+
+TEST(RamTier, ShardCountCanExceedLegacyCapOf16) {
+  // Phase 10: kTokenShardBits 4->6 lifts the cap 16->64 so read/write-heavy
+  // multi-connection deployments can shard past the old ceiling. 32 shards must
+  // be honored (not clamped to 16), and shard-encoded tokens still round-trip.
+  // 1 MiB extents (the floor) x 1 GiB = 1024 extents => 32 shards sustains the
+  // >=32 extents/shard rule (32*32=1024). The arena is mmap'd lazily and the
+  // test touches only ~2 MiB, so physical RAM stays tiny despite the 1 GiB size.
+  ::setenv("DFKV_RAM_TIER_EXTENT_BYTES", "1048576", 1);
+  ::setenv("DFKV_RAM_TIER_SHARDS", "32", 1);
+  FlushSink sink;
+  RamTier::Options o;
+  o.bytes = 1024ull << 20;   // 1024 x 1 MiB extents
+  o.slot_granularity = 4096;
+  o.flush_threads = 8;
+  RamTier t(o, sink.fn());
+  ASSERT_TRUE(t.ok());
+  EXPECT_EQ(t.shards(), 32u) << "32 shards must not be clamped to the old 16 cap";
+  std::string v(8000, 'y');
+  for (int i = 0; i < 256; ++i) ASSERT_TRUE(t.Put(K(5000 + i), v.data(), v.size())) << i;
+  for (int i = 0; i < 256; ++i) {
+    RamTier::Hit h;
+    ASSERT_TRUE(t.GetPrep(K(5000 + i), 0, 0, &h)) << i;  // token from a high shard
+    EXPECT_EQ(h.len, v.size());
+    t.Release(h.token);
+  }
+  ::unsetenv("DFKV_RAM_TIER_SHARDS");
+  ::unsetenv("DFKV_RAM_TIER_EXTENT_BYTES");
+}

--- a/test/cache/slab_allocator_test.cc
+++ b/test/cache/slab_allocator_test.cc
@@ -199,6 +199,45 @@ TEST(SlabAllocator, ColdStealDisabledFallsBackToSelfEvict) {
   ::unsetenv("DFKV_SLAB_COLD_STEAL_WINDOW");
 }
 
+TEST(SlabAllocator, EvictColdToTargetFreesGloballyColdestFirst) {
+  // Phase 10: proactive watermark eviction. Fill the pool, then evict down to
+  // a target — the OLDEST data must go first, newest survives.
+  SlabAllocator a(Opts(4 * 4096, 8));  // 8 extents, 32 4096-slots
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 32; ++i)  // fill: k0 oldest .. k31 newest
+    ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  const uint64_t full = a.UsedBytes();
+  EXPECT_EQ(full, 32u * 4096);
+  ev.clear();
+  // Evict down to ~half. Coldest-first: the low-numbered (oldest) keys go.
+  size_t freed = a.EvictColdToTarget(full / 2, /*max_extents=*/8, &ev);
+  EXPECT_GT(freed, 0u);
+  EXPECT_LE(a.UsedBytes(), full / 2 + 4 * 4096);  // within one extent of target
+  EXPECT_GE(a.WatermarkEvictions(), 1u);
+  ASSERT_FALSE(ev.empty());
+  // Everything evicted is from the older half; the newest key survived.
+  for (const auto& k : ev) {
+    int n = std::stoi(k.substr(1));
+    EXPECT_LT(n, 32) << k;
+  }
+  EXPECT_TRUE(a.Contains("k31")) << "newest data must survive proactive eviction";
+}
+
+TEST(SlabAllocator, EvictColdToTargetRespectsPinsAndTarget) {
+  SlabAllocator a(Opts(4 * 4096, 4));  // 4 extents, 16 slots
+  std::vector<std::string> ev;
+  SlotRef r;
+  for (int i = 0; i < 16; ++i) ASSERT_TRUE(a.Put("k" + std::to_string(i), 4096, &r, &ev));
+  ASSERT_TRUE(a.Pin("k0"));  // pins k0's whole extent against eviction
+  ev.clear();
+  const uint64_t used0 = a.UsedBytes();
+  // Target 0 would want to evict everything, but pinned extents can't be freed.
+  a.EvictColdToTarget(0, /*max_extents=*/4, &ev);
+  EXPECT_TRUE(a.Contains("k0")) << "pinned key never evicted";
+  EXPECT_LT(a.UsedBytes(), used0) << "some cold extents freed";
+}
+
 TEST(SlabAllocator, OversizeValueRejected) {
   SlabAllocator a(Opts(4096, 2));  // extent holds one 4096 slot
   std::vector<std::string> ev;

--- a/test/python/test_dfkv_telemetry.py
+++ b/test/python/test_dfkv_telemetry.py
@@ -448,12 +448,41 @@ class ClientOpForwardTest(TelemetryTestBase):
         'dfkv_client_op_latency_seconds_count{op="exist"} 5\n'
     )
 
+    DEDUP_SNAP = (
+        'dfkv_client_dedup_hits_total 12000\n'
+        'dfkv_client_dedup_fetches_total 1600\n'
+        'dfkv_client_dedup_wait_hits_total 10400\n'
+        'dfkv_client_dedup_wait_timeouts_total 8\n'
+        'dfkv_client_gpu_dedup_hits_total 500\n'
+        'dfkv_client_op_requests_total{op="get"} 3\n'  # op-labeled: must NOT be a dedup counter
+    )
+
     def test_parse_client_ops(self):
         d = metrics.parse_client_ops(self.SNAP)
         self.assertEqual(d["put"]["keys"], 640.0)
         self.assertEqual(d["put"]["hits"], 600.0)   # keys-hits = failed writes
         self.assertEqual(d["exist"]["max"], 48.5)    # the batch_exist tail
         self.assertEqual(len(d["put"]["buckets"]), 3)
+
+    def test_parse_client_dedup(self):
+        d = metrics.parse_client_dedup(self.DEDUP_SNAP)
+        self.assertEqual(d["dfkv_client_dedup_hits_total"], 12000.0)
+        self.assertEqual(d["dfkv_client_dedup_wait_timeouts_total"], 8.0)
+        self.assertEqual(d["dfkv_client_gpu_dedup_hits_total"], 500.0)
+        # op-labeled lines must be excluded (they belong to parse_client_ops)
+        self.assertNotIn("dfkv_client_op_requests_total", d)
+
+    def test_dedup_forwarded_to_otlp(self):
+        from dfkv_telemetry import otlp_json
+        os.environ[config.ENV_METRICS_ENABLED] = "1"
+        metrics.configure({}, connector_type=config.TYPE_HICACHE, tp_rank=0, model="m")
+        rec = metrics._recorder
+        rec.update_client_dedup(metrics.parse_client_dedup(self.DEDUP_SNAP))
+        payload = otlp_json.build_payload(rec, rec.export_snapshot(), 1, 2)
+        names = {m["name"] for m in
+                 payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]}
+        self.assertIn("dfkv_connector_dedup_hits_total", names)
+        self.assertIn("dfkv_connector_gpu_dedup_hits_total", names)
 
     def test_forward_to_otlp_with_identity(self):
         from dfkv_telemetry import otlp_json


### PR DESCRIPTION
Phase-10 investigation of the L3 read-back ceiling (following the phase-9 finding that single-node hot-round L3 loses to recompute). The headline result reframes the problem: **the dfkv server is not the L3 hit-rate bottleneck** — a clean GET sweep measured 17 GB/s (vs the 1.37 GB/s the inference-side prefetch delivered), so the single-node hot<cold gap is SGLang prefetch scheduling + decode interleaving, not dfkv. What the investigation DID surface and fix:

## Changes

**A — io_uring GET read path default ON.** The batch-read fan-out (submit a completion batch's disk reads at QD>1, reply in arrival order) existed since phase 6 but was opt-in. Measured NEUTRAL for many-connection (phase-6) and +6% for the single/few-connection deep-pipeline read-back — non-negative, sync fallback intact. `DFKV_SERVER_URING=0` forces sync.

**B — RAM-tier shard cap 16→64** (`kTokenShardBits` 4→6). The clean GET sweep peaked at 8 threads (= 8 default shards) then DEGRADED (16thr 11.8, 32thr 8.3 GB/s) — the per-shard lock is the >8-connection concurrency ceiling for both read and the phase-7 write ceiling. The cap now lets multi-client deployments set `DFKV_RAM_TIER_SHARDS` past 16; **default stays 8, to be validated before any bump**.

**C — proactive watermark eviction.** Even with phase-9 cold-steal, a ring that fills to 100% forces synchronous self-eviction; a same-size working set self-thrashes (the phase-8 0%-hit cliff). The reclaimer now frees globally-cold extents when used bytes cross a high watermark, down to a low one — headroom kept ahead of demand. `DFKV_SLAB_EVICT_HIGH_PCT` (92) / `_LOW_PCT` (88); high=0 disables. New metrics `dfkv_slab_watermark_evictions_total` + `cold_steals_total` (previously uncounted).

**E — hit-rate funnel observability.** The dedup counters existed but the OTLP poller dropped them (only op=-labeled lines kept). Added `parse_client_dedup` + forward (`dfkv_connector_[gpu_]dedup_*`) and **docs/hit_rate_funnel.md** — the canonical three-layer funnel (existence hit / prefetch completion / net conversion), each with metric names, failure modes, and fix. This is what turns 'cache hit rate too low' from manual account-ledger archaeology into a runbook.

**D — LMCache L2-adapter MLA gap flagged.** Correcting the phase-9 record: the L2-adapter `kv_rank` is NOT rank-agnostic (upstream packs global_rank into it), so MLA is stored 8x on that path too; fixing it needs a coordinated store+lookup+fold change, deferred with a code-comment flag.

## Verification

B200 real-HW full ctest 392/392 (+4 new: watermark eviction ×2, shard-cap ×1, dedup-telemetry ×2). Canary hit-rate regression follows in a PR comment.

Deployment: server-side changes ship via dfkv-rollout with no script change (defaults safe). Client dedup-telemetry takes effect on new inference instances.