### PR TITLE
fix(hicache): retry transiently failed backup puts once

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -281,6 +281,7 @@ class DfkvHiCache(HiCacheStorage):
             self._backup_exist_gate = _truthy(
                 cfg.get("backup_exist_gate",
                         os.environ.get("DFKV_BACKUP_EXIST_GATE", "1")))
+            self._put_retry_recovered = 0  # last _put_flat's retry recoveries
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0
@@ -587,6 +588,8 @@ class DfkvHiCache(HiCacheStorage):
             dur = time.perf_counter() - t0
             res = self._fold(flat, n, sub)
             r.result = f"ok {sum(res)}/{n}"
+            if self._put_retry_recovered:
+                r.result += f" retry_ok={self._put_retry_recovered}"
             if _sp:
                 _sp.hits = sum(res); _sp.bytes = sum(ss)
             self._metrics.on_set(pages=n, ok_pages=sum(res), nbytes=sum(ss), seconds=dur)
@@ -663,27 +666,44 @@ class DfkvHiCache(HiCacheStorage):
         return 1 if self.is_mla else 2
 
     def _put_flat(self, sks, sp, ss) -> List[bool]:
-        """batch_put with the phase-9 exist gate: sub-objects already in L3
-        are reported stored without rewriting. Falls back to a straight put
-        when the gate is off or everything is missing (cold path unchanged
-        except one exist round-trip)."""
-        if self._backup_exist_gate and sks:
+        """batch_put with the phase-9 exist gate (sub-objects already in L3
+        are reported stored without rewriting) and a single retry of failed
+        keys. Under a cold-round write burst ~0.1% of puts fail transiently,
+        and SGLang's backup bookkeeping does not consume per-page failures —
+        an unretried miss becomes a phantom "backed" page that the hot round
+        then fails to retrieve (R1 finding, 2026-07-17). The burst is
+        momentary, so one delayed retry recovers almost all of them; keys
+        still failing stay False (honest result, as before)."""
+        self._put_retry_recovered = 0
+        if not sks:
+            return []
+        if self._backup_exist_gate:
             present = list(self._batch_exist_flat(sks))
             todo = [i for i, p in enumerate(present) if not p]
             if not todo:
                 return [True] * len(sks)
-            if len(todo) < len(sks):
-                karr, parr, sarr, out, _kb = _arrays(
-                    [sks[i] for i in todo], [sp[i] for i in todo],
-                    [ss[i] for i in todo])
-                self._lib.dfkv_batch_put(self._h, karr, parr, sarr,
-                                         len(todo), out)
-                for m, i in enumerate(todo):
-                    present[i] = out[m] == 1
-                return present
-        karr, parr, sarr, out, _kb = _arrays(sks, sp, ss)
-        self._lib.dfkv_batch_put(self._h, karr, parr, sarr, len(sks), out)
-        return [out[i] == 1 for i in range(len(sks))]
+        else:
+            present = [False] * len(sks)
+            todo = list(range(len(sks)))
+        for attempt in (0, 1):
+            if not todo:
+                break
+            if attempt:
+                time.sleep(0.01)  # let the write burst drain first
+            karr, parr, sarr, out, _kb = _arrays(
+                [sks[i] for i in todo], [sp[i] for i in todo],
+                [ss[i] for i in todo])
+            self._lib.dfkv_batch_put(self._h, karr, parr, sarr,
+                                     len(todo), out)
+            failed = []
+            for m, i in enumerate(todo):
+                present[i] = out[m] == 1
+                if not present[i]:
+                    failed.append(i)
+                elif attempt:
+                    self._put_retry_recovered += 1
+            todo = failed
+        return present
 
     def _v2_io(self, transfers, putting):
         results = {}
@@ -723,6 +743,8 @@ class DfkvHiCache(HiCacheStorage):
                            lambda: f"{self._alog_tag} {_fmt_pools(transfers)}") as r:
             res = self._v2_io(transfers, putting=True)
             r.result = _fmt_pool_results(res)
+            if self._put_retry_recovered:
+                r.result += f" retry_ok={self._put_retry_recovered}"
             if _sp:
                 _sp.hits = sum(sum(rs) for rs in res.values())
             return res

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -1125,5 +1125,99 @@ class TestNodeDedupDefaults(unittest.TestCase):
         self.assertEqual(self._r(1, None, False, 1), ("1", False))
 
 
+class PutRetryTest(unittest.TestCase):
+    """_put_flat single-retry of transiently failed puts (R1 finding,
+    2026-07-17): under a cold-round write burst ~0.1% of batch_put keys fail;
+    SGLang's backup bookkeeping ignores per-page False, so an unretried
+    failure becomes a phantom "backed" page the hot round cannot retrieve.
+    One delayed retry recovers the transient portion; keys that keep failing
+    stay False (the honest result is unchanged)."""
+    PAGE_SIZE = 64
+    PAGE_BYTES = 4096
+
+    def _fake_lib(self, fail_first_call_last_n=0, fail_always_keys=()):
+        calls = {"put": [], "exist": 0}
+
+        class _FakeLib:
+            def __init__(self):
+                self.dfkv_open = lambda *a, **k: ctypes.c_void_p(0xBEEF)
+                self.dfkv_set_batch_concurrency = lambda *a, **k: 0
+                self.dfkv_transport_mode = lambda *a, **k: b"tcp"
+                self.dfkv_close = lambda *a, **k: None
+                self.dfkv_version = lambda *a, **k: b"1.27.0"
+                self.dfkv_batch_exist = self._exist
+                self.dfkv_batch_put = self._put
+
+            def _exist(self, h, karr, n, out):
+                calls["exist"] += 1
+                for i in range(n):
+                    out[i] = 0  # nothing in L3 yet: all keys proceed to put
+                return 0
+
+            def _put(self, h, karr, parr, sarr, n, out):
+                keys = [karr[i].decode() for i in range(n)]
+                calls["put"].append(keys)
+                first = len(calls["put"]) == 1
+                for i, k in enumerate(keys):
+                    if k in fail_always_keys:
+                        out[i] = 0
+                    elif first and i >= n - fail_first_call_last_n:
+                        out[i] = 0  # transient burst failure
+                    else:
+                        out[i] = 1
+                return 0
+
+        return _FakeLib(), calls
+
+    def _plugin(self, fake):
+        os.environ["DFKV_CLIENT_NODE_DEDUP"] = "0"
+        cfg = HiCacheStorageConfig(
+            tp_rank=0, tp_size=8, is_mla_model=True,
+            is_page_first_layout=False, model_name="glm-retry",
+            extra_config={
+                "members": "n0=127.0.0.1:1", "model_hash": 0x51,
+                "dtype_tag": 0x46384534, "page_size": self.PAGE_SIZE,
+                "layer_num": 78, "head_num": 1, "head_dim": 576,
+                "interface_v1": 1,
+            })
+        with patch.object(dfkv_hicache, "_load_lib", return_value=fake):
+            st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        st.register_mem_pool_host(FakeMlaPool(8, self.PAGE_BYTES,
+                                              self.PAGE_SIZE))
+        return st
+
+    def _set(self, st, npages):
+        keys = [f"k{i}" for i in range(npages)]
+        idx = list(range(npages * self.PAGE_SIZE))
+        return st.batch_set_v1(keys, idx)
+
+    def test_transient_failures_recovered_by_retry(self):
+        fake, calls = self._fake_lib(fail_first_call_last_n=3)
+        st = self._plugin(fake)
+        res = self._set(st, 8)
+        self.assertEqual(res, [True] * 8)
+        self.assertEqual(len(calls["put"]), 2)          # initial + one retry
+        self.assertEqual(len(calls["put"][1]), 3)       # only failed keys retried
+        self.assertEqual(st._put_retry_recovered, 3)
+
+    def test_persistent_failures_stay_false(self):
+        # MLA sub-key = "<model>/<page_hash>_k"; k0 fails on both attempts.
+        fake, calls = self._fake_lib(fail_always_keys={"glm-retry/k0_k"})
+        st = self._plugin(fake)
+        res = self._set(st, 4)
+        self.assertEqual(res, [False, True, True, True])
+        self.assertEqual(len(calls["put"]), 2)          # retry attempted once
+        self.assertEqual(calls["put"][1], ["glm-retry/k0_k"])
+        self.assertEqual(st._put_retry_recovered, 0)
+
+    def test_no_retry_when_all_succeed(self):
+        fake, calls = self._fake_lib()
+        st = self._plugin(fake)
+        res = self._set(st, 8)
+        self.assertEqual(res, [True] * 8)
+        self.assertEqual(len(calls["put"]), 1)          # no second call
+        self.assertEqual(st._put_retry_recovered, 0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
R1 iteration-campaign finding (B200, GLM-5.2 FP8/NVFP4 agg+dfkv, 100k-token prompts):

**Evidence chain**: 37/19,045 backup batches partially failed during the cold-round write storm (4,013 keys, 0.17%); sampled failed pages are absent from the ring even now (ring had zero evictions => never written); hot-round prefetch then hits real misses => 28 `failed to retrieve page` ops. The adapter honestly returned per-page False, but SGLang's backup bookkeeping doesn't consume it — the page is marked backed anyway.

**Fix**: single 10ms-delayed retry of failed keys in `_put_flat` (both v1 and v2 put paths route through it). Persistent failures stay False. `retry_ok=N` in the access log quantifies recoveries for the R2 rerun A/B.

Tests: 3 new (transient-recovered / persistent-stays-false / no-retry-when-clean), python_plugin suite 57/57.