### PR TITLE
fix(client): busy-vs-dead grace in peer health cooldown

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -281,6 +281,7 @@ class DfkvHiCache(HiCacheStorage):
             self._backup_exist_gate = _truthy(
                 cfg.get("backup_exist_gate",
                         os.environ.get("DFKV_BACKUP_EXIST_GATE", "1")))
+            self._put_retry_recovered = 0  # last _put_flat's retry recoveries
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0
@@ -587,6 +588,8 @@ class DfkvHiCache(HiCacheStorage):
             dur = time.perf_counter() - t0
             res = self._fold(flat, n, sub)
             r.result = f"ok {sum(res)}/{n}"
+            if self._put_retry_recovered:
+                r.result += f" retry_ok={self._put_retry_recovered}"
             if _sp:
                 _sp.hits = sum(res); _sp.bytes = sum(ss)
             self._metrics.on_set(pages=n, ok_pages=sum(res), nbytes=sum(ss), seconds=dur)
@@ -663,27 +666,44 @@ class DfkvHiCache(HiCacheStorage):
         return 1 if self.is_mla else 2
 
     def _put_flat(self, sks, sp, ss) -> List[bool]:
-        """batch_put with the phase-9 exist gate: sub-objects already in L3
-        are reported stored without rewriting. Falls back to a straight put
-        when the gate is off or everything is missing (cold path unchanged
-        except one exist round-trip)."""
-        if self._backup_exist_gate and sks:
+        """batch_put with the phase-9 exist gate (sub-objects already in L3
+        are reported stored without rewriting) and a single retry of failed
+        keys. Under a cold-round write burst ~0.1% of puts fail transiently,
+        and SGLang's backup bookkeeping does not consume per-page failures —
+        an unretried miss becomes a phantom "backed" page that the hot round
+        then fails to retrieve (R1 finding, 2026-07-17). The burst is
+        momentary, so one delayed retry recovers almost all of them; keys
+        still failing stay False (honest result, as before)."""
+        self._put_retry_recovered = 0
+        if not sks:
+            return []
+        if self._backup_exist_gate:
             present = list(self._batch_exist_flat(sks))
             todo = [i for i, p in enumerate(present) if not p]
             if not todo:
                 return [True] * len(sks)
-            if len(todo) < len(sks):
-                karr, parr, sarr, out, _kb = _arrays(
-                    [sks[i] for i in todo], [sp[i] for i in todo],
-                    [ss[i] for i in todo])
-                self._lib.dfkv_batch_put(self._h, karr, parr, sarr,
-                                         len(todo), out)
-                for m, i in enumerate(todo):
-                    present[i] = out[m] == 1
-                return present
-        karr, parr, sarr, out, _kb = _arrays(sks, sp, ss)
-        self._lib.dfkv_batch_put(self._h, karr, parr, sarr, len(sks), out)
-        return [out[i] == 1 for i in range(len(sks))]
+        else:
+            present = [False] * len(sks)
+            todo = list(range(len(sks)))
+        for attempt in (0, 1):
+            if not todo:
+                break
+            if attempt:
+                time.sleep(0.01)  # let the write burst drain first
+            karr, parr, sarr, out, _kb = _arrays(
+                [sks[i] for i in todo], [sp[i] for i in todo],
+                [ss[i] for i in todo])
+            self._lib.dfkv_batch_put(self._h, karr, parr, sarr,
+                                     len(todo), out)
+            failed = []
+            for m, i in enumerate(todo):
+                present[i] = out[m] == 1
+                if not present[i]:
+                    failed.append(i)
+                elif attempt:
+                    self._put_retry_recovered += 1
+            todo = failed
+        return present
 
     def _v2_io(self, transfers, putting):
         results = {}
@@ -723,6 +743,8 @@ class DfkvHiCache(HiCacheStorage):
                            lambda: f"{self._alog_tag} {_fmt_pools(transfers)}") as r:
             res = self._v2_io(transfers, putting=True)
             r.result = _fmt_pool_results(res)
+            if self._put_retry_recovered:
+                r.result += f" retry_ok={self._put_retry_recovered}"
             if _sp:
                 _sp.hits = sum(sum(rs) for rs in res.values())
             return res

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -173,7 +173,10 @@ GroupVec ShardReadGroups(GroupVec groups) {
 
 KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
                    ValueHeader self_hdr, Transport* transport)
-    : self_hdr_(self_hdr) {
+    : self_hdr_(self_hdr),
+      health_(EnvSize("DFKV_PEER_COOLDOWN_MS", 2000),
+              EnvSize("DFKV_PEER_COOLDOWN_MAX_MS", 30000),
+              EnvSize("DFKV_PEER_BAD_GRACE_MS", 1000)) {
   SetMembers(std::move(members));
   if (transport) {
     t_ = transport;
@@ -425,7 +428,7 @@ bool KVClient::Put(const std::string& key, const void* value, size_t n) {
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
   // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
   // client-side/oversize outcomes that must not clear a peer's cooldown.
-  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
   return st == Status::kOk;
 }
 
@@ -446,7 +449,7 @@ bool KVClient::Get(const std::string& key, void* out, size_t n) {
     // A miss decodes to kNotFound (a healthy response), not kIOError — only a
     // real transport error marks the node bad.
     if (st == Status::kIOError) { health_.MarkBad(node, now); return false; }
-    health_.MarkGood(node);
+    health_.MarkGood(node, NowMs());
     if (st != Status::kOk || hdrs[0].size() < ValueHeader::kSize) return false;
     ValueHeader h;
     if (!ValueHeader::Parse(hdrs[0].data(), hdrs[0].size(), &h)) return false;
@@ -463,7 +466,7 @@ bool KVClient::Get(const std::string& key, void* out, size_t n) {
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
   // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
   // client-side/oversize outcomes that must not clear a peer's cooldown.
-  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
   if (st != Status::kOk) return false;
   if (raw.size() < ValueHeader::kSize) return false;
 
@@ -496,7 +499,7 @@ bool KVClient::GetAuto(const std::string& key, std::string* out, size_t max_byte
     std::vector<std::string> hdrs;
     Status st = t_->RangeInto(node, keys, dsts, ValueHeader::kSize, &hdrs)[0];
     if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); out->clear(); return false; }
-    if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+    if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
     if (st != Status::kOk || hdrs[0].size() < ValueHeader::kSize) { out->clear(); return false; }
     ValueHeader h;
     if (!ValueHeader::Parse(hdrs[0].data(), hdrs[0].size(), &h) ||
@@ -516,7 +519,7 @@ bool KVClient::GetAuto(const std::string& key, std::string* out, size_t max_byte
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
   // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
   // client-side/oversize outcomes that must not clear a peer's cooldown.
-  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
   if (st != Status::kOk) return false;
   if (raw.size() < ValueHeader::kSize) return false;
   ValueHeader h;
@@ -544,7 +547,7 @@ bool KVClient::GetAuto(const std::string& key, void* out, size_t cap, size_t* ou
     std::vector<std::string> hdrs;
     Status st = t_->RangeInto(node, keys, dsts, ValueHeader::kSize, &hdrs)[0];
     if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
-    if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+    if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
     if (st != Status::kOk || hdrs[0].size() < ValueHeader::kSize) return false;
     ValueHeader h;
     if (!ValueHeader::Parse(hdrs[0].data(), hdrs[0].size(), &h)) return false;
@@ -562,7 +565,7 @@ bool KVClient::GetAuto(const std::string& key, void* out, size_t cap, size_t* ou
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
   // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
   // client-side/oversize outcomes that must not clear a peer's cooldown.
-  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
   if (st != Status::kOk) return false;
   if (raw.size() < ValueHeader::kSize) return false;
   ValueHeader h;
@@ -587,7 +590,7 @@ bool KVClient::Exist(const std::string& key) {
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
   // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
   // client-side/oversize outcomes that must not clear a peer's cooldown.
-  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
   return st == Status::kOk && e;
 }
 
@@ -602,7 +605,7 @@ bool KVClient::Remove(const std::string& key) {
   if (st == Status::kIOError) { health_.MarkBad(node, NowMs()); return false; }
   // Only a real reply (hit or logical miss) is "good"; kInvalid/kCacheFull are
   // client-side/oversize outcomes that must not clear a peer's cooldown.
-  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node);
+  if (st == Status::kOk || st == Status::kNotFound) health_.MarkGood(node, NowMs());
   // kNotFound is a success for the caller: the goal (key not present) holds.
   return st == Status::kOk || st == Status::kNotFound;
 }
@@ -650,7 +653,7 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
       if (s == Status::kIOError) ioerr = true;
       else if (s == Status::kOk || s == Status::kNotFound) resp = true;
     }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
   });
   // RDMA path records the batch once (TCP path above is counted per-key by Put()).
   uint64_t bytes = 0;
@@ -762,7 +765,7 @@ std::vector<bool> KVClient::BatchGetDirect(const std::vector<KvGetItem>& items) 
       if (s == Status::kIOError) ioerr = true;
       else if (s == Status::kOk || s == Status::kNotFound) resp = true;
     }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) {
       if (sts[m] != Status::kOk || hdrs[m].size() < ValueHeader::kSize) continue;
       ValueHeader h;
@@ -893,7 +896,7 @@ std::vector<bool> KVClient::BatchGetAutoDirect(const std::vector<KvGetItem>& ite
       if (s == Status::kIOError) ioerr = true;
       else if (s == Status::kOk || s == Status::kNotFound) resp = true;
     }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) {
       if (sts[m] != Status::kOk || hdrs[m].size() < ValueHeader::kSize) continue;
       ValueHeader h;
@@ -992,7 +995,7 @@ std::vector<bool> KVClient::BatchExistDirect(const std::vector<std::string>& key
       if (s == Status::kIOError) ioerr = true;
       else if (s == Status::kOk || s == Status::kNotFound) resp = true;
     }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) e[idx[m]] = (m < ex.size() && ex[m]) ? 1 : 0;
   });
   return RecordBatch(OpMetrics::kExist, t0, e, 0);
@@ -1032,7 +1035,7 @@ std::vector<bool> KVClient::BatchRemove(const std::vector<std::string>& keys) {
       if (s == Status::kIOError) ioerr = true;
       else if (s == Status::kOk || s == Status::kNotFound) resp = true;
     }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m)
       ok[idx[m]] = (m < sts.size() &&
                     (sts[m] == Status::kOk || sts[m] == Status::kNotFound)) ? 1 : 0;
@@ -1099,7 +1102,7 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
       if (s == Status::kIOError) ioerr = true;
       else if (s == Status::kOk || s == Status::kNotFound) resp = true;
     }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
   });
   uint64_t bytes = 0;
   for (size_t i = 0; i < N; ++i) if (ok[i]) for (size_t s : items[i].sizes) bytes += s;
@@ -1319,7 +1322,7 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
       if (s == Status::kIOError) ioerr = true;
       else if (s == Status::kOk || s == Status::kNotFound) resp = true;
     }
-    if (resp) health_.MarkGood(node); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) {
       size_t cap = groups[g].first.second;
       if (sts[m] != Status::kOk || hdrs[m].size() < ValueHeader::kSize) continue;

--- a/src/client/peer_health.h
+++ b/src/client/peer_health.h
@@ -27,9 +27,22 @@ class PeerHealth {
   // was re-dialed on the data path every base period, stalling each batch on a
   // full connect timeout indefinitely; exponential backoff caps that cost at
   // one connect per max_cooldown once a peer is persistently down.
+  //
+  // busy_grace_ms distinguishes BUSY from DEAD (R2-B, 2026-07-17): under a
+  // write burst one stalled op used to MarkBad a node that was concurrently
+  // serving other ops fine — the cooldown then instant-failed EVERY op to it
+  // for 2-30s (on a small ring: a total artificial outage; measured 4013
+  // swallowed backup puts per cold round, and it defeats the hicache put
+  // retry, which re-arrives well inside the cooldown). A failure now engages
+  // the cooldown only if the peer has had no served response within
+  // busy_grace_ms; a peer that answered recently is alive-busy, and the
+  // failed op's honest error still reaches its caller. Dead peers never
+  // MarkGood, so their first failure cools down exactly as before.
   explicit PeerHealth(uint64_t base_cooldown_ms = 2000,
-                      uint64_t max_cooldown_ms = 30000)
-      : base_cooldown_ms_(base_cooldown_ms), max_cooldown_ms_(max_cooldown_ms) {}
+                      uint64_t max_cooldown_ms = 30000,
+                      uint64_t busy_grace_ms = 1000)
+      : base_cooldown_ms_(base_cooldown_ms), max_cooldown_ms_(max_cooldown_ms),
+        busy_grace_ms_(busy_grace_ms) {}
 
   bool Healthy(const std::string& peer, uint64_t now_ms) const {
     std::lock_guard<std::mutex> lk(mu_);
@@ -41,6 +54,16 @@ class PeerHealth {
   }
   void MarkBad(const std::string& peer, uint64_t now_ms) {
     std::lock_guard<std::mutex> lk(mu_);
+    errors_.fetch_add(1, std::memory_order_relaxed);
+    // Alive-busy: the peer served a response within the grace window, so this
+    // failure is one slow/failed op on a live node, not a dead peer. Count the
+    // error but do NOT engage the cooldown (which would instant-fail every
+    // subsequent op to it, including the caller's retry).
+    auto lg = last_good_.find(peer);
+    if (lg != last_good_.end() && now_ms - lg->second < busy_grace_ms_) {
+      busy_suppressed_.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
     auto it = until_.find(peer);
     bool was_ok = it == until_.end() || it->second <= now_ms;
     // Exponential backoff: base << (fails-1), capped at max_cooldown.
@@ -49,18 +72,20 @@ class PeerHealth {
     uint64_t cd = base_cooldown_ms_ << shift;
     if (cd > max_cooldown_ms_ || cd < base_cooldown_ms_ /*overflow*/) cd = max_cooldown_ms_;
     until_[peer] = now_ms + cd;
-    errors_.fetch_add(1, std::memory_order_relaxed);
     if (was_ok) marked_bad_.fetch_add(1, std::memory_order_relaxed);  // healthy->bad edge
     // Bound per-peer cardinality: only track a new peer while under the cap, so a
     // long-lived client churning through many distinct addresses can't grow the
     // map (and its scrape series) without bound. Aggregate errors_ still counts.
     if (peer_errors_.size() < kMaxPeers || peer_errors_.count(peer)) peer_errors_[peer]++;
   }
-  // Data-path success: clears the cooldown and the backoff streak. Bumps the
+  // Data-path success: clears the cooldown and the backoff streak, and stamps
+  // the peer's last-served time (the busy-vs-dead grace signal). Bumps the
   // served counter (an op completed), so it is NOT for probe-driven recovery.
-  void MarkGood(const std::string& peer) {
+  void MarkGood(const std::string& peer, uint64_t now_ms) {
     std::lock_guard<std::mutex> lk(mu_);
     served_.fetch_add(1, std::memory_order_relaxed);
+    if (last_good_.size() < kMaxPeers || last_good_.count(peer))
+      last_good_[peer] = now_ms;
     ClearLocked(peer);
   }
   // Probe-driven recovery (off the data path): the background prober reached
@@ -93,6 +118,9 @@ class PeerHealth {
       marked_bad_.load(std::memory_order_relaxed));
     m(s, "dfkv_client_peer_recovered_total", "counter", "Bad->good peer transitions",
       recovered_.load(std::memory_order_relaxed));
+    m(s, "dfkv_client_busy_suppressed_total", "counter",
+      "Failures on alive-busy peers (cooldown suppressed by grace)",
+      busy_suppressed_.load(std::memory_order_relaxed));
     // per-peer errors (one HELP/TYPE, one series per peer seen)
     std::map<std::string, uint64_t> snap;
     {
@@ -112,6 +140,7 @@ class PeerHealth {
   uint64_t errors() const { return errors_.load(std::memory_order_relaxed); }
   uint64_t marked_bad() const { return marked_bad_.load(std::memory_order_relaxed); }
   uint64_t recovered() const { return recovered_.load(std::memory_order_relaxed); }
+  uint64_t busy_suppressed() const { return busy_suppressed_.load(std::memory_order_relaxed); }
 
  private:
   // Clear a peer's cooldown + backoff streak (recovery). Caller holds mu_.
@@ -124,11 +153,13 @@ class PeerHealth {
   mutable std::mutex mu_;
   uint64_t base_cooldown_ms_;
   uint64_t max_cooldown_ms_;
+  uint64_t busy_grace_ms_;
   std::unordered_map<std::string, uint64_t> until_;        // peer -> unhealthy-until (ms)
   std::unordered_map<std::string, uint32_t> fail_streak_;  // peer -> consecutive failures
   std::unordered_map<std::string, uint64_t> peer_errors_;  // peer -> cumulative IO errors
+  std::unordered_map<std::string, uint64_t> last_good_;    // peer -> last served-at (ms)
   mutable std::atomic<uint64_t> checks_{0}, unhealthy_skips_{0}, errors_{0},
-      marked_bad_{0}, served_{0}, recovered_{0};
+      marked_bad_{0}, served_{0}, recovered_{0}, busy_suppressed_{0};
 };
 
 }  // namespace dfkv

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -12,12 +12,12 @@ TEST(ClientMetrics, CountsServedErrorsTransitionsAndRenders) {
   const std::string p = "10.0.0.1:12000";
   // a healthy check, then a served response
   EXPECT_TRUE(h.Healthy(p, 1000));
-  h.MarkGood(p);
+  h.MarkGood(p, 0);
   // an IO error marks it bad (healthy->bad edge), then a skip while in cooldown
   h.MarkBad(p, 1000);
   EXPECT_FALSE(h.Healthy(p, 1500));   // still in cooldown -> skip
   // recovery: a later served response clears it (bad->good edge)
-  h.MarkGood(p);
+  h.MarkGood(p, 0);
 
   EXPECT_EQ(h.served(), 2u);
   EXPECT_EQ(h.errors(), 1u);

--- a/test/client/peer_health_test.cc
+++ b/test/client/peer_health_test.cc
@@ -19,7 +19,7 @@ TEST(PeerHealth, MarkGoodClearsImmediately) {
   PeerHealth h(1000);
   h.MarkBad("a", 1000);
   EXPECT_FALSE(h.Healthy("a", 1200));
-  h.MarkGood("a");
+  h.MarkGood("a", 0);
   EXPECT_TRUE(h.Healthy("a", 1200));
 }
 
@@ -46,10 +46,43 @@ TEST(PeerHealth, CooldownBacksOffExponentiallyAndCapsAtMax) {
 TEST(PeerHealth, MarkGoodResetsBackoffStreak) {
   PeerHealth h(/*base=*/100, /*max=*/10000);
   h.MarkBad("p", 0); h.MarkBad("p", 0); h.MarkBad("p", 0);  // streak -> 400ms
-  h.MarkGood("p");                                          // reset
+  h.MarkGood("p", 0);                                          // reset
   h.MarkBad("p", 1000);                                     // back to base 100ms
   EXPECT_FALSE(h.Healthy("p", 1099));
   EXPECT_TRUE(h.Healthy("p", 1100));
+}
+
+TEST(PeerHealth, BusyPeerFailureDoesNotCoolDown) {
+  // R2-B: a peer that served a response within the grace window is alive-busy;
+  // one failed op on it must not instant-fail everything else for the cooldown
+  // (that turned a single write-burst stall into a 2-30s artificial outage and
+  // defeated the hicache put retry).
+  PeerHealth h(/*base=*/1000, /*max=*/30000, /*busy_grace_ms=*/1000);
+  h.MarkGood("p", 5000);
+  h.MarkBad("p", 5500);                        // 500ms after a served op
+  EXPECT_TRUE(h.Healthy("p", 5500));           // no cooldown: retry can proceed
+  EXPECT_EQ(h.busy_suppressed(), 1u);
+  EXPECT_EQ(h.errors(), 1u);                   // the failure is still counted
+  EXPECT_EQ(h.marked_bad(), 0u);               // no healthy->bad transition
+}
+
+TEST(PeerHealth, StaleGoodPeerFailureCoolsDown) {
+  // Last served response is OLDER than the grace window: the peer may be dead,
+  // cooldown engages exactly as before.
+  PeerHealth h(/*base=*/1000, /*max=*/30000, /*busy_grace_ms=*/1000);
+  h.MarkGood("p", 5000);
+  h.MarkBad("p", 6500);                        // 1.5s silence > 1s grace
+  EXPECT_FALSE(h.Healthy("p", 6500));
+  EXPECT_EQ(h.busy_suppressed(), 0u);
+}
+
+TEST(PeerHealth, NeverServedPeerFailureCoolsDown) {
+  // First contact with a dead peer: no served history, first failure cools
+  // down immediately (the original connect-storm protection is preserved).
+  PeerHealth h(/*base=*/1000, /*max=*/30000, /*busy_grace_ms=*/1000);
+  h.MarkBad("p", 100);
+  EXPECT_FALSE(h.Healthy("p", 100));
+  EXPECT_EQ(h.busy_suppressed(), 0u);
 }
 
 TEST(PeerHealth, MarkProbeAliveRecoversWithoutCountingServed) {

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -1125,5 +1125,99 @@ class TestNodeDedupDefaults(unittest.TestCase):
         self.assertEqual(self._r(1, None, False, 1), ("1", False))
 
 
+class PutRetryTest(unittest.TestCase):
+    """_put_flat single-retry of transiently failed puts (R1 finding,
+    2026-07-17): under a cold-round write burst ~0.1% of batch_put keys fail;
+    SGLang's backup bookkeeping ignores per-page False, so an unretried
+    failure becomes a phantom "backed" page the hot round cannot retrieve.
+    One delayed retry recovers the transient portion; keys that keep failing
+    stay False (the honest result is unchanged)."""
+    PAGE_SIZE = 64
+    PAGE_BYTES = 4096
+
+    def _fake_lib(self, fail_first_call_last_n=0, fail_always_keys=()):
+        calls = {"put": [], "exist": 0}
+
+        class _FakeLib:
+            def __init__(self):
+                self.dfkv_open = lambda *a, **k: ctypes.c_void_p(0xBEEF)
+                self.dfkv_set_batch_concurrency = lambda *a, **k: 0
+                self.dfkv_transport_mode = lambda *a, **k: b"tcp"
+                self.dfkv_close = lambda *a, **k: None
+                self.dfkv_version = lambda *a, **k: b"1.27.0"
+                self.dfkv_batch_exist = self._exist
+                self.dfkv_batch_put = self._put
+
+            def _exist(self, h, karr, n, out):
+                calls["exist"] += 1
+                for i in range(n):
+                    out[i] = 0  # nothing in L3 yet: all keys proceed to put
+                return 0
+
+            def _put(self, h, karr, parr, sarr, n, out):
+                keys = [karr[i].decode() for i in range(n)]
+                calls["put"].append(keys)
+                first = len(calls["put"]) == 1
+                for i, k in enumerate(keys):
+                    if k in fail_always_keys:
+                        out[i] = 0
+                    elif first and i >= n - fail_first_call_last_n:
+                        out[i] = 0  # transient burst failure
+                    else:
+                        out[i] = 1
+                return 0
+
+        return _FakeLib(), calls
+
+    def _plugin(self, fake):
+        os.environ["DFKV_CLIENT_NODE_DEDUP"] = "0"
+        cfg = HiCacheStorageConfig(
+            tp_rank=0, tp_size=8, is_mla_model=True,
+            is_page_first_layout=False, model_name="glm-retry",
+            extra_config={
+                "members": "n0=127.0.0.1:1", "model_hash": 0x51,
+                "dtype_tag": 0x46384534, "page_size": self.PAGE_SIZE,
+                "layer_num": 78, "head_num": 1, "head_dim": 576,
+                "interface_v1": 1,
+            })
+        with patch.object(dfkv_hicache, "_load_lib", return_value=fake):
+            st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        st.register_mem_pool_host(FakeMlaPool(8, self.PAGE_BYTES,
+                                              self.PAGE_SIZE))
+        return st
+
+    def _set(self, st, npages):
+        keys = [f"k{i}" for i in range(npages)]
+        idx = list(range(npages * self.PAGE_SIZE))
+        return st.batch_set_v1(keys, idx)
+
+    def test_transient_failures_recovered_by_retry(self):
+        fake, calls = self._fake_lib(fail_first_call_last_n=3)
+        st = self._plugin(fake)
+        res = self._set(st, 8)
+        self.assertEqual(res, [True] * 8)
+        self.assertEqual(len(calls["put"]), 2)          # initial + one retry
+        self.assertEqual(len(calls["put"][1]), 3)       # only failed keys retried
+        self.assertEqual(st._put_retry_recovered, 3)
+
+    def test_persistent_failures_stay_false(self):
+        # MLA sub-key = "<model>/<page_hash>_k"; k0 fails on both attempts.
+        fake, calls = self._fake_lib(fail_always_keys={"glm-retry/k0_k"})
+        st = self._plugin(fake)
+        res = self._set(st, 4)
+        self.assertEqual(res, [False, True, True, True])
+        self.assertEqual(len(calls["put"]), 2)          # retry attempted once
+        self.assertEqual(calls["put"][1], ["glm-retry/k0_k"])
+        self.assertEqual(st._put_retry_recovered, 0)
+
+    def test_no_retry_when_all_succeed(self):
+        fake, calls = self._fake_lib()
+        st = self._plugin(fake)
+        res = self._set(st, 8)
+        self.assertEqual(res, [True] * 8)
+        self.assertEqual(len(calls["put"]), 1)          # no second call
+        self.assertEqual(st._put_retry_recovered, 0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
R2-B (iteration campaign): the write-burst put-failure amplifier.

**Chain (all measured on the R1 campaign)**: one multi-second stalled op under the cold-round write storm → MarkBad → 2-30s exponential cooldown → every subsequent op to the node instant-fails (whole groups skipped in BatchPut/BatchGet) → 4,013 swallowed backup puts per cold round in inference, 96/13600 in the bare bench, and the instant-fail also defeats PR#177's 10ms put retry.

**Fix**: cooldown engages only if the peer has had no served response within `DFKV_PEER_BAD_GRACE_MS` (default 1s). Alive-busy peers keep serving; the stalled op's honest failure still reaches its caller, whose retry now actually works. Dead-peer behavior (never served) is unchanged. New counter `dfkv_client_busy_suppressed_total`; cooldown base/max env-tunable.

Tests: 3 new PeerHealth cases (busy-suppressed / stale-good engages / never-served engages), local ctest 359/359.