### PR TITLE
fix(hicache): node-dedup default OFF — full-workload A/B refutes the auto-on

### DIFF
--- a/docs/hit_rate_funnel.md
+++ b/docs/hit_rate_funnel.md
@@ -37,7 +37,7 @@ exist 命中 **≠** 数据真被拉回。SGLang HiCache 的 `prefetch-policy=ti
 - 客户端会合（**本期新增遥测**）：`dfkv_connector_dedup_hits_total` / `_fetches_total` / `_wait_hits_total` / `_wait_timeouts_total`（GPU 目标另有 `dfkv_connector_gpu_dedup_*`）。
 
 **判读**：
-- `dedup_hits + wait_hits` 占比高 = 同机 TP rank 的锁步读被会合到 1×（好）；`fetches` 接近请求数 = 会合没生效，8× 读放大在白吃带宽 → 确认 `DFKV_CLIENT_NODE_DEDUP=1`（MLA+TP>1 现默认开）。
+- 会合（node-dedup）**默认关**（R2 A/B 实测 2026-07-17：推理批形状下会合协调开销反噬——dedup-on 热轮 TTFT +19-36% 恶化、批 p99 22s；dedup-off 直连 8× 读放大反而 TTFT −43%、吞吐 +50-71%）。仅多节点环 fabric 带宽吃紧时显式开 `DFKV_CLIENT_NODE_DEDUP=1`，且必须实测热轮为正收益。开了之后才看 `dedup_hits/wait_hits/fetches` 三兄弟。
 - `wait_timeouts` 高 = 会合等待超时回退直连 → 读回带宽跟不上，见第③层。
 
 ---
@@ -63,7 +63,7 @@ exist 命中 **≠** 数据真被拉回。SGLang HiCache 的 `prefetch-policy=ti
 |---|---|---|---|
 | exist 命中率低、环快满 | ① | `used_bytes/cap`、`watermark_evictions` | 容量水位 + 别写满 |
 | exist 命中率低、环不满 | ① | `model_name`/`model_hash` | keyspace 对齐 |
-| exist 高但读回量小 | ② | `dedup_*`、`bytes_read` | 开 dedup、查 prefetch timeout |
+| exist 高但读回量小 | ② | `bytes_read`、access log | 查 prefetch timeout、确认 dedup 未误开 |
 | 热轮慢于冷轮 | ③ | 冷/热吞吐、读回 GB/s | 多节点、prefetch overlap |
 | 热轮仍大量写入 | ③ | `bytes_written` 热轮增量 | backup exist 门 |
 | lookup 尾延迟爆 | ②/③ | access log `batch_exists` p99 | rdma_depth=32、控制 lane |

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -46,18 +46,24 @@ def _truthy(v) -> bool:
 def resolve_node_dedup(cfg_value, env_value, is_mla: bool, tp_size: int):
     """Decide DFKV_CLIENT_NODE_DEDUP: (value_to_set | None, auto_enabled).
 
-    Precedence: explicit extra-config beats the env, the env beats the auto
-    default. The auto default enables the same-host rendezvous exactly for
-    the topology it exists for — MLA (TP-replicated KV) with tp_size > 1;
-    other topologies never rendezvous (per-rank keys differ) and are spared
-    the /dev/shm arena. Pure function so the policy is unit-testable.
+    Precedence: explicit extra-config beats the env, the env beats the
+    default. The default is OFF (R2 A/B verdict, 2026-07-17): on the full
+    GLM-5.2 100k-token workload the shm rendezvous inverted the L3 value —
+    dedup-on hot rounds ran +19-36% TTFT WORSE than cold with 22s p99 batch
+    tails, while dedup-off hot rounds beat cold by 43% TTFT / +50-71%
+    throughput. The 8x direct-read amplification is cheaper than the
+    rendezvous coordination (publish copies through the 512MiB arena +
+    wait-timeout fallbacks) at inference batch shapes; the v1.26.0
+    conditional auto-on was validated only on microbenchmarks. Rendezvous
+    stays available explicitly (node_dedup=1 / DFKV_CLIENT_NODE_DEDUP=1)
+    for fabric-constrained multi-node rings until the publish path is
+    redesigned (zero-copy publish, per-key streaming). Pure function so the
+    policy is unit-testable.
     """
     if cfg_value is not None:
         return ("1" if _truthy(cfg_value) else "0"), False
     if env_value is not None:
         return None, False  # operator's env stands as-is
-    if is_mla and tp_size > 1:
-        return "1", True
     return None, False
 
 
@@ -256,13 +262,12 @@ class DfkvHiCache(HiCacheStorage):
                 os.environ.setdefault("DFKV_RDMA_NUMA", "1")
             # Same-host GET rendezvous (phase 5): dedups TP-replicated L3 loads
             # across the rank processes of one node (HiCache destinations are
-            # HOST memory — the host flavor applies). Since phase 9 it is ON BY
-            # DEFAULT exactly for the topology it exists for: MLA (replicated
-            # KV) with tp_size > 1 — the measured 8x lockstep read case. Other
-            # topologies gain nothing (per-rank keys never rendezvous) and are
-            # spared the 512 MiB /dev/shm arena. Explicit settings always win:
-            # extra-config `node_dedup` beats the env, the env beats the auto
-            # default; "0" anywhere disables.
+            # HOST memory — the host flavor applies). Default OFF since the R2
+            # A/B (2026-07-17): at inference batch shapes the rendezvous
+            # inverted the L3 benefit (see resolve_node_dedup docstring for
+            # the measured numbers); direct 8x reads are cheaper until the
+            # publish path is redesigned. Explicit settings always win:
+            # extra-config `node_dedup` beats the env; "1" opts back in.
             _dedup, _auto = resolve_node_dedup(
                 cfg.get("node_dedup"), os.environ.get("DFKV_CLIENT_NODE_DEDUP"),
                 self.is_mla, self.tp_size)

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -1095,15 +1095,18 @@ class DfkvClientRegistrationTest(unittest.TestCase):
 
 
 class TestNodeDedupDefaults(unittest.TestCase):
-    """resolve_node_dedup policy (phase 9): auto-on for MLA+TP>1 only, with
-    explicit extra-config > env > auto precedence."""
+    """resolve_node_dedup policy (R2, 2026-07-17): default OFF for every
+    topology — the phase-9 MLA+TP>1 auto-on was refuted by the full-workload
+    A/B (hot rounds +19-36% TTFT worse with rendezvous vs -43% TTFT better
+    without). Explicit extra-config > env > default precedence unchanged."""
 
     def _r(self, cfg, env, mla, tp):
         from dfkv_hicache import resolve_node_dedup
         return resolve_node_dedup(cfg, env, mla, tp)
 
-    def test_auto_enables_for_mla_tp_gt1(self):
-        self.assertEqual(self._r(None, None, True, 8), ("1", True))
+    def test_no_auto_for_mla_tp_gt1(self):
+        # The phase-9 auto-on case: now stays off unless explicitly enabled.
+        self.assertEqual(self._r(None, None, True, 8), (None, False))
 
     def test_no_auto_for_mha(self):
         self.assertEqual(self._r(None, None, False, 8), (None, False))
@@ -1111,7 +1114,10 @@ class TestNodeDedupDefaults(unittest.TestCase):
     def test_no_auto_for_tp1(self):
         self.assertEqual(self._r(None, None, True, 1), (None, False))
 
-    def test_env_beats_auto(self):
+    def test_explicit_optin_via_config(self):
+        self.assertEqual(self._r("1", None, True, 8), ("1", False))
+
+    def test_env_stands(self):
         # operator already set it (either way): leave untouched, no auto log
         self.assertEqual(self._r(None, "0", True, 8), (None, False))
         self.assertEqual(self._r(None, "1", False, 1), (None, False))


### PR DESCRIPTION
R2-A verdict. Clean-ring A/B (only dedup flag differs): dedup-on hot rounds run **+19-31% TTFT worse than cold** (batch p99 22.7s — publish path pathology); dedup-off hot rounds run **-43% TTFT / +50-71% throughput vs cold** (8 direct streams, ~9GB/s aggregate server reads). The phase-9 auto-on inverted the L3 value proposition at inference batch shapes; flipping the default recovers it. Explicit opt-in preserved for fabric-constrained multi-node rings. vLLM GPU rendezvous (different mechanism, separately validated) untouched. Includes hit-rate-funnel doc update. Tests 58/58.