### PR TITLE
fix(metrics): count RAM-tier misses on the uring prep path (dfkv_ram_miss_total stuck at 0)

### DIFF
--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -575,6 +575,12 @@ Status KvNodeServer::RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize
     if (out) *out = KVStore::RangePrep{};
     return Status::kInvalid;
   }
+  // RAM consulted and absent -> this GET is a RAM-tier miss regardless of the
+  // disk outcome (mirrors GetPrep's accounting on the sync path). Without this
+  // the uring path -- the default since v1.20.0 opt-in / v1.27.0 default-on --
+  // reports dfkv_ram_miss_total == 0 forever while hits accumulate, so
+  // hit/(hit+miss) reads as a fake 100%.
+  if (ram_) ram_->CountMiss();
   Status st = group_.RangeDirectPrep(key, offset, length, io_cap, out);
   // Only miss/io-error are final here; a kOk prep is accounted on read completion
   // (RangeDirectComplete) because the async read can still fail.

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -124,6 +124,14 @@ class RamTier {
   bool Contains(const BlockKey& key) const;
   bool Remove(const BlockKey& key);  // drop from RAM (cache); true if present
 
+  // Explicit miss accounting for GET paths that consult the tier via Contains()
+  // instead of GetPrep(). The uring prep path partitions keys up front
+  // (RAM-resident -> sync arena serve, absent -> async disk read); its absent
+  // branch never reaches GetPrep, so without this the dominant read path
+  // under-reports misses to zero. Contains() itself must NOT count: the exist
+  // path probes it too, and exist probes are not GETs.
+  void CountMiss() { misses_.fetch_add(1, std::memory_order_relaxed); }
+
   // Registers the arena's RDMA MR (set once by the RDMA server after reg_mr).
   void SetArenaMr(void* mr);
   char* arena() const { return arena_; }

--- a/test/cache/ram_tier_wiring_test.cc
+++ b/test/cache/ram_tier_wiring_test.cc
@@ -204,3 +204,42 @@ TEST(RamTierWiring, PutAdmissionGateRejectsWithCacheFull) {
   s.reset();
   fs::remove_all(dir);
 }
+
+// The uring prep path partitions keys up front: RAM-resident -> decline
+// (kInvalid, sync arena serve), absent -> async disk read. The absent branch
+// never reaches GetPrep, so it must count the RAM miss itself — without that,
+// the default read path reports dfkv_ram_miss_total == 0 forever while hits
+// accumulate, and hit/(hit+miss) reads as a fake 100% (seen in production:
+// 985k hits / 0 misses across a 15TB read campaign).
+TEST(RamTierWiring, UringPrepPathCountsRamMisses) {
+  ::setenv("DFKV_RAM_TIER", "1", 1);
+  ::setenv("DFKV_RAM_TIER_BYTES", "8388608", 1);
+  std::string addr;
+  auto dir = fs::temp_directory_path() / "dfkv_ramwire_prep";
+  auto s = Start(dir, &addr);
+  TcpTransport t;
+  std::string v(4096, 'q');
+  ASSERT_EQ(t.Cache(addr, ToBlockKey("resident"), v.data(), v.size()), Status::kOk);
+
+  const BlockKey rk = ToBlockKey("resident");
+  const BlockKey ak = ToBlockKey("absent-key");
+  KVStore::RangePrep prep;
+
+  // RAM-resident: prep declines so the serve loop falls back to the arena.
+  // Consulted-and-present is NOT a miss.
+  const long miss0 = MetricVal(s->MetricsText(), "dfkv_ram_miss_total");
+  EXPECT_EQ(s->RangeDirectPrep(rk.id, rk.index, rk.size, 0, v.size(), 1 << 20, &prep),
+            Status::kInvalid);
+  EXPECT_EQ(MetricVal(s->MetricsText(), "dfkv_ram_miss_total"), miss0);
+
+  // Absent everywhere: RAM consulted and absent -> exactly one RAM miss,
+  // regardless of the disk outcome (kNotFound here).
+  EXPECT_EQ(s->RangeDirectPrep(ak.id, ak.index, ak.size, 0, 16, 1 << 20, &prep),
+            Status::kNotFound);
+  EXPECT_EQ(MetricVal(s->MetricsText(), "dfkv_ram_miss_total"), miss0 + 1);
+
+  s.reset();
+  ::unsetenv("DFKV_RAM_TIER");
+  ::unsetenv("DFKV_RAM_TIER_BYTES");
+  fs::remove_all(dir);
+}


### PR DESCRIPTION
## Problem

`dfkv_ram_miss_total` never increments on the uring GET path (opt-in v1.20.0, **default-on v1.27.0**), while `dfkv_ram_hit_total` accumulates normally — so `hit/(hit+miss)` reads as a fake 100%.

**Production evidence** (bj09 glm-b2, B200 2-node ring, v1.27.0 and v1.28.0, GLM-5.2 100k-token benchmark campaign): 985k ram hits, ~15.5 TB served from disk, `ram_miss_total` pinned at exactly 0 across both versions.

## Root cause

`RangeDirectPrep` partitions keys up front:
- RAM-resident → decline the async prep (`kInvalid`) → sync fallback reaches `GetPrep` → **hit counted** ✓
- absent → straight to the disk prep — **never reaches `GetPrep`, the only place that counted misses** ✗

The docs' funnel guidance (`docs/hit_rate_funnel.md`) tells operators to compute the RAM hit rate from these two counters; with the default read path this is currently impossible.

## Fix

- `RamTier::CountMiss()` — explicit accounting hook (header-inline, relaxed atomic, same as the internal increments).
- `RangeDirectPrep`: count one RAM miss when the tier was consulted and the key is absent, mirroring `GetPrep`'s semantics (miss = consulted-and-absent, regardless of the disk outcome).
- `Contains()` itself stays count-free — the exist path (`kv_node_server.cc` kExist branch) probes it too, and exist probes are not GETs.

## Test

`RamTierWiring.UringPrepPathCountsRamMisses` drives `RangeDirectPrep` directly: resident key → `kInvalid\` + no miss; absent key → exactly +1 miss. Local: full rebuild clean, wiring suite 6/6, cache/store/transport subset 16/16.