### PR TITLE
feat(client): cooperative fetch — rank-partitioned rendezvous (DFKV_CLIENT_NODE_DEDUP=coop)

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -192,9 +192,19 @@ KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
     t_ = owned_.get();
     DFKV_LOG_INFO("dfkv client transport=" + transport_reason_);
   }
-  // Same-host GET rendezvous (phase 5). Off unless DFKV_CLIENT_NODE_DEDUP=1;
-  // namespaced by model_hash so distinct keyspaces never share entries.
-  dedup_ = NodeDedup::FromEnv(self_hdr_.model_hash);
+  // Same-host GET rendezvous (phase 5). Off unless DFKV_CLIENT_NODE_DEDUP is
+  // "1" (classic claim race) or "coop" (rank-partitioned cooperative fetch;
+  // rank/world come from the client identity header). Namespaced by model_hash
+  // so distinct keyspaces never share entries.
+  dedup_ = NodeDedup::FromEnv(self_hdr_.model_hash,
+                              static_cast<int>(self_hdr_.tp_rank),
+                              static_cast<int>(self_hdr_.tp_size));
+  if (dedup_ && dedup_->coop()) {
+    DFKV_LOG_INFO("node-dedup: cooperative fetch on (rank=" +
+                  std::to_string(self_hdr_.tp_rank) + "/" +
+                  std::to_string(self_hdr_.tp_size) +
+                  "): each rank fetches its key partition, peers copy via shm");
+  }
   // Batch fan-out workers override (0/unset = auto; see set_batch_concurrency).
   if (const char* bc = std::getenv("DFKV_BATCH_CONCURRENCY")) {
     long x = std::strtol(bc, nullptr, 10);
@@ -686,7 +696,13 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
       continue;
     }
     bks[i] = ToBlockKey(items[i].key, self_hdr_.model_hash);
-    switch (dedup_->Claim(bks[i], items[i].n, static_cast<char*>(items[i].out))) {
+    // Coop partition: only the owning rank claims a fetch; the rest go straight
+    // to the wait path so N ranks fetch N disjoint shards concurrently.
+    switch (dedup_->coop() && !dedup_->Owns(bks[i])
+                ? dedup_->ClaimPassive(bks[i], items[i].n,
+                                       static_cast<char*>(items[i].out))
+                : dedup_->Claim(bks[i], items[i].n,
+                                static_cast<char*>(items[i].out))) {
       case NodeDedup::Role::kHit:
         res[i] = true;
         break;
@@ -825,7 +841,11 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
     }
     bks[i] = ToBlockKey(items[i].key, self_hdr_.model_hash);
     size_t got = 0;
-    switch (dedup_->ClaimAuto(bks[i], items[i].n, static_cast<char*>(items[i].out), &got)) {
+    switch (dedup_->coop() && !dedup_->Owns(bks[i])
+                ? dedup_->ClaimAutoPassive(bks[i], items[i].n,
+                                           static_cast<char*>(items[i].out), &got)
+                : dedup_->ClaimAuto(bks[i], items[i].n,
+                                    static_cast<char*>(items[i].out), &got)) {
       case NodeDedup::Role::kHit:
         res[i] = true;
         lens[i] = got;
@@ -950,7 +970,9 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
   for (size_t i = 0; i < N; ++i) {
     bks[i] = ToBlockKey(keys[i], self_hdr_.model_hash);
     bool val = false;
-    switch (dedup_->ClaimExist(bks[i], &val)) {
+    switch (dedup_->coop() && !dedup_->Owns(bks[i])
+                ? dedup_->ClaimExistPassive(bks[i], &val)
+                : dedup_->ClaimExist(bks[i], &val)) {
       case NodeDedup::Role::kHit:
         res[i] = val;
         break;

--- a/src/client/node_dedup.cc
+++ b/src/client/node_dedup.cc
@@ -79,9 +79,13 @@ std::string NodeDedup::EnvSegmentName(uint64_t model_hash) {
   return name;
 }
 
-std::unique_ptr<NodeDedup> NodeDedup::FromEnv(uint64_t model_hash) {
+std::unique_ptr<NodeDedup> NodeDedup::FromEnv(uint64_t model_hash, int rank,
+                                              int world) {
   const char* on = std::getenv("DFKV_CLIENT_NODE_DEDUP");
-  if (!on || std::strcmp(on, "1") != 0) return nullptr;
+  if (!on) return nullptr;
+  const bool classic = std::strcmp(on, "1") == 0;
+  const bool coop = std::strcmp(on, "coop") == 0;
+  if (!classic && !coop) return nullptr;
   Options o;
   o.arena_bytes = EnvU64("DFKV_NODE_DEDUP_ARENA_MB", 512) << 20;
   o.slots = static_cast<uint32_t>(EnvU64("DFKV_NODE_DEDUP_SLOTS", 65536));
@@ -89,6 +93,17 @@ std::unique_ptr<NodeDedup> NodeDedup::FromEnv(uint64_t model_hash) {
   o.takeover_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TAKEOVER_MS", 2000));
   o.ttl_ms = static_cast<int>(EnvU64("DFKV_NODE_DEDUP_TTL_MS", 5000));
   o.name = EnvSegmentName(model_hash);
+  // Coop needs a real partition; a lone client (world < 2) or an unknown rank
+  // degrades to the classic claim race rather than silently owning nothing.
+  if (coop && world >= 2 && rank >= 0 && rank < world) {
+    o.coop = true;
+    o.rank = rank;
+    o.world = world;
+  } else if (coop) {
+    DFKV_LOG_INFO("node-dedup: coop requested but rank/world unavailable (rank=" +
+                  std::to_string(rank) + " world=" + std::to_string(world) +
+                  "), using classic claim mode");
+  }
   return Open(o);
 }
 
@@ -143,6 +158,9 @@ std::unique_ptr<NodeDedup> NodeDedup::Open(const Options& opt) {
   d->wait_ms_ = opt.wait_ms;
   d->takeover_ms_ = opt.takeover_ms;
   d->ttl_ms_ = opt.ttl_ms;
+  d->coop_ = opt.coop;
+  d->rank_ = opt.rank;
+  d->world_ = opt.world;
 
   if (creator) {
     // Fresh (ftruncate zero-fills): stamp the header last so concurrent
@@ -297,6 +315,69 @@ NodeDedup::Role NodeDedup::ClaimImpl(const BlockKey& key, Kind kind, size_t cap,
     return Role::kFetch;
   }
   return Role::kFetch;  // no slot available: plain fetch, nothing to publish
+}
+
+bool NodeDedup::Owns(const BlockKey& key) const {
+  if (!coop_) return true;
+  // Same fields as Find()'s slot hash but folded to a partition id. Every rank
+  // computes this identically, so exactly one rank owns each key. key.size is
+  // excluded on purpose: it is a payload attribute, and lockstep peers may
+  // carry it differently on the auto path — ownership must not fork on it.
+  const uint64_t h = key.id ^ (key.id >> 32) ^ (static_cast<uint64_t>(key.index) * 0x9E3779B97F4A7C15ull);
+  return static_cast<int>(h % static_cast<uint64_t>(world_)) == rank_;
+}
+
+NodeDedup::Role NodeDedup::ClaimPassiveImpl(const BlockKey& key, Kind kind,
+                                            size_t cap, size_t strict_n,
+                                            char* dst, size_t* got) {
+  if (cap == 0 || cap > arena_bytes_ / 2) return Role::kFetch;  // oversize: no dedup
+  const uint64_t now = NowMs();
+  if (Slot* s = Find(key, kind)) {
+    const uint32_t st = s->state.load(std::memory_order_acquire);
+    if (st == kStateReady) {
+      if (now - s->fetch_start_ms.load(std::memory_order_relaxed) <=
+              static_cast<uint64_t>(ttl_ms_) &&
+          CopyOut(s, cap, strict_n, dst, got)) {
+        hits_.fetch_add(1, std::memory_order_relaxed);
+        return Role::kHit;
+      }
+      // Expired/torn: the OWNER refreshes it; we just wait for that.
+      return Role::kWait;
+    }
+    if (st == kStateFetching) {
+      const uint64_t started = s->fetch_start_ms.load(std::memory_order_relaxed);
+      if (now - started <= static_cast<uint64_t>(takeover_ms_)) return Role::kWait;
+      // Owner looks dead: same takeover CAS as the classic path, so a crashed
+      // owner cannot park its partition forever.
+      uint64_t expect = started;
+      if (s->fetch_start_ms.compare_exchange_strong(expect, now,
+                                                    std::memory_order_acq_rel)) {
+        fetches_.fetch_add(1, std::memory_order_relaxed);
+        return Role::kFetch;
+      }
+      return Role::kWait;
+    }
+  }
+  // No slot yet: the owner has not arrived. Never reserve from the passive
+  // side — WaitImpl spins on the missing slot and the caller's timeout
+  // fallback (direct fetch) bounds an owner that never comes.
+  return Role::kWait;
+}
+
+NodeDedup::Role NodeDedup::ClaimPassive(const BlockKey& key, size_t n, char* dst) {
+  return ClaimPassiveImpl(key, Kind::kData, n, n, dst, nullptr);
+}
+
+NodeDedup::Role NodeDedup::ClaimAutoPassive(const BlockKey& key, size_t cap,
+                                            char* dst, size_t* got) {
+  return ClaimPassiveImpl(key, Kind::kData, cap, kAnyLen, dst, got);
+}
+
+NodeDedup::Role NodeDedup::ClaimExistPassive(const BlockKey& key, bool* val) {
+  char b = 0;
+  const Role r = ClaimPassiveImpl(key, Kind::kExist, 1, 1, &b, nullptr);
+  if (r == Role::kHit && val) *val = (b != 0);
+  return r;
 }
 
 NodeDedup::Role NodeDedup::Claim(const BlockKey& key, size_t n, char* dst) {

--- a/src/client/node_dedup.h
+++ b/src/client/node_dedup.h
@@ -52,6 +52,20 @@ class NodeDedup {
     int wait_ms = 500;                     // DFKV_NODE_DEDUP_WAIT_MS
     int takeover_ms = 2000;                // DFKV_NODE_DEDUP_TAKEOVER_MS
     int ttl_ms = 5000;                     // DFKV_NODE_DEDUP_TTL_MS
+    // Cooperative fetch (DFKV_CLIENT_NODE_DEDUP=coop): keys are partitioned
+    // deterministically by hash(key) % world, and only the owning rank ever
+    // claims a fetch (others go straight to the wait path). Motivation: the
+    // classic claim RACE collapses under a real inference batch — the ranks'
+    // arrival spread (~12 ms) is far below a fetch batch (~44 ms), so the
+    // first-arriving rank claims essentially the WHOLE batch and the other 7
+    // serialize behind ONE fetcher (measured live: only r0/r1 ever touched the
+    // server; hot rounds went net-negative, v1.28.0 release notes). The
+    // partition keeps the 1x fabric traffic of the rendezvous AND N-way fetch
+    // parallelism: every rank fetches 1/N of the batch concurrently, publishes
+    // its shard, and copies the rest from shm.
+    bool coop = false;
+    int rank = -1;                 // this process's TP rank (coop only)
+    int world = 0;                 // TP size (coop only; coop needs world >= 2)
   };
 
   // Entry namespaces sharing one index: a key's data payload and its exist
@@ -59,9 +73,12 @@ class NodeDedup {
   enum class Kind : uint32_t { kData = 1, kExist = 2 };
 
   // Builds Options from the environment; returns nullptr (feature off) unless
-  // DFKV_CLIENT_NODE_DEDUP=1. model_hash namespaces the segment so distinct
-  // keyspaces on one host never share entries.
-  static std::unique_ptr<NodeDedup> FromEnv(uint64_t model_hash);
+  // DFKV_CLIENT_NODE_DEDUP is "1" (classic claim-race) or "coop" (cooperative
+  // partition; needs rank/world from the client identity — with world < 2 or an
+  // unknown rank it degrades to classic). model_hash namespaces the segment so
+  // distinct keyspaces on one host never share entries.
+  static std::unique_ptr<NodeDedup> FromEnv(uint64_t model_hash, int rank = -1,
+                                            int world = 0);
   // The env-derived segment name. The shm LAYOUT VERSION is part of the name:
   // a layout change must never collide with a segment an older lib left
   // behind — v1.23.0 shipped a layout bump behind the same name, the header
@@ -101,6 +118,19 @@ class NodeDedup {
   Role ClaimExist(const BlockKey& key, bool* val);
   bool WaitExist(const BlockKey& key, bool* val);
 
+  // ---- cooperative partition (Options::coop) ----
+  bool coop() const { return coop_; }
+  // Deterministic key ownership: FNV-1a(key filename) % world == rank. Every
+  // rank computes the same answer, so exactly one rank fetches each key.
+  bool Owns(const BlockKey& key) const;
+  // Non-owner claim: READY -> kHit, missing/FETCHING -> kWait (never reserves
+  // a slot; the owner may not have arrived yet and the wait path covers that).
+  // The one exception: a FETCHING slot stale beyond takeover_ms is taken over
+  // (kFetch) so a crashed owner cannot park its keys forever.
+  Role ClaimPassive(const BlockKey& key, size_t n, char* dst);
+  Role ClaimAutoPassive(const BlockKey& key, size_t cap, char* dst, size_t* got);
+  Role ClaimExistPassive(const BlockKey& key, bool* val);
+
   // Fetch outcomes for keys claimed as kFetch (kind selects the namespace;
   // exist publishes a 1-byte payload).
   void Publish(const BlockKey& key, Kind kind, const char* data, size_t n);
@@ -124,6 +154,8 @@ class NodeDedup {
   bool CopyOut(Slot* s, size_t cap, size_t strict_n, char* dst, size_t* got) const;
   Role ClaimImpl(const BlockKey& key, Kind kind, size_t cap, size_t strict_n,
                  char* dst, size_t* got);
+  Role ClaimPassiveImpl(const BlockKey& key, Kind kind, size_t cap,
+                        size_t strict_n, char* dst, size_t* got);
   bool WaitImpl(const BlockKey& key, Kind kind, size_t cap, size_t strict_n,
                 char* dst, size_t* got);
   static uint64_t NowMs();
@@ -136,6 +168,9 @@ class NodeDedup {
   int wait_ms_ = 500;
   int takeover_ms_ = 2000;
   int ttl_ms_ = 5000;
+  bool coop_ = false;
+  int rank_ = -1;
+  int world_ = 0;
   void* map_base_ = nullptr;
   size_t map_len_ = 0;
 

--- a/test/client/node_dedup_test.cc
+++ b/test/client/node_dedup_test.cc
@@ -252,3 +252,96 @@ TEST(NodeDedup, SegmentIsEagerlyBackedNotSparse) {
   EXPECT_GE(static_cast<uint64_t>(st.st_blocks) * 512, static_cast<uint64_t>(st.st_size))
       << "segment is sparse: a full tmpfs would SIGBUS at publish time";
 }
+
+// ---- cooperative partition (Options::coop) ----
+
+NodeDedup::Options CoopOpts(const std::string& name, int rank, int world) {
+  NodeDedup::Options o = Opts(name);
+  o.coop = true;
+  o.rank = rank;
+  o.world = world;
+  return o;
+}
+
+// Ownership is a pure function of the key: every rank computes the same
+// owner, the partition covers all keys, and no key has two owners.
+TEST(NodeDedupCoop, OwnershipPartitionsKeysDeterministically) {
+  ShmGuard g("coop-own");
+  auto r0 = NodeDedup::Open(CoopOpts(g.name, 0, 4));
+  auto r1 = NodeDedup::Open(CoopOpts(g.name, 1, 4));
+  auto r2 = NodeDedup::Open(CoopOpts(g.name, 2, 4));
+  auto r3 = NodeDedup::Open(CoopOpts(g.name, 3, 4));
+  ASSERT_TRUE(r0 && r1 && r2 && r3);
+  NodeDedup* ranks[4] = {r0.get(), r1.get(), r2.get(), r3.get()};
+  int owned[4] = {0, 0, 0, 0};
+  for (uint64_t id = 1; id <= 400; ++id) {
+    int owners = 0;
+    for (int r = 0; r < 4; ++r)
+      if (ranks[r]->Owns(K(id))) { ++owners; ++owned[r]; }
+    EXPECT_EQ(owners, 1) << "key " << id;
+  }
+  for (int r = 0; r < 4; ++r)  // roughly balanced (no rank starved)
+    EXPECT_GT(owned[r], 40) << "rank " << r;
+}
+
+// The passive side never reserves: arriving FIRST it still waits, the owner
+// arriving later claims the fetch, publishes, and the waiter copies. This is
+// the exact inversion of the classic race (first arrival claims everything)
+// that serialized real inference batches.
+TEST(NodeDedupCoop, NonOwnerNeverClaimsEvenWhenFirst) {
+  ShmGuard g("coop-passive");
+  auto a = NodeDedup::Open(CoopOpts(g.name, 0, 2));
+  auto b = NodeDedup::Open(CoopOpts(g.name, 1, 2));
+  ASSERT_TRUE(a && b);
+  // Find a key owned by rank 1.
+  uint64_t id = 1;
+  while (!b->Owns(K(id))) ++id;
+  const std::string v = Val(id, 4096);
+  std::string dst(v.size(), '\0');
+
+  // Non-owner (rank 0) arrives FIRST: must wait, not claim.
+  EXPECT_EQ(a->ClaimPassive(K(id), v.size(), dst.data()), NodeDedup::Role::kWait);
+  // Owner arrives: claims the fetch.
+  std::string bdst(v.size(), '\0');
+  ASSERT_EQ(b->Claim(K(id), v.size(), bdst.data()), NodeDedup::Role::kFetch);
+  b->Publish(K(id), NodeDedup::Kind::kData, v.data(), v.size());
+  // Waiter's wait path lands the payload.
+  EXPECT_TRUE(a->WaitCopy(K(id), v.size(), dst.data()));
+  EXPECT_EQ(dst, v);
+  // A later passive claim is a straight hit.
+  std::string dst2(v.size(), '\0');
+  EXPECT_EQ(a->ClaimPassive(K(id), v.size(), dst2.data()), NodeDedup::Role::kHit);
+  EXPECT_EQ(dst2, v);
+}
+
+// A crashed owner cannot park its partition: past takeover_ms the passive
+// side takes the fetch over, same as the classic dead-fetcher path.
+TEST(NodeDedupCoop, PassiveTakesOverDeadOwner) {
+  ShmGuard g("coop-takeover");
+  auto a = NodeDedup::Open(CoopOpts(g.name, 0, 2));
+  auto b = NodeDedup::Open(CoopOpts(g.name, 1, 2));
+  ASSERT_TRUE(a && b);
+  uint64_t id = 1;
+  while (!b->Owns(K(id))) ++id;
+  const std::string v = Val(id, 1024);
+  std::string dst(v.size(), '\0');
+  // Owner claims then "dies" (never publishes).
+  ASSERT_EQ(b->Claim(K(id), v.size(), dst.data()), NodeDedup::Role::kFetch);
+  std::this_thread::sleep_for(250ms);  // > takeover_ms (200)
+  // Passive side takes over the stale FETCHING slot.
+  EXPECT_EQ(a->ClaimPassive(K(id), v.size(), dst.data()), NodeDedup::Role::kFetch);
+}
+
+// FromEnv: "coop" without usable rank/world degrades to the classic mode
+// (dedup on, coop off) instead of silently owning nothing.
+TEST(NodeDedupCoop, FromEnvDegradesWithoutRank) {
+  ::setenv("DFKV_CLIENT_NODE_DEDUP", "coop", 1);
+  auto d = NodeDedup::FromEnv(0xC0FFEE, /*rank=*/-1, /*world=*/0);
+  ASSERT_TRUE(d);
+  EXPECT_FALSE(d->coop());
+  auto d2 = NodeDedup::FromEnv(0xC0FFEE, /*rank=*/3, /*world=*/8);
+  ASSERT_TRUE(d2);
+  EXPECT_TRUE(d2->coop());
+  ::unsetenv("DFKV_CLIENT_NODE_DEDUP");
+  ::shm_unlink(NodeDedup::EnvSegmentName(0xC0FFEE).c_str());
+}


### PR DESCRIPTION
## Why

The v1.26→v1.28 dedup arc left a hole: **claim-race rendezvous serializes** (arrival spread ~12 ms ≪ fetch batch ~44 ms → first rank claims the whole batch, hot rounds −60%, hence v1.28's default-off), while **plain dedup-off pays N× read amplification** (measured 3.6× effective — 15.5 TB read for a 4.3 TB demand on the GLM-5.2 TP8 campaign).

Cooperative mode keeps both halves: deterministic key partition (`hash % world`), each rank fetches only its 1/N shard (N-way parallel, latency stays inside SGLang's prefetch window), publishes to the existing shm arena, and copies the rest from peers — every byte crosses the fabric **once**.

## Design

- `DFKV_CLIENT_NODE_DEDUP=coop` opt-in; **default unchanged** (off). Unusable rank/world → classic mode + INFO log.
- rank/world from the client identity header (tp_rank/tp_size, plumbed since CLIENT_RANKS).
- `ClaimPassive*` for non-owners: READY→hit, missing/FETCHING→wait; stale-FETCHING takeover (dead owner can't park its partition); **never reserves** — owner-never-arrives is bounded by the existing wait-timeout → direct-fetch fallback.
- Wrapper routing only (BatchGet/BatchGetAuto/BatchExists); shm layout/ABI untouched.

## Failure model

Every new path degrades to today's behavior: passive wait timeout → direct fetch; owner crash → takeover after `takeover_ms`; coop misconfig → classic mode. Nothing is load-bearing.

## Tests

4 new cases (partition completeness/uniqueness/balance; first-arriving non-owner waits; dead-owner takeover; FromEnv degradation). Full suite **364/364** local.

## Validation plan

Real-HW A/B on the bj09 glm-b2 B200 ring (coop vs off, C10/C30 hot rounds) before merge — expecting parity throughput at ~1/8 server read volume; results will be posted here.