### PR TITLE
feat(metrics): sample uring GET completion latency into op="get"

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -255,8 +255,8 @@ int main(int argc, char** argv) {
           return st;
         });
     rsrv->set_range_complete_handler(
-        [&srv](bool ok, size_t bytes_read) {
-          srv.RangeDirectComplete(ok, bytes_read);
+        [&srv](bool ok, size_t bytes_read, double elapsed_sec) {
+          srv.RangeDirectComplete(ok, bytes_read, elapsed_sec);
         });
     // RAM hot tier (P3 B5-3): when enabled, register the arena as a pool MR and
     // wire the zero-copy serve hooks so a RAM hit is scatter-sent straight from

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -592,13 +592,18 @@ Status KvNodeServer::RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize
   return st;
 }
 
-void KvNodeServer::RangeDirectComplete(bool ok, size_t bytes_read) {
+void KvNodeServer::RangeDirectComplete(bool ok, size_t bytes_read,
+                                       double elapsed_sec) {
   if (ok) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
     bytes_read_.fetch_add(bytes_read, std::memory_order_relaxed);
   } else {
     get_io_err_.fetch_add(1, std::memory_order_relaxed);
   }
+  // Sample the async (uring) read latency into the SAME op="get" histogram the
+  // synchronous RangeDirect feeds — before this the default read path since
+  // v1.27.0 contributed no latency samples at all.
+  if (lat_sampler_.ShouldSample()) get_lat_.Observe(elapsed_sec);
 }
 
 bool KvNodeServer::RamRangePrep(uint64_t id, uint32_t index, uint32_t ksize,

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -107,7 +107,9 @@ class KvNodeServer {
                          uint64_t offset, uint64_t length, size_t io_cap,
                          KVStore::RangePrep* out);
   // Account a completed prep-based GET (called after the async read finishes).
-  void RangeDirectComplete(bool ok, size_t bytes_read);
+  // elapsed_sec = submit->completion wall time; sampled into get_lat_ so the
+  // default (uring) read path is no longer absent from op="get" latency.
+  void RangeDirectComplete(bool ok, size_t bytes_read, double elapsed_sec);
   // Balance a prep whose RangePrep::token != 0 (slab pins the slot across the
   // async read); routed to the owning engine via the token's disk-index byte.
   void RangePrepRelease(uint64_t token) { group_.RangeRelease(token); }

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
@@ -35,6 +36,14 @@ namespace {
 static_assert(wire_limits::kIoAlign == rdma::kDirectIoAlign,
               "wire_limits must mirror the RDMA direct-IO alignment");
 using wire_limits::ResolveMaxPayload;
+
+// Monotonic seconds for the async-read submit->complete latency stamp. Read
+// twice per deferred GET (prep + completion), both off the SSD-bound path, so
+// the vDSO clock read is amortized away.
+inline double NowSteadySec() {
+  return std::chrono::duration<double>(
+             std::chrono::steady_clock::now().time_since_epoch()).count();
+}
 
 size_t ControlCapFor(size_t max_payload) {
   constexpr size_t kDefaultControlCap = 8u << 20;
@@ -504,6 +513,10 @@ void RdmaServer::Serve(int boot_fd) {
         uint64_t prep_token = 0;  // slab slot hold; released where fd is closed
         size_t head = 0;
         size_t payload_len = 0;
+        // Steady-clock seconds at prep (read submit), 0 = unsampled. Only the
+        // 1/64-sampled async reads are stamped; completion observes get_lat_ so
+        // the default uring read path is no longer latency-blind.
+        double submit_sec = 0.0;
         Reply reply;         // used when read_idx < 0
       };
       std::vector<UringReader::ReadDesc> descs;
@@ -568,6 +581,7 @@ void RdmaServer::Serve(int boot_fd) {
               qd.prep_token = pr.release_token;
               qd.head = pr.head;
               qd.payload_len = pr.payload_len;
+              qd.submit_sec = NowSteadySec();  // read submit -> completion latency
               deferred = true;
             } else if (pst == Status::kOk && pr.fd >= 0) {
               ::close(pr.fd);  // zero-len / oversize: handled by sync build below
@@ -646,7 +660,8 @@ void RdmaServer::Serve(int boot_fd) {
             qd.prep_token = 0;
           }
           if (range_complete_handler_)
-            range_complete_handler_(ok, ok ? qd.payload_len : 0);
+            range_complete_handler_(ok, ok ? qd.payload_len : 0,
+                                    NowSteadySec() - qd.submit_sec);
           char* sb = ep.sbuf(qd.send_slot);
           if (ok) {
             EncodeResp(sb, Status::kOk, qd.payload_len);

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -71,7 +71,14 @@ class RdmaServer {
       uint64_t length, size_t io_cap, RangePrepResult* out)>;
   // Optional accounting hook invoked once an async read completes (mirrors the
   // hit/io-error counters the synchronous RangeDirect bumps).
-  using RangeCompleteHandler = std::function<void(bool ok, size_t bytes_read)>;
+  // elapsed_sec = wall time from prep (read submit) to completion, so the
+  // accounting hook can observe the default (uring) path's disk-read latency —
+  // the synchronous RangeDirect samples get_lat_ itself, but the async path
+  // never did, leaving dfkv_op_latency_seconds{op="get"} blind to the default
+  // read path since v1.27.0. Negative/zero-cost when the sampler skips (the
+  // serve loop only stamps sampled reads).
+  using RangeCompleteHandler =
+      std::function<void(bool ok, size_t bytes_read, double elapsed_sec)>;
   // Releases a prep's release_token (slab slot pin) once its read is done.
   using RangeReleaseHandler = std::function<void(uint64_t token)>;
 

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -897,7 +897,9 @@ struct RdmaUringNode {
           return st;
         });
     rsrv->set_range_complete_handler(
-        [this](bool ok, size_t bytes) { srv->RangeDirectComplete(ok, bytes); });
+        [this](bool ok, size_t bytes, double elapsed_sec) {
+          srv->RangeDirectComplete(ok, bytes, elapsed_sec);
+        });
     EXPECT_EQ(rsrv->Start(0), Status::kOk);
     addr = "127.0.0.1:" + std::to_string(rsrv->port());
   }
@@ -994,6 +996,18 @@ TEST(RdmaLoopback, UringAsyncGetManyConcurrentInOrder) {
       EXPECT_FALSE(mgr[i]) << "absent key should miss: " << mkeys[i];
     }
   }
+
+  // The async (uring) read path now feeds op="get" latency: after this many
+  // disk-backed GETs the 1/64 sampler must have recorded at least one sample,
+  // where before this change the default read path was latency-blind. (When the
+  // shell forces DFKV_SERVER_URING=0 the sync RangeDirect samples the same
+  // series, so the assertion holds through both serve loops.)
+  const std::string mtext = node.srv->MetricsText();
+  auto gp = mtext.find("dfkv_op_latency_seconds_count{op=\"get\"}");
+  ASSERT_NE(gp, std::string::npos) << mtext;
+  long gcnt = std::stol(mtext.substr(
+      gp + std::string("dfkv_op_latency_seconds_count{op=\"get\"}").size()));
+  EXPECT_GT(gcnt, 0) << "uring GET path recorded no op=\"get\" latency sample";
 
   ::unsetenv("DFKV_SERVER_URING");
   ::unsetenv("DFKV_SERVER_URING_DEPTH");


### PR DESCRIPTION
Second of two default-path observability gaps found auditing the uring/RDMA read path (companion to #185 exist latency).

## Gap

The io_uring async read path (opt-in v1.20.0, **default-on v1.27.0**) never fed the `op="get"` latency histogram. The synchronous `RangeDirect` samples `get_lat_` itself, but `RangeDirectComplete` — the async accounting hook — only bumped hit/bytes/io-err counters. So `dfkv_op_latency_seconds{op="get"}` has been **blind to the default read path for two minor versions**, reflecting only RAM hits and the sync fallback.

## Change

The serve loop stamps a steady-clock second at read submit (prep) into the `Queued` entry and passes submit→completion `elapsed` to the completion handler; `RangeDirectComplete` samples it into the same 1/64 `get_lat_` the sync path uses. Two vDSO clock reads per deferred GET, both off the SSD-bound path.

`RangeCompleteHandler` gains an `elapsed_sec` arg (rdma_server → kv_node_server → main + the rdma_loopback test node).

## Why it matters

Together with #185 (exist latency), this makes the L3 read path's tail — the thing behind the **307s exist tail** seen in production (bj09 glm-b2 B200) — actually visible in metrics. You can't root-cause a tail the default path doesn't sample.

## Test

The uring async-GET loopback test now asserts `op="get"` recorded a latency sample. Verified locally on **Soft-RoCE (rdma_rxe)** through **both serve loops** — `DFKV_SERVER_URING=1` (async) and `=0` (sync fallback). Non-RDMA full suite **360/360**.

_(Note: `PipelinedPoolDepth` fails on my local rxe loopback with pool depth 16 vs 64 — reproduced identically on clean upstream/main, so it's an environment artifact of my Soft-RoCE setup, unrelated to this change. CI's rxe job is the source of truth.)_