### PR TITLE
feat(hicache): hot-reload access_log via control-file watcher

### DIFF
--- a/deploy/sync_telemetry.sh
+++ b/deploy/sync_telemetry.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Single source of truth for the dfkv telemetry package is
-# integration/hicache/dfkv_telemetry/ (shipped alongside the SGLang HiCache
-# plugin, which imports it unvendored). The vLLM and LMCache connectors are
-# independent pip wheels that can't import a repo-level module at runtime, so
-# they vendor a byte-identical copy as an internal _telemetry sub-package. Run
-# this after editing the canonical files; CI guards against drift via
-# test/python/test_telemetry_vendor_sync.py.
+# Single source of truth for shared connector modules lives alongside the SGLang
+# HiCache plugin (which imports them unvendored): the dfkv_telemetry package and
+# the dfkv_hot_config watcher. The vLLM and LMCache connectors are independent
+# pip wheels that can't import a repo-level module at runtime, so they vendor a
+# byte-identical copy (dfkv_telemetry -> _telemetry/, dfkv_hot_config.py ->
+# _hot_config.py). Run this after editing the canonical files; CI guards against
+# drift via test/python/test_telemetry_vendor_sync.py.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -22,4 +22,15 @@ for dst in "${DSTS[@]}"; do
     cp "$SRC/$f" "$dst/$f"
   done
   echo "synced $SRC -> $dst"
+done
+
+# Standalone hot-config watcher module -> _hot_config.py in each package root.
+HOT_SRC="integration/hicache/dfkv_hot_config.py"
+HOT_DSTS=(
+  "integration/vllm/src/dfkv_vllm/_hot_config.py"
+  "integration/lmcache/src/dfkv_connector/_hot_config.py"
+)
+for dst in "${HOT_DSTS[@]}"; do
+  cp "$HOT_SRC" "$dst"
+  echo "synced $HOT_SRC -> $dst"
 done

--- a/docs/access_log.md
+++ b/docs/access_log.md
@@ -39,7 +39,8 @@
 
 - 开关取值接受 `1/true/yes/on`（大小写不敏感）或 JSON 里的 `1`/布尔。
 - `access_log_threshold_us` 设成比如 `1000`，则只记录耗时 ≥ 1ms 的操作，排查长尾很方便。
-- 配置在插件 `__init__` 里**运行时解析一次**（每进程首个实例生效，幂等）；不像 dingofs 在 import 时读 env。
+- 配置在插件 `__init__` 里**解析一次**作为「启动基线」（每进程首个实例生效，幂等）；不像 dingofs 在 import 时读 env。
+- **不重启也能开关**：设了 `DFKV_HOT_CONFIG` 后，`access_log` / `access_log_path` / `access_log_threshold_us` 等可通过控制文件**运行时热生效**，见下文 [运行时热开关](#运行时热开关不重启-sglang)。
 
 ## 日志滚动与清理（自动，无需 logrotate）
 
@@ -97,6 +98,45 @@ SGLang 每个 TP rank 一个进程，会**同时写同一路径**。为避免互
 
 所以上面方式 A/B 配 `access.log`，rank 0 的实际文件是 `access.log.r0`。
 
+## 运行时热开关（不重启 SGLang）
+
+access log 的启动基线在插件 `__init__` 解析后，`access_log()` 每次调用**都读模块级开关**，所以只要能在运行时翻转开关就能免重启生效。dfkv 用**控制文件 + 后台 watcher 线程**实现（`dfkv_hot_config.py`），不占端口、不用信号、TP8 八个 rank 读同一文件一次全生效。
+
+**默认关闭（opt-in）**：只有显式设置了控制文件路径（`DFKV_HOT_CONFIG` 环境变量或 `extra_config` 的 `hot_config_path`）才会启动 watcher；没设则一切照旧、零新线程零开销。
+
+> ⚠️ 热开关目前**仅 SGLang HiCache 连接器**支持。vLLM 直连 / LMCache 连接器的 `DFKV_ACCESS_LOG_*` 仍是启动期一次性解析，改了要重启（其 access log 行格式与本文一致，仅无热加载）。
+
+| 作用 | `extra_config` 键 | 环境变量 | 默认 |
+|---|---|---|---|
+| 控制文件路径（**设了才开热加载**） | `hot_config_path` | `DFKV_HOT_CONFIG` | 空 → 热加载关闭 |
+| 轮询周期（秒） | `hot_config_poll_s` | `DFKV_HOT_CONFIG_POLL_S` | `5.0`；`≤0` 关闭 |
+
+**用法**：启动时只需多给一个控制文件路径（值本身可以先不存在）：
+
+```bash
+DFKV_HOT_CONFIG=/etc/dfkv/hot.json \
+DFKV_ACCESS_LOG_PATH=/var/log/dfkv/access.log \
+sglang serve ...        # 启动时 access_log 仍是关的
+```
+
+事故来了要抓日志时，**不重启**，写一下控制文件即可（最多 `hot_config_poll_s` 秒后八个 rank 全部生效）：
+
+```bash
+# 开（只抓 ≥1ms 的慢调用，减量）
+echo '{"access_log": true, "access_log_threshold_us": 1000}' > /etc/dfkv/hot.json
+# 排查完关掉：删文件即完全回到启动基线（此处基线是「关」）
+rm -f /etc/dfkv/hot.json
+```
+
+**语义**：控制文件是「实时覆盖层」，叠加在启动基线之上——
+
+- 文件里**出现**的键覆盖启动值；**缺失**的键回落到启动基线值。
+- **删除文件 = 清空覆盖**，所有热 knob 干净回到启动基线（上例即回到「关」）。
+- 文件格式错误会被**忽略**（保留上一份好配置）并下个周期重试，不会中断服务。
+- `access_log_path` / 滚动参数变了会安全重建 sink（旧 listener 先停），不双写。
+
+**范围（Phase 1）**：只有**零正确性影响的观测类** knob 可热生效——目前是 access_log 家族。结构/连接类（`rdma` / `lib` / `register` / `node_dedup`）和 **C 客户端里 `static const` 缓存的** knob（`peer_cooldown` / `get_miss_retries` / `node_dedup_log` …）**仍需重启**：它们在 native 客户端构造期或首个 op 就冻结了，Python 侧翻转 env 无效，属单独的 native 改动（Phase 2）。
+
 ## 日志格式与各 op 的结果含义
 
 `<op>(<参数>) : <结果> <耗时秒>`。覆盖的接口与对应 `<结果>`：
@@ -130,10 +170,14 @@ SGLang 每个 TP rank 一个进程，会**同时写同一路径**。为避免互
 DFKV_BUILD=$(pwd)/build python3 test/python/test_dfkv_hicache.py   # 含 access-log + 滚动用例
 # 滚动用例不依赖 node/so，可单独快速跑：
 python3 -m unittest test_dfkv_hicache.DfkvAccessLogRotationTest -v
+# 热开关（纯 Python，无需 node/so/GPU）：
+python3 -m unittest test_dfkv_hot_config -v
 ```
 
 ## 实现位置
 
-- [integration/hicache/dfkv_access_log.py](../integration/hicache/dfkv_access_log.py) — `configure()` / `access_log()` 上下文管理器、noop 单例、异步队列、格式化辅助。
-- [integration/hicache/dfkv_hicache.py](../integration/hicache/dfkv_hicache.py) — `__init__` 里调 `configure()`，并用 `with access_log(...)` 包住各继承接口。
+- [integration/hicache/dfkv_access_log.py](../integration/hicache/dfkv_access_log.py) — `configure()`（启动基线，幂等）/ `apply_hot()`（热覆盖）/ `access_log()` 上下文管理器、noop 单例、异步队列、格式化辅助。
+- [integration/hicache/dfkv_hot_config.py](../integration/hicache/dfkv_hot_config.py) — 控制文件 watcher（后台守护线程）+ 通用 `register()` 注册表；opt-in（`DFKV_HOT_CONFIG` 设了才启动）。
+- [integration/hicache/dfkv_hicache.py](../integration/hicache/dfkv_hicache.py) — `__init__` 里调 `configure()`、`register("access_log", apply_hot)` 并 `start()` watcher，并用 `with access_log(...)` 包住各继承接口。
 - [test/python/test_dfkv_hicache.py](../test/python/test_dfkv_hicache.py) — `DfkvAccessLogTest`（接口逐 op 日志）+ `DfkvAccessLogRotationTest`（滚动/清理）测试类。
+- [test/python/test_dfkv_hot_config.py](../test/python/test_dfkv_hot_config.py) — 热开关 + watcher 文件生命周期（纯 Python，无 native 依赖）。

--- a/docs/access_log.md
+++ b/docs/access_log.md
@@ -104,7 +104,7 @@ access log 的启动基线在插件 `__init__` 解析后，`access_log()` 每次
 
 **默认关闭（opt-in）**：只有显式设置了控制文件路径（`DFKV_HOT_CONFIG` 环境变量或 `extra_config` 的 `hot_config_path`）才会启动 watcher；没设则一切照旧、零新线程零开销。
 
-> ⚠️ 热开关目前**仅 SGLang HiCache 连接器**支持。vLLM 直连 / LMCache 连接器的 `DFKV_ACCESS_LOG_*` 仍是启动期一次性解析，改了要重启（其 access log 行格式与本文一致，仅无热加载）。
+> ✅ **三个连接器都支持**（SGLang HiCache / vLLM 直连 / LMCache）——同一个 `DFKV_HOT_CONFIG` 控制文件、同一套语义。vLLM/LMCache 连接器在客户端 `__init__` 里读启动基线（env 驱动）后即挂 watcher；控制文件里同样只有 `access_log` 家族这些观测 knob 会热生效。
 
 | 作用 | `extra_config` 键 | 环境变量 | 默认 |
 |---|---|---|---|
@@ -172,12 +172,15 @@ DFKV_BUILD=$(pwd)/build python3 test/python/test_dfkv_hicache.py   # 含 access-
 python3 -m unittest test_dfkv_hicache.DfkvAccessLogRotationTest -v
 # 热开关（纯 Python，无需 node/so/GPU）：
 python3 -m unittest test_dfkv_hot_config -v
+# vLLM/LMCache 连接器热开关 + vendored watcher 一致性：
+python3 -m unittest test_connector_access_log_hot test_telemetry_vendor_sync -v
 ```
 
 ## 实现位置
 
 - [integration/hicache/dfkv_access_log.py](../integration/hicache/dfkv_access_log.py) — `configure()`（启动基线，幂等）/ `apply_hot()`（热覆盖）/ `access_log()` 上下文管理器、noop 单例、异步队列、格式化辅助。
-- [integration/hicache/dfkv_hot_config.py](../integration/hicache/dfkv_hot_config.py) — 控制文件 watcher（后台守护线程）+ 通用 `register()` 注册表；opt-in（`DFKV_HOT_CONFIG` 设了才启动）。
+- [integration/hicache/dfkv_hot_config.py](../integration/hicache/dfkv_hot_config.py) — **canonical** 控制文件 watcher（后台守护线程）+ 通用 `register()` 注册表；opt-in（`DFKV_HOT_CONFIG` 设了才启动）。vLLM/LMCache 各 vendor 一份 byte-identical 的 `_hot_config.py`（`deploy/sync_telemetry.sh` 同步，`test/python/test_telemetry_vendor_sync.py` 守门）。
+- vLLM/LMCache 连接器的 `access_log.py`（各自独立文件，机制同 hicache）+ `_hot_config.py`（vendored），接线在 `dfkv_client.py` / `native_client.py` 的 `__init__`（`configure`+`register`+`start`）与 `close()`（`stop`）。
 - [integration/hicache/dfkv_hicache.py](../integration/hicache/dfkv_hicache.py) — `__init__` 里调 `configure()`、`register("access_log", apply_hot)` 并 `start()` watcher，并用 `with access_log(...)` 包住各继承接口。
 - [test/python/test_dfkv_hicache.py](../test/python/test_dfkv_hicache.py) — `DfkvAccessLogTest`（接口逐 op 日志）+ `DfkvAccessLogRotationTest`（滚动/清理）测试类。
 - [test/python/test_dfkv_hot_config.py](../test/python/test_dfkv_hot_config.py) — 热开关 + watcher 文件生命周期（纯 Python，无 native 依赖）。

--- a/integration/hicache/dfkv_access_log.py
+++ b/integration/hicache/dfkv_access_log.py
@@ -54,15 +54,25 @@ import logging.handlers
 import os
 import queue
 import sys
+import threading
 import time
 from typing import Any, Callable, Optional
 
-# Module state, populated by configure() (first call in the process wins).
+# Module state. configure() (first call in the process) snapshots the launch
+# config; apply_hot() (from the hot-config watcher thread, dfkv_hot_config) may
+# re-apply it later, so all mutating paths take _lock. access_log() reads
+# _ENABLED / _THRESHOLD_US WITHOUT the lock — plain bool/int reads under the GIL;
+# a stale read at worst mislabels one op, acceptable for a diagnostic log.
 _ENABLED: bool = False
 _THRESHOLD_US: int = 0
 _logger: Optional[logging.Logger] = None
 _listener: Optional[logging.handlers.QueueListener] = None
 _configured: bool = False
+_lock = threading.Lock()
+_sink_want: Optional[tuple] = None   # (path, max_bytes, backup_count) the live sink was built for
+_launch_cfg: dict = {}               # snapshot from configure(); apply_hot() layers file overrides on top
+_tp_rank: int = 0
+_model: str = ""
 
 
 def _truthy(v: Any) -> bool:
@@ -89,32 +99,27 @@ def _stop_listener(listener) -> None:
         listener.stop()
 
 
-def configure(cfg: Optional[dict], tp_rank: int = 0, model: str = "") -> None:
-    """Initialize the access logger from an extra_config dict (runtime).
-
-    Idempotent: the first call in the process builds (or skips) the logger and
-    later calls are no-ops, so it is safe to call from every
-    ``DfkvHiCache.__init__``. In SGLang each process owns one backend instance,
-    so divergent configs in one process don't occur in practice.
-    """
-    global _ENABLED, _THRESHOLD_US, _logger, _listener, _configured
-    if _configured:
-        return
-    _configured = True
-
-    cfg = cfg or {}
-    enabled = _truthy(_resolve(cfg, "access_log", "DFKV_ACCESS_LOG_ENABLED", False))
-    path = str(_resolve(cfg, "access_log_path", "DFKV_ACCESS_LOG_PATH", "")).strip()
+def _int(cfg: dict, key: str, env: str, default: int) -> int:
     try:
-        _THRESHOLD_US = int(_resolve(cfg, "access_log_threshold_us",
-                                     "DFKV_ACCESS_LOG_THRESHOLD_US", 0))
+        return int(_resolve(cfg, key, env, default))
     except (TypeError, ValueError):
-        _THRESHOLD_US = 0
+        return default
 
-    if not enabled:
-        _ENABLED = False
-        return
 
+def _build_sink(path: str, max_bytes: int, backup_count: int,
+                tp_rank: int, model: str) -> None:
+    """(Re)build the logger + async QueueListener for the given sink params.
+
+    Tears down any previous listener/handlers first so a hot path change never
+    double-writes. Sets _logger / _listener. Caller holds _lock.
+
+    Size-based rotation keeps an enabled log from growing a single file
+    unbounded: at max_bytes it rolls acc.log -> acc.log.1 -> ... up to
+    backup_count, then overwrites the oldest (disk per rank bounded by
+    max_bytes * (backup_count + 1)). max_bytes=0 disables rotation (legacy
+    single unbounded file, an escape hatch).
+    """
+    global _logger, _listener
     if path:
         if "{rank}" in path or "{model}" in path:
             path = path.format(rank=tp_rank, model=model)
@@ -122,32 +127,6 @@ def configure(cfg: Optional[dict], tp_rank: int = 0, model: str = "") -> None:
             # auto-suffix so per-rank processes never share one file:
             # access.log -> access.log.r0, access.log.r1, ...
             path = f"{path}.r{tp_rank}"
-
-    log = logging.getLogger("dfkv.access")
-    log.setLevel(logging.INFO)
-    log.propagate = False  # keep out of root logger / SGLang's stack
-    if log.handlers:  # already configured (defensive, e.g. on re-import)
-        _logger = log
-        _ENABLED = True
-        return
-
-    # Size-based rotation so an enabled access log can never grow a single file
-    # unbounded. max_bytes=0 disables rotation (legacy single-file behavior, an
-    # escape hatch). Disk per rank is bounded by max_bytes * (backup_count + 1).
-    try:
-        max_bytes = int(_resolve(cfg, "access_log_max_bytes",
-                                 "DFKV_ACCESS_LOG_MAX_BYTES", 128 * 1024 * 1024))
-    except (TypeError, ValueError):
-        max_bytes = 128 * 1024 * 1024
-    try:
-        backup_count = int(_resolve(cfg, "access_log_backup_count",
-                                    "DFKV_ACCESS_LOG_BACKUP_COUNT", 5))
-    except (TypeError, ValueError):
-        backup_count = 5
-    if max_bytes < 0:
-        max_bytes = 0
-    if backup_count < 0:
-        backup_count = 0
 
     if path:
         try:
@@ -169,6 +148,15 @@ def configure(cfg: Optional[dict], tp_rank: int = 0, model: str = "") -> None:
                           datefmt="%Y-%m-%d %H:%M:%S")
     )
 
+    # Tear down a prior listener/handlers (a hot path/rotation change rebuilds).
+    _stop_listener(_listener)
+    _listener = None
+    log = logging.getLogger("dfkv.access")
+    log.setLevel(logging.INFO)
+    log.propagate = False  # keep out of root logger / SGLang's stack
+    for h in list(log.handlers):
+        log.removeHandler(h)
+
     # Unbounded queue: enqueueing never blocks; if the listener can't keep up
     # we'd rather grow memory than stall the hot path. In practice the queue
     # stays empty because emit is ~10 us and ops are ~ms.
@@ -176,10 +164,69 @@ def configure(cfg: Optional[dict], tp_rank: int = 0, model: str = "") -> None:
     _listener = logging.handlers.QueueListener(q, sink, respect_handler_level=False)
     _listener.start()
     atexit.register(_stop_listener, _listener)
-
     log.addHandler(logging.handlers.QueueHandler(q))
     _logger = log
+
+
+def _apply(cfg: Optional[dict], tp_rank: int, model: str) -> None:
+    """Resolve the access-log knobs from cfg and (re)apply them. Caller holds
+    _lock. Enables/disables live; builds the sink lazily on first enable and
+    rebuilds only when path/rotation params change."""
+    global _ENABLED, _THRESHOLD_US, _sink_want
+    cfg = cfg or {}
+    _THRESHOLD_US = max(0, _int(cfg, "access_log_threshold_us",
+                                "DFKV_ACCESS_LOG_THRESHOLD_US", 0))
+    if not _truthy(_resolve(cfg, "access_log", "DFKV_ACCESS_LOG_ENABLED", False)):
+        _ENABLED = False   # keep the sink around for a cheap re-enable
+        return
+    path = str(_resolve(cfg, "access_log_path", "DFKV_ACCESS_LOG_PATH", "")).strip()
+    max_bytes = _int(cfg, "access_log_max_bytes", "DFKV_ACCESS_LOG_MAX_BYTES",
+                     128 * 1024 * 1024)
+    backup_count = _int(cfg, "access_log_backup_count",
+                        "DFKV_ACCESS_LOG_BACKUP_COUNT", 5)
+    if max_bytes < 0:
+        max_bytes = 0
+    if backup_count < 0:
+        backup_count = 0
+    want = (path, max_bytes, backup_count)
+    if _logger is None or _sink_want != want:
+        _build_sink(path, max_bytes, backup_count, tp_rank, model)
+        _sink_want = want
     _ENABLED = True
+
+
+def configure(cfg: Optional[dict], tp_rank: int = 0, model: str = "") -> None:
+    """Initialize the access logger from an extra_config dict (runtime).
+
+    Idempotent: the first call in the process snapshots the launch config and
+    applies it; later calls are no-ops, so it is safe to call from every
+    ``DfkvHiCache.__init__``. The snapshot lets :func:`apply_hot` (driven by the
+    dfkv_hot_config file watcher) layer live file overrides on top and revert
+    cleanly to launch behavior when the control file is removed.
+    """
+    global _configured, _launch_cfg, _tp_rank, _model
+    with _lock:
+        if _configured:
+            return
+        _configured = True
+        _launch_cfg = dict(cfg or {})
+        _tp_rank = tp_rank
+        _model = model
+        _apply(_launch_cfg, tp_rank, model)
+
+
+def apply_hot(overrides: Optional[dict]) -> None:
+    """Re-apply access-log knobs from a dict of live control-file overrides,
+    layered over the launch config (absent key -> launch default, so deleting
+    the control file reverts everything). Thread-safe; called by the
+    dfkv_hot_config watcher. No-op before :func:`configure` has run."""
+    with _lock:
+        if not _configured:
+            return
+        merged = dict(_launch_cfg)
+        if overrides:
+            merged.update(overrides)
+        _apply(merged, _tp_rank, _model)
 
 
 def is_enabled() -> bool:

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -28,8 +28,10 @@ from typing import List, Optional
 from sglang.srt.mem_cache.hicache_storage import HiCacheStorage, HiCacheStorageConfig
 
 from dfkv_access_log import (access_log, configure as _configure_access_log,
+                            apply_hot as _access_log_apply_hot,
                             fmt_bytes as _fmt_bytes, fmt_pools as _fmt_pools,
                             fmt_pool_results as _fmt_pool_results)
+import dfkv_hot_config as _hot_config
 from dfkv_metrics import Metrics as _Metrics, ClientStatsPoller as _ClientStatsPoller
 from dfkv_telemetry import metrics as _push_metrics, config as _tcfg
 from dfkv_telemetry import tracing as _tracing
@@ -198,6 +200,11 @@ class DfkvHiCache(HiCacheStorage):
         # Access log: idempotent per process (first instance wins). Configured
         # here so tp_rank/model are available for the {rank} path placeholder.
         _configure_access_log(cfg, tp_rank=self.tp_rank, model=self.model)
+        # Hot-reload: a background watcher lets ops flip access_log (and future
+        # observability knobs) live via a control file — no SGLang restart. Only
+        # zero-correctness-impact knobs are hot; structural/native knobs are not.
+        _hot_config.register("access_log", _access_log_apply_hot)
+        _hot_config.start(cfg, tp_rank=self.tp_rank)
         self._alog_tag = f"r{self.tp_rank}"
         # Client-side read/write counters (Prometheus when available). Lets ops
         # confirm SGLang->dfkv volume from /metrics instead of parsing access logs.
@@ -377,6 +384,10 @@ class DfkvHiCache(HiCacheStorage):
             lambda: _read_snapshot(self._lib, self._h), peer_poll_s)
 
     def __del__(self):
+        try:
+            _hot_config.stop()
+        except Exception:
+            pass
         try:
             if getattr(self, "_poller", None):
                 self._poller.stop()

--- a/integration/hicache/dfkv_hot_config.py
+++ b/integration/hicache/dfkv_hot_config.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime hot-reload of the dfkv client's OBSERVABILITY knobs — no restart.
+
+A background daemon thread polls a small JSON control file. On change it
+re-applies each registered subsystem's hot knobs, layered over that subsystem's
+launch config, so editing the file turns knobs on live and deleting it reverts
+to launch behavior. Multi-process safe by construction: every SGLang TP-rank
+process runs its own watcher over the SAME file, so one edit flips all ranks.
+
+Scope (Phase 1): access_log family only — knobs with ZERO correctness impact.
+Structural knobs (rdma / lib / register / node_dedup) and C-client-cached knobs
+(peer cooldown, get_miss_retries, node_dedup_log, ...) stay restart-only: they
+are frozen at construction / first-op inside the native client and cannot be
+flipped from Python. Those are a separate (Phase 2) native change.
+
+Opt-in: the watcher only runs when a control-file path is EXPLICITLY set. With
+no path configured, nothing new happens (zero threads, zero cost) — hot-reload
+is off, exactly as before. This keeps it out of the way of runs that never asked
+for it.
+
+Control file:
+    path = extra_config["hot_config_path"] | $DFKV_HOT_CONFIG   (unset -> disabled)
+    poll = extra_config["hot_config_poll_s"] | $DFKV_HOT_CONFIG_POLL_S | 5.0 (s)
+    poll <= 0 disables the watcher entirely.
+
+File format (all keys optional; an absent key -> that subsystem's launch value)::
+
+    {
+      "access_log": true,
+      "access_log_threshold_us": 500,
+      "access_log_path": "/var/log/dfkv/access.log"
+    }
+
+A missing control file means "no overrides" (revert to launch); a malformed file
+is ignored (last good config stays) and retried next tick. The file is polled by
+stat() — one syscall per interval, off the request path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from typing import Callable, List, Optional, Tuple
+
+_lock = threading.Lock()
+_appliers: List[Tuple[str, Callable[[Optional[dict]], None]]] = []
+_watcher: "Optional[_Watcher]" = None
+
+
+def register(name: str, apply_fn: Callable[[Optional[dict]], None]) -> None:
+    """Register a subsystem hot-apply callback ``apply_fn(overrides: dict)``.
+
+    Idempotent by name so repeated DfkvHiCache.__init__ calls don't stack
+    duplicate appliers in one process.
+    """
+    with _lock:
+        if any(n == name for n, _ in _appliers):
+            return
+        _appliers.append((name, apply_fn))
+
+
+class _Watcher(threading.Thread):
+    def __init__(self, path: str, poll_s: float, tp_rank: int) -> None:
+        super().__init__(name="dfkv-hot-config", daemon=True)
+        self._path = path
+        self._interval = float(poll_s)
+        self._tp_rank = tp_rank
+        self._stop = threading.Event()
+        # (mtime, size) of the file at the last successful apply; None = absent.
+        self._seen: object = "<never>"  # sentinel: force an apply on first tick
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _read(self) -> Optional[dict]:
+        """Return the override dict ({} if the file is absent), or None on a
+        transient read/parse error (so the caller keeps the last good config)."""
+        try:
+            with open(self._path, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return {}
+        except (OSError, ValueError) as exc:
+            sys.stderr.write(
+                f"[dfkv.hot] r{self._tp_rank} bad control file {self._path!r}: "
+                f"{exc}; keeping current config\n")
+            return None
+        return data if isinstance(data, dict) else {}
+
+    def _apply_all(self, overrides: dict) -> None:
+        with _lock:
+            appliers = list(_appliers)
+        for name, fn in appliers:
+            try:
+                fn(overrides)
+            except Exception as exc:  # one bad applier must not kill the watcher
+                sys.stderr.write(
+                    f"[dfkv.hot] r{self._tp_rank} applier {name!r} failed: {exc}\n")
+
+    def run(self) -> None:
+        first = True
+        while first or not self._stop.wait(self._interval):
+            first = False
+            try:
+                st = os.stat(self._path)
+                sig: object = (st.st_mtime, st.st_size)
+            except FileNotFoundError:
+                sig = None
+            except OSError:
+                continue  # transient; retry next tick
+            if sig == self._seen:
+                continue
+            overrides = self._read()
+            if overrides is None:
+                continue  # parse error: retry next tick, don't advance _seen
+            self._apply_all(overrides)
+            self._seen = sig
+            sys.stderr.write(
+                f"[dfkv.hot] r{self._tp_rank} applied {len(overrides)} override(s) "
+                f"from {self._path}\n")
+
+
+def _resolve(cfg: dict, key: str, env: str, default):
+    if cfg.get(key) is not None:
+        return cfg[key]
+    if env in os.environ:
+        return os.environ[env]
+    return default
+
+
+def start(cfg: Optional[dict] = None, tp_rank: int = 0) -> "Optional[_Watcher]":
+    """Start the control-file watcher (idempotent; first call in the process
+    wins). Returns the watcher, or None if disabled / nothing registered.
+
+    Opt-in: returns None unless a control-file path is explicitly set (via
+    extra_config["hot_config_path"] or $DFKV_HOT_CONFIG). Call AFTER registering
+    appliers and AFTER each subsystem's configure(), so the first tick layers
+    file overrides on a populated launch config.
+    """
+    global _watcher
+    with _lock:
+        if _watcher is not None:
+            return _watcher
+        if not _appliers:
+            return None
+        cfg = cfg or {}
+        path = str(_resolve(cfg, "hot_config_path", "DFKV_HOT_CONFIG", "")).strip()
+        try:
+            poll_s = float(_resolve(cfg, "hot_config_poll_s",
+                                    "DFKV_HOT_CONFIG_POLL_S", 5.0))
+        except (TypeError, ValueError):
+            poll_s = 5.0
+        if not path or poll_s <= 0:
+            return None
+        _watcher = _Watcher(path, poll_s, tp_rank)
+        _watcher.start()
+        return _watcher
+
+
+def stop() -> None:
+    global _watcher
+    with _lock:
+        w = _watcher
+        _watcher = None
+    if w is not None:
+        w.stop()

--- a/integration/hicache/dfkv_hot_config.py
+++ b/integration/hicache/dfkv_hot_config.py
@@ -82,10 +82,14 @@ class _Watcher(threading.Thread):
                 data = json.load(f)
         except FileNotFoundError:
             return {}
-        except (OSError, ValueError) as exc:
+        except Exception as exc:
+            # Catch-all on purpose: a garbage/binary file (UnicodeDecodeError,
+            # JSONDecodeError), a pathologically nested one (RecursionError), a
+            # permission/IO error (OSError) — none of it may crash or kill the
+            # watcher thread. Keep the last good config and retry next tick.
             sys.stderr.write(
                 f"[dfkv.hot] r{self._tp_rank} bad control file {self._path!r}: "
-                f"{exc}; keeping current config\n")
+                f"{type(exc).__name__}: {exc}; keeping current config\n")
             return None
         return data if isinstance(data, dict) else {}
 

--- a/integration/lmcache/src/dfkv_connector/_hot_config.py
+++ b/integration/lmcache/src/dfkv_connector/_hot_config.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime hot-reload of the dfkv client's OBSERVABILITY knobs — no restart.
+
+A background daemon thread polls a small JSON control file. On change it
+re-applies each registered subsystem's hot knobs, layered over that subsystem's
+launch config, so editing the file turns knobs on live and deleting it reverts
+to launch behavior. Multi-process safe by construction: every SGLang TP-rank
+process runs its own watcher over the SAME file, so one edit flips all ranks.
+
+Scope (Phase 1): access_log family only — knobs with ZERO correctness impact.
+Structural knobs (rdma / lib / register / node_dedup) and C-client-cached knobs
+(peer cooldown, get_miss_retries, node_dedup_log, ...) stay restart-only: they
+are frozen at construction / first-op inside the native client and cannot be
+flipped from Python. Those are a separate (Phase 2) native change.
+
+Opt-in: the watcher only runs when a control-file path is EXPLICITLY set. With
+no path configured, nothing new happens (zero threads, zero cost) — hot-reload
+is off, exactly as before. This keeps it out of the way of runs that never asked
+for it.
+
+Control file:
+    path = extra_config["hot_config_path"] | $DFKV_HOT_CONFIG   (unset -> disabled)
+    poll = extra_config["hot_config_poll_s"] | $DFKV_HOT_CONFIG_POLL_S | 5.0 (s)
+    poll <= 0 disables the watcher entirely.
+
+File format (all keys optional; an absent key -> that subsystem's launch value)::
+
+    {
+      "access_log": true,
+      "access_log_threshold_us": 500,
+      "access_log_path": "/var/log/dfkv/access.log"
+    }
+
+A missing control file means "no overrides" (revert to launch); a malformed file
+is ignored (last good config stays) and retried next tick. The file is polled by
+stat() — one syscall per interval, off the request path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from typing import Callable, List, Optional, Tuple
+
+_lock = threading.Lock()
+_appliers: List[Tuple[str, Callable[[Optional[dict]], None]]] = []
+_watcher: "Optional[_Watcher]" = None
+
+
+def register(name: str, apply_fn: Callable[[Optional[dict]], None]) -> None:
+    """Register a subsystem hot-apply callback ``apply_fn(overrides: dict)``.
+
+    Idempotent by name so repeated DfkvHiCache.__init__ calls don't stack
+    duplicate appliers in one process.
+    """
+    with _lock:
+        if any(n == name for n, _ in _appliers):
+            return
+        _appliers.append((name, apply_fn))
+
+
+class _Watcher(threading.Thread):
+    def __init__(self, path: str, poll_s: float, tp_rank: int) -> None:
+        super().__init__(name="dfkv-hot-config", daemon=True)
+        self._path = path
+        self._interval = float(poll_s)
+        self._tp_rank = tp_rank
+        self._stop = threading.Event()
+        # (mtime, size) of the file at the last successful apply; None = absent.
+        self._seen: object = "<never>"  # sentinel: force an apply on first tick
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _read(self) -> Optional[dict]:
+        """Return the override dict ({} if the file is absent), or None on a
+        transient read/parse error (so the caller keeps the last good config)."""
+        try:
+            with open(self._path, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return {}
+        except Exception as exc:
+            # Catch-all on purpose: a garbage/binary file (UnicodeDecodeError,
+            # JSONDecodeError), a pathologically nested one (RecursionError), a
+            # permission/IO error (OSError) — none of it may crash or kill the
+            # watcher thread. Keep the last good config and retry next tick.
+            sys.stderr.write(
+                f"[dfkv.hot] r{self._tp_rank} bad control file {self._path!r}: "
+                f"{type(exc).__name__}: {exc}; keeping current config\n")
+            return None
+        return data if isinstance(data, dict) else {}
+
+    def _apply_all(self, overrides: dict) -> None:
+        with _lock:
+            appliers = list(_appliers)
+        for name, fn in appliers:
+            try:
+                fn(overrides)
+            except Exception as exc:  # one bad applier must not kill the watcher
+                sys.stderr.write(
+                    f"[dfkv.hot] r{self._tp_rank} applier {name!r} failed: {exc}\n")
+
+    def run(self) -> None:
+        first = True
+        while first or not self._stop.wait(self._interval):
+            first = False
+            try:
+                st = os.stat(self._path)
+                sig: object = (st.st_mtime, st.st_size)
+            except FileNotFoundError:
+                sig = None
+            except OSError:
+                continue  # transient; retry next tick
+            if sig == self._seen:
+                continue
+            overrides = self._read()
+            if overrides is None:
+                continue  # parse error: retry next tick, don't advance _seen
+            self._apply_all(overrides)
+            self._seen = sig
+            sys.stderr.write(
+                f"[dfkv.hot] r{self._tp_rank} applied {len(overrides)} override(s) "
+                f"from {self._path}\n")
+
+
+def _resolve(cfg: dict, key: str, env: str, default):
+    if cfg.get(key) is not None:
+        return cfg[key]
+    if env in os.environ:
+        return os.environ[env]
+    return default
+
+
+def start(cfg: Optional[dict] = None, tp_rank: int = 0) -> "Optional[_Watcher]":
+    """Start the control-file watcher (idempotent; first call in the process
+    wins). Returns the watcher, or None if disabled / nothing registered.
+
+    Opt-in: returns None unless a control-file path is explicitly set (via
+    extra_config["hot_config_path"] or $DFKV_HOT_CONFIG). Call AFTER registering
+    appliers and AFTER each subsystem's configure(), so the first tick layers
+    file overrides on a populated launch config.
+    """
+    global _watcher
+    with _lock:
+        if _watcher is not None:
+            return _watcher
+        if not _appliers:
+            return None
+        cfg = cfg or {}
+        path = str(_resolve(cfg, "hot_config_path", "DFKV_HOT_CONFIG", "")).strip()
+        try:
+            poll_s = float(_resolve(cfg, "hot_config_poll_s",
+                                    "DFKV_HOT_CONFIG_POLL_S", 5.0))
+        except (TypeError, ValueError):
+            poll_s = 5.0
+        if not path or poll_s <= 0:
+            return None
+        _watcher = _Watcher(path, poll_s, tp_rank)
+        _watcher.start()
+        return _watcher
+
+
+def stop() -> None:
+    global _watcher
+    with _lock:
+        w = _watcher
+        _watcher = None
+    if w is not None:
+        w.stop()

--- a/integration/lmcache/src/dfkv_connector/access_log.py
+++ b/integration/lmcache/src/dfkv_connector/access_log.py
@@ -13,12 +13,21 @@ e.g.::
     get(model@1@0@cafebabe) : not_found <0.001012>
     put(model@1@0@cafebabe, 4194304) : FAIL RuntimeError: IoError <0.001230>
 
-Off by default. Controlled by environment variables (read once at import):
+Off by default. The SAME environment variables as every other dfkv access log,
+so one setting covers all integrations:
 
     DFKV_ACCESS_LOG_ENABLED       "1" to turn on (default off)
     DFKV_ACCESS_LOG_PATH          file path; empty = stderr (default empty)
     DFKV_ACCESS_LOG_THRESHOLD_US  only log ops whose wall time exceeds this
                                   (default 0 = log every call)
+    DFKV_ACCESS_LOG_MAX_BYTES     size-rotation threshold (default 128MiB;
+                                  0 disables rotation = single unbounded file)
+    DFKV_ACCESS_LOG_BACKUP_COUNT  rotated backups to keep (default 5)
+
+The launch baseline is parsed once in :func:`configure` (called from the client
+``__init__``); after that ``access_log()`` reads the enable flag per call, so a
+control-file watcher (:mod:`._hot_config`) can toggle it at runtime WITHOUT a
+restart. See docs/access_log.md → 运行时热开关.
 
 Performance:
   - Disabled: ~100 ns/call. A frozen _NoopLog singleton is returned, so the
@@ -37,44 +46,80 @@ import logging.handlers
 import os
 import queue
 import sys
+import threading
 import time
 from typing import Any, Callable, Optional
 
+# Module state. configure() (first call in the process) snapshots the launch
+# config; apply_hot() (from the _hot_config watcher thread) may re-apply it
+# later, so all mutating paths take _lock. access_log() reads _ENABLED /
+# _THRESHOLD_US WITHOUT the lock — plain bool/int reads under the GIL; a stale
+# read at worst mislabels one op, acceptable for a diagnostic log.
+_ENABLED: bool = False
+_THRESHOLD_US: int = 0
+_logger: Optional[logging.Logger] = None
+_listener: Optional[logging.handlers.QueueListener] = None
+_configured: bool = False
+_lock = threading.Lock()
+_sink_want: Optional[tuple] = None
+_launch_cfg: dict = {}
+_tp_rank: int = 0
+_model: str = ""
 
-# Read once at import; flipping env mid-process is not supported.
-_ENABLED = os.environ.get(
-    "DFKV_ACCESS_LOG_ENABLED", "0"
-) in ("1", "true", "yes", "on")
-_LOG_PATH = os.environ.get("DFKV_ACCESS_LOG_PATH", "").strip()
-try:
-    _THRESHOLD_US = int(os.environ.get("DFKV_ACCESS_LOG_THRESHOLD_US", "0"))
-except ValueError:
-    _THRESHOLD_US = 0
+
+def _truthy(v: Any) -> bool:
+    if isinstance(v, bool):
+        return v
+    if v is None:
+        return False
+    return str(v).strip().lower() in ("1", "true", "yes", "on")
 
 
-def _build_logger() -> Optional[logging.Logger]:
-    """Build a non-blocking access logger.
+def _resolve(cfg: dict, key: str, env: str, default: Any) -> Any:
+    """extra_config key wins; then env var; then default."""
+    if cfg.get(key) is not None:
+        return cfg[key]
+    if env in os.environ:
+        return os.environ[env]
+    return default
 
-    Foreground emit only enqueues a LogRecord; a background QueueListener
-    thread does the actual write/flush. This keeps the hot path under a few
-    microseconds even at thousands of ops per second.
-    """
-    if not _ENABLED:
-        return None
-    log = logging.getLogger("dfkv.access")
-    log.setLevel(logging.INFO)
-    log.propagate = False  # keep out of root logger / LMCache's stack
-    if log.handlers:
-        return log  # already configured (e.g. on re-import)
 
-    if _LOG_PATH:
+def _int(cfg: dict, key: str, env: str, default: int) -> int:
+    try:
+        return int(_resolve(cfg, key, env, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _stop_listener(listener) -> None:
+    if listener is not None and getattr(listener, "_thread", None) is not None:
+        listener.stop()
+
+
+def _build_sink(path: str, max_bytes: int, backup_count: int,
+                tp_rank: int, model: str) -> None:
+    """(Re)build the logger + async QueueListener. Tears down any previous
+    listener/handlers first so a hot path change never double-writes. Caller
+    holds _lock. Size-rotation bounds disk per rank to
+    max_bytes * (backup_count + 1); max_bytes=0 disables rotation."""
+    global _logger, _listener
+    if path:
+        if "{rank}" in path or "{model}" in path:
+            path = path.format(rank=tp_rank, model=model)
+        else:
+            path = f"{path}.r{tp_rank}"
+
+    if path:
         try:
-            sink: logging.Handler = logging.FileHandler(_LOG_PATH, mode="a")
+            if max_bytes > 0:
+                sink: logging.Handler = logging.handlers.RotatingFileHandler(
+                    path, mode="a", maxBytes=max_bytes, backupCount=backup_count)
+            else:
+                sink = logging.FileHandler(path, mode="a")
         except OSError as exc:
             sys.stderr.write(
-                f"[dfkv.access] cannot open {_LOG_PATH!r}: {exc}; "
-                f"falling back to stderr\n"
-            )
+                f"[dfkv.access] cannot open {path!r}: {exc}; "
+                f"falling back to stderr\n")
             sink = logging.StreamHandler(sys.stderr)
     else:
         sink = logging.StreamHandler(sys.stderr)
@@ -83,19 +128,78 @@ def _build_logger() -> Optional[logging.Logger]:
                           datefmt="%Y-%m-%d %H:%M:%S")
     )
 
-    # Unbounded queue: enqueueing never blocks; if the listener can't keep up
-    # we'd rather grow memory than stall the hot path. In practice the queue
-    # stays empty because emit is ~10 µs and ops are ~ms.
+    _stop_listener(_listener)
+    _listener = None
+    log = logging.getLogger("dfkv.access")
+    log.setLevel(logging.INFO)
+    log.propagate = False  # keep out of root logger / LMCache's stack
+    for h in list(log.handlers):
+        log.removeHandler(h)
+
+    # Unbounded queue: enqueueing never blocks; the background listener does the
+    # write/flush, keeping foreground emit at a few microseconds.
     q: "queue.Queue[logging.LogRecord]" = queue.Queue(-1)
-    listener = logging.handlers.QueueListener(q, sink, respect_handler_level=False)
-    listener.start()
-    atexit.register(listener.stop)
-
+    _listener = logging.handlers.QueueListener(q, sink, respect_handler_level=False)
+    _listener.start()
+    atexit.register(_stop_listener, _listener)
     log.addHandler(logging.handlers.QueueHandler(q))
-    return log
+    _logger = log
 
 
-_logger: Optional[logging.Logger] = _build_logger()
+def _apply(cfg: Optional[dict], tp_rank: int, model: str) -> None:
+    """Resolve the access-log knobs from cfg and (re)apply. Caller holds _lock.
+    Enables/disables live; builds the sink lazily on first enable and rebuilds
+    only when path/rotation params change."""
+    global _ENABLED, _THRESHOLD_US, _sink_want
+    cfg = cfg or {}
+    _THRESHOLD_US = max(0, _int(cfg, "access_log_threshold_us",
+                                "DFKV_ACCESS_LOG_THRESHOLD_US", 0))
+    if not _truthy(_resolve(cfg, "access_log", "DFKV_ACCESS_LOG_ENABLED", False)):
+        _ENABLED = False
+        return
+    path = str(_resolve(cfg, "access_log_path", "DFKV_ACCESS_LOG_PATH", "")).strip()
+    max_bytes = _int(cfg, "access_log_max_bytes", "DFKV_ACCESS_LOG_MAX_BYTES",
+                     128 * 1024 * 1024)
+    backup_count = _int(cfg, "access_log_backup_count",
+                        "DFKV_ACCESS_LOG_BACKUP_COUNT", 5)
+    if max_bytes < 0:
+        max_bytes = 0
+    if backup_count < 0:
+        backup_count = 0
+    want = (path, max_bytes, backup_count)
+    if _logger is None or _sink_want != want:
+        _build_sink(path, max_bytes, backup_count, tp_rank, model)
+        _sink_want = want
+    _ENABLED = True
+
+
+def configure(cfg: Optional[dict] = None, tp_rank: int = 0, model: str = "") -> None:
+    """Parse the launch baseline (first call in the process wins) and apply it.
+    Snapshots the config so :func:`apply_hot` can layer live control-file
+    overrides on top and revert cleanly. cfg may be None (env-only)."""
+    global _configured, _launch_cfg, _tp_rank, _model
+    with _lock:
+        if _configured:
+            return
+        _configured = True
+        _launch_cfg = dict(cfg or {})
+        _tp_rank = tp_rank
+        _model = model
+        _apply(_launch_cfg, tp_rank, model)
+
+
+def apply_hot(overrides: Optional[dict]) -> None:
+    """Re-apply access-log knobs from control-file overrides, layered over the
+    launch baseline (absent key -> launch default, so deleting the control file
+    reverts). Thread-safe; called by the _hot_config watcher. No-op before
+    :func:`configure`."""
+    with _lock:
+        if not _configured:
+            return
+        merged = dict(_launch_cfg)
+        if overrides:
+            merged.update(overrides)
+        _apply(merged, _tp_rank, _model)
 
 
 def is_enabled() -> bool:
@@ -158,13 +262,11 @@ _NOOP = _NoopLog()
 
 
 # ---------------------------------------------------------------------------
-# Public entry: cheap singleton when disabled, real timer when enabled.
+# Public entry: cheap singleton when disabled, real timer when enabled. Reads
+# the enable flag PER CALL so the _hot_config watcher can toggle it at runtime.
 # ---------------------------------------------------------------------------
 
-if _ENABLED:
-    def access_log(op: str, args_fn: Callable[[], str] = lambda: ""):
+def access_log(op: str = "", args_fn: Callable[[], str] = lambda: ""):
+    if _ENABLED:
         return _RealLog(op, args_fn)
-else:
-    def access_log(op: str = "",
-                   args_fn: Callable[[], str] = lambda: ""):
-        return _NOOP
+    return _NOOP

--- a/integration/lmcache/src/dfkv_connector/native_client.py
+++ b/integration/lmcache/src/dfkv_connector/native_client.py
@@ -24,7 +24,9 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List, Optional, Sequence, Tuple
 
+from . import access_log as _alog
 from .access_log import access_log
+from . import _hot_config
 from ._telemetry import config as _tcfg
 from ._telemetry import metrics as _push_metrics
 from ._telemetry import tracing as _push_tracing
@@ -246,6 +248,12 @@ class DfkvNativeClient:
                 {}, connector_type=_tcfg.TYPE_LMCACHE, tp_rank=int(g["tp_rank"]),
                 version=_tcfg.dist_version("dfkv-connector"),
                 native_version=_native_version(self._lib))
+            # Access log: parse the launch baseline (env-driven), then let a
+            # control file toggle it at runtime without restarting LMCache
+            # (opt-in via DFKV_HOT_CONFIG). docs/access_log.md -> 运行时热开关.
+            _alog.configure({}, tp_rank=int(g["tp_rank"]))
+            _hot_config.register("access_log", _alog.apply_hot)
+            _hot_config.start({}, tp_rank=int(g["tp_rank"]))
             r.result = f"ok regs={regs} transport={self.transport_mode}"
 
     # ------------------------------------------------------------------
@@ -431,6 +439,10 @@ class DfkvNativeClient:
     def close(self) -> None:
         if self._closed:
             return
+        try:
+            _hot_config.stop()
+        except Exception:  # pragma: no cover
+            pass
         with access_log("native.close", lambda: ""):
             self._closed = True
             try:

--- a/integration/vllm/src/dfkv_vllm/_hot_config.py
+++ b/integration/vllm/src/dfkv_vllm/_hot_config.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime hot-reload of the dfkv client's OBSERVABILITY knobs — no restart.
+
+A background daemon thread polls a small JSON control file. On change it
+re-applies each registered subsystem's hot knobs, layered over that subsystem's
+launch config, so editing the file turns knobs on live and deleting it reverts
+to launch behavior. Multi-process safe by construction: every SGLang TP-rank
+process runs its own watcher over the SAME file, so one edit flips all ranks.
+
+Scope (Phase 1): access_log family only — knobs with ZERO correctness impact.
+Structural knobs (rdma / lib / register / node_dedup) and C-client-cached knobs
+(peer cooldown, get_miss_retries, node_dedup_log, ...) stay restart-only: they
+are frozen at construction / first-op inside the native client and cannot be
+flipped from Python. Those are a separate (Phase 2) native change.
+
+Opt-in: the watcher only runs when a control-file path is EXPLICITLY set. With
+no path configured, nothing new happens (zero threads, zero cost) — hot-reload
+is off, exactly as before. This keeps it out of the way of runs that never asked
+for it.
+
+Control file:
+    path = extra_config["hot_config_path"] | $DFKV_HOT_CONFIG   (unset -> disabled)
+    poll = extra_config["hot_config_poll_s"] | $DFKV_HOT_CONFIG_POLL_S | 5.0 (s)
+    poll <= 0 disables the watcher entirely.
+
+File format (all keys optional; an absent key -> that subsystem's launch value)::
+
+    {
+      "access_log": true,
+      "access_log_threshold_us": 500,
+      "access_log_path": "/var/log/dfkv/access.log"
+    }
+
+A missing control file means "no overrides" (revert to launch); a malformed file
+is ignored (last good config stays) and retried next tick. The file is polled by
+stat() — one syscall per interval, off the request path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from typing import Callable, List, Optional, Tuple
+
+_lock = threading.Lock()
+_appliers: List[Tuple[str, Callable[[Optional[dict]], None]]] = []
+_watcher: "Optional[_Watcher]" = None
+
+
+def register(name: str, apply_fn: Callable[[Optional[dict]], None]) -> None:
+    """Register a subsystem hot-apply callback ``apply_fn(overrides: dict)``.
+
+    Idempotent by name so repeated DfkvHiCache.__init__ calls don't stack
+    duplicate appliers in one process.
+    """
+    with _lock:
+        if any(n == name for n, _ in _appliers):
+            return
+        _appliers.append((name, apply_fn))
+
+
+class _Watcher(threading.Thread):
+    def __init__(self, path: str, poll_s: float, tp_rank: int) -> None:
+        super().__init__(name="dfkv-hot-config", daemon=True)
+        self._path = path
+        self._interval = float(poll_s)
+        self._tp_rank = tp_rank
+        self._stop = threading.Event()
+        # (mtime, size) of the file at the last successful apply; None = absent.
+        self._seen: object = "<never>"  # sentinel: force an apply on first tick
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _read(self) -> Optional[dict]:
+        """Return the override dict ({} if the file is absent), or None on a
+        transient read/parse error (so the caller keeps the last good config)."""
+        try:
+            with open(self._path, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return {}
+        except Exception as exc:
+            # Catch-all on purpose: a garbage/binary file (UnicodeDecodeError,
+            # JSONDecodeError), a pathologically nested one (RecursionError), a
+            # permission/IO error (OSError) — none of it may crash or kill the
+            # watcher thread. Keep the last good config and retry next tick.
+            sys.stderr.write(
+                f"[dfkv.hot] r{self._tp_rank} bad control file {self._path!r}: "
+                f"{type(exc).__name__}: {exc}; keeping current config\n")
+            return None
+        return data if isinstance(data, dict) else {}
+
+    def _apply_all(self, overrides: dict) -> None:
+        with _lock:
+            appliers = list(_appliers)
+        for name, fn in appliers:
+            try:
+                fn(overrides)
+            except Exception as exc:  # one bad applier must not kill the watcher
+                sys.stderr.write(
+                    f"[dfkv.hot] r{self._tp_rank} applier {name!r} failed: {exc}\n")
+
+    def run(self) -> None:
+        first = True
+        while first or not self._stop.wait(self._interval):
+            first = False
+            try:
+                st = os.stat(self._path)
+                sig: object = (st.st_mtime, st.st_size)
+            except FileNotFoundError:
+                sig = None
+            except OSError:
+                continue  # transient; retry next tick
+            if sig == self._seen:
+                continue
+            overrides = self._read()
+            if overrides is None:
+                continue  # parse error: retry next tick, don't advance _seen
+            self._apply_all(overrides)
+            self._seen = sig
+            sys.stderr.write(
+                f"[dfkv.hot] r{self._tp_rank} applied {len(overrides)} override(s) "
+                f"from {self._path}\n")
+
+
+def _resolve(cfg: dict, key: str, env: str, default):
+    if cfg.get(key) is not None:
+        return cfg[key]
+    if env in os.environ:
+        return os.environ[env]
+    return default
+
+
+def start(cfg: Optional[dict] = None, tp_rank: int = 0) -> "Optional[_Watcher]":
+    """Start the control-file watcher (idempotent; first call in the process
+    wins). Returns the watcher, or None if disabled / nothing registered.
+
+    Opt-in: returns None unless a control-file path is explicitly set (via
+    extra_config["hot_config_path"] or $DFKV_HOT_CONFIG). Call AFTER registering
+    appliers and AFTER each subsystem's configure(), so the first tick layers
+    file overrides on a populated launch config.
+    """
+    global _watcher
+    with _lock:
+        if _watcher is not None:
+            return _watcher
+        if not _appliers:
+            return None
+        cfg = cfg or {}
+        path = str(_resolve(cfg, "hot_config_path", "DFKV_HOT_CONFIG", "")).strip()
+        try:
+            poll_s = float(_resolve(cfg, "hot_config_poll_s",
+                                    "DFKV_HOT_CONFIG_POLL_S", 5.0))
+        except (TypeError, ValueError):
+            poll_s = 5.0
+        if not path or poll_s <= 0:
+            return None
+        _watcher = _Watcher(path, poll_s, tp_rank)
+        _watcher.start()
+        return _watcher
+
+
+def stop() -> None:
+    global _watcher
+    with _lock:
+        w = _watcher
+        _watcher = None
+    if w is not None:
+        w.stop()

--- a/integration/vllm/src/dfkv_vllm/access_log.py
+++ b/integration/vllm/src/dfkv_vllm/access_log.py
@@ -14,14 +14,21 @@ e.g.::
     register_memory(base=0x7f00, 4294967296 bytes) : ok <0.012003>
     batch_put(8 keys, 524288 bytes) : FAIL RuntimeError: dfkv_batch_put rc=-1 <0.001230>
 
-Off by default. Controlled by environment variables (read once at import),
-the SAME variables as every other dfkv access log so one setting covers all
-integrations:
+Off by default. The SAME environment variables as every other dfkv access log,
+so one setting covers all integrations:
 
     DFKV_ACCESS_LOG_ENABLED       "1" to turn on (default off)
     DFKV_ACCESS_LOG_PATH          file path; empty = stderr (default empty)
     DFKV_ACCESS_LOG_THRESHOLD_US  only log ops whose wall time exceeds this
                                   (default 0 = log every call)
+    DFKV_ACCESS_LOG_MAX_BYTES     size-rotation threshold (default 128MiB;
+                                  0 disables rotation = single unbounded file)
+    DFKV_ACCESS_LOG_BACKUP_COUNT  rotated backups to keep (default 5)
+
+The launch baseline is parsed once in :func:`configure` (called from the client
+``__init__``); after that ``access_log()`` reads the enable flag per call, so a
+control-file watcher (:mod:`._hot_config`) can toggle it at runtime WITHOUT a
+restart. See docs/access_log.md → 运行时热开关.
 
 Performance:
   - Disabled: ~100 ns/call. A frozen _NoopLog singleton is returned, so the
@@ -40,44 +47,80 @@ import logging.handlers
 import os
 import queue
 import sys
+import threading
 import time
 from typing import Any, Callable, Optional
 
+# Module state. configure() (first call in the process) snapshots the launch
+# config; apply_hot() (from the _hot_config watcher thread) may re-apply it
+# later, so all mutating paths take _lock. access_log() reads _ENABLED /
+# _THRESHOLD_US WITHOUT the lock — plain bool/int reads under the GIL; a stale
+# read at worst mislabels one op, acceptable for a diagnostic log.
+_ENABLED: bool = False
+_THRESHOLD_US: int = 0
+_logger: Optional[logging.Logger] = None
+_listener: Optional[logging.handlers.QueueListener] = None
+_configured: bool = False
+_lock = threading.Lock()
+_sink_want: Optional[tuple] = None
+_launch_cfg: dict = {}
+_tp_rank: int = 0
+_model: str = ""
 
-# Read once at import; flipping env mid-process is not supported.
-_ENABLED = os.environ.get(
-    "DFKV_ACCESS_LOG_ENABLED", "0"
-) in ("1", "true", "yes", "on")
-_LOG_PATH = os.environ.get("DFKV_ACCESS_LOG_PATH", "").strip()
-try:
-    _THRESHOLD_US = int(os.environ.get("DFKV_ACCESS_LOG_THRESHOLD_US", "0"))
-except ValueError:
-    _THRESHOLD_US = 0
+
+def _truthy(v: Any) -> bool:
+    if isinstance(v, bool):
+        return v
+    if v is None:
+        return False
+    return str(v).strip().lower() in ("1", "true", "yes", "on")
 
 
-def _build_logger() -> Optional[logging.Logger]:
-    """Build a non-blocking access logger.
+def _resolve(cfg: dict, key: str, env: str, default: Any) -> Any:
+    """extra_config key wins; then env var; then default."""
+    if cfg.get(key) is not None:
+        return cfg[key]
+    if env in os.environ:
+        return os.environ[env]
+    return default
 
-    Foreground emit only enqueues a LogRecord; a background QueueListener
-    thread does the actual write/flush. This keeps the hot path under a few
-    microseconds even at thousands of ops per second.
-    """
-    if not _ENABLED:
-        return None
-    log = logging.getLogger("dfkv.access")
-    log.setLevel(logging.INFO)
-    log.propagate = False  # keep out of root logger / vLLM's logging stack
-    if log.handlers:
-        return log  # already configured (e.g. on re-import)
 
-    if _LOG_PATH:
+def _int(cfg: dict, key: str, env: str, default: int) -> int:
+    try:
+        return int(_resolve(cfg, key, env, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _stop_listener(listener) -> None:
+    if listener is not None and getattr(listener, "_thread", None) is not None:
+        listener.stop()
+
+
+def _build_sink(path: str, max_bytes: int, backup_count: int,
+                tp_rank: int, model: str) -> None:
+    """(Re)build the logger + async QueueListener. Tears down any previous
+    listener/handlers first so a hot path change never double-writes. Caller
+    holds _lock. Size-rotation bounds disk per rank to
+    max_bytes * (backup_count + 1); max_bytes=0 disables rotation."""
+    global _logger, _listener
+    if path:
+        if "{rank}" in path or "{model}" in path:
+            path = path.format(rank=tp_rank, model=model)
+        else:
+            path = f"{path}.r{tp_rank}"
+
+    if path:
         try:
-            sink: logging.Handler = logging.FileHandler(_LOG_PATH, mode="a")
+            if max_bytes > 0:
+                sink: logging.Handler = logging.handlers.RotatingFileHandler(
+                    path, mode="a", maxBytes=max_bytes, backupCount=backup_count)
+            else:
+                sink = logging.FileHandler(path, mode="a")
         except OSError as exc:
             sys.stderr.write(
-                f"[dfkv.access] cannot open {_LOG_PATH!r}: {exc}; "
-                f"falling back to stderr\n"
-            )
+                f"[dfkv.access] cannot open {path!r}: {exc}; "
+                f"falling back to stderr\n")
             sink = logging.StreamHandler(sys.stderr)
     else:
         sink = logging.StreamHandler(sys.stderr)
@@ -86,19 +129,78 @@ def _build_logger() -> Optional[logging.Logger]:
                           datefmt="%Y-%m-%d %H:%M:%S")
     )
 
-    # Unbounded queue: enqueueing never blocks; if the listener can't keep up
-    # we'd rather grow memory than stall the hot path. In practice the queue
-    # stays empty because emit is ~10 µs and ops are ~ms.
+    _stop_listener(_listener)
+    _listener = None
+    log = logging.getLogger("dfkv.access")
+    log.setLevel(logging.INFO)
+    log.propagate = False  # keep out of root logger / vLLM's logging stack
+    for h in list(log.handlers):
+        log.removeHandler(h)
+
+    # Unbounded queue: enqueueing never blocks; the background listener does the
+    # write/flush, keeping foreground emit at a few microseconds.
     q: "queue.Queue[logging.LogRecord]" = queue.Queue(-1)
-    listener = logging.handlers.QueueListener(q, sink, respect_handler_level=False)
-    listener.start()
-    atexit.register(listener.stop)
-
+    _listener = logging.handlers.QueueListener(q, sink, respect_handler_level=False)
+    _listener.start()
+    atexit.register(_stop_listener, _listener)
     log.addHandler(logging.handlers.QueueHandler(q))
-    return log
+    _logger = log
 
 
-_logger: Optional[logging.Logger] = _build_logger()
+def _apply(cfg: Optional[dict], tp_rank: int, model: str) -> None:
+    """Resolve the access-log knobs from cfg and (re)apply. Caller holds _lock.
+    Enables/disables live; builds the sink lazily on first enable and rebuilds
+    only when path/rotation params change."""
+    global _ENABLED, _THRESHOLD_US, _sink_want
+    cfg = cfg or {}
+    _THRESHOLD_US = max(0, _int(cfg, "access_log_threshold_us",
+                                "DFKV_ACCESS_LOG_THRESHOLD_US", 0))
+    if not _truthy(_resolve(cfg, "access_log", "DFKV_ACCESS_LOG_ENABLED", False)):
+        _ENABLED = False
+        return
+    path = str(_resolve(cfg, "access_log_path", "DFKV_ACCESS_LOG_PATH", "")).strip()
+    max_bytes = _int(cfg, "access_log_max_bytes", "DFKV_ACCESS_LOG_MAX_BYTES",
+                     128 * 1024 * 1024)
+    backup_count = _int(cfg, "access_log_backup_count",
+                        "DFKV_ACCESS_LOG_BACKUP_COUNT", 5)
+    if max_bytes < 0:
+        max_bytes = 0
+    if backup_count < 0:
+        backup_count = 0
+    want = (path, max_bytes, backup_count)
+    if _logger is None or _sink_want != want:
+        _build_sink(path, max_bytes, backup_count, tp_rank, model)
+        _sink_want = want
+    _ENABLED = True
+
+
+def configure(cfg: Optional[dict] = None, tp_rank: int = 0, model: str = "") -> None:
+    """Parse the launch baseline (first call in the process wins) and apply it.
+    Snapshots the config so :func:`apply_hot` can layer live control-file
+    overrides on top and revert cleanly. cfg may be None (env-only)."""
+    global _configured, _launch_cfg, _tp_rank, _model
+    with _lock:
+        if _configured:
+            return
+        _configured = True
+        _launch_cfg = dict(cfg or {})
+        _tp_rank = tp_rank
+        _model = model
+        _apply(_launch_cfg, tp_rank, model)
+
+
+def apply_hot(overrides: Optional[dict]) -> None:
+    """Re-apply access-log knobs from control-file overrides, layered over the
+    launch baseline (absent key -> launch default, so deleting the control file
+    reverts). Thread-safe; called by the _hot_config watcher. No-op before
+    :func:`configure`."""
+    with _lock:
+        if not _configured:
+            return
+        merged = dict(_launch_cfg)
+        if overrides:
+            merged.update(overrides)
+        _apply(merged, _tp_rank, _model)
 
 
 def is_enabled() -> bool:
@@ -161,13 +263,11 @@ _NOOP = _NoopLog()
 
 
 # ---------------------------------------------------------------------------
-# Public entry: cheap singleton when disabled, real timer when enabled.
+# Public entry: cheap singleton when disabled, real timer when enabled. Reads
+# the enable flag PER CALL so the _hot_config watcher can toggle it at runtime.
 # ---------------------------------------------------------------------------
 
-if _ENABLED:
-    def access_log(op: str, args_fn: Callable[[], str] = lambda: ""):
+def access_log(op: str = "", args_fn: Callable[[], str] = lambda: ""):
+    if _ENABLED:
         return _RealLog(op, args_fn)
-else:
-    def access_log(op: str = "",
-                   args_fn: Callable[[], str] = lambda: ""):
-        return _NOOP
+    return _NOOP

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -19,7 +19,9 @@ import os
 from typing import Optional, Sequence
 
 from ._cabi import load_lib, native_version
+from . import access_log as _alog
 from .access_log import access_log
+from . import _hot_config
 from ._telemetry import config as _tcfg
 from ._telemetry import metrics as _push_metrics
 from ._telemetry import tracing as _push_tracing
@@ -132,6 +134,12 @@ class DfkvDeviceClient:
             {}, connector_type=_tcfg.TYPE_VLLM, tp_rank=_env_rank(),
             version=_tcfg.dist_version("dfkv-vllm"),
             native_version=native_version(self._lib))
+        # Access log: parse the launch baseline (env-driven), then let a control
+        # file toggle it at runtime without restarting vLLM (opt-in via
+        # DFKV_HOT_CONFIG). See docs/access_log.md -> 运行时热开关.
+        _alog.configure({}, tp_rank=_env_rank())
+        _hot_config.register("access_log", _alog.apply_hot)
+        _hot_config.start({}, tp_rank=_env_rank())
 
     @property
     def transport_mode(self) -> str:
@@ -318,6 +326,10 @@ class DfkvDeviceClient:
             return res
 
     def close(self) -> None:
+        try:
+            _hot_config.stop()
+        except Exception:
+            pass
         if getattr(self, "_h", None):
             with access_log("close", lambda: ""):
                 self._lib.dfkv_close(self._h)

--- a/test/python/test_connector_access_log_hot.py
+++ b/test/python/test_connector_access_log_hot.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hot-reload of access_log in the vLLM + LMCache connectors (Phase 1.5).
+
+Loads each connector's access_log.py and its vendored _hot_config.py directly
+by file path (stdlib-only modules, so no native lib / package __init__ needed)
+and exercises the same toggle/threshold/watcher behavior proven for HiCache.
+"""
+import importlib.util
+import json
+import os
+import tempfile
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+
+CONNECTORS = {
+    "vllm": os.path.join(ROOT, "integration", "vllm", "src", "dfkv_vllm"),
+    "lmcache": os.path.join(ROOT, "integration", "lmcache", "src", "dfkv_connector"),
+}
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ConnectorAccessLogHotTest(unittest.TestCase):
+    def _mods(self, connector):
+        d = CONNECTORS[connector]
+        # unique module names per connector so the two don't collide in sys
+        alog = _load(os.path.join(d, "access_log.py"), f"_alog_{connector}")
+        hot = _load(os.path.join(d, "_hot_config.py"), f"_hot_{connector}")
+        return alog, hot
+
+    def _run_for(self, connector):
+        for k in list(os.environ):
+            if k.startswith("DFKV_"):
+                del os.environ[k]
+        alog, hot = self._mods(connector)
+        tmp = tempfile.mkdtemp(prefix=f"dfkv_{connector}_")
+        logpath = os.path.join(tmp, "acc.log")
+        ctl = os.path.join(tmp, "hot.json")
+
+        def emit(op):
+            with alog.access_log(op, lambda: "x"):
+                pass
+
+        def flush():
+            if alog._listener is not None:
+                alog._listener.stop()
+                alog._listener = None
+
+        def read():
+            p = logpath + ".r0"
+            if not os.path.exists(p):
+                return ""
+            with open(p) as f:
+                return f.read()
+
+        # launch disabled
+        alog.configure({}, tp_rank=0)
+        self.assertFalse(alog.is_enabled(), f"{connector}: launch disabled")
+        emit("get")
+        self.assertEqual(read(), "", f"{connector}: nothing written when off")
+
+        # hot enable
+        alog.apply_hot({"access_log": True, "access_log_path": logpath})
+        self.assertTrue(alog.is_enabled(), f"{connector}: hot enabled")
+        emit("batch_get")
+        flush()
+        self.assertIn("batch_get", read(), f"{connector}: op written")
+
+        # revert
+        alog.apply_hot({})
+        self.assertFalse(alog.is_enabled(), f"{connector}: reverted")
+
+        # garbage control file must not crash the vendored watcher
+        w = hot._Watcher(ctl, 0.1, 0)
+        for payload in (b"\x00\xffnot json", b"[1,2,3]", b"", b"[" * 4000,
+                        b'{"access_log_threshold_us":"x"}'):
+            with open(ctl, "wb") as f:
+                f.write(payload)
+            try:
+                out = w._read()
+            except Exception as exc:  # noqa: BLE001
+                self.fail(f"{connector}: _read raised on garbage: {exc}")
+            self.assertTrue(out is None or isinstance(out, dict))
+
+        # end-to-end watcher: opt-in + file-driven enable
+        alog._configured = False  # reset launch snapshot for a clean baseline
+        alog.configure({}, tp_rank=0)
+        hot.register("access_log", alog.apply_hot)
+        os.environ["DFKV_HOT_CONFIG"] = ctl
+        os.environ["DFKV_HOT_CONFIG_POLL_S"] = "0.15"
+        os.remove(ctl)
+        watcher = hot.start({}, tp_rank=0)
+        self.assertIsNotNone(watcher, f"{connector}: watcher started")
+        with open(ctl, "w") as f:
+            json.dump({"access_log": True, "access_log_path": logpath}, f)
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not alog.is_enabled():
+            time.sleep(0.1)
+        self.assertTrue(alog.is_enabled(), f"{connector}: watcher file-driven enable")
+        self.assertTrue(watcher.is_alive())
+        hot.stop()
+
+    def test_vllm(self):
+        self._run_for("vllm")
+
+    def test_lmcache(self):
+        self._run_for("lmcache")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/test_dfkv_hot_config.py
+++ b/test/python/test_dfkv_hot_config.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime hot-reload of the access-log knob (dfkv_hot_config + dfkv_access_log).
+
+Pure-Python: no native lib, no cache nodes. Drives dfkv_access_log.apply_hot()
+directly and the dfkv_hot_config file watcher end-to-end.
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), "..", "..", "integration", "hicache"))
+
+import dfkv_access_log as alog  # noqa: E402
+import dfkv_hot_config as hot   # noqa: E402
+
+
+def _reset():
+    """Reset both modules' process-global state for test isolation."""
+    alog._stop_listener(alog._listener)
+    import logging
+    logging.getLogger("dfkv.access").handlers.clear()
+    alog._ENABLED = False
+    alog._THRESHOLD_US = 0
+    alog._logger = None
+    alog._listener = None
+    alog._configured = False
+    alog._sink_want = None
+    alog._launch_cfg = {}
+    hot.stop()
+    with hot._lock:
+        hot._appliers.clear()
+        hot._watcher = None
+    for k in list(os.environ):
+        if k.startswith("DFKV_"):
+            del os.environ[k]
+
+
+class AccessLogHotToggleTest(unittest.TestCase):
+    def setUp(self):
+        _reset()
+        self.tmp = tempfile.mkdtemp(prefix="dfkv_hot_")
+        self.logpath = os.path.join(self.tmp, "acc.log")
+
+    def tearDown(self):
+        _reset()
+
+    def _emit(self, op):
+        with alog.access_log(op, lambda: "x"):
+            pass
+
+    def _flush(self):
+        if alog._listener is not None:
+            alog._listener.stop()
+            alog._listener = None
+
+    def _read(self):
+        p = self.logpath + ".r0"
+        if not os.path.exists(p):
+            return ""
+        with open(p) as f:
+            return f.read()
+
+    def test_hot_enable_then_revert(self):
+        # launch disabled
+        alog.configure({"access_log": False}, tp_rank=0, model="m")
+        self.assertFalse(alog.is_enabled())
+        self._emit("get")
+        self.assertEqual(self._read(), "")
+
+        # hot enable
+        alog.apply_hot({"access_log": True, "access_log_path": self.logpath})
+        self.assertTrue(alog.is_enabled())
+        self._emit("batch_get")
+        self._flush()
+        self.assertIn("batch_get", self._read())
+
+        # empty overrides -> revert to launch (disabled)
+        alog.apply_hot({})
+        self.assertFalse(alog.is_enabled())
+
+    def test_threshold_hot_change(self):
+        alog.configure({"access_log": True, "access_log_path": self.logpath},
+                       tp_rank=0, model="m")
+        # 10s threshold suppresses a sub-ms op
+        alog.apply_hot({"access_log": True, "access_log_path": self.logpath,
+                        "access_log_threshold_us": 10_000_000})
+        n0 = self._read().count("\n")
+        self._emit("fast")
+        self.assertEqual(self._read().count("\n"), n0)
+        # threshold 0 logs again
+        alog.apply_hot({"access_log": True, "access_log_path": self.logpath,
+                        "access_log_threshold_us": 0})
+        self._emit("logged")
+        self._flush()
+        self.assertIn("logged", self._read())
+
+    def test_apply_hot_before_configure_is_noop(self):
+        # no configure() yet -> apply_hot must not enable
+        alog.apply_hot({"access_log": True, "access_log_path": self.logpath})
+        self.assertFalse(alog.is_enabled())
+
+
+class WatcherOptInTest(unittest.TestCase):
+    def setUp(self):
+        _reset()
+        self.tmp = tempfile.mkdtemp(prefix="dfkv_hotw_")
+        self.logpath = os.path.join(self.tmp, "acc.log")
+        self.ctl = os.path.join(self.tmp, "hot.json")
+
+    def tearDown(self):
+        _reset()
+
+    def test_watcher_disabled_without_explicit_path(self):
+        hot.register("access_log", alog.apply_hot)
+        self.assertIsNone(hot.start({}, tp_rank=0))
+
+    def test_watcher_file_lifecycle(self):
+        alog.configure({"access_log": False}, tp_rank=0, model="m")
+        hot.register("access_log", alog.apply_hot)
+        os.environ["DFKV_HOT_CONFIG"] = self.ctl
+        os.environ["DFKV_HOT_CONFIG_POLL_S"] = "0.2"
+        w = hot.start({}, tp_rank=0)
+        self.assertIsNotNone(w)
+        time.sleep(0.4)  # first tick, file absent -> disabled
+        self.assertFalse(alog.is_enabled())
+
+        with open(self.ctl, "w") as f:
+            json.dump({"access_log": True, "access_log_path": self.logpath}, f)
+        self._wait(lambda: alog.is_enabled(), 3.0)
+        self.assertTrue(alog.is_enabled())
+
+        os.remove(self.ctl)
+        self._wait(lambda: not alog.is_enabled(), 3.0)
+        self.assertFalse(alog.is_enabled())
+
+    def _wait(self, pred, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if pred():
+                return
+            time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/test_dfkv_hot_config.py
+++ b/test/python/test_dfkv_hot_config.py
@@ -145,5 +145,92 @@ class WatcherOptInTest(unittest.TestCase):
             time.sleep(0.1)
 
 
+# Garbage/malformed control-file payloads that must never crash or kill the
+# watcher. (name, raw-bytes-or-text) pairs.
+_GARBAGE = [
+    ("binary", b"\x00\x01\x02\xff\xfe garbage \x80\x81"),
+    ("truncated_json", b'{"access_log": tru'),
+    ("not_json", b"this is not json at all !!!"),
+    ("json_list", b"[1, 2, 3]"),
+    ("json_number", b"42"),
+    ("json_string", b'"hello"'),
+    ("json_null", b"null"),
+    ("empty", b""),
+    ("deeply_nested", b"[" * 5000),  # RecursionError from json
+    ("bad_threshold_type", b'{"access_log_threshold_us": "abc"}'),
+    ("bad_enable_type", b'{"access_log": {"nested": 1}}'),
+    ("bad_path_type", b'{"access_log_path": 12345}'),
+    ("stray_placeholder", b'{"access_log": true, "access_log_path": "/tmp/x/{foo}.log"}'),
+]
+
+
+class WatcherRobustnessTest(unittest.TestCase):
+    """A malformed/garbage control file must never crash the program or kill the
+    watcher thread; it must keep the last good config and recover afterwards."""
+
+    def setUp(self):
+        _reset()
+        self.tmp = tempfile.mkdtemp(prefix="dfkv_hotr_")
+        self.ctl = os.path.join(self.tmp, "hot.json")
+        self.logpath = os.path.join(self.tmp, "acc.log")
+
+    def tearDown(self):
+        _reset()
+
+    def test_read_never_raises_on_garbage(self):
+        w = hot._Watcher(self.ctl, 0.1, 0)
+        for name, payload in _GARBAGE:
+            with open(self.ctl, "wb") as f:
+                f.write(payload)
+            try:
+                out = w._read()
+            except Exception as exc:  # noqa: BLE001
+                self.fail(f"_read raised on {name!r}: {type(exc).__name__}: {exc}")
+            # never a crash; either ignored (None) or coerced to a dict
+            self.assertTrue(out is None or isinstance(out, dict),
+                            f"{name}: unexpected {out!r}")
+
+    def test_apply_hot_survives_bad_value_types(self):
+        alog.configure({"access_log": False}, tp_rank=0, model="m")
+        for bad in ({"access_log_threshold_us": "abc"},
+                    {"access_log": {"nested": 1}},
+                    {"access_log_path": 12345},
+                    {"access_log": True, "access_log_path": "/tmp/x/{foo}.log"}):
+            try:
+                alog.apply_hot(bad)
+            except Exception as exc:  # noqa: BLE001
+                self.fail(f"apply_hot raised on {bad!r}: {exc}")
+        # still responsive to a good config afterwards
+        alog.apply_hot({"access_log": True, "access_log_path": self.logpath})
+        self.assertTrue(alog.is_enabled())
+
+    def test_watcher_survives_garbage_then_recovers(self):
+        alog.configure({"access_log": False}, tp_rank=0, model="m")
+        hot.register("access_log", alog.apply_hot)
+        os.environ["DFKV_HOT_CONFIG"] = self.ctl
+        os.environ["DFKV_HOT_CONFIG_POLL_S"] = "0.15"
+        w = hot.start({}, tp_rank=0)
+        self.assertIsNotNone(w)
+        # fire every garbage payload through the live watcher loop
+        for _, payload in _GARBAGE:
+            with open(self.ctl, "wb") as f:
+                f.write(payload)
+            time.sleep(0.2)
+            self.assertTrue(w.is_alive(), "watcher thread died on garbage")
+        # recovery: a good file must still take effect
+        with open(self.ctl, "w") as f:
+            json.dump({"access_log": True, "access_log_path": self.logpath}, f)
+        self._wait(lambda: alog.is_enabled(), 3.0)
+        self.assertTrue(alog.is_enabled(), "watcher did not recover after garbage")
+        self.assertTrue(w.is_alive())
+
+    def _wait(self, pred, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if pred():
+                return
+            time.sleep(0.1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/test_telemetry_vendor_sync.py
+++ b/test/python/test_telemetry_vendor_sync.py
@@ -34,5 +34,27 @@ class VendorSyncTest(unittest.TestCase):
                     "{} drifted from canonical; run deploy/sync_telemetry.sh".format(path))
 
 
+# Standalone hot-config watcher: canonical dfkv_hot_config.py -> _hot_config.py
+# vendored byte-identical into each connector package root.
+HOT_CANON = os.path.join(ROOT, "integration", "hicache", "dfkv_hot_config.py")
+HOT_VENDORED = [
+    os.path.join(ROOT, "integration", "vllm", "src", "dfkv_vllm", "_hot_config.py"),
+    os.path.join(ROOT, "integration", "lmcache", "src", "dfkv_connector", "_hot_config.py"),
+]
+
+
+class HotConfigVendorSyncTest(unittest.TestCase):
+    def test_vendored_hot_config_is_byte_identical(self):
+        with open(HOT_CANON, "rb") as fh:
+            canon = fh.read()
+        for path in HOT_VENDORED:
+            self.assertTrue(os.path.exists(path), "missing vendored file: " + path)
+            with open(path, "rb") as fh:
+                got = fh.read()
+            self.assertEqual(
+                got, canon,
+                "{} drifted from canonical; run deploy/sync_telemetry.sh".format(path))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Toggle the dfkv client **access log** (and future observability knobs) at runtime **without restarting SGLang**.

A background daemon thread polls a small JSON control file. On change it re-applies knobs layered over the launch-time config, so **creating/editing the file turns knobs on live and deleting it reverts to launch behavior**. Multi-process safe: every SGLang TP-rank process watches the **same** file, so one edit flips all ranks.

**Opt-in**: the watcher only runs when a control-file path is explicitly set (`DFKV_HOT_CONFIG` or `extra_config["hot_config_path"]`). With no path configured, nothing new happens — zero threads, zero cost, byte-for-byte the old behavior.

## Why

Access-log config was parsed once in `DfkvHiCache.__init__`, so turning it on to debug a live hit-rate/latency issue required a full inference restart.

## Scope (Phase 1)

Only **zero-correctness-impact observability** knobs are hot — currently the `access_log` family. Structural knobs (`rdma`/`lib`/`register`/`node_dedup`) and **C-client `static const`-cached** knobs (`peer_cooldown`/`get_miss_retries`/`node_dedup_log`) stay restart-only; they freeze at native construction / first op, so a Python env flip is a no-op. Those need a native `set_runtime_opt` API (Phase 2). Hot-reload is currently **HiCache-only**.

## Changes

- `dfkv_access_log.py` — split `_build_sink()`/`_apply()`; `configure()` snapshots the launch baseline; new `apply_hot()` re-applies under a lock (lazy sink build, rebuild only on path/rotation change).
- `dfkv_hot_config.py` **(new)** — generic `register()` table + file-watch daemon; opt-in `start()`/`stop()`.
- `dfkv_hicache.py` — `register`+`start` after `configure()`; `stop()` in `__del__`.
- `test/python/test_dfkv_hot_config.py` **(new)** — 5 pure-Python cases (toggle / threshold / apply-before-configure no-op / opt-in gate / control-file lifecycle).
- `docs/access_log.md` — new hot-reload section + updated pointers.

## Usage

```bash
DFKV_HOT_CONFIG=/etc/dfkv/hot.json DFKV_ACCESS_LOG_PATH=/var/log/dfkv/access.log sglang serve ...   # access_log off
echo '{"access_log": true, "access_log_threshold_us": 1000}' > /etc/dfkv/hot.json                    # on, no restart
rm -f /etc/dfkv/hot.json                                                                              # revert to launch
```

## Test

```bash
cd test/python
python3 -m unittest test_dfkv_hot_config -v                          # 5/5 new
python3 -m unittest test_dfkv_hicache.DfkvAccessLogRotationTest -v   # 3/3 existing, no regression
```
