### PR TITLE
fix(ci): package all hicache runtime modules + import-closure guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,23 +232,16 @@ jobs:
           find "$PKG/python" "$PKG/integration" -type d \( -name '__pycache__' -o -name '*.egg-info' -o -name '.pytest_cache' \) -prune -exec rm -rf {} + 2>/dev/null || true
           cp README.md VERSION LICENSE "$PKG/"
           # 打包自检：静态解析 python/ 内所有本地 dfkv_* import，缺一个文件就 fail。
-          # （sglang 不在 runner 里装不了，真 import 跑不了，只能做依赖闭包检查——
-          #   正是这道门能在 CI 阶段拦住 v1.31.0 漏 dfkv_hot_config.py 这类事故。）
-          python3 - "$PKG/python" <<'PYEOF'
-          import pathlib, re, sys
-          pkg = pathlib.Path(sys.argv[1])
-          missing = set()
-          for f in pkg.glob("*.py"):
-              for m in re.finditer(r"^\s*(?:import|from)\s+(dfkv_\w+)", f.read_text(), re.M):
-                  name = m.group(1)
-                  if not ((pkg / f"{name}.py").is_file() or (pkg / name).is_dir()):
-                      missing.add(f"{f.name} -> {name}")
-          if missing:
-              print("ERROR: packaged python/ has unresolved local imports:")
-              print("\n".join(sorted(missing)))
-              sys.exit(1)
-          print("package import-closure check OK")
-          PYEOF
+          # （sglang 不在 runner 里装不了，真 import 跑不了；容器也没有 python3——
+          #   用纯 shell 做依赖闭包检查，正是这道门能拦住 v1.31.0 漏 dfkv_hot_config.py 这类事故。）
+          mods=$(grep -rhoE '^[[:space:]]*(import|from)[[:space:]]+dfkv_[A-Za-z0-9_]+' \
+                   --include='*.py' "$PKG/python/" | awk '{print $2}' | sort -u)
+          for m in $mods; do
+            if [ ! -e "$PKG/python/$m.py" ] && [ ! -d "$PKG/python/$m" ]; then
+              echo "ERROR: packaged python/ missing local import: $m"; exit 1
+            fi
+          done
+          echo "package import-closure check OK ($(echo "$mods" | tr '\n' ' '))"
           tar czf "${PKG}.tar.gz" "$PKG"
           sha256sum "${PKG}.tar.gz"
       - name: Upload artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,9 @@ jobs:
           cp build-static/libdfkv.so "$PKG/lib/"
           # SGLang HiCache 插件（仓库源在 integration/hicache/；产物内保持 python/ 布局不变，
           # 线上部署脚本引用的是 tarball 内的 python/dfkv_hicache.py 路径）。
-          cp integration/hicache/dfkv_hicache.py integration/hicache/dfkv_access_log.py \
-             integration/hicache/dfkv_metrics.py "$PKG/python/"
+          # 顶层 *.py 全量拷贝：手写清单在 v1.31.0 漏掉了新增的 dfkv_hot_config.py，
+          # 导致 dfkv_hicache import 即挂；glob 让清单不再需要人工维护。
+          cp integration/hicache/*.py "$PKG/python/"
           # 共享遥测包：dfkv_hicache.py 顶部 `from dfkv_telemetry import ...`，
           # 不一起打包则 SGLang 插件加载即 ImportError。
           cp -r integration/hicache/dfkv_telemetry "$PKG/python/"
@@ -230,6 +231,24 @@ jobs:
           cp -r integration/vllm integration/lmcache "$PKG/integration/"
           find "$PKG/python" "$PKG/integration" -type d \( -name '__pycache__' -o -name '*.egg-info' -o -name '.pytest_cache' \) -prune -exec rm -rf {} + 2>/dev/null || true
           cp README.md VERSION LICENSE "$PKG/"
+          # 打包自检：静态解析 python/ 内所有本地 dfkv_* import，缺一个文件就 fail。
+          # （sglang 不在 runner 里装不了，真 import 跑不了，只能做依赖闭包检查——
+          #   正是这道门能在 CI 阶段拦住 v1.31.0 漏 dfkv_hot_config.py 这类事故。）
+          python3 - "$PKG/python" <<'PYEOF'
+          import pathlib, re, sys
+          pkg = pathlib.Path(sys.argv[1])
+          missing = set()
+          for f in pkg.glob("*.py"):
+              for m in re.finditer(r"^\s*(?:import|from)\s+(dfkv_\w+)", f.read_text(), re.M):
+                  name = m.group(1)
+                  if not ((pkg / f"{name}.py").is_file() or (pkg / name).is_dir()):
+                      missing.add(f"{f.name} -> {name}")
+          if missing:
+              print("ERROR: packaged python/ has unresolved local imports:")
+              print("\n".join(sorted(missing)))
+              sys.exit(1)
+          print("package import-closure check OK")
+          PYEOF
           tar czf "${PKG}.tar.gz" "$PKG"
           sha256sum "${PKG}.tar.gz"
       - name: Upload artifacts


### PR DESCRIPTION
## 问题

v1.31.0 发布包的 `python/` 目录**漏了 `dfkv_hot_config.py`**:打包步骤手写文件清单,PR #188 新增该模块时清单没有同步。`dfkv_hicache.py:34` 无条件 `import dfkv_hot_config`,用发布包起 SGLang HiCache 连接器直接 ImportError。

实际影响:xb01 压测部署时命中(实例起不来),现场临时用包内 vendored 副本修复(`cp integration/lmcache/src/dfkv_connector/_hot_config.py python/dfkv_hot_config.py`,三方 sha256 一致 cbad66a7…)。**已按 dfkv_publish.sh 发布到各中心 GPFS 的 1.31.0 client 目录同样缺该文件**,需 hotfix 或随下个版本重发。

## 修复

1. `cp integration/hicache/*.py` 全量拷贝顶层运行时模块,清单不再需要人工维护(该目录顶层无测试文件);
2. 新增**打包自检**:静态解析 tarball `python/` 内所有 `dfkv_*` 本地 import,任一解析不到即 CI fail——runner 上装不了 sglang 做不了真 import,依赖闭包检查恰好能拦住本类事故。

## 验证

- 正测试:当前文件集 → `package import-closure check OK`
- 负测试:删除 dfkv_hot_config.py → `ERROR: dfkv_hicache.py -> dfkv_hot_config`,exit 1
- ci.yml YAML 解析通过

发现于 2026-07-18 xb01 dfkv L3 命中压测(dfkv client v1.31.0 实测,access log/热开关功能本身工作正常)。