### PR TITLE
feat(server): add --ram-tier-shards flag facade for DFKV_RAM_TIER_SHARDS

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,6 +217,7 @@ a stock `v1.7.0` node behaves exactly like `v1.6.x`.
 |---------|-------------|---------|-------|
 | slab storage engine | `--store-engine=slab` / `DFKV_STORE_ENGINE=slab` | `file` | needs clean-disk cold start |
 | RAM hot tier | `DFKV_RAM_TIER=1` (+ `DFKV_RAM_TIER_BYTES`) | off | write-through + RDMA zero-copy GET |
+| RAM tier lock shards | `--ram-tier-shards` / `DFKV_RAM_TIER_SHARDS` | 8 | 1-64; per-shard lock is the >8-connection concurrency ceiling; auto-halved while a shard would hold <32 extents |
 | RDMA transport | build `-DDFKV_WITH_RDMA=ON`, `DFKV_RDMA=1` | TCP | device by name `DFKV_RDMA_DEV` |
 | io_uring async GET | build `-DDFKV_WITH_URING`, `DFKV_SERVER_URING=1` | off | disk-read path only |
 

--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
       "  --server-uring-depth <n>  io_uring SQ depth (env DFKV_SERVER_URING_DEPTH)\n"
       "  --ram-flush-threads <n>   RAM tier flush thread count (env DFKV_RAM_FLUSH_THREADS)\n"
       "  --ram-tier-numa <n>  RAM tier NUMA node (env DFKV_RAM_TIER_NUMA)\n"
+      "  --ram-tier-shards <n>  RAM tier lock shards, 1-64 (env DFKV_RAM_TIER_SHARDS; default 8)\n"
       "  --slab-table-sync-ms <n>  slab table sync cadence ms (env DFKV_SLAB_TABLE_SYNC_MS)\n"
       "  --slab-reclaim-ms <n>  slab background free-slot reclaimer cadence ms, 0 = off (env DFKV_SLAB_RECLAIM_MS)\n"
       "  --ram-reclaim-ms <n>   RAM tier background reclaimer cadence ms, 0 = off (env DFKV_RAM_RECLAIM_MS)\n"
@@ -85,7 +86,7 @@ int main(int argc, char** argv) {
                    "--rdma-depth", "--rdma-numa", "--rdma-idle-ms",
                    "--rdma-op-timeout-ms", "--server-uring",
                    "--server-uring-depth", "--ram-flush-threads",
-                   "--ram-tier-numa", "--slab-table-sync-ms",
+                   "--ram-tier-numa", "--ram-tier-shards", "--slab-table-sync-ms",
                    "--slab-reclaim-ms", "--ram-reclaim-ms", "--log"});
   std::string dir = args.Get("--dir", "/tmp/dfkv_node");
   std::string rdma_dev = args.Get("--rdma-dev", "");
@@ -150,6 +151,11 @@ int main(int argc, char** argv) {
     ::setenv("DFKV_RAM_FLUSH_THREADS", ram_flush_threads.c_str(), 1);
   std::string ram_tier_numa = args.Get("--ram-tier-numa", "");
   if (!ram_tier_numa.empty()) ::setenv("DFKV_RAM_TIER_NUMA", ram_tier_numa.c_str(), 1);
+  // RAM tier lock shards (1-64; the tier halves it while a shard would hold
+  // <32 extents, so small arenas degrade to fewer shards).
+  std::string ram_tier_shards = args.Get("--ram-tier-shards", "");
+  if (!ram_tier_shards.empty())
+    ::setenv("DFKV_RAM_TIER_SHARDS", ram_tier_shards.c_str(), 1);
   // Slab table sync cadence (ms).
   std::string slab_table_sync_ms = args.Get("--slab-table-sync-ms", "");
   if (!slab_table_sync_ms.empty())

--- a/test/utils/args_test.cc
+++ b/test/utils/args_test.cc
@@ -108,7 +108,8 @@ TEST(Args, ServerFlagFacadesAllAccepted) {
       "--rdma-depth", "--rdma-numa", "--rdma-idle-ms",
       "--rdma-op-timeout-ms", "--server-uring",
       "--server-uring-depth", "--ram-flush-threads",
-      "--ram-tier-numa", "--slab-table-sync-ms", "--log"};
+      "--ram-tier-numa", "--ram-tier-shards", "--slab-table-sync-ms",
+      "--slab-reclaim-ms", "--ram-reclaim-ms", "--log"};
   // Every facade flag parses cleanly (non-empty value, ok=true).
   for (const auto& f : server_valued) {
     Argv a({"prog", f, "1"});


### PR DESCRIPTION
## What

Adds a `--ram-tier-shards <n>` flag facade over `DFKV_RAM_TIER_SHARDS` (same setenv-overwrite pattern as the other RAM-tier knobs), plus:

- args_test facade mirror set synced — it had drifted (missing `--slab-reclaim-ms` / `--ram-reclaim-ms`)
- ARCHITECTURE.md configuration matrix row for the knob

## Why

The shard count is the RAM tier's >8-connection concurrency lever (phase 10: GET scaling peaked at 8 threads with the default 8 shards, then degraded — the per-shard lock is the ceiling for both read and write). It was the only tier knob without a flag facade, making it unreachable through the rollout start script, which sources `dfkv-server.env` without exporting and passes knobs as flags. With the facade, deployments can set it per-center via rollout conf (`SERVER_RAM_TIER_SHARDS` → `--ram-tier-shards`).

## Verification

- `args_test` 11/11 pass
- `--help` lists the flag
- Functional: `--ram-tier-shards 4` on a 4 GiB arena logs `ram tier sharded: 4 shards x 32 extents`

No behavior change when the flag/env is unset (default stays 8; small arenas still auto-halve while a shard would hold <32 extents).