### PR TITLE
chore: fix all compiler warnings (-Wall -Wextra clean)

### DIFF
--- a/src/cache/disk_cache_group.h
+++ b/src/cache/disk_cache_group.h
@@ -28,7 +28,7 @@ class DiskCacheGroup {
     // Backend: "file" (KVStore, default) or "slab" (DiskSlabStore). Empty =>
     // read DFKV_STORE_ENGINE (default "file"). Selectable so slab lands off by
     // default with zero production impact.
-    std::string engine;
+    std::string engine{};
   };
 
   explicit DiskCacheGroup(Options opt);

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -229,7 +229,12 @@ bool DiskSlabStore::OpenOrInit() {
   } else {
     int tfd = ::open(tbl_path.c_str(), O_RDWR);
     if (tfd < 0) return false;
-    ::ftruncate(tfd, static_cast<off_t>(tbl_bytes));  // ensure full size (idempotent)
+    // Ensure full size (idempotent); a table we cannot size is a broken store,
+    // same as the create path above.
+    if (::ftruncate(tfd, static_cast<off_t>(tbl_bytes)) != 0) {
+      ::close(tfd);
+      return false;
+    }
     table_fd_ = tfd;
   }
 
@@ -243,8 +248,11 @@ bool DiskSlabStore::OpenOrInit() {
     int fd = ::open(ep.c_str(), O_RDWR | O_CREAT, 0644);
     if (fd < 0) return false;
     off_t sz = ::lseek(fd, 0, SEEK_END);
-    if (sz < static_cast<off_t>(opt_.extent_bytes))
-      ::ftruncate(fd, static_cast<off_t>(opt_.extent_bytes));
+    if (sz < static_cast<off_t>(opt_.extent_bytes) &&
+        ::ftruncate(fd, static_cast<off_t>(opt_.extent_bytes)) != 0) {
+      ::close(fd);
+      return false;
+    }
     // Materialize the extent (idempotent): DIO OVERWRITES of allocated/unwritten
     // ranges parallelize on XFS; allocating writes into ftruncate holes would
     // serialize on the exclusive iolock (measured 4.2 vs 2.0 GB/s at 8 writers).

--- a/src/common/membership.h
+++ b/src/common/membership.h
@@ -44,11 +44,13 @@ struct MemberInfo {
   // storage engine, capacity, RAM tier, RDMA dev ...). Empty = unknown / older peer.
   // Purely informational: surfaced by `dfkvctl ring` for fleet audit (version skew,
   // silently-skipped upgrades, engine mismatch) without per-node ssh.
-  std::string info;
+  std::string info{};
   // Dynamic stats (STA1); has_stats=false = legacy peer / no report yet.
   // LAST members on purpose: MemberInfo is aggregate-initialized positionally
-  // in tests/tools, and appending keeps those initializers valid.
-  MemberStats stats;
+  // in tests/tools, and appending keeps those initializers valid. The explicit
+  // {} initializers keep those shorter positional inits warning-free
+  // (-Wmissing-field-initializers skips NSDMI'd members).
+  MemberStats stats{};
   bool has_stats = false;
   // tcp_port and info ride OPTIONAL trailing extensions in Encode/DecodeMembers, so peers
   // that don't send them still interoperate. Both are intentionally EXCLUDED from

--- a/src/utils/thread_name.h
+++ b/src/utils/thread_name.h
@@ -26,8 +26,14 @@ inline void NameThisThread(const char* name) {
 // Indexed flavor for worker pools: "<prefix><idx>", truncated to the kernel's
 // 15-char limit ("rt-flush-12", "kv-fan-7").
 inline void NameThisThread(const char* prefix, size_t idx) {
-  char buf[16];
+  // pthread_setname_np fails (ERANGE) on names >15 chars rather than
+  // truncating, so the name must be clamped. Format into a buffer wide enough
+  // for any real prefix + 20-digit idx (a 16-byte buffer makes snprintf do the
+  // clamp, but trips -Wformat-truncation at every inlined call site), then
+  // clamp to the kernel limit explicitly.
+  char buf[32];
   std::snprintf(buf, sizeof(buf), "%s%zu", prefix, idx);
+  buf[15] = '\0';
   NameThisThread(buf);
 }
 

--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -140,9 +140,9 @@ TEST_F(DiskSlabTest, TornTableRecordReadsAsFreeNotResurrected) {
     // "SLTB" little-endian = 53 54 4C 42
     if (m[0] == 0x53 && m[1] == 0x54 && m[2] == 0x4C && m[3] == 0x42) {
       uint8_t byte = 0;
-      ::pread(fd, &byte, 1, o + 12);
+      ASSERT_EQ(::pread(fd, &byte, 1, o + 12), 1);
       byte ^= 0xFF;
-      ::pwrite(fd, &byte, 1, o + 12);
+      ASSERT_EQ(::pwrite(fd, &byte, 1, o + 12), 1);
       corrupted = true;
       break;
     }

--- a/test/client/node_dedup_test.cc
+++ b/test/client/node_dedup_test.cc
@@ -151,8 +151,9 @@ TEST(NodeDedup, LappedArenaNeverServesOverwrittenBytes) {
   // still carry the exact original value (possible if the slot was recycled
   // and republished, which this workload doesn't do).
   std::string out(v.size(), '\1');
-  if (a->Claim(K(6), v.size(), &out[0]) == NodeDedup::Role::kHit)
+  if (a->Claim(K(6), v.size(), &out[0]) == NodeDedup::Role::kHit) {
     EXPECT_EQ(out, v);
+  }
 }
 
 TEST(NodeDedup, CrossProcessRendezvous) {

--- a/test/utils/http_client_test.cc
+++ b/test/utils/http_client_test.cc
@@ -43,9 +43,9 @@ TEST(HttpClient, TcpRoundTripAgainstLoopbackServer) {
 
   std::thread th([srv] {
     int c = accept(srv, nullptr, nullptr);
-    char buf[4096]; ::read(c, buf, sizeof(buf));
+    char buf[4096]; EXPECT_GT(::read(c, buf, sizeof(buf)), 0);
     const char* resp = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\n{\"ok\":\"yes\"}\n";
-    ::write(c, resp, std::strlen(resp));
+    EXPECT_EQ(::write(c, resp, std::strlen(resp)), (ssize_t)std::strlen(resp));
     ::close(c);
   });
 
@@ -77,11 +77,11 @@ TEST(HttpClient, TcpRoundTripChunkedResponse) {
   int port = ntohs(a.sin_port);
   std::thread th([srv] {
     int c = accept(srv, nullptr, nullptr);
-    char buf[4096]; ::read(c, buf, sizeof(buf));
+    char buf[4096]; EXPECT_GT(::read(c, buf, sizeof(buf)), 0);
     const char* resp =
         "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
         "6\r\n{\"ok\":\r\n6\r\n\"yes\"}\r\n0\r\n\r\n";  // 2 chunks of 6 bytes + terminator
-    ::write(c, resp, std::strlen(resp));
+    EXPECT_EQ(::write(c, resp, std::strlen(resp)), (ssize_t)std::strlen(resp));
     ::close(c);
   });
   TcpHttpTransport t("127.0.0.1:" + std::to_string(port), 2000);
@@ -104,9 +104,9 @@ TEST(HttpClient, ShortContentLengthBodyFailsLoud) {
   int port = ntohs(a.sin_port);
   std::thread th([srv] {
     int c = accept(srv, nullptr, nullptr);
-    char buf[4096]; ::read(c, buf, sizeof(buf));
+    char buf[4096]; EXPECT_GT(::read(c, buf, sizeof(buf)), 0);
     const char* resp = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nonly-9-by";  // promises 100, sends 9 then closes
-    ::write(c, resp, std::strlen(resp));
+    EXPECT_EQ(::write(c, resp, std::strlen(resp)), (ssize_t)std::strlen(resp));
     ::close(c);
   });
   TcpHttpTransport t("127.0.0.1:" + std::to_string(port), 2000);


### PR DESCRIPTION
## What

Clears all 94 unique warning sites from a clean `-Wall -Wextra` build (g++ 15.2). Zero intended behavior change except two hardened error paths (see below).

| Warning | Sites | Fix |
|---|---|---|
| `-Wmissing-field-initializers` | 82 | `MemberInfo::{info,stats}` and `DiskCacheGroup::Options::engine` get explicit `{}` NSDMI at the struct — shorter positional aggregate inits stop warning, call sites untouched, and new call sites can't reintroduce it |
| `-Wunused-result` (src) | 2 | **behavior change**: `DiskSlabStore` Init now fails on `ftruncate` errors (existing-table resize + extent sizing) instead of ignoring them — a store whose table/extent cannot be sized is broken either way; the sibling create path already checked |
| `-Wunused-result` (tests) | 10 | stub-server `read`/`write` and the corruption injector's `pread`/`pwrite` assert their byte counts |
| `-Wformat-truncation` | 1 | `thread_name.h`: `pthread_setname_np` fails (ERANGE) on >15-char names rather than truncating — format into a wide buffer, clamp to the kernel limit explicitly |
| `-Wdangling-else` | 1 | braces around a conditional `EXPECT_EQ` |

## Verification

- Clean rebuild: **0 warnings**
- `ctest`: **361/361 pass**

Follow-up candidate (not in this PR): add `-Werror` in CI to keep the build warning-clean.