### PR TITLE
chore: fix clang warnings in the non-uring build

### DIFF
--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -461,9 +461,9 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
     }
   }
   // -- IO: payloads (uring one-submit when possible), then records --
+#ifdef DFKV_WITH_URING
   size_t direct_n = 0;
   for (size_t i = 0; i < N; ++i) if (st[i].active && st[i].direct) direct_n++;
-#ifdef DFKV_WITH_URING
   bool did_uring = false;
   if (uring_write_enabled_ && direct_n >= 2) {
     // One submission ring PER THREAD: the previous single shared ring + mutex

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -216,7 +216,9 @@ class DiskSlabStore : public StoreEngine {
   std::atomic<uint64_t> rebalanced_{0};
   std::atomic<uint64_t> batched_writes_{0};
   std::atomic<uint64_t> uring_write_batches_{0};
-  bool uring_write_enabled_ = false;   // DFKV_SLAB_URING_WRITE (needs DFKV_WITH_URING build)
+  // DFKV_SLAB_URING_WRITE (only read under DFKV_WITH_URING; [[maybe_unused]]
+  // keeps the class layout identical across builds instead of #ifdef'ing it).
+  [[maybe_unused]] bool uring_write_enabled_ = false;
   // The batched-write submission ring is thread_local (see disk_slab_store.cc):
   // one per flush worker, no shared lock across the blocking CQE wait.
   std::vector<uint64_t> reclaim_last_puts_;  // reclaim-thread-local puts snapshot


### PR DESCRIPTION
Follow-up to #193 — two clang-only warnings its g++ sweep missed:

- `disk_slab_store.cc:464` `-Wunused-but-set-variable`: `direct_n` is only read inside the `DFKV_WITH_URING` block; its computation moves in there (also skips the wasted count in non-uring builds).
- `disk_slab_store.h:219` `-Wunused-private-field`: `uring_write_enabled_` is only read under `DFKV_WITH_URING`; `[[maybe_unused]]` silences it while keeping the class layout identical across builds (no `#ifdef` on the field).

Verified locally: 0 warnings in both configs (default g++, and `-DDFKV_WITH_RDMA=ON -DDFKV_WITH_URING=ON`); slab tests 51/51 pass.