### PR TITLE
perf: demand-aware client fan-out pool + flat disk-ring placement + zero-registration bench arena

### DIFF
--- a/src/cache/disk_cache_group.cc
+++ b/src/cache/disk_cache_group.cc
@@ -4,8 +4,27 @@
 #include <map>
 
 #include "cache/disk_slab_store.h"
+#include "utils/log.h"
 
 namespace dfkv {
+
+namespace {
+// DFKV_DISK_HASH_WEIGHT: ketama vnode multiplier for the intra-server disk
+// ring, clamped [1, 64]. Default 1 keeps the historical placement (existing
+// cache entries stay routable); raising it re-routes a share of old keys
+// (misses, refilled on demand) in exchange for a much flatter per-disk load.
+int DiskHashWeight() {
+  static const int v = [] {
+    const char* e = std::getenv("DFKV_DISK_HASH_WEIGHT");
+    if (e && *e) {
+      long x = std::strtol(e, nullptr, 10);
+      if (x >= 1 && x <= 64) return static_cast<int>(x);
+    }
+    return 1;
+  }();
+  return v;
+}
+}  // namespace
 
 DiskCacheGroup::DiskCacheGroup(Options opt) {
   size_t n = opt.cache_dirs.empty() ? 1 : opt.cache_dirs.size();
@@ -61,9 +80,28 @@ DiskCacheGroup::DiskCacheGroup(Options opt) {
     }
     by_id_[dir] = store.get();
     disks_.push_back(std::move(store));
-    ring_.AddNode(dir);  // disk id = its dir path
+    // Disk id = its dir path. The hash weight multiplies ketama vnodes
+    // (160/weight-unit): at the default weight 1 the realized per-disk key
+    // share on a 6-disk group varies ±20%, so the hottest disk saturates at
+    // ~83% of aggregate disk bandwidth (measured: one disk at aqu-sz 600+
+    // while its five peers idle at 20-50, capping a 6x6.9GB/s server at
+    // ~33GB/s cold-read). Weight 10 (1600 vnodes/disk) shrinks the share
+    // spread to ~±6%. Env-tunable; NOTE changing it re-routes existing keys
+    // (cache semantics: old entries become misses, not corruption).
+    ring_.AddNode(dir, DiskHashWeight());
   }
   ring_.Build();
+  if (disks_.size() > 1) {
+    // Realized routing-share spread (min/max ring points per disk): the ops
+    // signal for placement skew — a hot disk saturates first and gates the
+    // whole group's cold-read throughput.
+    auto pts = ring_.NodePointCounts();
+    size_t mn = SIZE_MAX, mx = 0;
+    for (const auto& [_, c] : pts) { if (c < mn) mn = c; if (c > mx) mx = c; }
+    DFKV_LOG_INFO("disk ring: " + std::to_string(disks_.size()) + " disks, weight=" +
+                  std::to_string(DiskHashWeight()) + ", points min=" + std::to_string(mn) +
+                  " max=" + std::to_string(mx));
+  }
 }
 
 StoreEngine* DiskCacheGroup::Route(const BlockKey& key) const {

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -49,7 +49,7 @@ class FanoutPool {
   void Run(size_t n, size_t workers, const std::function<void(size_t)>& fn) {
     if (n == 0) return;
     if (workers > n) workers = n;
-    if (workers > kMaxThreads) workers = kMaxThreads;
+    if (workers > MaxThreads()) workers = MaxThreads();
     if (workers <= 1) {  // serial path: exceptions propagate as before
       for (size_t i = 0; i < n; ++i) fn(i);
       return;
@@ -58,11 +58,20 @@ class FanoutPool {
     job->n = n;
     job->fn = fn;  // one std::function copy per batch (vs a thread per worker)
     const size_t helpers = workers - 1;
-    EnsureThreads(helpers);
+    size_t want;
     {
       std::lock_guard<std::mutex> lk(mu_);
       for (size_t i = 0; i < helpers; ++i) queue_.push_back(job);
+      want = queue_.size();
     }
+    // Demand-aware sizing: grow toward the OUTSTANDING helper-job backlog, not
+    // this call's helper count. The old EnsureThreads(helpers) meant the pool
+    // never exceeded workers-1 threads (~4 for a 5-node ring) no matter how
+    // many callers ran concurrently — helper jobs queued behind each other,
+    // arrived late, found no indices and dropped out, and every caller
+    // processed its node groups nearly serially (per-call latency = sum of
+    // groups instead of max). Capped at MaxThreads().
+    EnsureThreads(want);
     cv_.notify_all();
     Work(*job);  // caller participates; late helpers find no indices and drop out
     std::unique_lock<std::mutex> lk(job->m);
@@ -96,7 +105,7 @@ class FanoutPool {
 
   void EnsureThreads(size_t want) {
     std::lock_guard<std::mutex> lk(mu_);
-    while (threads_ < want && threads_ < kMaxThreads) {
+    while (threads_ < want && threads_ < MaxThreads()) {
       std::thread([this, i = threads_] { NameThisThread("kv-fan-", i); Loop(); }).detach();
       ++threads_;
     }
@@ -115,7 +124,23 @@ class FanoutPool {
     }
   }
 
-  static constexpr size_t kMaxThreads = 32;
+  // Pool ceiling. The old constexpr 32 quietly serialized wide fan-out under
+  // many concurrent Batch* callers (callers × node-groups >> 32: helpers queue
+  // behind other jobs, groups fall back to caller-serial and per-call latency
+  // grows from max(group) to sum(group)). Env-tunable (DFKV_FANOUT_THREADS,
+  // clamped [1, 1024]) so high-concurrency clients can raise it; default
+  // unchanged at 32.
+  static size_t MaxThreads() {
+    static const size_t v = [] {
+      const char* e = std::getenv("DFKV_FANOUT_THREADS");
+      if (e && *e) {
+        long x = std::strtol(e, nullptr, 10);
+        if (x >= 1 && x <= 1024) return static_cast<size_t>(x);
+      }
+      return size_t{32};
+    }();
+    return v;
+  }
   std::mutex mu_;
   std::condition_variable cv_;
   std::deque<std::shared_ptr<Job>> queue_;

--- a/src/tools/dfkv_bench_main.cc
+++ b/src/tools/dfkv_bench_main.cc
@@ -155,18 +155,50 @@ int main(int argc, char** argv) {
   }
   if (op == "get" || op == "both") {
     fails = 0;
+    // One contiguous, page-aligned destination arena for ALL threads, declared
+    // once via RegisterMemory: every dst then resolves to the pre-registered
+    // pool MR (the production connectors' registered-host-pool shape). The old
+    // per-thread std::string buffers exceeded the per-connection user-MR cache
+    // (threads*batch addrs vs cap ~64) once calls rotate over pooled
+    // connections, so under load nearly every GET paid an ad-hoc 4MiB
+    // ibv_reg_mr+dereg (gup pins + mmap_lock) — measured as second-scale call
+    // tails that capped throughput. Falls back to the old buffers if the
+    // allocation fails.
+    const size_t stride = (size + 4095) & ~size_t{4095};
+    char* arena = static_cast<char*>(std::aligned_alloc(4096, threads * batch * stride));
+    if (arena) c.RegisterMemory(arena, threads * batch * stride);
+    std::atomic<size_t> arena_slot{0};
     double s = RunPhase(units, threads, [&](size_t u) {
       size_t base = u * batch, w = std::min(batch, count - base);
-      // Reuse per-thread destination buffers across calls so the RDMA MR cache
-      // hits (models SGLang HiCache's stable registered host pool / zero-copy).
+      thread_local char* mybuf = nullptr;
       thread_local std::vector<std::string> outs;
-      if (outs.size() < batch) { outs.resize(batch); for (auto& o : outs) o.resize(size); }
+      if (arena) {
+        if (!mybuf) mybuf = arena + arena_slot.fetch_add(1) * batch * stride;
+      } else if (outs.size() < batch) {
+        outs.resize(batch); for (auto& o : outs) o.resize(size);
+      }
       std::vector<KvGetItem> items(w);
-      for (size_t j = 0; j < w; ++j) items[j] = {key(base + j), &outs[j][0], size};
+      for (size_t j = 0; j < w; ++j)
+        items[j] = {key(base + j), arena ? mybuf + j * stride : &outs[j][0], size};
+      // DFKV_BENCH_STALL_MS: log wall-clock timestamps of slow calls to stderr
+      // so stalls can be time-correlated across processes/nodes (diagnostics).
+      static const long stall_ms = [] {
+        const char* e = std::getenv("DFKV_BENCH_STALL_MS");
+        return e && *e ? std::strtol(e, nullptr, 10) : 0;
+      }();
+      const auto st0 = std::chrono::system_clock::now();
       auto hits = c.BatchGet(items);
+      if (stall_ms > 0) {
+        const auto st1 = std::chrono::system_clock::now();
+        double ms = std::chrono::duration<double, std::milli>(st1 - st0).count();
+        if (ms >= static_cast<double>(stall_ms))
+          std::fprintf(stderr, "STALL %.3f dur=%.1fms u=%zu\n",
+                       std::chrono::duration<double>(st1.time_since_epoch()).count(), ms, u);
+      }
       size_t f = 0; for (bool h : hits) if (!h) ++f; return f;
     }, &lat, &fails);
     Report("GET", count, size, threads, batch, s, lat, fails.load());
+    std::free(arena);
   }
   return 0;
 }


### PR DESCRIPTION
Cold-read long-tail campaign on the bj09 experiment ring (5x B200, 6x Micron 7450 Gen4/server, 400G IB). Full measurement narrative in the commit message; summary:

## What
1. **client FanoutPool: demand-aware sizing** (+ `DFKV_FANOUT_THREADS`, default 32, clamp [1,1024]). `EnsureThreads(helpers)` capped the shared pool at workers-1 threads (~4) process-wide; concurrent Batch* callers serialized their node groups (per-call = sum(group) instead of max(group)). Now grows toward the outstanding helper backlog, capped at MaxThreads().
2. **server disk ring: `DFKV_DISK_HASH_WEIGHT`** (ketama vnode multiplier, default 1 = placement unchanged, clamp [1,64]) + startup log of realized point spread. Default 160 vnodes/disk gives ~±20% share spread on 6 disks — the hot disk saturates first (measured aqu-sz 600+ vs 20-50 on peers) and caps the server at hot_disk_bw/hot_share ≈ 33GB/s. Weight 10 flattens per-disk MB/s to ±3%.
3. **dfkv_bench: registered destination arena** (RegisterMemory once = production connector shape; kills per-op 4MiB ibv_reg_mr/dereg churn from user-MR cache overflow) + `DFKV_BENCH_STALL_MS` wall-clock stall log for cross-node correlation.

## Measured (cold read, 5-node mesh)
- per-call p50 21ms → 13ms (pool fix), single-client 21 → 36.5 GB/s
- ring aggregate 97-110 → **130.6 GB/s**, p99 0.9s → **~52ms** (pool fix + weight 10 + t16 sweet spot)
- single-server ceiling 33-35 GB/s ≈ 84% of raw fio ceiling (queueing knee + FTL GC account for the rest)

## Compatibility
- All three knobs default to existing behavior except the FanoutPool sizing itself, which is a straight bugfix (pool still capped at 32 by default).
- Raising `DFKV_DISK_HASH_WEIGHT` re-routes existing keys (cache miss + refill, no corruption) — flip alongside a planned warm-up.