### PR TITLE
feat: multi-rail server anchors — full 8x400G utilization via --rdma-dev comma list

### DIFF
--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -62,6 +62,18 @@ RdmaServer::RdmaServer(Handler handler, size_t max_msg, const std::string& dev_n
     const char* e = std::getenv("DFKV_RDMA_DEV");
     if (e && *e) dev_name_ = e;
   }
+  // --rdma-dev accepts a comma list (multi-rail): every listed device gets a
+  // lifetime anchor in Start(); the FIRST entry stays the default for legacy
+  // clients whose bootstrap dev frame is empty.
+  for (size_t i = 0; i <= dev_name_.size();) {
+    size_t c = dev_name_.find(',', i);
+    if (c == std::string::npos) c = dev_name_.size();
+    std::string d = dev_name_.substr(i, c - i);
+    if (!d.empty()) anchor_devs_.push_back(d);
+    i = c + 1;
+  }
+  if (anchor_devs_.empty()) anchor_devs_.push_back("");
+  dev_name_ = anchor_devs_.front();
 }
 
 RdmaServer::~RdmaServer() { Stop(); }
@@ -95,12 +107,19 @@ Status RdmaServer::Start(int port) {
   // different rail still pays that rail's first registration
   // (SharedAddPoolMr logs slow ones).
   if (!user_regions_.empty()) {
-    anchor_ep_ = std::make_unique<rdma::RcEndpoint>();
-    if (anchor_ep_->Open(dev_name_.empty() ? nullptr : dev_name_.c_str(), 4096, 1)) {
-      anchor_ep_->EnsurePoolMrs(user_regions_);
-    } else {
-      anchor_ep_.reset();  // no usable device: Serve would fail the same way
+    for (const auto& d : anchor_devs_) {
+      auto a = std::make_unique<rdma::RcEndpoint>();
+      if (a->Open(d.empty() ? nullptr : d.c_str(), 4096, 1)) {
+        a->EnsurePoolMrs(user_regions_);  // arena-scale pin: once, here, reported
+        anchors_.push_back(std::move(a));
+      }
+      // An unusable listed rail is skipped (clients requesting it fail the
+      // same way with or without an anchor); the default rail failing is the
+      // legacy no-anchor behavior.
     }
+    if (anchor_devs_.size() > 1)
+      DFKV_LOG_INFO("rdma multi-rail anchors: " + std::to_string(anchors_.size()) +
+                    "/" + std::to_string(anchor_devs_.size()) + " devices pinned");
   }
   running_ = true;
   accept_thread_ = std::thread([this] { NameThisThread("rdma-accept"); AcceptLoop(); });
@@ -121,7 +140,7 @@ void RdmaServer::Stop() {
     conns.swap(conns_);
   }
   for (auto& c : conns) if (c.th.joinable()) c.th.join();
-  anchor_ep_.reset();  // drop the lifetime device ref (frees pool MRs last)
+  anchors_.clear();  // drop the lifetime device refs (frees pool MRs last)
 }
 
 // Join and drop any Serve threads that have already finished. Called from

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -194,7 +194,11 @@ class RdmaServer {
   std::vector<Conn> conns_;
   std::unordered_set<rdma::RcEndpoint*> live_eps_;
   // Lifetime device ref + one-time pool-MR registration (see Start()).
-  std::unique_ptr<rdma::RcEndpoint> anchor_ep_;
+  // One anchor per configured rail (--rdma-dev comma list): each holds a
+  // lifetime device ref + the pool-region MRs, so neither first-touch nor
+  // idle-reclaim of the last data connection ever re-pins the arena.
+  std::vector<std::unique_ptr<rdma::RcEndpoint>> anchors_;
+  std::vector<std::string> anchor_devs_;  // parsed from dev_name_ (>=1 entries)
   std::atomic<uint64_t> uring_reads_{0}, uring_init_fallbacks_{0};
   std::atomic<uint64_t> completions_{0}, completion_errors_{0}, active_conns_{0},
       idle_reclaims_{0};


### PR DESCRIPTION
Companion to #196's cold-read campaign; unlocks the existing (latent) multi-rail path for production use.

## Context
Multi-rail was already wired end-to-end: the client stripes connections across a `DFKV_RDMA_DEV` comma list (NUMA-aware) and the bootstrap dev frame makes the server open the requested device per connection. In practice it collapsed after idle: only the default rail had a lifetime anchor, so idle reclaim of the last connection on any other rail dropped the shared device + arena pool MRs, and the next burst hit a serialized re-registration storm (7×~8s for a 128GiB arena; measured 100% op-failure window on an idle-soaked 8-rail ring).

## Change
`--rdma-dev` / server `DFKV_RDMA_DEV` accepts a comma list; `Start()` pins one anchor endpoint per listed device and registers pool regions on each at startup. First entry stays the legacy default (single-value config = bit-identical behavior).

## Measured (5-node B200, 8×400G, 128GiB arena)
- single-pair **hot** read 48.4 → **96.9 GB/s (2.0×)** — one NIC was the wall
- 5-node mesh **cold** read 141 → **155.9 GB/s (+10%)**
- idle soak >10 min with anchors: **zero re-registrations, burst fails=0** (previously 100% failure window)

## Compatibility
Single-device configs unchanged. Client-side rollout is pure env (`DFKV_RDMA_DEV=p0,...,p7` per process, or per-rank rail affinity in TP8 connectors).