### PR TITLE
feat(server): coalesce concurrent identical GETs into one disk read

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -250,20 +250,30 @@ int main(int argc, char** argv) {
         [&srv](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
                size_t cap, dfkv::RdmaServer::RangePrepResult* out) {
           dfkv::KVStore::RangePrep p;
-          Status st = srv.RangeDirectPrep(id, idx, ks, off, len, cap, &p);
+          Status st = srv.RangeDirectPrep(id, idx, ks, off, len, cap, &p,
+                                          &out->flight);
           if (st == Status::kOk) {
             out->fd = p.fd;
             out->aligned_off = p.aligned_off;
             out->aligned_len = p.aligned_len;
             out->head = p.head;
             out->payload_len = p.payload_len;
+            // Slab slot hold (0 on the file engine). Dropping this token was a
+            // real leak: the serve loop can only release what it was handed,
+            // so every uring GET left its slot pinned+inflight forever.
+            out->release_token = p.token;
           }
           return st;
         });
+    rsrv->set_range_release_handler(
+        [&srv](uint64_t tok) { srv.RangePrepRelease(tok); });
     rsrv->set_range_complete_handler(
-        [&srv](bool ok, size_t bytes_read, double elapsed_sec) {
-          srv.RangeDirectComplete(ok, bytes_read, elapsed_sec);
+        [&srv](bool ok, size_t bytes_read, double elapsed_sec, uint64_t flight,
+               const char* data) {
+          srv.RangeDirectComplete(ok, bytes_read, elapsed_sec, flight, data);
         });
+    rsrv->set_range_flight_abort_handler(
+        [&srv](uint64_t flight) { srv.RangeFlightAbort(flight); });
     // RAM hot tier (P3 B5-3): when enabled, register the arena as a pool MR and
     // wire the zero-copy serve hooks so a RAM hit is scatter-sent straight from
     // the arena (no copy into the connection buffer, no disk). No-op if off.

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -656,6 +656,7 @@ Status DiskSlabStore::RangeDirectPrep(const BlockKey& key, uint64_t offset,
     ReleaseInflightLocked(key, fn);
     return s;
   };
+  out->value_len = plen;
   if (offset >= plen) { out->payload_len = 0; return bail(Status::kOk); }  // zero-len hit, fd=-1
   const uint64_t n = std::min(length ? length : (plen - offset),
                               static_cast<uint64_t>(plen - offset));

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <string>
 
 #include <vector>
@@ -218,6 +219,9 @@ std::string KvNodeServer::MetricsText() const {
          "Disk reads executed on behalf of a convoy", read_coalescer_.leaders());
   metric("dfkv_read_coalesced_total", "counter",
          "GETs served from an in-flight identical read", read_coalescer_.coalesced());
+  metric("dfkv_read_coalesce_timeouts_total", "counter",
+         "Coalesce waiters that timed out and fell back to their own read",
+         read_coalescer_.timeouts());
   metric("dfkv_accepts_total", "counter", "TCP connections accepted", AcceptCount());
   metric("dfkv_evictions_total", "counter", "Objects evicted (capacity pressure)",
          group_.Evictions());
@@ -308,6 +312,8 @@ std::string KvNodeServer::MetricsText() const {
     metric("dfkv_ram_miss_total", "counter", "GETs that missed RAM (fell to disk)", ram_->Misses());
     metric("dfkv_ram_put_total", "counter", "PUTs accepted into the RAM hot tier", ram_->Puts());
     metric("dfkv_ram_put_bypass_total", "counter", "PUTs bypassing RAM (flush backpressure)", ram_->PutBypass());
+    metric("dfkv_ram_promoted_total", "counter",
+           "Coalesced cold reads promoted into RAM as durable residents", ram_->Promoted());
     metric("dfkv_ram_flushed_total", "counter", "RAM slots flushed to disk (now durable)", ram_->Flushed());
     metric("dfkv_ram_flush_dropped_total", "counter", "RAM slots dropped after flush failure", ram_->FlushDropped());
     metric("dfkv_ram_evictions_total", "counter", "RAM slots evicted under capacity pressure", ram_->Evictions());
@@ -402,10 +408,13 @@ Status KvNodeServer::ProcessRequest(uint8_t op_raw, uint64_t id, uint32_t index,
         }
       }
       if (!ram_served) {
-        if (coalesce_enabled_) {
+        // length==0 stays on the plain path: its scratch would have to be
+        // sized at the max-value worst case (a 64 MiB zeroed allocation per
+        // request), which costs more than the duplicate read it would save.
+        if (coalesce_enabled_ && length > 0) {
           // TCP convoy collapse: leader reads via group_.Range into a scratch
           // string sized by the store; followers copy the shared bytes.
-          const size_t cap = length ? length : (64u << 20);
+          const size_t cap = length;
           out_data->resize(cap);
           size_t n = 0;
           st = read_coalescer_.Read(key, offset, length, out_data->empty() ? nullptr : &(*out_data)[0], cap, &n,
@@ -621,8 +630,10 @@ Status KvNodeServer::RangeDirect(uint64_t id, uint32_t index, uint32_t ksize,
 
 Status KvNodeServer::RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize,
                                      uint64_t offset, uint64_t length,
-                                     size_t io_cap, KVStore::RangePrep* out) {
+                                     size_t io_cap, KVStore::RangePrep* out,
+                                     uint64_t* out_flight) {
   BlockKey key{id, index, ksize};
+  if (out_flight) *out_flight = 0;
   // A RAM-resident key has no fd to hand io_uring (and may be RAM-only, not yet
   // on disk). Decline the async prep (kInvalid) WITHOUT counting a miss so the
   // RDMA serve loop falls back to the synchronous RangeDirect, which serves it
@@ -652,21 +663,65 @@ Status KvNodeServer::RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize
   } else if (st == Status::kIOError) {
     get_io_err_.fetch_add(1, std::memory_order_relaxed);
   }
+  // Register the flight ONLY under the exact conditions the RDMA serve loop
+  // defers on (readable fd, non-zero payload, fits the connection buffer):
+  // any other prep outcome is served by the sync fallback, which joins flights
+  // itself — registering one here that no async read will ever complete would
+  // strand its waiters.
+  if (st == Status::kOk && coalesce_enabled_ && out_flight && out->fd >= 0 &&
+      out->payload_len != 0 && out->aligned_len <= io_cap &&
+      out->aligned_len <= std::numeric_limits<unsigned>::max()) {
+    // Whole-value reads only are promotable: RAM-tier entries are full
+    // [ValueHeader|payload] blobs, so installing a sub-range would corrupt
+    // every later reader of the key.
+    const bool whole = offset == 0 && out->value_len != 0 &&
+                       out->payload_len == out->value_len;
+    uint64_t t = read_coalescer_.TryRegisterAsync(key, offset, length, whole);
+    if (t == 0) {
+      // Lost the race to an identical read registered since the InFlight()
+      // check above: decline the async prep; the sync fallback joins the
+      // flight instead of issuing a duplicate NVMe fetch.
+      ::close(out->fd);
+      if (out->token) group_.RangeRelease(out->token);
+      *out = KVStore::RangePrep{};
+      return Status::kInvalid;
+    }
+    *out_flight = t;
+  }
   return st;
 }
 
 void KvNodeServer::RangeDirectComplete(bool ok, size_t bytes_read,
-                                       double elapsed_sec) {
+                                       double elapsed_sec, uint64_t flight,
+                                       const char* data) {
   if (ok) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
     bytes_read_.fetch_add(bytes_read, std::memory_order_relaxed);
   } else {
     get_io_err_.fetch_add(1, std::memory_order_relaxed);
   }
+  if (flight) {
+    BlockKey key{0, 0, 0};
+    bool whole = false;
+    const bool had_waiters = read_coalescer_.CompleteAsync(
+        flight, ok ? Status::kOk : Status::kIOError, data, bytes_read, &key,
+        &whole);
+    // Fan-in admission gate: promote ONLY pages with convoy evidence (>=1
+    // waiter joined during the read). A convoy page's laggard ranks, repeat
+    // cold reads and post-restart replays are then served from the arena; a
+    // one-off cold read never pollutes the RAM tier (the num_extents churn
+    // lesson). Durable install: costs no flush bandwidth, evictable at once.
+    if (ok && had_waiters && whole && ram_ && data && bytes_read)
+      ram_->PutDurable(key, data, bytes_read);
+  }
   // Sample the async (uring) read latency into the SAME op="get" histogram the
   // synchronous RangeDirect feeds — before this the default read path since
   // v1.27.0 contributed no latency samples at all.
   if (lat_sampler_.ShouldSample()) get_lat_.Observe(elapsed_sec);
+}
+
+void KvNodeServer::RangeFlightAbort(uint64_t flight) {
+  read_coalescer_.CompleteAsync(flight, Status::kIOError, nullptr, 0);
 }
 
 bool KvNodeServer::RamRangePrep(uint64_t id, uint32_t index, uint32_t ksize,

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -214,6 +214,10 @@ std::string KvNodeServer::MetricsText() const {
          bytes_written_.load(std::memory_order_relaxed));
   metric("dfkv_bytes_read_total", "counter", "Payload bytes read",
          bytes_read_.load(std::memory_order_relaxed));
+  metric("dfkv_read_coalesce_leaders_total", "counter",
+         "Disk reads executed on behalf of a convoy", read_coalescer_.leaders());
+  metric("dfkv_read_coalesced_total", "counter",
+         "GETs served from an in-flight identical read", read_coalescer_.coalesced());
   metric("dfkv_accepts_total", "counter", "TCP connections accepted", AcceptCount());
   metric("dfkv_evictions_total", "counter", "Objects evicted (capacity pressure)",
          group_.Evictions());
@@ -398,7 +402,27 @@ Status KvNodeServer::ProcessRequest(uint8_t op_raw, uint64_t id, uint32_t index,
         }
       }
       if (!ram_served) {
-        st = group_.Range(key, offset, length, out_data);
+        if (coalesce_enabled_) {
+          // TCP convoy collapse: leader reads via group_.Range into a scratch
+          // string sized by the store; followers copy the shared bytes.
+          const size_t cap = length ? length : (64u << 20);
+          out_data->resize(cap);
+          size_t n = 0;
+          st = read_coalescer_.Read(key, offset, length, out_data->empty() ? nullptr : &(*out_data)[0], cap, &n,
+              [&](char* buf, size_t bcap, size_t* on) {
+                std::string tmp;
+                Status s = group_.Range(key, offset, length, &tmp);
+                if (s == Status::kOk) {
+                  size_t m = tmp.size() < bcap ? tmp.size() : bcap;
+                  std::memcpy(buf, tmp.data(), m);
+                  *on = m;
+                }
+                return s;
+              });
+          out_data->resize(st == Status::kOk ? n : 0);
+        } else {
+          st = group_.Range(key, offset, length, out_data);
+        }
         if (st == Status::kOk) {
           cache_hit_.fetch_add(1, std::memory_order_relaxed);
           bytes_read_.fetch_add(out_data->size(), std::memory_order_relaxed);
@@ -483,7 +507,15 @@ Status KvNodeServer::RangeInto(uint64_t id, uint32_t index, uint32_t ksize,
       return Status::kOk;
     }
   }
-  Status st = group_.RangeInto(key, offset, length, dst, dst_cap, out_len);
+  Status st;
+  if (coalesce_enabled_) {
+    st = read_coalescer_.Read(key, offset, length, dst, dst_cap, out_len,
+        [&](char* buf, size_t cap, size_t* n) {
+          return group_.RangeInto(key, offset, length, buf, cap, n);
+        });
+  } else {
+    st = group_.RangeInto(key, offset, length, dst, dst_cap, out_len);
+  }
   if (st == Status::kOk) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
     bytes_read_.fetch_add(*out_len, std::memory_order_relaxed);
@@ -559,7 +591,22 @@ Status KvNodeServer::RangeDirect(uint64_t id, uint32_t index, uint32_t ksize,
       return Status::kOk;
     }
   }
-  Status st = group_.RangeDirect(key, offset, length, io_buf, io_cap, out_data, out_len);
+  Status st;
+  if (coalesce_enabled_) {
+    // Leader reads into the shared scratch, every rank's convoy copy lands in
+    // its own registered io_buf; *out_data must point at io_buf either way.
+    st = read_coalescer_.Read(key, offset, length, io_buf, io_cap, out_len,
+        [&](char* buf, size_t cap, size_t* n) {
+          const char* p = nullptr;
+          Status s = group_.RangeDirect(key, offset, length, buf, cap, &p, n);
+          if (s == Status::kOk && p && p != buf && *n > 0)
+            std::memcpy(buf, p, *n < cap ? *n : cap);
+          return s;
+        });
+    if (st == Status::kOk && out_data) *out_data = io_buf;
+  } else {
+    st = group_.RangeDirect(key, offset, length, io_buf, io_cap, out_data, out_len);
+  }
   if (st == Status::kOk) {
     cache_hit_.fetch_add(1, std::memory_order_relaxed);
     bytes_read_.fetch_add(*out_len, std::memory_order_relaxed);
@@ -581,6 +628,13 @@ Status KvNodeServer::RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize
   // RDMA serve loop falls back to the synchronous RangeDirect, which serves it
   // from the arena. (Only reached when the RAM tier is enabled.)
   if (ram_ && ram_->Contains(key)) {
+    if (out) *out = KVStore::RangePrep{};
+    return Status::kInvalid;
+  }
+  // An identical read is already on the disk: decline the async prep so the
+  // serve loop falls back to the synchronous RangeDirect, which joins the
+  // in-flight read instead of issuing a duplicate NVMe fetch.
+  if (coalesce_enabled_ && read_coalescer_.InFlight(key, offset, length)) {
     if (out) *out = KVStore::RangePrep{};
     return Status::kInvalid;
   }

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -222,6 +222,9 @@ std::string KvNodeServer::MetricsText() const {
   metric("dfkv_read_coalesce_timeouts_total", "counter",
          "Coalesce waiters that timed out and fell back to their own read",
          read_coalescer_.timeouts());
+  metric("dfkv_read_coalesce_recur_total", "counter",
+         "Reads that hit a recurrence tombstone (drift-window promotion evidence)",
+         read_coalescer_.recur_hits());
   metric("dfkv_accepts_total", "counter", "TCP connections accepted", AcceptCount());
   metric("dfkv_evictions_total", "counter", "Objects evicted (capacity pressure)",
          group_.Evictions());
@@ -703,15 +706,17 @@ void KvNodeServer::RangeDirectComplete(bool ok, size_t bytes_read,
   if (flight) {
     BlockKey key{0, 0, 0};
     bool whole = false;
+    bool recurrent = false;
     const bool had_waiters = read_coalescer_.CompleteAsync(
         flight, ok ? Status::kOk : Status::kIOError, data, bytes_read, &key,
-        &whole);
-    // Fan-in admission gate: promote ONLY pages with convoy evidence (>=1
-    // waiter joined during the read). A convoy page's laggard ranks, repeat
+        &whole, &recurrent);
+    // Admission gate: promote ONLY pages with convoy evidence — an in-flight
+    // waiter (overlap) or a recurrence-tombstone hit (same range re-read
+    // within the drift window; v2). A convoy page's laggard ranks, repeat
     // cold reads and post-restart replays are then served from the arena; a
     // one-off cold read never pollutes the RAM tier (the num_extents churn
     // lesson). Durable install: costs no flush bandwidth, evictable at once.
-    if (ok && had_waiters && whole && ram_ && data && bytes_read)
+    if (ok && (had_waiters || recurrent) && whole && ram_ && data && bytes_read)
       ram_->PutDurable(key, data, bytes_read);
   }
   // Sample the async (uring) read latency into the SAME op="get" histogram the

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -104,13 +104,28 @@ class KvNodeServer {
   // issues the pread (io_uring) into its io_buf and closes out->fd afterward.
   // Updates miss/io-error counters; the hit/bytes-read counters are bumped by
   // RangeDirectComplete once the read result is known.
+  // On a deferrable hit with read-coalescing enabled, registers the read as an
+  // async flight and returns its token via *out_flight (0 = none): the caller
+  // MUST route the token to RangeDirectComplete (read finished, ok or not) or
+  // RangeFlightAbort (read never ran). A prep that loses the registration race
+  // to an identical in-flight read declines with kInvalid so the serve loop
+  // falls back to the sync path, which joins the flight.
   Status RangeDirectPrep(uint64_t id, uint32_t index, uint32_t ksize,
                          uint64_t offset, uint64_t length, size_t io_cap,
-                         KVStore::RangePrep* out);
+                         KVStore::RangePrep* out,
+                         uint64_t* out_flight = nullptr);
   // Account a completed prep-based GET (called after the async read finishes).
   // elapsed_sec = submit->completion wall time; sampled into get_lat_ so the
   // default (uring) read path is no longer absent from op="get" latency.
-  void RangeDirectComplete(bool ok, size_t bytes_read, double elapsed_sec);
+  // `data` = payload bytes in the caller's direct buffer (nullptr on failure),
+  // valid only during the call: completes the flight (waiters copy from it)
+  // and, when the flight had fan-in AND covered the whole value, promotes the
+  // page into the RAM tier as a durable resident.
+  void RangeDirectComplete(bool ok, size_t bytes_read, double elapsed_sec,
+                           uint64_t flight, const char* data);
+  // Abort a flight whose read never completed (connection teardown): waiters
+  // fall back to their own reads immediately.
+  void RangeFlightAbort(uint64_t flight);
   // Balance a prep whose RangePrep::token != 0 (slab pins the slot across the
   // async read); routed to the owning engine via the token's disk-index byte.
   void RangePrepRelease(uint64_t token) { group_.RangeRelease(token); }

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -17,6 +17,7 @@
 
 #include "cache/disk_cache_group.h"
 #include "cache/ram_tier.h"
+#include "cache/read_coalescer.h"
 #include "utils/latency_hist.h"
 
 namespace dfkv {
@@ -141,6 +142,12 @@ class KvNodeServer {
   std::atomic<size_t> exist_hit_{0}, exist_miss_{0};
   std::atomic<size_t> remove_ok_{0}, remove_miss_{0};
   std::atomic<size_t> bytes_written_{0}, bytes_read_{0};
+  // Read-side convoy collapse (env DFKV_READ_COALESCE=1; see read_coalescer.h).
+  ReadCoalescer read_coalescer_;
+  bool coalesce_enabled_ = [] {
+    const char* e = std::getenv("DFKV_READ_COALESCE");
+    return e && *e && *e != '0';
+  }();
   // depth metrics: errors by op, live connections, sampled op latency
   std::atomic<size_t> put_io_err_{0}, get_io_err_{0}, invalid_ops_{0};
   // PUT admission gate (I6): reject with kCacheFull once this many disk writes

--- a/src/cache/kv_store.cc
+++ b/src/cache/kv_store.cc
@@ -584,6 +584,7 @@ Status KVStore::RangeDirectPrep(const BlockKey& key, uint64_t offset,
   // From here a failure must close raw_fd (the caller only owns it on kOk).
   auto fail = [&](Status s) { ::close(raw_fd); return s; };
   if (offset > fsize) return fail(Status::kInvalid);
+  out->value_len = static_cast<size_t>(fsize);
   uint64_t n = length;
   if (n > fsize - offset) n = fsize - offset;
   if (n == 0) {  // valid zero-length hit: nothing to read, no fd to keep

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -292,6 +292,46 @@ bool RamTier::Put(const BlockKey& key, const void* data, size_t len) {
   return true;
 }
 
+bool RamTier::PutDurable(const BlockKey& key, const void* data, size_t len) {
+  if (!arena_) return false;
+  if (data == nullptr && len != 0) return false;
+  const std::string fn = key.Filename();
+  Shard& s = ShardFor(fn);
+
+  uint64_t offset = 0;
+  uint32_t cap = 0;
+  {
+    std::lock_guard<std::mutex> lk(s.mu);
+    if (s.index.count(fn) || s.writing.count(fn)) return true;  // already resident
+    SlabAllocator::SlotRef ref;
+    std::vector<std::string> evicted;
+    if (!s.alloc->Put(fn, len, &ref, &evicted)) return false;  // best-effort skip
+    for (const auto& ev : evicted) s.index.erase(ev);
+    // Pin only for the copy window: the slot is not in the index yet, but the
+    // allocator knows it and an unpinned slot could be CLOCK-evicted mid-copy.
+    s.alloc->Pin(fn);
+    s.writing.insert(fn);
+    offset = s.base_off + ref.extent * extent_bytes_ + ref.offset;
+    cap = ref.slot_size;
+  }
+
+  std::memcpy(arena_ + offset, data, len);
+
+  {
+    std::lock_guard<std::mutex> lk(s.mu);
+    Entry e;
+    e.offset = offset;
+    e.len = static_cast<uint32_t>(len);
+    e.cap = cap;
+    e.durable = true;  // already on disk: no flushq, no flush-pin
+    s.index[fn] = e;
+    s.writing.erase(fn);
+    s.alloc->Unpin(fn);  // refcount 0 => evictable immediately
+  }
+  promotes_.fetch_add(1, std::memory_order_relaxed);
+  return true;
+}
+
 bool RamTier::GetPrep(const BlockKey& key, uint64_t offset, uint64_t length,
                       Hit* out) {
   if (shards_.empty()) return false;  // failed-construction guard (ok()==false)

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -116,6 +116,15 @@ class RamTier {
   // slots) or if len exceeds the shard -- caller then does the normal disk write.
   bool Put(const BlockKey& key, const void* data, size_t len);
 
+  // Read-promotion entry: install a value that is ALREADY durable on disk
+  // (a coalesced cold read with fan-in evidence). Same allocation/index logic
+  // as Put, but the slot is born durable — never enqueued for flush, never
+  // holds a flush-pin, so it costs zero DIO write bandwidth and is evictable
+  // by CLOCK the moment no send is in flight. Best-effort: a full shard
+  // declines (false) and the promotion is silently skipped; promoted slots can
+  // never crowd out the write path's flush resources.
+  bool PutDurable(const BlockKey& key, const void* data, size_t len);
+
   // On hit, pins the slot (send-pin) and returns its arena location. The caller
   // MUST call Release(hit.token) when the RDMA send completes. Miss => false.
   bool GetPrep(const BlockKey& key, uint64_t offset, uint64_t length, Hit* out);
@@ -142,6 +151,7 @@ class RamTier {
   uint64_t Hits() const { return hits_.load(std::memory_order_relaxed); }
   uint64_t Misses() const { return misses_.load(std::memory_order_relaxed); }
   uint64_t Puts() const { return puts_.load(std::memory_order_relaxed); }
+  uint64_t Promoted() const { return promotes_.load(std::memory_order_relaxed); }
   uint64_t PutBypass() const { return put_bypass_.load(std::memory_order_relaxed); }
   uint64_t Flushed() const { return flushed_.load(std::memory_order_relaxed); }
   uint64_t FlushDropped() const { return flush_dropped_.load(std::memory_order_relaxed); }
@@ -221,7 +231,7 @@ class RamTier {
   std::mutex reclaim_mu_;
   bool reclaim_stop_ = false;
 
-  std::atomic<uint64_t> hits_{0}, misses_{0}, puts_{0}, put_bypass_{0};
+  std::atomic<uint64_t> hits_{0}, misses_{0}, puts_{0}, put_bypass_{0}, promotes_{0};
   std::atomic<uint64_t> flushed_{0}, flush_dropped_{0}, reclaimed_{0}, rebalanced_{0};
 };
 

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -530,6 +530,7 @@ void RdmaServer::Serve(int boot_fd) {
         int read_idx = -1;   // >=0: index into descs (async read); -1: sync reply
         int fd = -1;         // owned (async only); closed after the batch read
         uint64_t prep_token = 0;  // slab slot hold; released where fd is closed
+        uint64_t flight = 0;      // coalescer registration; completed or aborted
         size_t head = 0;
         size_t payload_len = 0;
         // Steady-clock seconds at prep (read submit), 0 = unsampled. Only the
@@ -598,6 +599,7 @@ void RdmaServer::Serve(int boot_fd) {
               descs.push_back(d);
               qd.fd = pr.fd;
               qd.prep_token = pr.release_token;
+              qd.flight = pr.flight;
               qd.head = pr.head;
               qd.payload_len = pr.payload_len;
               qd.submit_sec = NowSteadySec();  // read submit -> completion latency
@@ -606,6 +608,8 @@ void RdmaServer::Serve(int boot_fd) {
               ::close(pr.fd);  // zero-len / oversize: handled by sync build below
               if (pr.release_token && range_release_handler_)
                 range_release_handler_(pr.release_token);
+              if (pr.flight && range_flight_abort_handler_)
+                range_flight_abort_handler_(pr.flight);
             }
           }
 
@@ -678,9 +682,15 @@ void RdmaServer::Serve(int boot_fd) {
             if (range_release_handler_) range_release_handler_(qd.prep_token);
             qd.prep_token = 0;
           }
-          if (range_complete_handler_)
+          // Runs BEFORE the reply send on purpose: coalesced waiters and the
+          // RAM promotion copy from the dbuf payload, and the buffer is reused
+          // the moment the scatter SEND is posted.
+          if (range_complete_handler_) {
             range_complete_handler_(ok, ok ? qd.payload_len : 0,
-                                    NowSteadySec() - qd.submit_sec);
+                                    NowSteadySec() - qd.submit_sec, qd.flight,
+                                    ok ? ep.dbuf(qd.recv_slot) + qd.head : nullptr);
+            qd.flight = 0;  // completed: the teardown sweep must not abort it
+          }
           char* sb = ep.sbuf(qd.send_slot);
           if (ok) {
             EncodeResp(sb, Status::kOk, qd.payload_len);
@@ -699,10 +709,13 @@ void RdmaServer::Serve(int boot_fd) {
         }
       }
 
-      // Connection ending: close any fds still owned by un-emitted queue entries.
+      // Connection ending: close any fds still owned by un-emitted queue
+      // entries, and abort their flights so coalesced waiters on other
+      // connections stop waiting NOW instead of eating the full timeout.
       for (auto& qd : queue) {
         if (qd.fd >= 0) ::close(qd.fd);
         if (qd.prep_token && range_release_handler_) range_release_handler_(qd.prep_token);
+        if (qd.flight && range_flight_abort_handler_) range_flight_abort_handler_(qd.flight);
       }
     }
     // Release RAM-hit pins for sends that never completed (conn tore down) so the

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -65,6 +65,12 @@ class RdmaServer {
     // 0 = no hold. A slot-based engine (slab) pins the slot for the read's
     // duration; passed to range_release_handler_ wherever fd is closed.
     uint64_t release_token = 0;
+    // 0 = no flight. Read-coalescer registration made at prep time: the serve
+    // loop passes it to range_complete_handler_ with the payload once the async
+    // read finishes, or to range_flight_abort_handler_ on any teardown path
+    // where the read never completes — a registered flight MUST reach exactly
+    // one of the two, or a convoy follower waits out its full timeout.
+    uint64_t flight = 0;
   };
   using RangePrepHandler = std::function<Status(
       uint64_t id, uint32_t index, uint32_t ksize, uint64_t offset,
@@ -77,10 +83,20 @@ class RdmaServer {
   // never did, leaving dfkv_op_latency_seconds{op="get"} blind to the default
   // read path since v1.27.0. Negative/zero-cost when the sampler skips (the
   // serve loop only stamps sampled reads).
+  // `flight` is the prep's coalescer registration (0 = none) and `data` points
+  // at the payload bytes in the connection's direct buffer (nullptr on
+  // failure) — valid only for the duration of the call, which runs BEFORE the
+  // reply send, so the handler may copy from it (coalesced waiters, RAM
+  // promotion) but must not retain it.
   using RangeCompleteHandler =
-      std::function<void(bool ok, size_t bytes_read, double elapsed_sec)>;
+      std::function<void(bool ok, size_t bytes_read, double elapsed_sec,
+                         uint64_t flight, const char* data)>;
   // Releases a prep's release_token (slab slot pin) once its read is done.
   using RangeReleaseHandler = std::function<void(uint64_t token)>;
+  // Aborts a prep's flight registration on paths where the async read never
+  // completes (poisoned ring teardown, connection death): waiters fall back to
+  // their own reads instead of hanging until timeout.
+  using RangeFlightAbortHandler = std::function<void(uint64_t flight)>;
 
   // dev_name empty => env DFKV_RDMA_DEV, else first device.
   explicit RdmaServer(Handler handler, size_t max_msg = (64u << 20),
@@ -101,6 +117,9 @@ class RdmaServer {
   }
   void set_range_release_handler(RangeReleaseHandler h) {
     range_release_handler_ = std::move(h);
+  }
+  void set_range_flight_abort_handler(RangeFlightAbortHandler h) {
+    range_flight_abort_handler_ = std::move(h);
   }
 
   // --- RAM hot-tier zero-copy GET (P3 B5-3, ADDITIVE + OFF unless wired) --------
@@ -177,6 +196,7 @@ class RdmaServer {
   RangePrepHandler range_prep_handler_;
   RangeCompleteHandler range_complete_handler_;
   RangeReleaseHandler range_release_handler_;
+  RangeFlightAbortHandler range_flight_abort_handler_;
   RamRangeHandler ram_range_handler_;
   RamReleaseHandler ram_release_handler_;
   std::vector<std::pair<void*, size_t>> user_regions_;  // RAM arena pool MRs (RegisterMemory)

--- a/src/cache/read_coalescer.h
+++ b/src/cache/read_coalescer.h
@@ -6,9 +6,26 @@
  * because the disk path is O_DIRECT with no read cache, hit the NVMe eight
  * times (measured 1:1 disk:wire on replay workloads, E11B 2026-07-20). The
  * write path already absorbs this convoy via the RAM write-through arena; this
- * class is the read-side counterpart: the first arrival ("leader") does the
- * disk read into a shared scratch buffer, every overlapping arrival
- * ("follower") blocks until it completes and memcpy()s from the scratch.
+ * class is the read-side counterpart, and it registers BOTH read paths:
+ *
+ *  - Synchronous (TCP kRange, RangeInto, sync RangeDirect): Read() — the first
+ *    arrival ("leader") does the disk read into a shared scratch buffer, every
+ *    overlapping arrival ("follower") blocks until it completes and memcpy()s
+ *    from the scratch.
+ *  - Asynchronous (the io_uring serve path, the production default since
+ *    v1.27.0): TryRegisterAsync() at prep time creates the flight WITHOUT
+ *    performing the read; the serve loop does the read out-of-band and calls
+ *    CompleteAsync() with the payload, which hands it to any waiters. A
+ *    duplicate GET's prep declines (token 0 / InFlight), falls back to the
+ *    sync path, and joins the flight through Read() like any follower.
+ *
+ * A follower waits at most WaitMs() (DFKV_READ_COALESCE_TIMEOUT_MS, default
+ * 500 ms) and falls back to its OWN disk read on timeout or on a failed/
+ * abandoned flight — a leader connection can be torn down mid-batch (ring
+ * poisoned, batch fail), so a waiter must never be able to hang forever.
+ * A follower whose flight was registered by ITS OWN serve thread (a pipelined
+ * duplicate on one connection: the leader's read has not been submitted yet)
+ * skips waiting entirely and reads itself — waiting would deadlock.
  *
  * Blocking a follower is never worse than the duplicate pread it replaces
  * (both are bounded by one disk read), so this is safe on thread-per-conn
@@ -20,13 +37,15 @@
 #define DFKV_READ_COALESCER_H_
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <unordered_map>
-#include <vector>
 
 #include "common/kv_types.h"
 #include "common/status.h"
@@ -56,20 +75,84 @@ class ReadCoalescer {
   };
 
   // True if an identical read is currently in flight (used by the async-prep
-  // path to decline io_uring and fall back to the synchronous path, which
-  // then joins the flight instead of issuing a duplicate disk read).
+  // path as a cheap early decline, before the index lookup + fd open).
   bool InFlight(const BlockKey& bk, uint64_t offset, uint64_t length) {
     Key k{bk.id, bk.index, bk.size, offset, length};
     std::lock_guard<std::mutex> lk(mu_);
     return map_.find(k) != map_.end();
   }
 
+  // Register a flight for a read the CALLER will perform out-of-band (io_uring).
+  // Returns a non-zero completion token, or 0 if an identical read is already in
+  // flight — the caller then declines the async prep and joins via Read().
+  // `whole_value` records whether this read covers the entire stored value
+  // (offset 0, full length): only such reads are eligible for RAM promotion.
+  uint64_t TryRegisterAsync(const BlockKey& bk, uint64_t offset, uint64_t length,
+                            bool whole_value) {
+    Key k{bk.id, bk.index, bk.size, offset, length};
+    std::lock_guard<std::mutex> lk(mu_);
+    if (map_.find(k) != map_.end()) return 0;
+    auto f = std::make_shared<Flight>();
+    f->key = k;
+    f->whole = whole_value;
+    f->leader_tid = std::this_thread::get_id();
+    map_.emplace(k, f);
+    const uint64_t t = ++token_seq_;
+    tokens_.emplace(t, std::move(f));
+    return t;
+  }
+
+  // Complete (or abort) an async flight. On st==kOk with data, any waiters are
+  // handed a copy of the payload; on any other status (or abort: data==nullptr)
+  // waiters fall back to their own disk reads. Returns true if at least one
+  // waiter had joined — the fan-in evidence the caller's RAM-promotion
+  // admission gate keys on — and fills *key / *whole from registration.
+  // Idempotent per token; unknown tokens return false.
+  bool CompleteAsync(uint64_t token, Status st, const char* data, size_t len,
+                     BlockKey* key = nullptr, bool* whole = nullptr) {
+    std::shared_ptr<Flight> f;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      auto it = tokens_.find(token);
+      if (it == tokens_.end()) return false;
+      f = std::move(it->second);
+      tokens_.erase(it);
+      auto mit = map_.find(f->key);
+      if (mit != map_.end() && mit->second == f) map_.erase(mit);
+    }
+    const bool waiters = f->waiters.load(std::memory_order_acquire) > 0;
+    if (waiters && st == Status::kOk && data && len) {
+      f->data = AlignedAlloc(len);
+      if (f->data) std::memcpy(f->data.get(), data, len);
+    }
+    {
+      std::lock_guard<std::mutex> fl(f->m);
+      f->st = st;
+      f->len = len;
+      f->done = true;
+    }
+    f->cv.notify_all();
+    leaders_.fetch_add(1, std::memory_order_relaxed);
+    if (key) *key = BlockKey{f->key.id, f->key.index, f->key.ksize};
+    if (whole) *whole = f->whole;
+    return waiters;
+  }
+
+  // Leader/follower outcome of a Read() call, for the caller's promotion gate
+  // on the synchronous path (only meaningful when leader is true).
+  struct Outcome {
+    bool leader = false;
+    bool had_waiters = false;
+  };
+
   // Execute `fill(buf, cap, out_len)` exactly once per concurrent set of
   // identical (key, offset, length) readers; copy the result into every
-  // caller's dst. Returns the fill status (shared verbatim by followers).
+  // caller's dst. A follower that times out, joins its own thread's pending
+  // flight, or sees a failed/aborted flight runs its own fill instead.
   Status Read(const BlockKey& bk, uint64_t offset, uint64_t length, char* dst,
               size_t dst_cap, size_t* out_len,
-              const std::function<Status(char*, size_t, size_t*)>& fill) {
+              const std::function<Status(char*, size_t, size_t*)>& fill,
+              Outcome* oc = nullptr) {
     Key k{bk.id, bk.index, bk.size, offset, length};
     std::shared_ptr<Flight> f;
     bool leader = false;
@@ -78,6 +161,8 @@ class ReadCoalescer {
       auto it = map_.find(k);
       if (it == map_.end()) {
         f = std::make_shared<Flight>();
+        f->key = k;
+        f->leader_tid = std::this_thread::get_id();
         map_.emplace(k, f);
         leader = true;
       } else {
@@ -85,12 +170,15 @@ class ReadCoalescer {
       }
     }
     if (leader) {
-      f->data = std::make_shared<std::vector<char>>(dst_cap);
+      // Aligned scratch: the fill may be an O_DIRECT read straight into it.
+      f->data = AlignedAlloc(dst_cap);
       size_t n = 0;
-      Status st = fill(f->data->data(), dst_cap, &n);
+      Status st = f->data ? fill(f->data.get(), dst_cap, &n)
+                          : fill(dst, dst_cap, &n);  // alloc failed: no sharing
       {
         std::lock_guard<std::mutex> lk(mu_);
-        map_.erase(k);  // late arrivals after this start their own flight
+        auto it = map_.find(k);
+        if (it != map_.end() && it->second == f) map_.erase(it);
       }
       {
         std::lock_guard<std::mutex> fl(f->m);
@@ -100,28 +188,47 @@ class ReadCoalescer {
       }
       f->cv.notify_all();
       leaders_.fetch_add(1, std::memory_order_relaxed);
-      if (st == Status::kOk && n > 0) {
-        std::memcpy(dst, f->data->data(), n < dst_cap ? n : dst_cap);
+      if (oc) {
+        oc->leader = true;
+        oc->had_waiters = f->waiters.load(std::memory_order_acquire) > 0;
+      }
+      if (st == Status::kOk && n > 0 && f->data) {
+        std::memcpy(dst, f->data.get(), n < dst_cap ? n : dst_cap);
         if (out_len) *out_len = n < dst_cap ? n : dst_cap;
+      } else if (st == Status::kOk && out_len && !f->data) {
+        // fill wrote dst directly; *out_len was set by fill via &n above.
+        *out_len = n;
       }
       return st;
     }
-    // Follower: wait for the leader's read, then copy from the shared buffer.
-    std::unique_lock<std::mutex> fl(f->m);
-    f->cv.wait(fl, [&] { return f->done; });
-    Status st = f->st;
-    size_t n = f->len;
-    if (st == Status::kOk && n > 0) {
-      size_t c = n < dst_cap ? n : dst_cap;
-      std::memcpy(dst, f->data->data(), c);
-      if (out_len) *out_len = c;
+    // A pipelined duplicate on the flight's own serve thread: the leader's read
+    // has not been submitted yet (async prep registers before the uring batch
+    // runs), so waiting here would deadlock. Read it ourselves.
+    if (f->leader_tid == std::this_thread::get_id())
+      return fill(dst, dst_cap, out_len);
+    // Follower: wait (bounded) for the leader, then copy from the shared
+    // buffer; on timeout / failure / abort, fall back to our own read.
+    f->waiters.fetch_add(1, std::memory_order_acq_rel);
+    {
+      std::unique_lock<std::mutex> fl(f->m);
+      if (!f->cv.wait_for(fl, std::chrono::milliseconds(WaitMs()),
+                          [&] { return f->done; })) {
+        timeouts_.fetch_add(1, std::memory_order_relaxed);
+        fl.unlock();
+        return fill(dst, dst_cap, out_len);
+      }
     }
+    if (f->st != Status::kOk || !f->data) return fill(dst, dst_cap, out_len);
+    const size_t c = f->len < dst_cap ? f->len : dst_cap;
+    if (c) std::memcpy(dst, f->data.get(), c);
+    if (out_len) *out_len = c;
     coalesced_.fetch_add(1, std::memory_order_relaxed);
-    return st;
+    return Status::kOk;
   }
 
   size_t leaders() const { return leaders_.load(std::memory_order_relaxed); }
   size_t coalesced() const { return coalesced_.load(std::memory_order_relaxed); }
+  size_t timeouts() const { return timeouts_.load(std::memory_order_relaxed); }
 
  private:
   struct Flight {
@@ -130,11 +237,40 @@ class ReadCoalescer {
     bool done = false;
     Status st = Status::kInvalid;
     size_t len = 0;
-    std::shared_ptr<std::vector<char>> data;
+    std::shared_ptr<char> data;  // 4096-aligned scratch (leader's read target)
+    Key key{};
+    bool whole = false;
+    std::thread::id leader_tid;
+    std::atomic<int> waiters{0};
   };
+
+  static std::shared_ptr<char> AlignedAlloc(size_t n) {
+    void* p = nullptr;
+    if (posix_memalign(&p, 4096, n ? n : 4096) != 0 || !p) return nullptr;
+    return std::shared_ptr<char>(static_cast<char*>(p),
+                                 [](char* q) { std::free(q); });
+  }
+
+  // Follower wait bound. A leader connection can die mid-batch with the flight
+  // never completed (every known path aborts it, but a waiter must not bet its
+  // liveness on that); 500 ms is ~2 orders above a healthy NVMe read.
+  static int WaitMs() {
+    static const int ms = [] {
+      const char* e = std::getenv("DFKV_READ_COALESCE_TIMEOUT_MS");
+      if (e && *e) {
+        long v = std::strtol(e, nullptr, 10);
+        if (v >= 10 && v <= 60000) return static_cast<int>(v);
+      }
+      return 500;
+    }();
+    return ms;
+  }
+
   std::mutex mu_;
   std::unordered_map<Key, std::shared_ptr<Flight>, KeyHash> map_;
-  std::atomic<size_t> leaders_{0}, coalesced_{0};
+  std::unordered_map<uint64_t, std::shared_ptr<Flight>> tokens_;
+  uint64_t token_seq_ = 0;
+  std::atomic<size_t> leaders_{0}, coalesced_{0}, timeouts_{0};
 };
 
 }  // namespace dfkv

--- a/src/cache/read_coalescer.h
+++ b/src/cache/read_coalescer.h
@@ -1,0 +1,142 @@
+/* ReadCoalescer — collapse concurrent identical GETs into one disk read.
+ *
+ * Why: with TP8 + MLA every rank is a separate process fetching the SAME page
+ * (same BlockKey, same range) within the same prefetch window; client-side
+ * NodeDedup is per-process so eight copies of every read reach the node and,
+ * because the disk path is O_DIRECT with no read cache, hit the NVMe eight
+ * times (measured 1:1 disk:wire on replay workloads, E11B 2026-07-20). The
+ * write path already absorbs this convoy via the RAM write-through arena; this
+ * class is the read-side counterpart: the first arrival ("leader") does the
+ * disk read into a shared scratch buffer, every overlapping arrival
+ * ("follower") blocks until it completes and memcpy()s from the scratch.
+ *
+ * Blocking a follower is never worse than the duplicate pread it replaces
+ * (both are bounded by one disk read), so this is safe on thread-per-conn
+ * TCP and on the RDMA serve loop, which already blocks in RangeDirect.
+ *
+ * Opt-in via env DFKV_READ_COALESCE=1 (checked by the caller, not here).
+ */
+#ifndef DFKV_READ_COALESCER_H_
+#define DFKV_READ_COALESCER_H_
+
+#include <atomic>
+#include <condition_variable>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "common/kv_types.h"
+#include "common/status.h"
+
+namespace dfkv {
+
+class ReadCoalescer {
+ public:
+  struct Key {
+    uint64_t id;
+    uint32_t index, ksize;
+    uint64_t offset, length;
+    bool operator==(const Key& o) const {
+      return id == o.id && index == o.index && ksize == o.ksize &&
+             offset == o.offset && length == o.length;
+    }
+  };
+  struct KeyHash {
+    size_t operator()(const Key& k) const {
+      size_t h = std::hash<uint64_t>()(k.id);
+      h ^= std::hash<uint64_t>()((static_cast<uint64_t>(k.index) << 32) ^ k.ksize) +
+           0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+      h ^= std::hash<uint64_t>()(k.offset ^ (k.length << 1)) + 0x9e3779b97f4a7c15ULL +
+           (h << 6) + (h >> 2);
+      return h;
+    }
+  };
+
+  // True if an identical read is currently in flight (used by the async-prep
+  // path to decline io_uring and fall back to the synchronous path, which
+  // then joins the flight instead of issuing a duplicate disk read).
+  bool InFlight(const BlockKey& bk, uint64_t offset, uint64_t length) {
+    Key k{bk.id, bk.index, bk.size, offset, length};
+    std::lock_guard<std::mutex> lk(mu_);
+    return map_.find(k) != map_.end();
+  }
+
+  // Execute `fill(buf, cap, out_len)` exactly once per concurrent set of
+  // identical (key, offset, length) readers; copy the result into every
+  // caller's dst. Returns the fill status (shared verbatim by followers).
+  Status Read(const BlockKey& bk, uint64_t offset, uint64_t length, char* dst,
+              size_t dst_cap, size_t* out_len,
+              const std::function<Status(char*, size_t, size_t*)>& fill) {
+    Key k{bk.id, bk.index, bk.size, offset, length};
+    std::shared_ptr<Flight> f;
+    bool leader = false;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      auto it = map_.find(k);
+      if (it == map_.end()) {
+        f = std::make_shared<Flight>();
+        map_.emplace(k, f);
+        leader = true;
+      } else {
+        f = it->second;
+      }
+    }
+    if (leader) {
+      f->data = std::make_shared<std::vector<char>>(dst_cap);
+      size_t n = 0;
+      Status st = fill(f->data->data(), dst_cap, &n);
+      {
+        std::lock_guard<std::mutex> lk(mu_);
+        map_.erase(k);  // late arrivals after this start their own flight
+      }
+      {
+        std::lock_guard<std::mutex> fl(f->m);
+        f->st = st;
+        f->len = n;
+        f->done = true;
+      }
+      f->cv.notify_all();
+      leaders_.fetch_add(1, std::memory_order_relaxed);
+      if (st == Status::kOk && n > 0) {
+        std::memcpy(dst, f->data->data(), n < dst_cap ? n : dst_cap);
+        if (out_len) *out_len = n < dst_cap ? n : dst_cap;
+      }
+      return st;
+    }
+    // Follower: wait for the leader's read, then copy from the shared buffer.
+    std::unique_lock<std::mutex> fl(f->m);
+    f->cv.wait(fl, [&] { return f->done; });
+    Status st = f->st;
+    size_t n = f->len;
+    if (st == Status::kOk && n > 0) {
+      size_t c = n < dst_cap ? n : dst_cap;
+      std::memcpy(dst, f->data->data(), c);
+      if (out_len) *out_len = c;
+    }
+    coalesced_.fetch_add(1, std::memory_order_relaxed);
+    return st;
+  }
+
+  size_t leaders() const { return leaders_.load(std::memory_order_relaxed); }
+  size_t coalesced() const { return coalesced_.load(std::memory_order_relaxed); }
+
+ private:
+  struct Flight {
+    std::mutex m;
+    std::condition_variable cv;
+    bool done = false;
+    Status st = Status::kInvalid;
+    size_t len = 0;
+    std::shared_ptr<std::vector<char>> data;
+  };
+  std::mutex mu_;
+  std::unordered_map<Key, std::shared_ptr<Flight>, KeyHash> map_;
+  std::atomic<size_t> leaders_{0}, coalesced_{0};
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_READ_COALESCER_H_

--- a/src/cache/read_coalescer.h
+++ b/src/cache/read_coalescer.h
@@ -41,11 +41,13 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <utility>
 
 #include "common/kv_types.h"
 #include "common/status.h"
@@ -96,6 +98,22 @@ class ReadCoalescer {
     f->key = k;
     f->whole = whole_value;
     f->leader_tid = std::this_thread::get_id();
+    // Recurrence window (v2): a convoy whose ranks drift past the in-flight
+    // window never produces a waiter, so v1's fan-in gate missed it entirely.
+    // A completed no-waiter whole read leaves a key FINGERPRINT (not payload —
+    // that is what keeps the window seconds-cheap) for RecurMs(); finding it
+    // here means this same range is being read AGAIN within the window, which
+    // is promotion evidence just as strong as an overlap.
+    if (whole_value) {
+      auto it = recents_.find(k);
+      if (it != recents_.end()) {
+        if (std::chrono::steady_clock::now() <= it->second) {
+          f->recurrent = true;
+          recur_hits_.fetch_add(1, std::memory_order_relaxed);
+        }
+        recents_.erase(it);
+      }
+    }
     map_.emplace(k, f);
     const uint64_t t = ++token_seq_;
     tokens_.emplace(t, std::move(f));
@@ -107,10 +125,16 @@ class ReadCoalescer {
   // waiters fall back to their own disk reads. Returns true if at least one
   // waiter had joined — the fan-in evidence the caller's RAM-promotion
   // admission gate keys on — and fills *key / *whole from registration.
-  // Idempotent per token; unknown tokens return false.
+  // A successful whole-value completion with NO waiter leaves a recurrence
+  // tombstone (key fingerprint, not payload) for RecurMs(): a second identical
+  // read inside that window is recurrence evidence, so ITS completion promotes
+  // even without an in-flight overlap (the drift-tolerant half of the gate;
+  // see TryRegisterAsync). Idempotent per token; unknown tokens return false.
   bool CompleteAsync(uint64_t token, Status st, const char* data, size_t len,
-                     BlockKey* key = nullptr, bool* whole = nullptr) {
+                     BlockKey* key = nullptr, bool* whole = nullptr,
+                     bool* recurrent = nullptr) {
     std::shared_ptr<Flight> f;
+    bool waiters = false;
     {
       std::lock_guard<std::mutex> lk(mu_);
       auto it = tokens_.find(token);
@@ -119,8 +143,28 @@ class ReadCoalescer {
       tokens_.erase(it);
       auto mit = map_.find(f->key);
       if (mit != map_.end() && mit->second == f) map_.erase(mit);
+      waiters = f->waiters.load(std::memory_order_acquire) > 0;
+      // Lay the recurrence tombstone for a successful lone whole read: no
+      // waiter (nothing promoted this page) and not itself a recurrence hit
+      // (its completion promotes, RAM covers later arrivals). Fingerprints
+      // only — bounded by kRecurCap with amortized FIFO expiry.
+      if (RecurMs() > 0 && st == Status::kOk && f->whole && !waiters &&
+          !f->recurrent) {
+        const auto dl = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(RecurMs());
+        recents_[f->key] = dl;
+        recent_fifo_.emplace_back(f->key, dl);
+        const auto now = std::chrono::steady_clock::now();
+        while (!recent_fifo_.empty() &&
+               (recent_fifo_.front().second < now ||
+                recent_fifo_.size() > kRecurCap)) {
+          auto rit = recents_.find(recent_fifo_.front().first);
+          if (rit != recents_.end() && rit->second == recent_fifo_.front().second)
+            recents_.erase(rit);
+          recent_fifo_.pop_front();
+        }
+      }
     }
-    const bool waiters = f->waiters.load(std::memory_order_acquire) > 0;
     if (waiters && st == Status::kOk && data && len) {
       f->data = AlignedAlloc(len);
       if (f->data) std::memcpy(f->data.get(), data, len);
@@ -135,6 +179,7 @@ class ReadCoalescer {
     leaders_.fetch_add(1, std::memory_order_relaxed);
     if (key) *key = BlockKey{f->key.id, f->key.index, f->key.ksize};
     if (whole) *whole = f->whole;
+    if (recurrent) *recurrent = f->recurrent;
     return waiters;
   }
 
@@ -229,6 +274,7 @@ class ReadCoalescer {
   size_t leaders() const { return leaders_.load(std::memory_order_relaxed); }
   size_t coalesced() const { return coalesced_.load(std::memory_order_relaxed); }
   size_t timeouts() const { return timeouts_.load(std::memory_order_relaxed); }
+  size_t recur_hits() const { return recur_hits_.load(std::memory_order_relaxed); }
 
  private:
   struct Flight {
@@ -240,6 +286,7 @@ class ReadCoalescer {
     std::shared_ptr<char> data;  // 4096-aligned scratch (leader's read target)
     Key key{};
     bool whole = false;
+    bool recurrent = false;  // registered while a recurrence tombstone was live
     std::thread::id leader_tid;
     std::atomic<int> waiters{0};
   };
@@ -266,11 +313,31 @@ class ReadCoalescer {
     return ms;
   }
 
+  // Recurrence window length. Default 1000 ms: the free-run 8-process bench
+  // convoy (worst-case drift; production ranks are layer-locked) spreads a
+  // page's reads over <=~500 ms, so 1s covers it with margin, and the window
+  // holds fingerprints (64 B), not payloads, so seconds-scale is nearly free.
+  // DFKV_READ_COALESCE_RECUR_MS overrides; 0 disables (v1 overlap-only gate).
+  static int RecurMs() {
+    static const int ms = [] {
+      const char* e = std::getenv("DFKV_READ_COALESCE_RECUR_MS");
+      if (e && *e) {
+        long v = std::strtol(e, nullptr, 10);
+        if (v >= 0 && v <= 60000) return static_cast<int>(v);
+      }
+      return 1000;
+    }();
+    return ms;
+  }
+  static constexpr size_t kRecurCap = 65536;  // fingerprint bound (~4 MiB worst)
+
   std::mutex mu_;
   std::unordered_map<Key, std::shared_ptr<Flight>, KeyHash> map_;
   std::unordered_map<uint64_t, std::shared_ptr<Flight>> tokens_;
+  std::unordered_map<Key, std::chrono::steady_clock::time_point, KeyHash> recents_;
+  std::deque<std::pair<Key, std::chrono::steady_clock::time_point>> recent_fifo_;
   uint64_t token_seq_ = 0;
-  std::atomic<size_t> leaders_{0}, coalesced_{0}, timeouts_{0};
+  std::atomic<size_t> leaders_{0}, coalesced_{0}, timeouts_{0}, recur_hits_{0};
 };
 
 }  // namespace dfkv

--- a/src/cache/store_engine.h
+++ b/src/cache/store_engine.h
@@ -30,6 +30,9 @@ struct RangePrep {
   size_t aligned_len = 0;   // O_DIRECT-aligned read length (multiple of 4096)
   size_t head = 0;          // offset of requested bytes within the aligned read
   size_t payload_len = 0;   // exact requested bytes (after clamp to file size)
+  size_t value_len = 0;     // full stored value size — lets the server tell a
+                            // whole-value read (offset 0, payload_len ==
+                            // value_len) from a sub-range (RAM promotion gate)
   // 0 = nothing to release. A slot-based engine (slab) must hold the slot
   // against eviction/remove while the caller's async read is in flight -- the
   // caller passes this back via RangeRelease once the read is done (KVStore's

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -404,3 +404,39 @@ TEST(RamTier, ShardCountCanExceedLegacyCapOf16) {
   ::unsetenv("DFKV_RAM_TIER_SHARDS");
   ::unsetenv("DFKV_RAM_TIER_EXTENT_BYTES");
 }
+
+// PutDurable: read-promotion entry. The slot is born durable — never enqueued
+// for flush (zero DIO write cost) and immediately evictable/removable (no
+// flush-pin). Dedup semantics match Put.
+TEST(RamTier, PutDurableNoFlushIOAndImmediatelyEvictable) {
+  FlushSink sink;
+  sink.close();  // any enqueued flush would block forever -> test would hang
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  ASSERT_TRUE(rt.ok());
+  std::string v = "promoted-cold-page";
+  ASSERT_TRUE(rt.PutDurable(K(90), v.data(), v.size()));
+  EXPECT_EQ(rt.Promoted(), 1u);
+  EXPECT_EQ(rt.FlushBacklog(), 0u);  // never touched the flush queue
+  {
+    std::lock_guard<std::mutex> lk(sink.m);
+    EXPECT_EQ(sink.calls, 0);        // zero flush IO
+  }
+  RamTier::Hit h;
+  ASSERT_TRUE(rt.GetPrep(K(90), 0, v.size(), &h));
+  EXPECT_EQ(std::string(h.ptr, h.len), v);
+  rt.Release(h.token);
+  // No flush-pin held: Remove (which declines on any pin) succeeds at once.
+  EXPECT_TRUE(rt.Remove(K(90)));
+  EXPECT_FALSE(rt.Contains(K(90)));
+}
+
+TEST(RamTier, PutDurableDedupsAgainstResident) {
+  FlushSink sink;
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  std::string v(500, 'p');
+  ASSERT_TRUE(rt.Put(K(91), v.data(), v.size()));
+  const uint64_t used = rt.UsedBytes();
+  EXPECT_TRUE(rt.PutDurable(K(91), v.data(), v.size()));  // resident -> no-op true
+  EXPECT_EQ(rt.UsedBytes(), used);                        // no second slot
+  EXPECT_EQ(rt.Promoted(), 0u);                           // dedup is not a promotion
+}

--- a/test/cache/read_coalescer_test.cc
+++ b/test/cache/read_coalescer_test.cc
@@ -1,0 +1,208 @@
+// ReadCoalescer: sync leader/follower collapse plus the async-flight protocol
+// used by the io_uring serve path (TryRegisterAsync / CompleteAsync). Hermetic:
+// "disk reads" are lambdas. Covers: async register -> follower join -> complete
+// hands the payload; fan-in evidence (waiters) reporting; abort and failure ->
+// followers fall back to their own read; waiter timeout fallback; same-thread
+// pipelined duplicate never deadlocks; duplicate registration declines.
+#include "cache/read_coalescer.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+using dfkv::BlockKey;
+using dfkv::ReadCoalescer;
+using dfkv::Status;
+using namespace std::chrono_literals;
+
+namespace {
+
+BlockKey K(uint64_t id) { return BlockKey{id, 0, 1}; }
+
+// The wait bound is latched on first use (function-local static); pin it to a
+// test-friendly value before any test can latch the 500ms default.
+[[maybe_unused]] const bool kEnvSet = [] {
+  ::setenv("DFKV_READ_COALESCE_TIMEOUT_MS", "200", 1);
+  return true;
+}();
+
+// Spin until the coalescer reports an in-flight read (a follower has to join
+// while the leader is still open) or the deadline passes.
+bool WaitInFlight(ReadCoalescer& c, const BlockKey& k, uint64_t off, uint64_t len) {
+  for (int i = 0; i < 2000; ++i) {
+    if (c.InFlight(k, off, len)) return true;
+    std::this_thread::sleep_for(1ms);
+  }
+  return false;
+}
+
+TEST(ReadCoalescer, AsyncFlightHandsPayloadToFollower) {
+  ReadCoalescer c;
+  const std::string v = "payload-bytes";
+  uint64_t t = c.TryRegisterAsync(K(1), 0, v.size(), /*whole_value=*/true);
+  ASSERT_NE(t, 0u);
+  ASSERT_TRUE(c.InFlight(K(1), 0, v.size()));
+
+  std::atomic<int> own_reads{0};
+  std::string got(v.size(), '\0');
+  size_t got_len = 0;
+  std::thread follower([&] {
+    Status st = c.Read(K(1), 0, v.size(), &got[0], got.size(), &got_len,
+                       [&](char* buf, size_t cap, size_t* n) {
+                         own_reads.fetch_add(1);
+                         std::memcpy(buf, v.data(), v.size());
+                         *n = v.size();
+                         return Status::kOk;
+                       });
+    EXPECT_EQ(st, Status::kOk);
+  });
+  // Give the follower time to join the flight, then complete it.
+  std::this_thread::sleep_for(50ms);
+  BlockKey key{0, 0, 0};
+  bool whole = false;
+  EXPECT_TRUE(c.CompleteAsync(t, Status::kOk, v.data(), v.size(), &key, &whole));
+  follower.join();
+  EXPECT_EQ(own_reads.load(), 0);  // served from the flight, no duplicate read
+  EXPECT_EQ(got, v);
+  EXPECT_EQ(got_len, v.size());
+  EXPECT_EQ(key.id, 1u);
+  EXPECT_TRUE(whole);
+  EXPECT_EQ(c.coalesced(), 1u);
+}
+
+TEST(ReadCoalescer, CompleteWithoutWaitersReportsNoFanIn) {
+  ReadCoalescer c;
+  uint64_t t = c.TryRegisterAsync(K(2), 0, 8, false);
+  ASSERT_NE(t, 0u);
+  EXPECT_FALSE(c.CompleteAsync(t, Status::kOk, "abcdefgh", 8));
+  EXPECT_FALSE(c.InFlight(K(2), 0, 8));       // flight erased
+  EXPECT_FALSE(c.CompleteAsync(t, Status::kOk, "abcdefgh", 8));  // idempotent
+}
+
+TEST(ReadCoalescer, DuplicateRegistrationDeclines) {
+  ReadCoalescer c;
+  uint64_t t1 = c.TryRegisterAsync(K(3), 0, 8, false);
+  ASSERT_NE(t1, 0u);
+  EXPECT_EQ(c.TryRegisterAsync(K(3), 0, 8, false), 0u);   // identical -> decline
+  EXPECT_NE(c.TryRegisterAsync(K(3), 8, 8, false), 0u);   // other range -> own flight
+  c.CompleteAsync(t1, Status::kIOError, nullptr, 0);
+}
+
+TEST(ReadCoalescer, AbortedFlightFollowerFallsBackToOwnRead) {
+  ReadCoalescer c;
+  uint64_t t = c.TryRegisterAsync(K(4), 0, 4, false);
+  ASSERT_NE(t, 0u);
+  std::atomic<int> own_reads{0};
+  char buf[4];
+  size_t n = 0;
+  std::thread follower([&] {
+    Status st = c.Read(K(4), 0, 4, buf, sizeof(buf), &n,
+                       [&](char* b, size_t, size_t* on) {
+                         own_reads.fetch_add(1);
+                         std::memcpy(b, "sane", 4);
+                         *on = 4;
+                         return Status::kOk;
+                       });
+    EXPECT_EQ(st, Status::kOk);  // fallback read succeeded despite the abort
+  });
+  std::this_thread::sleep_for(50ms);
+  c.CompleteAsync(t, Status::kIOError, nullptr, 0);  // teardown-path abort
+  follower.join();
+  EXPECT_EQ(own_reads.load(), 1);
+  EXPECT_EQ(std::string(buf, 4), "sane");
+}
+
+TEST(ReadCoalescer, WaiterTimeoutFallsBackToOwnRead) {
+  // The flight is NEVER completed: an abandoned flight (leader connection
+  // died without reaching complete/abort) must not hang its waiters.
+  ReadCoalescer c;
+  uint64_t t = c.TryRegisterAsync(K(5), 0, 4, false);
+  ASSERT_NE(t, 0u);
+  std::atomic<int> own_reads{0};
+  char buf[4];
+  size_t n = 0;
+  std::thread follower([&] {
+    Status st = c.Read(K(5), 0, 4, buf, sizeof(buf), &n,
+                       [&](char* b, size_t, size_t* on) {
+                         own_reads.fetch_add(1);
+                         std::memcpy(b, "wake", 4);
+                         *on = 4;
+                         return Status::kOk;
+                       });
+    EXPECT_EQ(st, Status::kOk);
+  });
+  follower.join();  // returns after the latched timeout, via its own read
+  EXPECT_EQ(own_reads.load(), 1);
+  EXPECT_EQ(c.timeouts(), 1u);
+  (void)t;  // never completed on purpose: an abandoned flight must not hang waiters
+}
+
+TEST(ReadCoalescer, SameThreadDuplicateReadsItselfImmediately) {
+  ReadCoalescer c;
+  // Register on THIS thread (as the async prep does), then issue the duplicate
+  // GET's sync fallback on the SAME thread: it must not wait (the "leader"
+  // read would only run after this call returned -> deadlock-until-timeout).
+  uint64_t t = c.TryRegisterAsync(K(6), 0, 4, false);
+  ASSERT_NE(t, 0u);
+  char buf[4];
+  size_t n = 0;
+  const auto t0 = std::chrono::steady_clock::now();
+  Status st = c.Read(K(6), 0, 4, buf, sizeof(buf), &n,
+                     [&](char* b, size_t, size_t* on) {
+                       std::memcpy(b, "self", 4);
+                       *on = 4;
+                       return Status::kOk;
+                     });
+  const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now() - t0).count();
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(std::string(buf, 4), "self");
+  EXPECT_LT(ms, 100);  // no wait: read executed inline
+  c.CompleteAsync(t, Status::kIOError, nullptr, 0);
+}
+
+TEST(ReadCoalescer, SyncLeaderReportsFanIn) {
+  ReadCoalescer c;
+  const std::string v(8192, 'x');
+  std::atomic<int> fills{0};
+  std::atomic<bool> leader_entered{false};
+  ReadCoalescer::Outcome oc;
+  std::string lbuf(v.size(), '\0');
+  size_t ln = 0;
+  std::thread leader([&] {
+    c.Read(K(7), 0, v.size(), &lbuf[0], lbuf.size(), &ln,
+           [&](char* b, size_t, size_t* on) {
+             leader_entered.store(true);
+             std::this_thread::sleep_for(100ms);  // hold the flight open
+             fills.fetch_add(1);
+             std::memcpy(b, v.data(), v.size());
+             *on = v.size();
+             return Status::kOk;
+           },
+           &oc);
+  });
+  while (!leader_entered.load()) std::this_thread::sleep_for(1ms);
+  std::string fbuf(v.size(), '\0');
+  size_t fn = 0;
+  Status st = c.Read(K(7), 0, v.size(), &fbuf[0], fbuf.size(), &fn,
+                     [&](char* b, size_t, size_t* on) {
+                       fills.fetch_add(1);
+                       std::memcpy(b, v.data(), v.size());
+                       *on = v.size();
+                       return Status::kOk;
+                     });
+  leader.join();
+  EXPECT_EQ(st, Status::kOk);
+  EXPECT_EQ(fills.load(), 1);  // one disk read served both
+  EXPECT_EQ(fbuf, v);
+  EXPECT_EQ(lbuf, v);
+  EXPECT_TRUE(oc.leader);
+  EXPECT_TRUE(oc.had_waiters);
+}
+
+}  // namespace

--- a/test/cache/read_coalescer_test.cc
+++ b/test/cache/read_coalescer_test.cc
@@ -28,18 +28,9 @@ BlockKey K(uint64_t id) { return BlockKey{id, 0, 1}; }
 // test-friendly value before any test can latch the 500ms default.
 [[maybe_unused]] const bool kEnvSet = [] {
   ::setenv("DFKV_READ_COALESCE_TIMEOUT_MS", "200", 1);
+  ::setenv("DFKV_READ_COALESCE_RECUR_MS", "200", 1);  // recurrence-window tests
   return true;
 }();
-
-// Spin until the coalescer reports an in-flight read (a follower has to join
-// while the leader is still open) or the deadline passes.
-bool WaitInFlight(ReadCoalescer& c, const BlockKey& k, uint64_t off, uint64_t len) {
-  for (int i = 0; i < 2000; ++i) {
-    if (c.InFlight(k, off, len)) return true;
-    std::this_thread::sleep_for(1ms);
-  }
-  return false;
-}
 
 TEST(ReadCoalescer, AsyncFlightHandsPayloadToFollower) {
   ReadCoalescer c;
@@ -53,7 +44,7 @@ TEST(ReadCoalescer, AsyncFlightHandsPayloadToFollower) {
   size_t got_len = 0;
   std::thread follower([&] {
     Status st = c.Read(K(1), 0, v.size(), &got[0], got.size(), &got_len,
-                       [&](char* buf, size_t cap, size_t* n) {
+                       [&](char* buf, size_t, size_t* n) {
                          own_reads.fetch_add(1);
                          std::memcpy(buf, v.data(), v.size());
                          *n = v.size();
@@ -206,3 +197,62 @@ TEST(ReadCoalescer, SyncLeaderReportsFanIn) {
 }
 
 }  // namespace
+
+// v2 recurrence window: a lone whole-value read leaves a key fingerprint; a
+// re-read within DFKV_READ_COALESCE_RECUR_MS reports recurrence evidence on
+// completion (the drift-tolerant promotion gate). Env pinned to 200ms below.
+TEST(ReadCoalescer, RecurrenceTombstoneReportsOnReRead) {
+  ReadCoalescer c;
+  const char v[8] = "payload";
+  uint64_t t1 = c.TryRegisterAsync(K(20), 0, 8, /*whole=*/true);
+  ASSERT_NE(t1, 0u);
+  EXPECT_FALSE(c.CompleteAsync(t1, Status::kOk, v, 8));  // lone read: tombstone laid
+  BlockKey key{0, 0, 0};
+  bool whole = false, recur = false;
+  uint64_t t2 = c.TryRegisterAsync(K(20), 0, 8, true);   // re-read inside window
+  ASSERT_NE(t2, 0u);
+  EXPECT_EQ(c.recur_hits(), 1u);
+  c.CompleteAsync(t2, Status::kOk, v, 8, &key, &whole, &recur);
+  EXPECT_TRUE(recur);      // promotion evidence without any in-flight waiter
+  EXPECT_TRUE(whole);
+  EXPECT_EQ(key.id, 20u);
+  // The hit consumed the tombstone, and a recurrent completion lays none
+  // (promotion put the page in RAM): a third read reports no recurrence.
+  uint64_t t3 = c.TryRegisterAsync(K(20), 0, 8, true);
+  ASSERT_NE(t3, 0u);
+  recur = false;
+  c.CompleteAsync(t3, Status::kOk, v, 8, nullptr, nullptr, &recur);
+  EXPECT_FALSE(recur);
+}
+
+TEST(ReadCoalescer, RecurrenceTombstoneExpires) {
+  ReadCoalescer c;
+  const char v[8] = "payload";
+  uint64_t t1 = c.TryRegisterAsync(K(21), 0, 8, true);
+  c.CompleteAsync(t1, Status::kOk, v, 8);
+  std::this_thread::sleep_for(250ms);  // past the 200ms env-pinned window
+  bool recur = true;
+  uint64_t t2 = c.TryRegisterAsync(K(21), 0, 8, true);
+  ASSERT_NE(t2, 0u);
+  c.CompleteAsync(t2, Status::kOk, v, 8, nullptr, nullptr, &recur);
+  EXPECT_FALSE(recur);
+}
+
+TEST(ReadCoalescer, NoTombstoneForPartialFailedOrFannedReads) {
+  ReadCoalescer c;
+  const char v[8] = "payload";
+  // Partial (whole=false) completion: no tombstone.
+  uint64_t t1 = c.TryRegisterAsync(K(22), 4, 4, false);
+  c.CompleteAsync(t1, Status::kOk, v, 4);
+  bool recur = true;
+  uint64_t t2 = c.TryRegisterAsync(K(22), 4, 4, false);
+  c.CompleteAsync(t2, Status::kOk, v, 4, nullptr, nullptr, &recur);
+  EXPECT_FALSE(recur);
+  // Failed/aborted completion: no tombstone.
+  uint64_t t3 = c.TryRegisterAsync(K(23), 0, 8, true);
+  c.CompleteAsync(t3, Status::kIOError, nullptr, 0);
+  recur = true;
+  uint64_t t4 = c.TryRegisterAsync(K(23), 0, 8, true);
+  c.CompleteAsync(t4, Status::kOk, v, 8, nullptr, nullptr, &recur);
+  EXPECT_FALSE(recur);
+}

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -889,17 +889,23 @@ struct RdmaUringNode {
         [this](uint64_t id, uint32_t idx, uint32_t ks, uint64_t off, uint64_t len,
                size_t cap, RdmaServer::RangePrepResult* o) {
           KVStore::RangePrep p;
-          Status st = srv->RangeDirectPrep(id, idx, ks, off, len, cap, &p);
+          Status st = srv->RangeDirectPrep(id, idx, ks, off, len, cap, &p, &o->flight);
           if (st == Status::kOk) {
             o->fd = p.fd; o->aligned_off = p.aligned_off; o->aligned_len = p.aligned_len;
             o->head = p.head; o->payload_len = p.payload_len;
+            o->release_token = p.token;
           }
           return st;
         });
     rsrv->set_range_complete_handler(
-        [this](bool ok, size_t bytes, double elapsed_sec) {
-          srv->RangeDirectComplete(ok, bytes, elapsed_sec);
+        [this](bool ok, size_t bytes, double elapsed_sec, uint64_t flight,
+               const char* data) {
+          srv->RangeDirectComplete(ok, bytes, elapsed_sec, flight, data);
         });
+    rsrv->set_range_release_handler(
+        [this](uint64_t tok) { srv->RangePrepRelease(tok); });
+    rsrv->set_range_flight_abort_handler(
+        [this](uint64_t f) { srv->RangeFlightAbort(f); });
     EXPECT_EQ(rsrv->Start(0), Status::kOk);
     addr = "127.0.0.1:" + std::to_string(rsrv->port());
   }


### PR DESCRIPTION
## 背景(xb01 Phase D 定位链)

TP8+MLA 下 8 个 rank(独立进程)在同一预取窗口内取同一页(同 BlockKey/range);客户端 NodeDedup 是进程内的,server 盘路径 O_DIRECT 无读缓存 → **同一 3.7MB 页被 NVMe 真实读至多 8 次**(E11B 实测盘:线=1:1,零合并)。写侧 convoy 早已被 RAM write-through arena 吸收;本 PR 补齐读侧。

## 实现

- `ReadCoalescer`(header-only):首到者为 leader 执行盘读入共享 scratch,重叠到达者阻塞等待(上界=一次盘读,不劣于它替代的重复 pread)后 memcpy;键=(BlockKey, offset, length)
- 挂点:RangeDirect(RDMA 同步)、RangeInto、TCP kRange;RangeDirectPrep 在同键读在途时拒绝 io_uring 异步 prep 回落同步路径加入合并(与 RAM-resident 拒绝同型)
- **opt-in**:`DFKV_READ_COALESCE=1`,默认关闭零行为变化;新指标 `dfkv_read_coalesce_leaders_total` / `dfkv_read_coalesced_total`

## 验证

- 本地 8 进程同键 convoy 冒烟:coalesced=53/leaders=235,合并后复读 fails=0
- xb01 canary(E12)计划:开关滚动开启 → 重放大集 → 预期盘读需求 ÷≈8、聚合读供给大幅抬升(canary 数据将回帖)

预期收益:重放/热点负载盘读需求 ÷≈8;40 盘环下 10 节点(~110GB/s wire)冗余覆盖。