### PR TITLE
fix(hicache): register DSA hybrid host pools via get_hybrid_pool_buffer()

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -306,6 +306,10 @@ class DfkvHiCache(HiCacheStorage):
                 int(cfg.get("head_dim", 0)))
             if not self._h:
                 raise RuntimeError("dfkv_open failed")
+            # (base, size) of host regions already handed to dfkv_register_memory,
+            # so a buffer shared across multiple hybrid pools (DSA registers the
+            # KV anchor plus several sidecar pools) is registered exactly once.
+            self._registered_regions = set()
             mode_b = self._lib.dfkv_transport_mode(self._h)
             self.transport_mode = (
                 mode_b.decode("utf-8", errors="replace") if mode_b else "unknown"
@@ -416,28 +420,57 @@ class DfkvHiCache(HiCacheStorage):
         return self._lib.dfkv_register_memory(
             self._h, ctypes.c_void_p(int(base)), ctypes.c_uint64(int(size))) == 0
 
-    def _register_pool_buffers(self, pool) -> int:
-        """Best-effort: register a host pool's backing buffer(s) so its pages
-        transfer zero-copy without per-op MR registration. Probes the common
-        SGLang HostKVCache backing-buffer attributes; failure is non-fatal (pages
-        just fall back to ad-hoc per-buffer registration). Returns #regions done."""
-        done = 0
+    def _pool_backing_tensors(self, pool):
+        """Yield a host pool's backing tensor(s) for RDMA registration.
+
+        Preference order mirrors SGLang's own Mooncake backend
+        (_iter_host_pool_buffers): a hybrid/DSA pool self-reports its physical
+        tensors via get_hybrid_pool_buffer(), because they do NOT all live under
+        the same attribute name -- DeepSeekV4PagedHostPool/DeepSeekV4StateHostPool
+        expose a list under `kv_buffer`, but DSAIndexerPoolHost keeps its buffer in
+        `index_k_with_scale_buffer`, and MambaPoolHost in yet others. Probing a
+        fixed attribute list (the old behaviour) missed those and logged
+        "no backing buffer found". Simple KV pools with no accessor fall back to
+        the classic attribute probe."""
+        get_buffers = getattr(pool, "get_hybrid_pool_buffer", None)
+        if callable(get_buffers):
+            for buf in get_buffers() or ():
+                if buf is not None:
+                    yield buf
+            return
         for attr in ("kv_buffer", "host_kv_buffer", "data_buffer", "buffer", "data"):
             buf = getattr(pool, attr, None)
             if buf is None:
                 continue
-            tensors = buf if isinstance(buf, (list, tuple)) else [buf]
-            for t in tensors:
-                if not (hasattr(t, "data_ptr") and hasattr(t, "numel")
-                        and hasattr(t, "element_size")):
+            for t in (buf if isinstance(buf, (list, tuple)) else [buf]):
+                if t is not None:
+                    yield t
+            return  # first attribute that yielded buffers wins
+
+    def _register_pool_buffers(self, pool) -> int:
+        """Best-effort: register a host pool's backing buffer(s) so its pages
+        transfer zero-copy without per-op MR registration. Registers EVERY tensor
+        the pool exposes (a DSA multi-pool model has several), deduping regions
+        already registered. Failure is non-fatal (pages just fall back to ad-hoc
+        per-buffer registration). Returns #regions newly registered."""
+        if not hasattr(self, "_registered_regions"):
+            self._registered_regions = set()
+        done = 0
+        for t in self._pool_backing_tensors(pool):
+            if not (hasattr(t, "data_ptr") and hasattr(t, "numel")
+                    and hasattr(t, "element_size")):
+                continue
+            try:
+                base = int(t.data_ptr())
+                size = int(t.numel()) * int(t.element_size())
+                region = (base, size)
+                if not base or not size or region in self._registered_regions:
                     continue
-                try:
-                    if self.register_memory(t.data_ptr(), t.numel() * t.element_size()):
-                        done += 1
-                except Exception:
-                    pass
-            if done:
-                break  # first attribute that yielded registrable tensors wins
+                if self.register_memory(base, size):
+                    self._registered_regions.add(region)
+                    done += 1
+            except Exception:
+                pass
         return done
 
     def register_mem_pool_host(self, mem_pool_host):

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -110,11 +110,38 @@ class FlatBuf:
 
 
 class RegistrablePool(FakeMlaPool):
-    """Fake v2 pool with a tensor-like backing buffer attribute."""
+    """Fake v2 pool with a tensor-like backing buffer attribute (no hybrid
+    accessor) — exercises the fixed-attribute fallback probe."""
 
     def __init__(self, num_pages, page_bytes, page_size=64):
         super().__init__(num_pages, page_bytes, page_size)
         self.data_buffer = FlatBuf(num_pages * page_bytes)
+
+
+class FakeDSAIndexerPool(FakeMlaPool):
+    """Stand-in for SGLang's DSAIndexerPoolHost: its backing tensor lives under
+    `index_k_with_scale_buffer`, a name NOT in the old fixed-attr probe list, so
+    it is reachable only through get_hybrid_pool_buffer(). This is the pool whose
+    registration logged "no backing buffer found" for GLM-5.2 DSA."""
+
+    def __init__(self, num_pages, page_bytes, page_size=64):
+        super().__init__(num_pages, page_bytes, page_size)
+        self.index_k_with_scale_buffer = FlatBuf(num_pages * page_bytes)
+
+    def get_hybrid_pool_buffer(self):
+        return [self.index_k_with_scale_buffer]
+
+
+class FakeDSAPagedPool(FakeMlaPool):
+    """Stand-in for DeepSeekV4PagedHostPool: kv_buffer is a LIST of per-layer
+    tensors, self-reported via get_hybrid_pool_buffer() (mirrors the real pool)."""
+
+    def __init__(self, num_pages, page_bytes, page_size=64, layers=2):
+        super().__init__(num_pages, page_bytes, page_size)
+        self.kv_buffer = [FlatBuf(num_pages * page_bytes) for _ in range(layers)]
+
+    def get_hybrid_pool_buffer(self):
+        return self.kv_buffer if isinstance(self.kv_buffer, list) else [self.kv_buffer]
 
 
 class FakeLogicalAnchorPool:
@@ -601,6 +628,80 @@ class DingoFSHiCacheTest(unittest.TestCase):
         self.assertEqual(calls, [
             (pool.data_buffer.data_ptr(),
              pool.data_buffer.numel() * pool.data_buffer.element_size())
+        ])
+
+    def test_register_dsa_indexer_pool_via_hybrid_accessor(self):
+        # DSAIndexerPoolHost keeps its buffer under `index_k_with_scale_buffer`,
+        # not kv_buffer — reachable only via get_hybrid_pool_buffer(). The old
+        # fixed-attr probe missed it ("no backing buffer found") and every DSA
+        # indexer page fell back to per-op MR registration, which then failed in
+        # RdmaTransport::CacheFrom and flunked the whole write batch.
+        members, _, _ = self._node("dsaidx")
+        cfg = self._cfg(members, model="glm-5.2")
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        pool = FakeDSAIndexerPool(2, self.PAGE_BYTES, self.PAGE_SIZE)
+        calls = []
+        st.register_memory = lambda base, size: calls.append((base, size)) or True
+        # Drive the real failing entrypoint, not just the helper.
+        st.register_mem_host_pool_v2(pool, "deepseek_v4_c4_indexer")
+        self.assertIs(st.registered_pools["deepseek_v4_c4_indexer"], pool)
+        self.assertEqual(calls, [
+            (pool.index_k_with_scale_buffer.data_ptr(),
+             pool.index_k_with_scale_buffer.numel()
+             * pool.index_k_with_scale_buffer.element_size())
+        ])
+
+    def test_register_dsa_paged_pool_registers_all_layer_buffers(self):
+        # DeepSeekV4PagedHostPool exposes a LIST of per-layer tensors; every one
+        # must be registered (the old "first attribute wins" break stopped early).
+        members, _, _ = self._node("dsapaged")
+        cfg = self._cfg(members, model="glm-5.2")
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        pool = FakeDSAPagedPool(2, self.PAGE_BYTES, self.PAGE_SIZE, layers=3)
+        calls = []
+        st.register_memory = lambda base, size: calls.append((base, size)) or True
+        self.assertEqual(st._register_pool_buffers(pool), 3)
+        self.assertEqual(
+            calls,
+            [(b.data_ptr(), b.numel() * b.element_size()) for b in pool.kv_buffer],
+        )
+
+    def test_hybrid_accessor_preferred_over_attribute_probe(self):
+        # When a pool offers get_hybrid_pool_buffer(), it is authoritative — a
+        # stale/misleading kv_buffer attribute must NOT be probed instead.
+        members, _, _ = self._node("dsaprec")
+        cfg = self._cfg(members, model="glm-5.2")
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        pool = FakeMlaPool(2, self.PAGE_BYTES, self.PAGE_SIZE)
+        accessor_buf = FlatBuf(2 * self.PAGE_BYTES)
+        decoy = FlatBuf(2 * self.PAGE_BYTES)
+        pool.kv_buffer = decoy  # would be picked by the fixed-attr probe
+        pool.get_hybrid_pool_buffer = lambda: [accessor_buf]
+        calls = []
+        st.register_memory = lambda base, size: calls.append((base, size)) or True
+        st._register_pool_buffers(pool)
+        self.assertEqual(calls, [
+            (accessor_buf.data_ptr(),
+             accessor_buf.numel() * accessor_buf.element_size())
+        ])
+
+    def test_register_dedups_region_shared_across_pools(self):
+        # A DSA model registers the KV anchor plus several sidecar pools; if two
+        # pools surface the same physical tensor it must be registered once.
+        members, _, _ = self._node("dsadedup")
+        cfg = self._cfg(members, model="glm-5.2")
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        shared = FlatBuf(2 * self.PAGE_BYTES)
+        pool_a = FakeDSAIndexerPool(2, self.PAGE_BYTES, self.PAGE_SIZE)
+        pool_a.index_k_with_scale_buffer = shared
+        pool_b = FakeDSAIndexerPool(2, self.PAGE_BYTES, self.PAGE_SIZE)
+        pool_b.index_k_with_scale_buffer = shared
+        calls = []
+        st.register_memory = lambda base, size: calls.append((base, size)) or True
+        self.assertEqual(st._register_pool_buffers(pool_a), 1)
+        self.assertEqual(st._register_pool_buffers(pool_b), 0)  # already registered
+        self.assertEqual(calls, [
+            (shared.data_ptr(), shared.numel() * shared.element_size())
         ])
 
 


### PR DESCRIPTION
## Problem

For GLM-5.2 DSA, HiCache installs `DeepSeekV4PagedHostPool` / `DeepSeekV4StateHostPool` / `DSAIndexerPoolHost`. The connector's `_register_pool_buffers` probed a **fixed attribute list** (`kv_buffer`/`host_kv_buffer`/`data_buffer`/`buffer`/`data`) to find each pool's backing tensors. `DSAIndexerPoolHost` keeps its buffer under `index_k_with_scale_buffer`, which is not on that list, so registration logged:

```
register_mem_host_pool_v2(indexer): no backing buffer found
```

The indexer pool's host pages were therefore never RDMA-registered. Those unregistered pointers then failed ad-hoc MR registration in `RdmaTransport::CacheFrom`, which flunked the **entire write batch** (~10 ms client-side fast-fail per page, L3 never populated) — the "Write page 100% failed / L3 empty" symptom on GLM-5.2.

## Fix

Mirror SGLang's own Mooncake backend (`_iter_host_pool_buffers` in `storage/mooncake_store/mooncake_store.py`): **prefer the pool-reported `get_hybrid_pool_buffer()` accessor**, and fall back to the fixed-attribute probe only for simple pools that lack it. Every SGLang hybrid/DSA host pool implements `get_hybrid_pool_buffer()` and self-reports its physical tensors regardless of attribute name.

Also:
- Register **every** tensor a pool exposes — dropped the old `break` ("first attribute wins"), which stopped after one of a DSA pool's several buffers.
- Dedup regions via a `(base, size)` set so a buffer shared across multiple pools (KV anchor + sidecars) registers exactly once.

The write path is unchanged — it already used `get_page_buffer_meta()`, matching Mooncake.

## Tests

New fake DSA pools + 4 tests in `test/python/test_dfkv_hicache.py`:
- `test_register_dsa_indexer_pool_via_hybrid_accessor` — the failing indexer pool now registers through the v2 entrypoint
- `test_register_dsa_paged_pool_registers_all_layer_buffers` — all list buffers register (no early break)
- `test_hybrid_accessor_preferred_over_attribute_probe` — accessor wins over a stale attribute
- `test_register_dedups_region_shared_across_pools` — shared region registers once

The fixed-attribute fallback remains covered by the existing `test_register_mem_host_pool_v2_registers_backing_buffer`. Full module: **62/62 pass**.

## Scope / notes

This resolves the **registration** gap (unregistered pool → CacheFrom MR-register-gate failure). It does not touch CacheFrom's separate size gate (`payload_len > OpBound()`); if any DSA page genuinely exceeds `OpBound()`, that is a distinct follow-up. Recommend confirming `ok`-rate recovery in access-log on a GLM-5.2 DSA fleet after this lands.