### PR TITLE
feat(client): surface MDS reachability so a bad mds_endpoint isn't silent

### DIFF
--- a/integration/hicache/dfkv_metrics.py
+++ b/integration/hicache/dfkv_metrics.py
@@ -24,7 +24,8 @@ Metric names (labels: tp_rank):
 import threading
 
 try:
-    from prometheus_client import Counter as _PromCounter, Histogram as _PromHistogram
+    from prometheus_client import (Counter as _PromCounter, Gauge as _PromGauge,
+                                    Histogram as _PromHistogram)
     _HAVE_PROM = True
 except Exception:  # prometheus_client absent -> in-process counters only
     _HAVE_PROM = False
@@ -117,21 +118,42 @@ class Metrics:
 # Prometheus Counters by delta, so they aggregate across the per-TP-rank
 # processes in SGLang's multiprocess metrics mode. Off the request hot path.
 
-_CLIENT_NAMES = [
+# Counters mirrored by positive delta (monotonic across polls).
+_CLIENT_COUNTER_NAMES = [
     "dfkv_client_ops_served_total",
     "dfkv_client_io_errors_total",
     "dfkv_client_unhealthy_skips_total",
     "dfkv_client_peer_marked_bad_total",
     "dfkv_client_peer_recovered_total",
+    "dfkv_client_mds_unreachable_polls_total",
 ]
+# Gauges mirrored by set() to the current value each poll: ring size and MDS
+# reachability, so a bad/unreachable mds_endpoint is visible on the SCRAPE
+# (ring_members==0 / mds_reachable==0), not just in the client log.
+_CLIENT_GAUGE_NAMES = [
+    "dfkv_client_ring_members",
+    "dfkv_client_mds_reachable",
+]
+# The union the snapshot parser captures (per-peer labeled series stay excluded).
+_CLIENT_NAMES = _CLIENT_COUNTER_NAMES + _CLIENT_GAUGE_NAMES
 
 _CLIENT_PROM = {}
+_CLIENT_GAUGE_PROM = {}
 if _HAVE_PROM:
-    for _n in _CLIENT_NAMES:
+    for _n in _CLIENT_COUNTER_NAMES:
         try:
             _CLIENT_PROM[_n] = _PromCounter(_n, _n, ["tp_rank"])
         except Exception:
             _CLIENT_PROM = {}
+            break
+    for _n in _CLIENT_GAUGE_NAMES:
+        try:
+            # multiprocess_mode is consulted only under PROMETHEUS_MULTIPROC_DIR;
+            # 'liveall' keeps each live rank's current value (tp_rank labels them).
+            _CLIENT_GAUGE_PROM[_n] = _PromGauge(_n, _n, ["tp_rank"],
+                                                multiprocess_mode="liveall")
+        except Exception:
+            _CLIENT_GAUGE_PROM = {}
             break
 
 
@@ -143,8 +165,9 @@ class ClientStatsPoller:
         self._get_text = get_text
         self._rank = str(int(tp_rank))
         self._interval = float(interval_s)
-        self._last = {n: 0 for n in _CLIENT_NAMES}
-        self._totals = {n: 0 for n in _CLIENT_NAMES}  # in-process mirror (tests/debug)
+        self._last = {n: 0 for n in _CLIENT_COUNTER_NAMES}
+        self._totals = {n: 0 for n in _CLIENT_COUNTER_NAMES}  # in-process mirror (tests/debug)
+        self._gauges = {n: 0 for n in _CLIENT_GAUGE_NAMES}    # last-seen gauge values
         self._stop = threading.Event()
         self._thread = None
 
@@ -170,7 +193,7 @@ class ClientStatsPoller:
 
     def poll_once(self):
         vals = self._parse(self._get_text() or "")
-        for n in _CLIENT_NAMES:
+        for n in _CLIENT_COUNTER_NAMES:  # counters: mirror by positive delta
             v = vals.get(n, 0)
             d = v - self._last[n]
             if d > 0:
@@ -178,9 +201,17 @@ class ClientStatsPoller:
                 self._totals[n] += d
                 if _HAVE_PROM and n in _CLIENT_PROM:
                     _CLIENT_PROM[n].labels(self._rank).inc(d)
+        for n in _CLIENT_GAUGE_NAMES:  # gauges: mirror the current value each poll
+            v = vals.get(n, 0)
+            self._gauges[n] = v
+            if _HAVE_PROM and n in _CLIENT_GAUGE_PROM:
+                _CLIENT_GAUGE_PROM[n].labels(self._rank).set(v)
 
     def totals(self):
         return dict(self._totals)
+
+    def gauges(self):
+        return dict(self._gauges)
 
     def _loop(self):
         while not self._stop.wait(self._interval):

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -22,6 +22,27 @@
 namespace dfkv {
 
 namespace {
+// Summarize a membership change as "+A -R (added: ...; removed: ...)", comparing
+// new node ids against the currently-adopted ones. Empty when there is no id
+// churn (e.g. only an address/weight changed). Ids only; small lists spelled out
+// so an operator sees exactly which node joined or left.
+std::string MembershipDelta(const std::map<std::string, std::string>& old_m,
+                            const std::map<std::string, std::string>& new_m) {
+  std::vector<std::string> added, removed;
+  for (const auto& kv : new_m) if (!old_m.count(kv.first)) added.push_back(kv.first);
+  for (const auto& kv : old_m) if (!new_m.count(kv.first)) removed.push_back(kv.first);
+  if (added.empty() && removed.empty()) return {};
+  auto join = [](const std::vector<std::string>& v) {
+    std::string s;
+    for (size_t i = 0; i < v.size(); ++i) { if (i) s += ","; s += v[i]; }
+    return s;
+  };
+  std::string s = "+" + std::to_string(added.size()) + " -" + std::to_string(removed.size());
+  if (!added.empty()) s += " (added: " + join(added) + ")";
+  if (!removed.empty()) s += " (removed: " + join(removed) + ")";
+  return s;
+}
+
 // Max payload segments per scatter-gather key: the guards below use the LIVE
 // Transport::MaxSgPayloadSegs() (negotiated max_sge - 1 on RDMA; 29 on TCP),
 // and the connector reads the same value through dfkv_max_sg_segs, so its
@@ -233,6 +254,27 @@ KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
   }
 }
 
+void KVClient::AdoptRing(ConHash ring, std::map<std::string, std::string> addr) {
+  const size_t count = addr.size();
+  std::string delta;
+  {
+    std::lock_guard<std::mutex> lk(ring_mu_);
+    delta = MembershipDelta(addr_, addr);  // vs the previously-adopted view
+    ring_ = std::move(ring);
+    addr_ = std::move(addr);
+  }
+  // A membership change is rare (epoch-gated) and worth one line: its presence
+  // confirms discovery populated the ring; its ABSENCE at startup is the fastest
+  // tell that the ring is empty and every op is silently missing. The delta
+  // (added/removed node ids) makes a scale-up or a node loss obvious at a glance.
+  if (count == 0)
+    DFKV_LOG_WARN("ring: adopted EMPTY membership (0 nodes) — puts/gets route to nowhere (ok=0)");
+  else if (delta.empty())
+    DFKV_LOG_INFO("ring: " + std::to_string(count) + " member(s) (unchanged)");
+  else
+    DFKV_LOG_INFO("ring: " + std::to_string(count) + " member(s) " + delta);
+}
+
 void KVClient::SetMembers(std::vector<std::pair<std::string, std::string>> members) {
   ConHash ring;
   std::map<std::string, std::string> addr;
@@ -241,9 +283,7 @@ void KVClient::SetMembers(std::vector<std::pair<std::string, std::string>> membe
     addr[name] = a;
   }
   ring.Build();
-  std::lock_guard<std::mutex> lk(ring_mu_);
-  ring_ = std::move(ring);
-  addr_ = std::move(addr);
+  AdoptRing(std::move(ring), std::move(addr));
 }
 
 void KVClient::SetMembers(const std::vector<MemberInfo>& members) {
@@ -254,9 +294,7 @@ void KVClient::SetMembers(const std::vector<MemberInfo>& members) {
     addr[m.id] = m.ip + ":" + std::to_string(m.port);
   }
   ring.Build();
-  std::lock_guard<std::mutex> lk(ring_mu_);
-  ring_ = std::move(ring);
-  addr_ = std::move(addr);
+  AdoptRing(std::move(ring), std::move(addr));
 }
 
 void KVClient::StartMdsDiscovery(std::vector<std::string> mds_eps,
@@ -373,6 +411,25 @@ std::string KVClient::MetricsSnapshot() const {
     s += "# HELP dfkv_client_gpu_dedup_wait_timeouts_total Waits that fell back to a direct fetch\n";
     s += "# TYPE dfkv_client_gpu_dedup_wait_timeouts_total counter\n";
     s += "dfkv_client_gpu_dedup_wait_timeouts_total " + std::to_string(gd->wait_timeouts()) + "\n";
+  }
+  // MDS discovery / placement-ring health. An empty ring means every put/get
+  // routes to nowhere and silently reports ok=0, so surface both the current
+  // ring size and MDS reachability — the fastest tell of a bad mds_endpoint.
+  {
+    size_t members;
+    { std::lock_guard<std::mutex> lk(ring_mu_); members = addr_.size(); }
+    s += "# HELP dfkv_client_ring_members Placement-ring members currently adopted from MDS discovery\n";
+    s += "# TYPE dfkv_client_ring_members gauge\n";
+    s += "dfkv_client_ring_members " + std::to_string(members) + "\n";
+  }
+  if (poller_) {
+    s += "# HELP dfkv_client_mds_unreachable_polls_total MDS list-members polls that failed (endpoint unreachable or RPC error)\n";
+    s += "# TYPE dfkv_client_mds_unreachable_polls_total counter\n";
+    s += "dfkv_client_mds_unreachable_polls_total " +
+         std::to_string(poller_->unreachable_polls_total()) + "\n";
+    s += "# HELP dfkv_client_mds_reachable 1 if the most recent MDS poll succeeded, 0 during an outage\n";
+    s += "# TYPE dfkv_client_mds_reachable gauge\n";
+    s += "dfkv_client_mds_reachable " + std::string(poller_->reachable() ? "1" : "0") + "\n";
   }
   if (t_) s += t_->MetricsText();
   return s;

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -186,6 +186,10 @@ class KVClient {
   std::string Route(const std::string& key) const;
   uint64_t NowMs() const;
   void ProbeLoop();
+  // Swap in a freshly-built ring under ring_mu_ and log the membership delta
+  // (added/removed node ids) vs the previously-adopted view. Shared by both
+  // SetMembers overloads so static and MDS-discovery paths log identically.
+  void AdoptRing(ConHash ring, std::map<std::string, std::string> addr);
   // The plain (no-dedup) batch bodies; the public methods wrap them with the
   // same-host rendezvous when DFKV_CLIENT_NODE_DEDUP=1 (see node_dedup.h).
   std::vector<bool> BatchGetDirect(const std::vector<KvGetItem>& items);

--- a/src/mds/mds_endpoints.h
+++ b/src/mds/mds_endpoints.h
@@ -20,6 +20,13 @@ class MdsEndpoints {
 
   size_t size() const { return eps_.size(); }
 
+  // Comma-joined endpoint list, for diagnostics/logging only.
+  std::string Join() const {
+    std::string s;
+    for (const auto& e : eps_) { if (!s.empty()) s += ","; s += e; }
+    return s;
+  }
+
   // Returns the next endpoint whose backoff has expired, advancing the cursor.
   // If ALL are in backoff, returns the one closest to recovery (degrade, never
   // fail). Empty string only when the list itself is empty.

--- a/src/mds/mds_member_poller.cc
+++ b/src/mds/mds_member_poller.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "common/status.h"
+#include "utils/log.h"
 #include "utils/net_util.h"
 #include "utils/thread_name.h"
 #include "utils/wire_limits.h"
@@ -88,9 +89,44 @@ bool MdsMemberPoller::PollOnce() {
   if (!have_epoch_ || epoch != last_epoch_) {
     last_epoch_ = epoch;
     have_epoch_ = true;
+    if (!ms.empty()) ever_adopted_ = true;
     cb_(ms);
   }
   return true;
+}
+
+void MdsMemberPoller::ReportHealth(bool query_ok) {
+  if (query_ok) {
+    reachable_.store(true, std::memory_order_relaxed);
+    if (consec_fail_ > 0) {
+      DFKV_LOG_INFO("mds-poll: MDS reachable again for group=" + group_ +
+                    " after " + std::to_string(consec_fail_) + " failed poll(s)");
+      consec_fail_ = 0;
+      last_fail_log_ms_ = 0;
+    }
+    return;
+  }
+  // Query failed: no MDS endpoint answered ListMembers (unreachable or RPC
+  // error). The ring is intentionally NOT cleared, but if it was never
+  // populated the client routes every op to an empty ring and silently returns
+  // ok=0 — the exact trap where a mistyped mds_endpoint looks like a write/data
+  // failure. Log rate-limited so a sustained outage stays a heartbeat.
+  ++consec_fail_;
+  unreachable_total_.fetch_add(1, std::memory_order_relaxed);
+  reachable_.store(false, std::memory_order_relaxed);
+  const uint64_t now = NowMs();
+  const bool first = (consec_fail_ == 1);
+  if (!first && (now - last_fail_log_ms_) < kFailLogEveryMs) return;
+  last_fail_log_ms_ = now;
+  const std::string base =
+      "mds-poll: cannot reach MDS for group=" + group_ + " (mds=" + eps_.Join() +
+      ", " + std::to_string(consec_fail_) + " consecutive failed poll(s))";
+  if (!ever_adopted_)
+    DFKV_LOG_WARN(base +
+                  " — ring is EMPTY (never populated); all puts/gets route to "
+                  "nowhere and report ok=0. Check mds_endpoints reachability.");
+  else
+    DFKV_LOG_WARN(base + " — serving stale ring (last known members).");
 }
 
 bool MdsMemberPoller::WaitMs(int ms) {
@@ -101,7 +137,7 @@ bool MdsMemberPoller::WaitMs(int ms) {
 
 void MdsMemberPoller::Loop() {
   while (running_.load()) {
-    PollOnce();
+    ReportHealth(PollOnce());
     if (WaitMs(poll_ms_)) return;
   }
 }

--- a/src/mds/mds_member_poller.h
+++ b/src/mds/mds_member_poller.h
@@ -91,6 +91,16 @@ class MdsMemberPoller {
   uint64_t empty_view_rejected() const { return guard_.rejected_empty(); }
   uint64_t shrink_view_rejected() const { return guard_.rejected_shrink(); }
 
+  // MDS reachability, surfaced to metrics/logs. The poll thread is otherwise
+  // silent, so a mistyped/unreachable mds endpoint leaves the ring empty forever
+  // while every op just reports ok=0 with no hint why.
+  // ReportHealth() is Loop()'s per-poll helper (query_ok = PollOnce()'s result);
+  // it is public so it is unit-testable without a live MDS. The two accessors
+  // are thread-safe (atomics) for KVClient::MetricsSnapshot().
+  void ReportHealth(bool query_ok);
+  uint64_t unreachable_polls_total() const { return unreachable_total_.load(); }
+  bool reachable() const { return reachable_.load(); }
+
  private:
   bool Query(std::vector<MemberInfo>* out, uint64_t* epoch);
   void Loop();
@@ -104,6 +114,15 @@ class MdsMemberPoller {
   int io_ms_;
   uint64_t last_epoch_ = 0;
   bool have_epoch_ = false;
+  // MDS reachability diagnostics (ReportHealth). Without these a bad mds
+  // endpoint fails 100% silently — the exact trap where "ok=0" writes look like
+  // a data/write bug instead of "the ring was never populated".
+  bool ever_adopted_ = false;      // has a non-empty view ever been adopted?
+  uint64_t consec_fail_ = 0;       // consecutive failed polls (poll-thread only)
+  uint64_t last_fail_log_ms_ = 0;  // rate-limit anchor for the sustained-outage WARN
+  std::atomic<uint64_t> unreachable_total_{0};  // cumulative failed polls (metric)
+  std::atomic<bool> reachable_{true};           // last poll succeeded? (metric)
+  static constexpr uint64_t kFailLogEveryMs = 30000;  // outage heartbeat cadence
   // Suspicious-view hysteresis depth (empty and mass-shrink arms alike).
   static constexpr int kViewsToAccept = 3;
   MemberViewGuard guard_;

--- a/test/client/dynamic_members_test.cc
+++ b/test/client/dynamic_members_test.cc
@@ -47,3 +47,48 @@ TEST(DynamicMembers, AddingNodeReroutesNewKeys) {
   EXPECT_TRUE(c.Get("p2_0", &out[0], out.size()));
   a->srv->Stop(); b->srv->Stop();
 }
+
+// AdoptRing()/MembershipDelta: a membership change must log WHICH node ids
+// joined/left, so a scale-up or a node loss is obvious at a glance. The logger
+// writes to stderr; capture it around each SetMembers. No servers/ops are
+// needed — only the ring rebuild runs (the probe + MDS discovery threads stay
+// off unless their env knobs are set), so nothing else pollutes the capture.
+TEST(DynamicMembers, SetMembersLogsAddRemoveDelta) {
+  using P = std::vector<std::pair<std::string, std::string>>;
+  KVClient c(P{{"n1", "127.0.0.1:1"}, {"n2", "127.0.0.1:2"}}, Hdr());
+
+  // add n3
+  testing::internal::CaptureStderr();
+  c.SetMembers(P{{"n1", "127.0.0.1:1"}, {"n2", "127.0.0.1:2"}, {"n3", "127.0.0.1:3"}});
+  std::string log = testing::internal::GetCapturedStderr();
+  EXPECT_NE(log.find("3 member(s) +1 -0"), std::string::npos) << log;
+  EXPECT_NE(log.find("added: n3"), std::string::npos) << log;
+  EXPECT_EQ(log.find("removed:"), std::string::npos) << log;
+
+  // remove n1
+  testing::internal::CaptureStderr();
+  c.SetMembers(P{{"n2", "127.0.0.1:2"}, {"n3", "127.0.0.1:3"}});
+  log = testing::internal::GetCapturedStderr();
+  EXPECT_NE(log.find("2 member(s) +0 -1"), std::string::npos) << log;
+  EXPECT_NE(log.find("removed: n1"), std::string::npos) << log;
+
+  // rolling replace: n2 out, n4 in
+  testing::internal::CaptureStderr();
+  c.SetMembers(P{{"n3", "127.0.0.1:3"}, {"n4", "127.0.0.1:4"}});
+  log = testing::internal::GetCapturedStderr();
+  EXPECT_NE(log.find("+1 -1"), std::string::npos) << log;
+  EXPECT_NE(log.find("added: n4"), std::string::npos) << log;
+  EXPECT_NE(log.find("removed: n2"), std::string::npos) << log;
+
+  // same ids, only the address changed -> no id churn -> "(unchanged)"
+  testing::internal::CaptureStderr();
+  c.SetMembers(P{{"n3", "127.0.0.1:33"}, {"n4", "127.0.0.1:44"}});
+  log = testing::internal::GetCapturedStderr();
+  EXPECT_NE(log.find("(unchanged)"), std::string::npos) << log;
+
+  // empty membership -> WARN (the "ring is empty, ops report ok=0" case)
+  testing::internal::CaptureStderr();
+  c.SetMembers(P{});
+  log = testing::internal::GetCapturedStderr();
+  EXPECT_NE(log.find("EMPTY membership"), std::string::npos) << log;
+}

--- a/test/mds/mds_member_poller_test.cc
+++ b/test/mds/mds_member_poller_test.cc
@@ -204,3 +204,45 @@ TEST(MdsMemberPoller, FailsOverPastDeadEndpointAcrossPolls) {
   EXPECT_TRUE(ok);
   EXPECT_EQ(got.size(), 2u) << "failover to the live MDS must return its members";
 }
+
+// ReportHealth() is Loop()'s per-poll health helper (query_ok = PollOnce()'s
+// result). It is what turns a silently-unreachable MDS into a visible signal,
+// so unit-test its state machine directly — no etcd/MDS needed.
+TEST(MdsMemberPoller, ReportHealthTracksReachabilityAndCounts) {
+  MdsMemberPoller poller({"127.0.0.1:9"}, "g",
+                         [](const std::vector<MemberInfo>&) {});
+  EXPECT_TRUE(poller.reachable());
+  EXPECT_EQ(poller.unreachable_polls_total(), 0u);
+
+  // Each failed poll marks the client unreachable and bumps the counter.
+  poller.ReportHealth(false);
+  EXPECT_FALSE(poller.reachable());
+  EXPECT_EQ(poller.unreachable_polls_total(), 1u);
+  poller.ReportHealth(false);
+  EXPECT_FALSE(poller.reachable());
+  EXPECT_EQ(poller.unreachable_polls_total(), 2u);
+
+  // A successful poll flips back to reachable; the counter is monotonic.
+  poller.ReportHealth(true);
+  EXPECT_TRUE(poller.reachable());
+  EXPECT_EQ(poller.unreachable_polls_total(), 2u);
+
+  // A subsequent outage keeps counting from where it left off.
+  poller.ReportHealth(false);
+  EXPECT_FALSE(poller.reachable());
+  EXPECT_EQ(poller.unreachable_polls_total(), 3u);
+}
+
+// End-to-end: a poll against an unreachable endpoint fails, never populates the
+// ring, and (via ReportHealth, as Loop() calls it) is marked unreachable — the
+// exact scenario a mistyped mds_endpoint used to hit 100% silently.
+TEST(MdsMemberPoller, UnreachableEndpointIsSurfacedNotSilent) {
+  int fires = 0;
+  MdsMemberPoller poller({"127.0.0.1:9"}, "g",  // discard port: connect refused fast
+                         [&](const std::vector<MemberInfo>&) { ++fires; });
+  EXPECT_FALSE(poller.PollOnce()) << "unreachable MDS must fail the poll";
+  EXPECT_EQ(fires, 0) << "the ring must never be populated";
+  poller.ReportHealth(false);  // Loop() feeds PollOnce()'s result here
+  EXPECT_FALSE(poller.reachable());
+  EXPECT_GE(poller.unreachable_polls_total(), 1u);
+}

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -1022,6 +1022,27 @@ class ClientStatsPollerTest(unittest.TestCase):
         self.assertEqual(t2["dfkv_client_ops_served_total"], 8)
         self.assertEqual(t2["dfkv_client_io_errors_total"], 1)  # unchanged
 
+    def test_mirrors_mds_reachability_counter_and_gauges(self):
+        # MDS-reachability metrics: the unreachable-polls COUNTER mirrors by
+        # delta; ring_members / mds_reachable are GAUGES that track the current
+        # value (0 during an outage, then the recovered value).
+        p = self._poller([
+            ("dfkv_client_mds_unreachable_polls_total 2\n"
+             "dfkv_client_ring_members 0\n"
+             "dfkv_client_mds_reachable 0\n"),
+            ("dfkv_client_mds_unreachable_polls_total 2\n"
+             "dfkv_client_ring_members 5\n"
+             "dfkv_client_mds_reachable 1\n"),
+        ])
+        p.poll_once()  # outage: 2 failed polls, empty ring, unreachable
+        self.assertEqual(p.totals()["dfkv_client_mds_unreachable_polls_total"], 2)
+        self.assertEqual(p.gauges()["dfkv_client_ring_members"], 0)
+        self.assertEqual(p.gauges()["dfkv_client_mds_reachable"], 0)
+        p.poll_once()  # recovered: ring of 5, reachable; counter unchanged
+        self.assertEqual(p.totals()["dfkv_client_mds_unreachable_polls_total"], 2)
+        self.assertEqual(p.gauges()["dfkv_client_ring_members"], 5)
+        self.assertEqual(p.gauges()["dfkv_client_mds_reachable"], 1)
+
     def test_disabled_interval_starts_no_thread(self):
         from dfkv_metrics import ClientStatsPoller
         p = ClientStatsPoller(lambda: "", tp_rank=0, interval_s=0)


### PR DESCRIPTION
## Problem

A mistyped or unreachable `mds_endpoints` fails **100% silently** today:

- `MdsMemberPoller` retries every 3s with **no log** (`Query()` just `MarkFailed`s and returns false; `Loop()` ignores the result).
- The placement ring is never populated, so `KVClient::Route()` returns empty and every `put`/`get` routes to nowhere and reports **`ok=0`**.
- To an operator that reads as a **write/data bug**, not a connectivity one. In a recent GLM-5.2 HiCache bring-up this cost a multi-hour misdiagnosis (chasing the DSA write path) before the empty ring was found — the only visible symptom was `batch_set ... ok 0/N` in the access log.

Nothing in the client told anyone the MDS was unreachable or the ring was empty.

## Changes

**Logging**
- `mds_member_poller`: `ReportHealth()` (Loop's per-poll helper) logs a **rate-limited WARN** (first failure immediately, then a 30s heartbeat) when no MDS endpoint answers `ListMembers`. It distinguishes **"ring never populated"** (startup / bad config — emphatic, and it names the `ok=0` symptom + says *check mds_endpoints*) from **"serving stale ring"** (transient outage, last members kept). INFO on recovery.
- `KVClient::SetMembers` → new shared `AdoptRing()`: one INFO per membership change carrying the **added/removed node-id delta** (`ring: 5 member(s) +1 -1 (added: n4) (removed: n2)`); WARN on an empty adoption. Its **absence** at startup is the fastest tell the ring is empty. `(unchanged)` when only an address/weight changed.

**Metrics** (`KVClient::MetricsSnapshot`)
- `dfkv_client_ring_members` (gauge)
- `dfkv_client_mds_unreachable_polls_total` (counter)
- `dfkv_client_mds_reachable` (gauge)

Suggested alert: `dfkv_client_ring_members == 0` or `dfkv_client_mds_reachable == 0` sustained.

**Tests** (no etcd required)
- `MdsMemberPoller.ReportHealthTracksReachabilityAndCounts` / `UnreachableEndpointIsSurfacedNotSilent` — state machine + a poll against a closed port.
- `DynamicMembers.SetMembersLogsAddRemoveDelta` — add / remove / rolling-replace / unchanged / empty, asserted via captured stderr.

## Notes
- No behavior change on the data path; logging is rate-limited and INFO/WARN only (`DFKV_LOG=warn` quiets the INFO lines).
- Built `-DDFKV_WITH_RDMA=ON`; all three new tests pass.