### PR TITLE
feat(hicache): instrument v2 (DSA side-pool) path with client metrics

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -294,6 +294,11 @@ class DfkvHiCache(HiCacheStorage):
                 cfg.get("backup_exist_gate",
                         os.environ.get("DFKV_BACKUP_EXIST_GATE", "1")))
             self._put_retry_recovered = 0  # last _put_flat's retry recoveries
+            # last _v2_io()'s transferred bytes + I/O seconds, read by
+            # batch_set_v2/batch_get_v2 to feed the v2 metrics (mirrors the
+            # _put_retry_recovered instance-state handoff pattern).
+            self._v2_io_bytes = 0
+            self._v2_io_seconds = 0.0
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0
@@ -773,6 +778,7 @@ class DfkvHiCache(HiCacheStorage):
                 for j, sk in enumerate(self._pool_keys(name, k)):
                     sks.append(sk); sp.append(int(ptrs[i * sub + j])); ss.append(int(sizes[i * sub + j]))
             segments.append((name, len(keys), sub, start, len(sks)))
+        t0 = time.perf_counter()
         if sks and putting:
             flat = self._put_flat(sks, sp, ss)
         elif sks:
@@ -781,6 +787,11 @@ class DfkvHiCache(HiCacheStorage):
             flat = [out[i] == 1 for i in range(len(sks))]
         else:
             flat = []
+        # Expose the actual I/O cost/volume for the v2 metrics (the caller reads
+        # these). ss covers only pools that did I/O (MLA backup_skip pools were
+        # `continue`d before appending), so bytes are 0 on a pure skip.
+        self._v2_io_bytes = sum(ss)
+        self._v2_io_seconds = time.perf_counter() - t0
         for name, nkeys, sub, start, end in segments:
             results[name] = self._fold(flat[start:end], nkeys, sub)
         return results
@@ -796,6 +807,14 @@ class DfkvHiCache(HiCacheStorage):
                 r.result += f" retry_ok={self._put_retry_recovered}"
             if _sp:
                 _sp.hits = sum(sum(rs) for rs in res.values())
+            # MLA rank!=0 replicated latent is a no-op skip ([True] markers, no
+            # I/O) — don't inflate the write-ok metric with it (mirrors
+            # batch_set_v1, which returns before on_set on backup_skip).
+            if nkeys and not (self.is_mla and self.tp_rank != 0):
+                self._metrics.on_set_v2(
+                    pages=sum(len(rs) for rs in res.values()),
+                    ok_pages=sum(sum(rs) for rs in res.values()),
+                    nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
             return res
 
     def batch_get_v2(self, transfers, extra_info=None) -> dict:
@@ -807,6 +826,11 @@ class DfkvHiCache(HiCacheStorage):
             r.result = _fmt_pool_results(res)
             if _sp:
                 _sp.hits = sum(sum(rs) for rs in res.values())
+            if nkeys:
+                self._metrics.on_get_v2(
+                    pages=sum(len(rs) for rs in res.values()),
+                    hit_pages=sum(sum(rs) for rs in res.values()),
+                    nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
             return res
 
     def batch_exists_v2(self, keys, pool_transfers=None, extra_info=None):
@@ -853,6 +877,12 @@ class DfkvHiCache(HiCacheStorage):
             r.result = (f"kv={result.kv_hit_pages}/{total} "
                         + ",".join(f"{k}={v}" for k, v in hit.items()
                                    if k != "kv")).strip()
+            # The usable hit prefix (kv_hit_pages) over the probed candidate
+            # prefix (total keys) is the L3 hit-rate signal for V4/DSA models,
+            # where the *_v1 get counters only see empty anchor markers.
+            if total:
+                self._metrics.on_exists_v2(probe_pages=total,
+                                           hit_pages=result.kv_hit_pages)
             return result
 
     # --- required abstract methods (non zero-copy / introspection) ---

--- a/integration/hicache/dfkv_metrics.py
+++ b/integration/hicache/dfkv_metrics.py
@@ -20,6 +20,22 @@ Metric names (labels: tp_rank):
   dfkv_client_get_pages_total      KV pages requested
   dfkv_client_get_hit_pages_total  pages returned as hits
   dfkv_client_get_bytes_total      bytes requested (sum of sub-object sizes)
+
+v2 (hybrid/DSA side-pool) path. For V4/DSA models (e.g. GLM-5.2) the real KV
+rides these while the *_v1 counters see only empty anchor markers, so the L3
+write/hit rate lives here. The DSA L3 hit rate =
+exist_v2_hit_pages_total / exist_v2_probe_pages_total.
+  dfkv_client_set_v2_calls_total       batch_set_v2 calls that wrote (MLA: rank0 only)
+  dfkv_client_set_v2_pages_total       side-pool pages offered to set_v2
+  dfkv_client_set_v2_ok_pages_total    side-pool pages acked OK
+  dfkv_client_set_v2_bytes_total       bytes sent on set_v2
+  dfkv_client_get_v2_calls_total       batch_get_v2 calls
+  dfkv_client_get_v2_pages_total       side-pool pages requested
+  dfkv_client_get_v2_hit_pages_total   side-pool pages returned as hits
+  dfkv_client_get_v2_bytes_total       bytes requested on get_v2
+  dfkv_client_exist_v2_calls_total     batch_exists_v2 calls
+  dfkv_client_exist_v2_probe_pages_total  candidate KV prefix pages probed
+  dfkv_client_exist_v2_hit_pages_total    usable hit-prefix pages (kv_hit_pages)
 """
 import threading
 
@@ -41,6 +57,12 @@ if _HAVE_PROM:
         _HIST["get"] = _PromHistogram("dfkv_client_get_seconds",
                                       "batch_get_v1 call duration seconds",
                                       ["tp_rank"], buckets=_HIST_BUCKETS)
+        _HIST["set_v2"] = _PromHistogram("dfkv_client_set_v2_seconds",
+                                         "batch_set_v2 I/O duration seconds",
+                                         ["tp_rank"], buckets=_HIST_BUCKETS)
+        _HIST["get_v2"] = _PromHistogram("dfkv_client_get_v2_seconds",
+                                         "batch_get_v2 I/O duration seconds",
+                                         ["tp_rank"], buckets=_HIST_BUCKETS)
     except Exception:
         _HIST = {}
 
@@ -53,6 +75,23 @@ _SPECS = [
     ("get_pages", "dfkv_client_get_pages_total", "KV pages requested"),
     ("get_hit_pages", "dfkv_client_get_hit_pages_total", "pages returned as hits"),
     ("get_bytes", "dfkv_client_get_bytes_total", "bytes requested on get"),
+    # v2 (hybrid/DSA side-pool) path. For V4/DSA models (e.g. GLM-5.2) the real KV
+    # rides batch_set_v2/batch_get_v2 while the v1 "kv" path only writes/reads
+    # empty anchor markers, so the *_v1 counters above cannot express the L3
+    # hit/write rate for those models — these do. batch_exists_v2 is the prefix
+    # existence probe that drives the scheduler's hit prefix, so its hit rate
+    # (exist_v2_hit_pages / exist_v2_probe_pages) is the L3 hit-rate signal.
+    ("set_v2_calls", "dfkv_client_set_v2_calls_total", "batch_set_v2 calls that wrote"),
+    ("set_v2_pages", "dfkv_client_set_v2_pages_total", "side-pool pages offered to set_v2"),
+    ("set_v2_ok_pages", "dfkv_client_set_v2_ok_pages_total", "side-pool pages acked OK on set_v2"),
+    ("set_v2_bytes", "dfkv_client_set_v2_bytes_total", "bytes sent on set_v2"),
+    ("get_v2_calls", "dfkv_client_get_v2_calls_total", "batch_get_v2 calls"),
+    ("get_v2_pages", "dfkv_client_get_v2_pages_total", "side-pool pages requested on get_v2"),
+    ("get_v2_hit_pages", "dfkv_client_get_v2_hit_pages_total", "side-pool pages returned as hits on get_v2"),
+    ("get_v2_bytes", "dfkv_client_get_v2_bytes_total", "bytes requested on get_v2"),
+    ("exist_v2_calls", "dfkv_client_exist_v2_calls_total", "batch_exists_v2 calls"),
+    ("exist_v2_probe_pages", "dfkv_client_exist_v2_probe_pages_total", "candidate KV prefix pages probed by exists_v2"),
+    ("exist_v2_hit_pages", "dfkv_client_exist_v2_hit_pages_total", "usable hit-prefix pages from exists_v2 (kv_hit_pages)"),
 ]
 
 # Prometheus Counters are process-global singletons (re-creating the same name
@@ -75,7 +114,8 @@ class Metrics:
         self._rank = str(int(tp_rank))
         self._lock = threading.Lock()
         self._c = {attr: 0 for attr, _, _ in _SPECS}
-        self._obs = {"set": 0, "get": 0}  # histogram observation counts (tests/debug)
+        # histogram observation counts (tests/debug)
+        self._obs = {"set": 0, "get": 0, "set_v2": 0, "get_v2": 0}
 
     def _add(self, **deltas):
         with self._lock:
@@ -102,11 +142,26 @@ class Metrics:
         if seconds is not None:
             self._observe("get", seconds)
 
+    def on_set_v2(self, pages, ok_pages, nbytes, seconds=None):
+        self._add(set_v2_calls=1, set_v2_pages=pages, set_v2_ok_pages=ok_pages,
+                  set_v2_bytes=nbytes)
+        if seconds is not None:
+            self._observe("set_v2", seconds)
+
+    def on_get_v2(self, pages, hit_pages, nbytes, seconds=None):
+        self._add(get_v2_calls=1, get_v2_pages=pages, get_v2_hit_pages=hit_pages,
+                  get_v2_bytes=nbytes)
+        if seconds is not None:
+            self._observe("get_v2", seconds)
+
+    def on_exists_v2(self, probe_pages, hit_pages):
+        self._add(exist_v2_calls=1, exist_v2_probe_pages=probe_pages,
+                  exist_v2_hit_pages=hit_pages)
+
     def snapshot(self):
         with self._lock:
             snap = dict(self._c)
-            snap.update({"set_observations": self._obs["set"],
-                         "get_observations": self._obs["get"]})
+            snap.update({f"{op}_observations": cnt for op, cnt in self._obs.items()})
             return snap
 
 

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -370,6 +370,70 @@ class DingoFSHiCacheTest(unittest.TestCase):
         self.assertEqual(m["set_observations"], 1)
         self.assertEqual(m["get_observations"], 1)
 
+    def test_client_metrics_count_v2_set_get_exists(self):
+        # v2 (DSA side-pool) path metrics. For a V4/DSA model (GLM-5.2) the real
+        # KV rides batch_set_v2/get_v2 while batch_set_v1 only writes empty anchor
+        # markers, so the *_v1 counters stay blind — the *_v2 counters are what
+        # express the L3 write/hit rate. Mirrors the anchor+side-pool v2 flow.
+        from sglang.srt.mem_cache.hicache_storage import PoolTransfer
+        members, _, _ = self._node("metricsv2")
+        cfg = self._cfg(members, model="glm-5.2")
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        st.register_mem_pool_host(FakeLogicalAnchorPool(self.PAGE_SIZE))
+        side = FakeMlaPool(3, self.PAGE_BYTES, self.PAGE_SIZE)
+        st.register_mem_host_pool_v2(side, "deepseek_v4_c4")
+        keys = ["v0", "v1", "v2"]
+        hi = list(range(3 * self.PAGE_SIZE))
+        st.batch_set_v1(keys, hi)  # empty anchor markers -> v1 write counter inert
+        st.batch_set_v2([PoolTransfer(name="deepseek_v4_c4",
+                                      host_indices=hi, keys=keys)])
+        st.batch_get_v2([PoolTransfer(name="deepseek_v4_c4",
+                                      host_indices=hi, keys=keys)])
+        res = st.batch_exists_v2(
+            keys, [PoolTransfer(name="deepseek_v4_c4", host_indices=hi, keys=keys)])
+        m = st._metrics.snapshot()
+        # set_v2: one call, 3 side-pool pages acked OK, bytes = 3 * page
+        self.assertEqual(m["set_v2_calls"], 1)
+        self.assertEqual(m["set_v2_pages"], 3)
+        self.assertEqual(m["set_v2_ok_pages"], 3)
+        self.assertEqual(m["set_v2_bytes"], 3 * self.PAGE_BYTES)
+        # get_v2: one call, 3 pages requested, all hit
+        self.assertEqual(m["get_v2_calls"], 1)
+        self.assertEqual(m["get_v2_pages"], 3)
+        self.assertEqual(m["get_v2_hit_pages"], 3)
+        self.assertEqual(m["get_v2_bytes"], 3 * self.PAGE_BYTES)
+        # exist_v2: probed 3 candidate keys; all 3 form the usable hit prefix.
+        # This ratio (hit/probe) is the DSA L3 hit-rate signal.
+        self.assertEqual(m["exist_v2_calls"], 1)
+        self.assertEqual(m["exist_v2_probe_pages"], 3)
+        self.assertEqual(m["exist_v2_hit_pages"], res.kv_hit_pages)
+        self.assertEqual(m["exist_v2_hit_pages"], 3)
+        # v2 latency histograms observed once per set_v2/get_v2 call
+        self.assertEqual(m["set_v2_observations"], 1)
+        self.assertEqual(m["get_v2_observations"], 1)
+        # the v1 write counter never moved: batch_set_v1 hit the anchor branch
+        # and returned before on_set — proving the *_v1 blindness these fix.
+        self.assertEqual(m["set_calls"], 0)
+
+    def test_v2_set_metrics_skip_on_mla_rank_nonzero(self):
+        # MLA rank!=0 replicates the latent, so batch_set_v2 is a no-op skip
+        # ([True] markers, no I/O). It must NOT inflate the write-ok metric.
+        from sglang.srt.mem_cache.hicache_storage import PoolTransfer
+        members, _, _ = self._node("metricsv2skip")
+        cfg = self._cfg(members, model="glm-5.2", tp_rank=3)  # rank!=0, MLA
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        st.register_mem_pool_host(FakeLogicalAnchorPool(self.PAGE_SIZE))
+        side = FakeMlaPool(2, self.PAGE_BYTES, self.PAGE_SIZE)
+        st.register_mem_host_pool_v2(side, "deepseek_v4_c4")
+        keys = ["s0", "s1"]
+        hi = list(range(2 * self.PAGE_SIZE))
+        st.batch_set_v2([PoolTransfer(name="deepseek_v4_c4",
+                                      host_indices=hi, keys=keys)])
+        m = st._metrics.snapshot()
+        self.assertEqual(m["set_v2_calls"], 0)
+        self.assertEqual(m["set_v2_ok_pages"], 0)
+        self.assertEqual(m["set_v2_bytes"], 0)
+
     # --- PP key-isolation tests (pure logic, no server/lib needed) ---
     # _keys()/_pool_keys() are pure functions of self.{model,tp_rank,tp_size,
     # is_mla,pp_rank,pp_size,enable_pp}. Bypass __init__ (which needs libdfkv.so


### PR DESCRIPTION
## Motivation

For V4/DSA models (e.g. GLM-5.2), the real KV rides `batch_set_v2` / `batch_get_v2` while the v1 `kv` path only writes/reads **empty anchor markers**. The existing `dfkv_client_{set,get}_*_total` counters are recorded only in `batch_set_v1` / `batch_get_v1`, so on a DSA model they stay pinned to the empty markers — there is currently **no Prometheus signal for the L3 write rate or hit rate**. Ops have to parse `batch_exists_v2` access logs, which is exactly what the client metrics were meant to replace.

## Change

Add v2 counters (+ `set_v2`/`get_v2` latency histograms), recorded in the three v2 methods:

| method | counters |
|---|---|
| `batch_set_v2` | `dfkv_client_set_v2_{calls,pages,ok_pages,bytes}_total` |
| `batch_get_v2` | `dfkv_client_get_v2_{calls,pages,hit_pages,bytes}_total` |
| `batch_exists_v2` | `dfkv_client_exist_v2_{calls,probe_pages,hit_pages}_total` |

**DSA L3 hit rate** (the value that drives the scheduler's hit prefix):
```promql
sum(rate(dfkv_client_exist_v2_hit_pages_total[5m]))
  / sum(rate(dfkv_client_exist_v2_probe_pages_total[5m]))
```
**DSA L3 write success**:
```promql
sum(rate(dfkv_client_set_v2_ok_pages_total[5m]))
  / sum(rate(dfkv_client_set_v2_pages_total[5m]))
```

## Notes

- `_v2_io` now times the actual I/O and exposes the transferred byte count via instance state (mirrors the existing `_put_retry_recovered` handoff), so `set_v2`/`get_v2` can feed bytes+seconds without changing `_v2_io`'s return type.
- MLA rank!=0 replicated-latent writes are a no-op skip (`[True]` markers, no I/O) and are **excluded** from `set_v2` (mirrors `batch_set_v1`'s backup_skip early return), so the write-ok metric is not inflated on non-writing ranks.
- Non-DSA models are unaffected (they use the v1 path; the v2 counters simply stay at 0).
- No C ABI change — Python connector only.

## Why this matters now

This closes the DSA observability gap that companion PR #206 (register DSA hybrid host pools) exposed: after #206 makes DSA L3 writes succeed, `dfkv_client_set_v2_ok_pages_total / dfkv_client_set_v2_pages_total` is the direct Prometheus confirmation of the fix, and `exist_v2` gives the hit rate — no access-log parsing.

## Tests

`test/python/test_dfkv_hicache.py`:
- `test_client_metrics_count_v2_set_get_exists` — set_v2/get_v2/exist_v2 counter values over the anchor+side-pool flow; asserts `exist_v2_hit_pages == kv_hit_pages` and that the v1 write counter stayed at 0 (proving the blindness this fixes).
- `test_v2_set_metrics_skip_on_mla_rank_nonzero` — rank!=0 MLA skip is excluded from set_v2.

Full module: **112/112 pass**.