### PR TITLE
feat(connectors): require model_hash isolation identity + add MDS discovery to dfkv_bench

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -240,8 +240,7 @@ class DfkvHiCache(HiCacheStorage):
                         f"tp={self.tp_rank}/{self.tp_size} mla={int(self.is_mla)}") as r:
             mds = cfg.get("mds_endpoints", "")
             members = cfg.get("members", "")
-            if not mds and not members:
-                raise ValueError("dingofs hicache: extra_config needs 'mds_endpoints' (MDS discovery) or 'members' (static)")
+            _tcfg.require_ring_endpoint(members, mds)
             # RDMA write pipelining: depth>1 keeps multiple PUTs in flight on one
             # connection, hiding per-op latency (single-rank MLA writes are
             # latency-bound). The C client reads DFKV_RDMA_DEPTH when it builds the
@@ -302,7 +301,10 @@ class DfkvHiCache(HiCacheStorage):
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0
-            model_hash = int(cfg.get("model_hash", 0)) & 0xFFFFFFFFFFFFFFFF
+            # Refuse to start on a missing/invalid isolation identity (ring
+            # endpoint already validated above). Opt out with
+            # allow_shared_keyspace=1 for a single-model shared keyspace.
+            model_hash = _tcfg.require_model_hash(cfg)
             self._h = self._lib.dfkv_open(
                 members.encode(), model_hash,
                 int(cfg.get("page_size", 64)), int(cfg.get("dtype_tag", 0)), flags,

--- a/integration/hicache/dfkv_telemetry/config.py
+++ b/integration/hicache/dfkv_telemetry/config.py
@@ -65,6 +65,107 @@ def resolve(cfg: Optional[dict], key: str, env: str, default: Any) -> Any:
     return default
 
 
+# --- required-config validation --------------------------------------------
+# Important connector parameters (the per-model isolation identity, and the ring
+# to connect to) are checked at startup so the inference service refuses to
+# START rather than serve with a silently-wrong config. The isolation identity
+# is the sharpest case: a forgotten model_hash used to default to 0 (the shared
+# keyspace), which reads as valid but lets two models collide/share KV. The
+# checks distinguish "not passed" from "passed 0" and abort on either, unless
+# the operator explicitly opts into the shared keyspace.
+ENV_MODEL_HASH = "DFKV_MODEL_HASH"
+ENV_ALLOW_SHARED_KEYSPACE = "DFKV_ALLOW_SHARED_KEYSPACE"
+
+_UINT64_MAX = 0xFFFFFFFFFFFFFFFF
+_MISSING = object()
+
+
+class DfkvConfigError(ValueError):
+    """A required dfkv connector config value is missing or invalid.
+
+    Raised at connector startup so the inference service refuses to start
+    instead of serving with a broken isolation identity (silently sharing or
+    colliding KV across models) or with no ring to connect to. Messages name the
+    offending parameter and how to set it, including the explicit
+    shared-keyspace opt-in.
+    """
+
+
+def allow_shared_keyspace(cfg: Optional[dict] = None, override: Optional[bool] = None) -> bool:
+    """Whether the operator EXPLICITLY opted into the shared (no-isolation)
+    keyspace via allow_shared_keyspace=1 / DFKV_ALLOW_SHARED_KEYSPACE=1.
+    `override` (when not None) wins, for callers that resolved it themselves."""
+    if override is not None:
+        return bool(override)
+    return truthy(resolve(cfg, "allow_shared_keyspace",
+                          ENV_ALLOW_SHARED_KEYSPACE, False))
+
+
+def require_model_hash(cfg: Optional[dict] = None, *, allow_shared: Optional[bool] = None) -> int:
+    """Return a validated nonzero uint64 model_hash, or raise DfkvConfigError.
+
+    model_hash is the per-model isolation identity of the dfkv keyspace and is
+    REQUIRED: a missing / zero / non-integer / out-of-uint64 value aborts
+    startup, UNLESS the operator opts into the shared keyspace (returns 0 then).
+    The missing-vs-zero distinction is intentional — ``cfg.get('model_hash', 0)``
+    used to mask a forgotten param as the shared keyspace."""
+    shared = allow_shared_keyspace(cfg, allow_shared)
+    raw = resolve(cfg, "model_hash", ENV_MODEL_HASH, _MISSING)
+    if raw is _MISSING or (isinstance(raw, str) and not raw.strip()):
+        if shared:
+            return 0
+        raise DfkvConfigError(
+            "model_hash is required as the per-model isolation identity but was "
+            "not set. Set a nonzero per-model value (extra_config 'model_hash' or "
+            "env DFKV_MODEL_HASH), or allow_shared_keyspace=1 to opt into the "
+            "shared keyspace (no cross-model isolation).")
+    if isinstance(raw, bool):  # bool is an int subclass; reject it explicitly
+        raise DfkvConfigError("model_hash must be an integer (uint64), not a bool.")
+    try:
+        v = raw if isinstance(raw, int) else int(str(raw), 0)
+    except (TypeError, ValueError):
+        raise DfkvConfigError(
+            "model_hash must be an integer (uint64); got {!r}.".format(raw))
+    if v < 0 or v > _UINT64_MAX:
+        raise DfkvConfigError(
+            "model_hash out of uint64 range [0, 2^64): {}.".format(v))
+    if v == 0:
+        if shared:
+            return 0
+        raise DfkvConfigError(
+            "model_hash=0 is the shared keyspace (no cross-model isolation). Set "
+            "a nonzero per-model value, or allow_shared_keyspace=1 to opt in.")
+    return v
+
+
+def require_isolation_name(name: Any, *, field: str = "model_name",
+                           cfg: Optional[dict] = None,
+                           allow_shared: Optional[bool] = None) -> str:
+    """Validate an isolation-namespace string (the source a connector hashes into
+    model_hash, e.g. LMCache's model_name). Empty / blank / non-string makes
+    every deployment collide on one derived keyspace, so it aborts startup unless
+    the shared keyspace is explicitly allowed."""
+    if isinstance(name, str) and name.strip():
+        return name
+    if allow_shared_keyspace(cfg, allow_shared):
+        return name if isinstance(name, str) else ""
+    raise DfkvConfigError(
+        "{0} is required as the isolation namespace (it derives the dfkv "
+        "model_hash); an empty {0} makes every deployment share one keyspace. "
+        "Set {0}, or allow_shared_keyspace=1 to opt in.".format(field))
+
+
+def require_ring_endpoint(members: Any = None, mds_endpoints: Any = None) -> None:
+    """At least one of static ``members`` or ``mds_endpoints`` must be set, else
+    the client has no dfkv ring to connect to. Raises DfkvConfigError otherwise."""
+    if (str(members).strip() if members else "") or \
+            (str(mds_endpoints).strip() if mds_endpoints else ""):
+        return
+    raise DfkvConfigError(
+        "no dfkv ring to connect to: set either 'members' (static member list) "
+        "or 'mds_endpoints' (MDS discovery).")
+
+
 def metrics_enabled(cfg: Optional[dict]) -> bool:
     """Whether the push-metrics layer should be active for this process."""
     v = resolve(cfg, "metrics", ENV_METRICS_ENABLED, None)

--- a/integration/lmcache/src/dfkv_connector/_telemetry/config.py
+++ b/integration/lmcache/src/dfkv_connector/_telemetry/config.py
@@ -65,6 +65,107 @@ def resolve(cfg: Optional[dict], key: str, env: str, default: Any) -> Any:
     return default
 
 
+# --- required-config validation --------------------------------------------
+# Important connector parameters (the per-model isolation identity, and the ring
+# to connect to) are checked at startup so the inference service refuses to
+# START rather than serve with a silently-wrong config. The isolation identity
+# is the sharpest case: a forgotten model_hash used to default to 0 (the shared
+# keyspace), which reads as valid but lets two models collide/share KV. The
+# checks distinguish "not passed" from "passed 0" and abort on either, unless
+# the operator explicitly opts into the shared keyspace.
+ENV_MODEL_HASH = "DFKV_MODEL_HASH"
+ENV_ALLOW_SHARED_KEYSPACE = "DFKV_ALLOW_SHARED_KEYSPACE"
+
+_UINT64_MAX = 0xFFFFFFFFFFFFFFFF
+_MISSING = object()
+
+
+class DfkvConfigError(ValueError):
+    """A required dfkv connector config value is missing or invalid.
+
+    Raised at connector startup so the inference service refuses to start
+    instead of serving with a broken isolation identity (silently sharing or
+    colliding KV across models) or with no ring to connect to. Messages name the
+    offending parameter and how to set it, including the explicit
+    shared-keyspace opt-in.
+    """
+
+
+def allow_shared_keyspace(cfg: Optional[dict] = None, override: Optional[bool] = None) -> bool:
+    """Whether the operator EXPLICITLY opted into the shared (no-isolation)
+    keyspace via allow_shared_keyspace=1 / DFKV_ALLOW_SHARED_KEYSPACE=1.
+    `override` (when not None) wins, for callers that resolved it themselves."""
+    if override is not None:
+        return bool(override)
+    return truthy(resolve(cfg, "allow_shared_keyspace",
+                          ENV_ALLOW_SHARED_KEYSPACE, False))
+
+
+def require_model_hash(cfg: Optional[dict] = None, *, allow_shared: Optional[bool] = None) -> int:
+    """Return a validated nonzero uint64 model_hash, or raise DfkvConfigError.
+
+    model_hash is the per-model isolation identity of the dfkv keyspace and is
+    REQUIRED: a missing / zero / non-integer / out-of-uint64 value aborts
+    startup, UNLESS the operator opts into the shared keyspace (returns 0 then).
+    The missing-vs-zero distinction is intentional — ``cfg.get('model_hash', 0)``
+    used to mask a forgotten param as the shared keyspace."""
+    shared = allow_shared_keyspace(cfg, allow_shared)
+    raw = resolve(cfg, "model_hash", ENV_MODEL_HASH, _MISSING)
+    if raw is _MISSING or (isinstance(raw, str) and not raw.strip()):
+        if shared:
+            return 0
+        raise DfkvConfigError(
+            "model_hash is required as the per-model isolation identity but was "
+            "not set. Set a nonzero per-model value (extra_config 'model_hash' or "
+            "env DFKV_MODEL_HASH), or allow_shared_keyspace=1 to opt into the "
+            "shared keyspace (no cross-model isolation).")
+    if isinstance(raw, bool):  # bool is an int subclass; reject it explicitly
+        raise DfkvConfigError("model_hash must be an integer (uint64), not a bool.")
+    try:
+        v = raw if isinstance(raw, int) else int(str(raw), 0)
+    except (TypeError, ValueError):
+        raise DfkvConfigError(
+            "model_hash must be an integer (uint64); got {!r}.".format(raw))
+    if v < 0 or v > _UINT64_MAX:
+        raise DfkvConfigError(
+            "model_hash out of uint64 range [0, 2^64): {}.".format(v))
+    if v == 0:
+        if shared:
+            return 0
+        raise DfkvConfigError(
+            "model_hash=0 is the shared keyspace (no cross-model isolation). Set "
+            "a nonzero per-model value, or allow_shared_keyspace=1 to opt in.")
+    return v
+
+
+def require_isolation_name(name: Any, *, field: str = "model_name",
+                           cfg: Optional[dict] = None,
+                           allow_shared: Optional[bool] = None) -> str:
+    """Validate an isolation-namespace string (the source a connector hashes into
+    model_hash, e.g. LMCache's model_name). Empty / blank / non-string makes
+    every deployment collide on one derived keyspace, so it aborts startup unless
+    the shared keyspace is explicitly allowed."""
+    if isinstance(name, str) and name.strip():
+        return name
+    if allow_shared_keyspace(cfg, allow_shared):
+        return name if isinstance(name, str) else ""
+    raise DfkvConfigError(
+        "{0} is required as the isolation namespace (it derives the dfkv "
+        "model_hash); an empty {0} makes every deployment share one keyspace. "
+        "Set {0}, or allow_shared_keyspace=1 to opt in.".format(field))
+
+
+def require_ring_endpoint(members: Any = None, mds_endpoints: Any = None) -> None:
+    """At least one of static ``members`` or ``mds_endpoints`` must be set, else
+    the client has no dfkv ring to connect to. Raises DfkvConfigError otherwise."""
+    if (str(members).strip() if members else "") or \
+            (str(mds_endpoints).strip() if mds_endpoints else ""):
+        return
+    raise DfkvConfigError(
+        "no dfkv ring to connect to: set either 'members' (static member list) "
+        "or 'mds_endpoints' (MDS discovery).")
+
+
 def metrics_enabled(cfg: Optional[dict]) -> bool:
     """Whether the push-metrics layer should be active for this process."""
     v = resolve(cfg, "metrics", ENV_METRICS_ENABLED, None)

--- a/integration/lmcache/src/dfkv_connector/l2_adapter.py
+++ b/integration/lmcache/src/dfkv_connector/l2_adapter.py
@@ -53,6 +53,7 @@ from lmcache.v1.distributed.l2_adapters.config import L2AdapterConfigBase
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.platform import create_event_notifier
 
+from ._telemetry import config as _tcfg
 from .config import parse_dfkv_url
 from .native_client import DfkvNativeClient
 
@@ -181,6 +182,9 @@ class DfkvL2AdapterConfig(L2AdapterConfigBase):
         model_name = d.get("model_name", "")
         if not isinstance(model_name, str):
             raise ValueError("dfkv L2 adapter: 'model_name' must be a string")
+        # model_name is the isolation namespace (derives the dfkv model_hash);
+        # refuse to start on an empty one unless the shared keyspace is opted in.
+        _tcfg.require_isolation_name(model_name, cfg=d)
 
         mds_poll_ms = d.get("mds_poll_ms", 3000)
         if not isinstance(mds_poll_ms, int) or mds_poll_ms <= 0:

--- a/integration/lmcache/src/dfkv_connector/remote_connector.py
+++ b/integration/lmcache/src/dfkv_connector/remote_connector.py
@@ -32,6 +32,7 @@ from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
+from ._telemetry import config as _tcfg
 from .access_log import access_log
 from .config import parse_dfkv_url
 from .exists_cache import ExistsLRU
@@ -67,8 +68,13 @@ def _geometry_from_metadata(md: Any) -> dict:
     layer_num = int(kv_shape[0]) if len(kv_shape) > 0 else 0
     head_num = int(kv_shape[3]) if len(kv_shape) > 3 else 0
     head_dim = int(kv_shape[4]) if len(kv_shape) > 4 else 0
+    # model_name is the isolation namespace (derives model_hash); an empty one
+    # makes every deployment collide on blake2b("") — refuse to start unless the
+    # shared keyspace is opted in via env DFKV_ALLOW_SHARED_KEYSPACE=1.
+    model_name = getattr(md, "model_name", "")
+    _tcfg.require_isolation_name(model_name)
     return {
-        "model_hash": _stable_model_hash(getattr(md, "model_name", "")),
+        "model_hash": _stable_model_hash(model_name),
         "page_size": int(getattr(md, "chunk_size", 0)),
         "dtype_tag": 0,
         "flags": _FLAG_IS_MLA if getattr(md, "use_mla", False) else 0,

--- a/integration/vllm/src/dfkv_vllm/_telemetry/config.py
+++ b/integration/vllm/src/dfkv_vllm/_telemetry/config.py
@@ -65,6 +65,107 @@ def resolve(cfg: Optional[dict], key: str, env: str, default: Any) -> Any:
     return default
 
 
+# --- required-config validation --------------------------------------------
+# Important connector parameters (the per-model isolation identity, and the ring
+# to connect to) are checked at startup so the inference service refuses to
+# START rather than serve with a silently-wrong config. The isolation identity
+# is the sharpest case: a forgotten model_hash used to default to 0 (the shared
+# keyspace), which reads as valid but lets two models collide/share KV. The
+# checks distinguish "not passed" from "passed 0" and abort on either, unless
+# the operator explicitly opts into the shared keyspace.
+ENV_MODEL_HASH = "DFKV_MODEL_HASH"
+ENV_ALLOW_SHARED_KEYSPACE = "DFKV_ALLOW_SHARED_KEYSPACE"
+
+_UINT64_MAX = 0xFFFFFFFFFFFFFFFF
+_MISSING = object()
+
+
+class DfkvConfigError(ValueError):
+    """A required dfkv connector config value is missing or invalid.
+
+    Raised at connector startup so the inference service refuses to start
+    instead of serving with a broken isolation identity (silently sharing or
+    colliding KV across models) or with no ring to connect to. Messages name the
+    offending parameter and how to set it, including the explicit
+    shared-keyspace opt-in.
+    """
+
+
+def allow_shared_keyspace(cfg: Optional[dict] = None, override: Optional[bool] = None) -> bool:
+    """Whether the operator EXPLICITLY opted into the shared (no-isolation)
+    keyspace via allow_shared_keyspace=1 / DFKV_ALLOW_SHARED_KEYSPACE=1.
+    `override` (when not None) wins, for callers that resolved it themselves."""
+    if override is not None:
+        return bool(override)
+    return truthy(resolve(cfg, "allow_shared_keyspace",
+                          ENV_ALLOW_SHARED_KEYSPACE, False))
+
+
+def require_model_hash(cfg: Optional[dict] = None, *, allow_shared: Optional[bool] = None) -> int:
+    """Return a validated nonzero uint64 model_hash, or raise DfkvConfigError.
+
+    model_hash is the per-model isolation identity of the dfkv keyspace and is
+    REQUIRED: a missing / zero / non-integer / out-of-uint64 value aborts
+    startup, UNLESS the operator opts into the shared keyspace (returns 0 then).
+    The missing-vs-zero distinction is intentional — ``cfg.get('model_hash', 0)``
+    used to mask a forgotten param as the shared keyspace."""
+    shared = allow_shared_keyspace(cfg, allow_shared)
+    raw = resolve(cfg, "model_hash", ENV_MODEL_HASH, _MISSING)
+    if raw is _MISSING or (isinstance(raw, str) and not raw.strip()):
+        if shared:
+            return 0
+        raise DfkvConfigError(
+            "model_hash is required as the per-model isolation identity but was "
+            "not set. Set a nonzero per-model value (extra_config 'model_hash' or "
+            "env DFKV_MODEL_HASH), or allow_shared_keyspace=1 to opt into the "
+            "shared keyspace (no cross-model isolation).")
+    if isinstance(raw, bool):  # bool is an int subclass; reject it explicitly
+        raise DfkvConfigError("model_hash must be an integer (uint64), not a bool.")
+    try:
+        v = raw if isinstance(raw, int) else int(str(raw), 0)
+    except (TypeError, ValueError):
+        raise DfkvConfigError(
+            "model_hash must be an integer (uint64); got {!r}.".format(raw))
+    if v < 0 or v > _UINT64_MAX:
+        raise DfkvConfigError(
+            "model_hash out of uint64 range [0, 2^64): {}.".format(v))
+    if v == 0:
+        if shared:
+            return 0
+        raise DfkvConfigError(
+            "model_hash=0 is the shared keyspace (no cross-model isolation). Set "
+            "a nonzero per-model value, or allow_shared_keyspace=1 to opt in.")
+    return v
+
+
+def require_isolation_name(name: Any, *, field: str = "model_name",
+                           cfg: Optional[dict] = None,
+                           allow_shared: Optional[bool] = None) -> str:
+    """Validate an isolation-namespace string (the source a connector hashes into
+    model_hash, e.g. LMCache's model_name). Empty / blank / non-string makes
+    every deployment collide on one derived keyspace, so it aborts startup unless
+    the shared keyspace is explicitly allowed."""
+    if isinstance(name, str) and name.strip():
+        return name
+    if allow_shared_keyspace(cfg, allow_shared):
+        return name if isinstance(name, str) else ""
+    raise DfkvConfigError(
+        "{0} is required as the isolation namespace (it derives the dfkv "
+        "model_hash); an empty {0} makes every deployment share one keyspace. "
+        "Set {0}, or allow_shared_keyspace=1 to opt in.".format(field))
+
+
+def require_ring_endpoint(members: Any = None, mds_endpoints: Any = None) -> None:
+    """At least one of static ``members`` or ``mds_endpoints`` must be set, else
+    the client has no dfkv ring to connect to. Raises DfkvConfigError otherwise."""
+    if (str(members).strip() if members else "") or \
+            (str(mds_endpoints).strip() if mds_endpoints else ""):
+        return
+    raise DfkvConfigError(
+        "no dfkv ring to connect to: set either 'members' (static member list) "
+        "or 'mds_endpoints' (MDS discovery).")
+
+
 def metrics_enabled(cfg: Optional[dict]) -> bool:
     """Whether the push-metrics layer should be active for this process."""
     v = resolve(cfg, "metrics", ENV_METRICS_ENABLED, None)

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -862,16 +862,14 @@ class DfkvStoreWorker:
                 f"role={self.kv_role},tp_size={self.tp_size},"
                 f"tp_rank={self.tp_rank},ver={_tcfg.dist_version('dfkv-vllm')}"
             )
-        model_hash = int(extra.get("model_hash", 0))
-        if model_hash == 0:
-            # mh=0 is the shared legacy keyspace with NO geometry guard beyond
-            # the byte-length check: two models with the same model_name but a
-            # different dtype/page layout can cross-read each other's blocks.
-            # (hicache derives real geometry; lmcache derives a stable hash.)
-            logger.warning(
-                "dfkv connector: model_hash is 0 (shared keyspace, no "
-                "cross-model isolation). Set kv_connector_extra_config."
-                "model_hash to a per-model value in multi-model fleets.")
+        # Refuse to start on a missing/invalid isolation identity or with no ring
+        # to connect to. mh=0 is the shared legacy keyspace with NO geometry
+        # guard beyond the byte-length check (two models with the same
+        # model_name but a different dtype/page layout can cross-read each
+        # other's blocks), so it now requires an explicit opt-in
+        # (allow_shared_keyspace=1) rather than being the silent default.
+        _tcfg.require_ring_endpoint(extra.get("members", ""), mds_endpoints)
+        model_hash = _tcfg.require_model_hash(extra)
         # Phase 9: same-host rendezvous ON BY DEFAULT for exactly the topology
         # it exists for — MLA with REPLICATED KV across tp ranks (dcp/pcp
         # shard the KV, so their per-rank keys never rendezvous). The vLLM SG

--- a/src/tools/dfkv_bench_main.cc
+++ b/src/tools/dfkv_bench_main.cc
@@ -1,7 +1,14 @@
 /* dfkv_bench — throughput / latency benchmark for a dfkv cluster.
  *
- *   dfkv_bench --members "n=ip:port,..." [--size BYTES] [--count N]
- *              [--threads T] [--batch B] [--op put|get|both] [--key-seed S]
+ *   dfkv_bench (--members "n=ip:port,..." | --mds "ip:port,..." [--group g])
+ *              [--size BYTES] [--count N] [--threads T] [--batch B]
+ *              [--op put|get|both] [--key-seed S] [--ready-timeout SECS]
+ *
+ * Ring membership is EITHER a static --members list OR --mds discovery (exactly
+ * one). With --mds the client populates the ring from the MDS group and waits
+ * (up to --ready-timeout, default 30s) for a warmup Put to succeed before the
+ * measured phases start, so you can point bench straight at a production ring
+ * without hand-listing members from `dfkvctl ring`.
  *
  * Transport is chosen by the same env switch as the client: DFKV_RDMA=1 (+ device
  * DFKV_RDMA_DEV) uses RDMA, else TCP. --batch B issues B keys per BatchPut/
@@ -53,6 +60,21 @@ static std::vector<std::pair<std::string, std::string>> ParseMembers(const std::
   return out;
 }
 
+// Comma-split MDS endpoints ("ip:port,ip:port") — no name= prefix, unlike members.
+static std::vector<std::string> SplitComma(const std::string& s) {
+  std::vector<std::string> out;
+  size_t i = 0;
+  while (i <= s.size()) {
+    size_t c = s.find(',', i);
+    if (c == std::string::npos) c = s.size();
+    std::string tok = s.substr(i, c - i);
+    if (!tok.empty()) out.push_back(tok);
+    if (c == s.size()) break;
+    i = c + 1;
+  }
+  return out;
+}
+
 static double Pct(std::vector<double>& v, double p) {
   if (v.empty()) return 0;
   size_t k = static_cast<size_t>(p * (v.size() - 1));
@@ -94,10 +116,14 @@ static void Report(const char* phase, size_t count, size_t size, size_t threads,
 
 int main(int argc, char** argv) {
   if (dfkv::WantsVersion(argc, argv)) { std::printf("dfkv_bench %s\n", dfkv::Version()); return 0; }
-  std::string members, op = "both", key_seed;
+  std::string members, mds, group = "default", op = "both", key_seed;
   size_t size = 2752512, count = 2000, threads = 8, batch = 1, bc = 0;
+  size_t ready_timeout_s = 30, mds_poll_ms = 1000;
   for (int i = 1; i + 1 < argc; i += 2) {
     if (!std::strcmp(argv[i], "--members")) members = argv[i + 1];
+    else if (!std::strcmp(argv[i], "--mds")) mds = argv[i + 1];       // MDS discovery endpoints
+    else if (!std::strcmp(argv[i], "--group")) group = argv[i + 1];   // MDS ring group
+    else if (!std::strcmp(argv[i], "--ready-timeout")) ready_timeout_s = std::stoull(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--size")) size = std::stoull(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--count")) count = std::stoull(argv[i + 1]);
     else if (!std::strcmp(argv[i], "--threads")) threads = std::stoull(argv[i + 1]);
@@ -107,17 +133,46 @@ int main(int argc, char** argv) {
     else if (!std::strcmp(argv[i], "--key-seed")) key_seed = argv[i + 1];
   }
   if (batch < 1) batch = 1;
+  // Ring membership: exactly one of a static --members list or --mds discovery.
   auto mem = ParseMembers(members);
-  if (mem.empty()) { std::fprintf(stderr, "need --members name=ip:port,...\n"); return 2; }
+  if (mem.empty() == mds.empty()) {
+    std::fprintf(stderr,
+                 "need exactly one of --members name=ip:port,... "
+                 "or --mds ip:port[,...] [--group g]\n");
+    return 2;
+  }
 
   std::string reason;
   MakeClientTransport(&reason);
-  std::printf("dfkv_bench transport=%s members=%zu\n", reason.c_str(), mem.size());
+  if (mds.empty())
+    std::printf("dfkv_bench transport=%s members=%zu\n", reason.c_str(), mem.size());
+  else
+    std::printf("dfkv_bench transport=%s mds=%s group=%s\n",
+                reason.c_str(), mds.c_str(), group.c_str());
 
   // GLM-5.1 / MLA geometry (matches dfkv_smoke / dfkvctl defaults)
   ValueHeader hdr = ValueHeader::Make(0x51, 64, 0x46384534u, ValueHeader::kFlagIsMla,
                                       8, 0, 78, 1, 576);
-  KVClient c(mem, hdr);
+  KVClient c(mem, hdr);   // empty members when discovering via MDS
+  if (!mds.empty()) {
+    // Populate the ring from MDS, then wait until it's usable (a warmup Put
+    // succeeds) so the measured phases don't race discovery. Mirrors
+    // dfkv_discover_smoke's readiness probe.
+    c.StartMdsDiscovery(SplitComma(mds), group, static_cast<int>(mds_poll_ms));
+    std::vector<char> probe(size, 'w');
+    auto deadline = Clock::now() + std::chrono::seconds(ready_timeout_s);
+    bool ready = false;
+    while (!ready && Clock::now() < deadline) {
+      if (c.Put("dfkv_bench/warmup_k", probe.data(), probe.size())) ready = true;
+      else std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    if (!ready) {
+      std::fprintf(stderr,
+                   "dfkv_bench: ring not ready after %zus (mds=%s group=%s)\n",
+                   ready_timeout_s, mds.c_str(), group.c_str());
+      return 2;
+    }
+  }
   // External --threads already provide concurrency; with multi-node members the
   // client's per-call internal RunParallel(batch_concurrency) would nest under
   // each external thread (threads x nodes x bc) and can exhaust threads/connections.

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -228,6 +228,38 @@ class DingoFSHiCacheTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
 
+    def test_requires_model_hash(self):
+        # A forgotten model_hash (the per-model isolation identity) must abort
+        # startup, not silently fall back to the shared keyspace. Raises before
+        # any server connection, so a fake member is fine.
+        cfg = self._cfg("n=127.0.0.1:1")
+        cfg.extra_config.pop("model_hash")
+        with self.assertRaises(dfkv_hicache._tcfg.DfkvConfigError):
+            dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+
+    def test_rejects_zero_model_hash(self):
+        cfg = self._cfg("n=127.0.0.1:1")
+        cfg.extra_config["model_hash"] = 0
+        with self.assertRaises(dfkv_hicache._tcfg.DfkvConfigError):
+            dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+
+    def test_requires_ring_endpoint(self):
+        # Neither members nor mds_endpoints => no ring to connect to.
+        cfg = self._cfg("")  # empty members
+        with self.assertRaises(dfkv_hicache._tcfg.DfkvConfigError):
+            dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+
+    def test_shared_keyspace_opt_in_allows_missing_model_hash(self):
+        # Explicit opt-in lets a single-model deployment start with the shared
+        # keyspace (model_hash 0) — this is the escape hatch that keeps the
+        # strict default from breaking legitimate single-model fleets.
+        members, _, _ = self._node("sharedok")
+        cfg = self._cfg(members)
+        cfg.extra_config.pop("model_hash")
+        cfg.extra_config["allow_shared_keyspace"] = 1
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        self.assertTrue(hasattr(st, "get"))
+
     def test_rdma_depth_extra_config_sets_env(self):
         # extra_config rdma_depth must propagate to DFKV_RDMA_DEPTH so the C client
         # builds its transport with write pipelining (#1). Set before dfkv_open.

--- a/test/python/test_dfkv_telemetry.py
+++ b/test/python/test_dfkv_telemetry.py
@@ -761,5 +761,103 @@ class OtlpTracesTest(unittest.TestCase):
         self.assertEqual(exp.buffered(), 0)      # drained after flush
 
 
+class RequiredConfigValidationTest(unittest.TestCase):
+    """Startup validation of required connector config (isolation identity +
+    ring endpoint). Pure config logic — no server / libdfkv.so."""
+
+    _KEYS = (config.ENV_MODEL_HASH, config.ENV_ALLOW_SHARED_KEYSPACE)
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in self._KEYS}
+        for k in self._KEYS:
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # --- model_hash: the missing/zero/illegal cases all abort ---------------
+    def test_model_hash_missing_raises(self):
+        with self.assertRaises(config.DfkvConfigError):
+            config.require_model_hash({})              # not passed
+        with self.assertRaises(config.DfkvConfigError):
+            config.require_model_hash(None)
+
+    def test_model_hash_zero_raises(self):
+        # the exact bug: cfg.get('model_hash', 0) used to accept a forgotten
+        # param as the shared keyspace.
+        with self.assertRaises(config.DfkvConfigError):
+            config.require_model_hash({"model_hash": 0})
+
+    def test_model_hash_illegal_values_raise(self):
+        for bad in ("", "   ", "abc", -1, 1 << 64, True, 1.5):
+            with self.assertRaises(config.DfkvConfigError, msg=repr(bad)):
+                config.require_model_hash({"model_hash": bad})
+
+    def test_model_hash_valid_returned_as_uint64(self):
+        self.assertEqual(config.require_model_hash({"model_hash": 0x51}), 0x51)
+        # string (env-style) incl. hex is accepted and coerced
+        self.assertEqual(config.require_model_hash({"model_hash": "129"}), 129)
+        self.assertEqual(config.require_model_hash({"model_hash": "0x51"}), 0x51)
+        self.assertEqual(
+            config.require_model_hash({"model_hash": config._UINT64_MAX}),
+            config._UINT64_MAX)
+
+    def test_model_hash_from_env(self):
+        os.environ[config.ENV_MODEL_HASH] = "0x1234"
+        self.assertEqual(config.require_model_hash({}), 0x1234)
+
+    def test_model_hash_cfg_wins_over_env(self):
+        os.environ[config.ENV_MODEL_HASH] = "0x1234"
+        self.assertEqual(config.require_model_hash({"model_hash": 0x51}), 0x51)
+
+    # --- shared-keyspace opt-in --------------------------------------------
+    def test_shared_keyspace_opt_in_allows_missing_and_zero(self):
+        self.assertEqual(
+            config.require_model_hash({"allow_shared_keyspace": True}), 0)
+        self.assertEqual(
+            config.require_model_hash(
+                {"model_hash": 0, "allow_shared_keyspace": 1}), 0)
+
+    def test_shared_keyspace_opt_in_via_env(self):
+        os.environ[config.ENV_ALLOW_SHARED_KEYSPACE] = "1"
+        self.assertEqual(config.require_model_hash({}), 0)
+
+    def test_shared_keyspace_still_rejects_illegal(self):
+        # opt-in permits 0/missing, but a genuinely malformed value still fails.
+        with self.assertRaises(config.DfkvConfigError):
+            config.require_model_hash(
+                {"model_hash": "abc", "allow_shared_keyspace": True})
+
+    # --- isolation name (lmcache model_name) --------------------------------
+    def test_isolation_name_empty_raises(self):
+        for bad in ("", "   ", None, 123):
+            with self.assertRaises(config.DfkvConfigError, msg=repr(bad)):
+                config.require_isolation_name(bad)
+
+    def test_isolation_name_valid_returned(self):
+        self.assertEqual(config.require_isolation_name("glm-5.2"), "glm-5.2")
+
+    def test_isolation_name_shared_opt_in(self):
+        self.assertEqual(
+            config.require_isolation_name("", cfg={"allow_shared_keyspace": 1}), "")
+        os.environ[config.ENV_ALLOW_SHARED_KEYSPACE] = "1"
+        self.assertEqual(config.require_isolation_name(""), "")
+
+    # --- ring endpoint ------------------------------------------------------
+    def test_ring_endpoint_requires_members_or_mds(self):
+        with self.assertRaises(config.DfkvConfigError):
+            config.require_ring_endpoint("", "")
+        with self.assertRaises(config.DfkvConfigError):
+            config.require_ring_endpoint(None, None)
+
+    def test_ring_endpoint_ok_with_either(self):
+        config.require_ring_endpoint("n0=127.0.0.1:1", "")   # no raise
+        config.require_ring_endpoint("", "mds0=127.0.0.1:2")  # no raise
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two operability fixes: a forgotten-but-important parameter now fails loudly instead of silently degrading, and `dfkv_bench` can target a real ring.

## 1. Required-config validation (sglang / vllm / lmcache)

`model_hash` is the per-model **isolation identity** of the dfkv keyspace, but a forgotten one defaulted to `0` (the shared keyspace) — valid-looking yet lets two models collide/share KV. All three connectors now validate at startup and **refuse to start** on a missing / zero / non-integer / out-of-uint64 value, plus a ring-endpoint check (`members` or `mds_endpoints` required).

| connector | check | site |
|---|---|---|
| hicache | `require_model_hash(cfg)` | `dfkv_hicache.configure` |
| vllm | `require_model_hash(extra)` | worker connector init |
| lmcache | `require_isolation_name(model_name)` | `l2_adapter.from_dict` + `remote_connector._geometry_from_metadata` |

lmcache derives `model_hash` from `model_name`, so an empty name (`blake2b("")`) is the equivalent collision and is rejected there instead.

**Missing vs zero**: the check uses a sentinel to distinguish "not passed" from "passed 0" — plain `cfg.get('model_hash', 0)` could not, which is exactly how a forgotten param slipped through as the shared keyspace.

**Escape hatch**: `allow_shared_keyspace=1` / `DFKV_ALLOW_SHARED_KEYSPACE=1` preserves the legitimate single-model shared-keyspace deployment, so the strict default does not break existing single-model fleets (vLLM's old warning explicitly said only multi-model fleets need `model_hash`).

Shared logic lives in the canonical `dfkv_telemetry/config.py` (`DfkvConfigError`, `require_model_hash`, `require_isolation_name`, `require_ring_endpoint`, `allow_shared_keyspace`), vendored byte-identical into the vllm/lmcache copies via `deploy/sync_telemetry.sh` (guarded by `test_telemetry_vendor_sync`).

## 2. `dfkv_bench --mds` discovery

`dfkv_bench` was **static-members-only** (`--members "n=ip:port,..."`) while every other tool (`dfkvctl`, `dfkv_discover_smoke`, the C API) supports MDS discovery — so benchmarking a production ring meant hand-listing members from `dfkvctl ring`. Added:

```
dfkv_bench --mds "ip:port,..." [--group g] [--ready-timeout SECS]  ...
```

It builds an empty-member client, `StartMdsDiscovery`, and waits for a warmup Put to succeed before the measured phases (mirrors `dfkv_discover_smoke`). Exactly one of `--members` / `--mds` is required.

## Tests

- 14 pure validator unit tests (`test_dfkv_telemetry.RequiredConfigValidationTest`): missing/zero/illegal/valid/env/cfg-precedence, shared opt-in, isolation-name, ring-endpoint.
- hicache startup-refusal + shared-opt-in integration tests (`test_dfkv_hicache`).
- Full hicache+telemetry suite **132/132**; vendor-sync guard green.
- `dfkv_bench` builds; arg-validation and mds-timeout paths smoke-tested.
- lmcache/vllm connector tests are CI-only (packages absent locally) but exercise the same vendored validators.

## Compatibility

Behavior change: connectors that previously started with `model_hash=0`/unset now refuse unless `allow_shared_keyspace=1` is set. This is intentional (catches the silent cross-model-collision footgun); single-model deployments set the one opt-in flag.