### PR TITLE
test(disk-slab): deflake RebindWipes steal-eviction count (disable reclaimer)

### DIFF
--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -400,7 +400,14 @@ TEST_F(DiskSlabTest, RebindWipesStaleRecordsNoResurrectionAcrossRestart) {
   {
     bool ok = false;
     // 2 extents x 4 slots(4096): 8 class-A keys fill both extents.
-    DiskSlabStore s(Opts(2 * 4 * 4096, 4 * 4096, 4096), &ok);
+    // Reclaimer OFF: this test asserts an EXACT steal-eviction count (one
+    // extent's 4 residents). With the default 50ms reclaimer running on this
+    // full store, the background thread can free an extra resident between the
+    // steal and the IsCached check, flaking the count to 5 (seen on clang CI).
+    // Determinism here is about the steal/rebind path, not reclaiming.
+    auto o = Opts(2 * 4 * 4096, 4 * 4096, 4096);
+    o.reclaim_interval_ms = 0;
+    DiskSlabStore s(o, &ok);
     ASSERT_TRUE(ok);
     std::string a(4000, 'A');
     for (int i = 0; i < 8; ++i)
@@ -415,9 +422,11 @@ TEST_F(DiskSlabTest, RebindWipesStaleRecordsNoResurrectionAcrossRestart) {
     ASSERT_EQ(absent_after_steal.size(), 4u) << "steal evicts one extent's residents";
   }
   // Restart: the stolen extent's old keys must STAY dead; B and the surviving
-  // extent's keys must read back intact.
+  // extent's keys must read back intact. Reclaimer OFF for the same reason.
   bool ok = false;
-  DiskSlabStore s2(Opts(2 * 4 * 4096, 4 * 4096, 4096), &ok);
+  auto o2 = Opts(2 * 4 * 4096, 4 * 4096, 4096);
+  o2.reclaim_interval_ms = 0;
+  DiskSlabStore s2(o2, &ok);
   ASSERT_TRUE(ok);
   EXPECT_EQ(s2.Count(), 5u) << "4 surviving A keys + B; no resurrection";
   for (int id : absent_after_steal)


### PR DESCRIPTION
## Symptom

`DiskSlabTest.RebindWipesStaleRecordsNoResurrectionAcrossRestart` intermittently fails on the clang++ CI job:

```
disk_slab_store_test.cc:415: Failure
Expected equality of these values:  Which is: 5   Which is: 4
```

## Root cause

The test asserts an **exact** eviction count: caching a class-B value into a full store (8/8 slots) must **steal one A extent**, evicting exactly that extent's **4** residents — `ASSERT_EQ(absent_after_steal.size(), 4)`. The restart invariant then depends on it (`Count()==5` = 4 surviving A + B).

The `Opts()` test helper leaves `reclaim_interval_ms` at its **50ms default**, so the background free-slot reclaimer thread is running. On this full store it can free an extra resident between the steal and the `IsCached()` sweep, making the count **5** and flaking the assert. `g++` happened not to hit the timing; clang++ did.

Loosening to `>=4` would not help — the post-restart `Count()==5` assertion also requires exactly 4 evicted, so the flake would just move.

## Fix

The test exercises the **steal / rebind-wipe** path, not the reclaimer, so disable the reclaimer (`reclaim_interval_ms = 0`) on both the pre- and post-restart stores. Eviction becomes deterministic; the assertions keep their exact semantics.

## Verification

- Previously-flaky test run **100×** locally: **100/100 pass**.
- Full `DiskSlabTest` suite: **18/18**.

Test-only change; no production code touched.