### PR TITLE
feat(observability): dump effective config at startup (server/mds/client)

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -17,6 +17,7 @@
 #include "cache/kv_node_server.h"
 #include "utils/wire_limits.h"
 #include "utils/log.h"
+#include "common/config_dump.h"
 #include "mds/mds_registrar.h"
 #include "utils/metrics_http.h"
 #include "common/version.h"
@@ -183,6 +184,28 @@ int main(int argc, char** argv) {
     return 2;
   }
   (void)rdma_port;
+  // Record the direct (non-env-facade) flags for the startup config dump.
+  // Source is flag ONLY when the flag was actually passed, else default — so the
+  // dump truthfully separates externally-specified from built-in-default values.
+  // The env-facade flags above already reach environ via setenv, so Emit()'s
+  // environ scan folds them in (shown as env with their effective value).
+  {
+    namespace cd = dfkv::config_dump;
+    auto src = [&](const char* flag) {
+      return args.Has(flag) ? cd::Source::kFlag : cd::Source::kDefault;
+    };
+    cd::Record("dir", dir, src("--dir"));
+    cd::Record("port", std::to_string(port), src("--port"));
+    cd::Record("cap", std::to_string(cap), src("--cap"));
+    cd::Record("rdma_dev", rdma_dev.empty() ? "(unset)" : rdma_dev, src("--rdma-dev"));
+    cd::Record("mds", mds.empty() ? "(none)" : mds, src("--mds"));
+    cd::Record("group", group, src("--group"));
+    cd::Record("id", node_id.empty() ? "(auto)" : node_id, src("--id"));
+    cd::Record("advertise", advertise.empty() ? "(auto)" : advertise, src("--advertise"));
+    cd::Record("weight", std::to_string(weight), src("--weight"));
+    cd::Record("metrics_port", std::to_string(metrics_port), src("--metrics-port"));
+    cd::Record("metrics_bind", metrics_bind.empty() ? "(any)" : metrics_bind, src("--metrics-bind"));
+  }
   std::signal(SIGINT, OnSig);
   std::signal(SIGTERM, OnSig);
 
@@ -294,6 +317,10 @@ int main(int argc, char** argv) {
                     (rdma_dev.empty() ? "" : ", dev=" + rdma_dev));
     else
       DFKV_LOG_WARN("dfkv_server RDMA listener failed to start (no device?)");
+    // Force-resolve the RDMA depth/uring knobs so their defaults land in the
+    // config dump (they are otherwise read lazily on the serve path, after Emit).
+    (void)rsrv->PipelineDepth();
+    (void)rsrv->UseUringPath();
   }
 #endif
 
@@ -388,6 +415,7 @@ int main(int argc, char** argv) {
                   " advertise=" + advertise);
   }
 
+  dfkv::config_dump::Emit("server");
   ready_flag->store(true, std::memory_order_release);
   DFKV_LOG_INFO("dfkv_server ready (all startup stages complete)");
 

--- a/src/cache/disk_cache_group.cc
+++ b/src/cache/disk_cache_group.cc
@@ -4,6 +4,7 @@
 #include <map>
 
 #include "cache/disk_slab_store.h"
+#include "common/config_dump.h"
 #include "utils/log.h"
 
 namespace dfkv {
@@ -60,6 +61,14 @@ DiskCacheGroup::DiskCacheGroup(Options opt) {
   uint32_t reclaim_ms = 50;
   if (const char* r = std::getenv("DFKV_SLAB_RECLAIM_MS"))
     reclaim_ms = static_cast<uint32_t>(std::strtoul(r, nullptr, 10));
+  // Effective values into the startup config dump (defaults included).
+  config_dump::RecordResolved("DFKV_STORE_ENGINE", engine_);
+  config_dump::RecordResolved("DFKV_DISK_HASH_WEIGHT", std::to_string(DiskHashWeight()));
+  config_dump::RecordResolved("DFKV_SLAB_WRITE", slab_direct ? "direct" : "buffered");
+  config_dump::RecordResolved("DFKV_SLAB_GRANULARITY",
+                              slab_gran ? std::to_string(slab_gran) : std::string("1048576"));
+  config_dump::RecordResolved("DFKV_SLAB_TABLE_SYNC_MS", std::to_string(sync_ms));
+  config_dump::RecordResolved("DFKV_SLAB_RECLAIM_MS", std::to_string(reclaim_ms));
   for (const auto& dir : opt.cache_dirs) {
     std::unique_ptr<StoreEngine> store;
     if (use_slab) {

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -1,5 +1,7 @@
 #include "cache/disk_slab_store.h"
 
+#include "common/config_dump.h"
+
 #ifdef DFKV_WITH_URING
 #include <liburing.h>
 #endif
@@ -145,6 +147,8 @@ DiskSlabStore::DiskSlabStore(Options opt, bool* ok) : opt_(std::move(opt)) {
   {
     const char* v = std::getenv("DFKV_SLAB_URING_WRITE");
     uring_write_enabled_ = !(v && *v == '0');
+    config_dump::RecordResolved("DFKV_SLAB_URING_WRITE",
+                                uring_write_enabled_ ? "on" : "off");
   }
 #endif
   if (ok_ && opt_.reclaim_interval_ms > 0) {

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -8,6 +8,7 @@
 
 #include <vector>
 
+#include "common/config_dump.h"
 #include "utils/net_util.h"
 #include "utils/thread_name.h"
 #include "utils/wire_limits.h"
@@ -46,15 +47,22 @@ void KvNodeServer::InitAdmission() {
     unsigned long long n = std::strtoull(v, nullptr, 10);
     put_busy_limit_ = static_cast<size_t>(n);
   }
+  config_dump::RecordResolved("DFKV_PUT_INFLIGHT_LIMIT",
+                              std::to_string(put_busy_limit_));
+  // Read-side convoy collapse master switch, plus its timeout/recur sub-knobs
+  // (forced now so their defaults show even before the first coalesced read).
+  config_dump::RecordResolved("DFKV_READ_COALESCE", coalesce_enabled_ ? "on" : "off");
+  if (coalesce_enabled_) ReadCoalescer::RecordConfig();
 }
 
 void KvNodeServer::InitRamTier() {
   // Off by default. DFKV_RAM_TIER in {1,on,true,yes} enables the RAM hot tier;
   // DFKV_RAM_TIER_BYTES sizes the pre-registered arena (default 4 GiB).
   const char* e = std::getenv("DFKV_RAM_TIER");
-  if (!e || !*e) return;
-  const std::string v(e);
-  if (v != "1" && v != "on" && v != "true" && v != "yes") return;
+  const std::string v = (e && *e) ? std::string(e) : "";
+  const bool enabled = (v == "1" || v == "on" || v == "true" || v == "yes");
+  config_dump::RecordResolved("DFKV_RAM_TIER", enabled ? "on" : "off");
+  if (!enabled) return;
   RamTier::Options o;
   if (const char* b = std::getenv("DFKV_RAM_TIER_BYTES")) {
     unsigned long long n = std::strtoull(b, nullptr, 10);
@@ -74,6 +82,9 @@ void KvNodeServer::InitRamTier() {
   // Background free-slot reclaimer cadence (ms; 0 disables). Default 10.
   if (const char* r = std::getenv("DFKV_RAM_RECLAIM_MS"))
     o.reclaim_interval_ms = static_cast<uint32_t>(std::strtoul(r, nullptr, 10));
+  config_dump::RecordResolved("DFKV_RAM_TIER_BYTES", std::to_string(o.bytes));
+  config_dump::RecordResolved("DFKV_RAM_FLUSH_THREADS", std::to_string(o.flush_threads));
+  config_dump::RecordResolved("DFKV_RAM_RECLAIM_MS", std::to_string(o.reclaim_interval_ms));
   // Flusher persists a RAM slot to the disk group. CacheDirect (not Cache): the
   // arena slot is 4 KiB-aligned with cap slack, so a direct-mode slab lands it
   // via O_DIRECT -- a buffered flush would route the RAM tier's entire write

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "utils/log.h"
+#include "common/config_dump.h"
 #include "utils/thread_name.h"
 #include "utils/numa_util.h"
 
@@ -28,6 +29,7 @@ RamTier::RamTier(Options opt, FlushFn flush)
   // DFKV_RDMA_NUMA-pinned single-rail setups).
   const char* nm = std::getenv("DFKV_RAM_TIER_NUMA");
   const bool interleave = !(nm && std::strcmp(nm, "off") == 0);
+  config_dump::RecordResolved("DFKV_RAM_TIER_NUMA", interleave ? "interleave" : "off");
   const int nodes = numa::OnlineNodeCount();
   if (interleave) numa::InterleaveMemory(arena_, opt_.bytes, nodes);
   // Pre-fault the arena now (one bounded, REPORTED cost at startup) instead of
@@ -76,6 +78,7 @@ RamTier::RamTier(Options opt, FlushFn flush)
   }
   if (ext > opt_.bytes) ext = opt_.bytes;
   extent_bytes_ = ext;
+  config_dump::RecordResolved("DFKV_RAM_TIER_EXTENT_BYTES", std::to_string(ext));
   const uint64_t total_extents = std::max<uint64_t>(1, opt_.bytes / ext);
 
   // Shard count: enough shards to take the single lock off the hot path, few
@@ -90,6 +93,13 @@ RamTier::RamTier(Options opt, FlushFn flush)
   nshards = std::min(nshards, kMaxShards);
   while (nshards > 1 && total_extents / nshards < 32) nshards /= 2;
   if (nshards < 1) nshards = 1;
+  // Record the EFFECTIVE shard count (post-clamp), which can differ from the
+  // requested DFKV_RAM_TIER_SHARDS on a small arena; a plain env echo would
+  // mislead. Explicit record wins over Emit's environ scan.
+  config_dump::Record("DFKV_RAM_TIER_SHARDS", std::to_string(nshards),
+                      std::getenv("DFKV_RAM_TIER_SHARDS")
+                          ? config_dump::Source::kEnv
+                          : config_dump::Source::kDefault);
 
   const uint64_t ext_per_shard = total_extents / nshards;  // remainder unused (<1 extent/shard)
   shards_.reserve(nshards);

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -1,3 +1,4 @@
+#include "common/config_dump.h"
 #include "cache/rdma_server.h"
 
 #include <arpa/inet.h>
@@ -62,6 +63,7 @@ RdmaServer::RdmaServer(Handler handler, size_t max_msg, const std::string& dev_n
     const char* e = std::getenv("DFKV_RDMA_DEV");
     if (e && *e) dev_name_ = e;
   }
+  config_dump::RecordResolved("DFKV_RDMA_DEV", dev_name_.empty() ? "(auto)" : dev_name_);
   // --rdma-dev accepts a comma list (multi-rail): every listed device gets a
   // lifetime anchor in Start(); the FIRST entry stays the default for legacy
   // clients whose bootstrap dev frame is empty.
@@ -193,9 +195,11 @@ size_t ServerDepth() {
   // Pipeline depth (requests in flight per connection). Default 1 keeps per-conn
   // pinned memory low; set DFKV_RDMA_DEPTH>1 to enable pipelining (helps the
   // latency-bound PUT path; GET scales via more conns).
+  size_t out = 1;
   const char* e = std::getenv("DFKV_RDMA_DEPTH");
-  if (e && *e) { long v = std::strtol(e, nullptr, 10); if (v >= 1 && v <= 256) return (size_t)v; }
-  return 1;
+  if (e && *e) { long v = std::strtol(e, nullptr, 10); if (v >= 1 && v <= 256) out = (size_t)v; }
+  config_dump::RecordResolved("DFKV_RDMA_DEPTH", std::to_string(out));
+  return out;
 }
 
 int ServerIdleMs() {
@@ -208,14 +212,15 @@ int ServerIdleMs() {
   // the client re-dials a stale pooled connection via RdmaTransport's 2-attempt
   // retry. Default 10 min keeps active/recently-used pooled conns alive; set
   // DFKV_RDMA_IDLE_MS=0 to disable (block forever, the legacy behavior).
+  int out = 600000;  // 10 minutes
   const char* e = std::getenv("DFKV_RDMA_IDLE_MS");
   if (e && *e) {
     long v = std::strtol(e, nullptr, 10);
-    if (v <= 0) return -1;               // disabled => block forever
-    if (v > 86400000) v = 86400000;      // clamp to 24h
-    return static_cast<int>(v);
+    if (v <= 0) out = -1;                     // disabled => block forever
+    else out = static_cast<int>(v > 86400000 ? 86400000 : v);  // clamp to 24h
   }
-  return 600000;  // 10 minutes
+  config_dump::RecordResolved("DFKV_RDMA_IDLE_MS", std::to_string(out));
+  return out;
 }
 
 #ifdef DFKV_WITH_URING
@@ -224,12 +229,14 @@ int ServerIdleMs() {
 // expose more disk queue depth without growing the RDMA pipeline. Clamped to
 // [1, 256] and to >= K by the caller.
 size_t UringDepth(size_t k) {
+  size_t out = k;  // one outstanding read per in-flight request by default
   const char* e = std::getenv("DFKV_SERVER_URING_DEPTH");
   if (e && *e) {
     long v = std::strtol(e, nullptr, 10);
-    if (v >= 1 && v <= 256) return static_cast<size_t>(v);
+    if (v >= 1 && v <= 256) out = static_cast<size_t>(v);
   }
-  return k;  // one outstanding read per in-flight request by default
+  config_dump::RecordResolved("DFKV_SERVER_URING_DEPTH", std::to_string(out));
+  return out;
 }
 #endif  // DFKV_WITH_URING
 
@@ -248,7 +255,9 @@ bool RdmaServer::UseUringPath() const {
   // Non-negative across cases, with a sync fallback on any ring/batch failure.
   // DFKV_SERVER_URING=0 forces the legacy synchronous read loop.
   const char* e = std::getenv("DFKV_SERVER_URING");
-  return !(e && std::strcmp(e, "0") == 0);
+  const bool out = !(e && std::strcmp(e, "0") == 0);
+  config_dump::RecordResolved("DFKV_SERVER_URING", out ? "on" : "off");
+  return out;
 #else
   return false;
 #endif

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -171,15 +171,16 @@ class RdmaServer {
   // on pipelined GETs), they don't fail.
   size_t PipelineDepth() const;
   std::string MetricsText() const;  // Prometheus text (dfkv_rdma_*)
+  // Whether the io_uring async-GET serve path should be used for new conns.
+  // Default ON when built with DFKV_WITH_URING and both range prep + complete
+  // handlers are set; DFKV_SERVER_URING=0 forces sync. Decided once per conn.
+  // Public so startup can force-resolve DFKV_SERVER_URING into the config dump.
+  bool UseUringPath() const;
 
  private:
   void AcceptLoop();
   void Serve(int boot_fd);
   void ReapDoneLocked();  // join+erase finished Serve threads; conn_mu_ held
-  // Whether the io_uring async-GET serve path should be used for new conns.
-  // Default ON when built with DFKV_WITH_URING and both range prep + complete
-  // handlers are set; DFKV_SERVER_URING=0 forces sync. Decided once per conn.
-  bool UseUringPath() const;
 
   // A live connection: its Serve thread plus a flag the thread sets (last thing
   // it does) so AcceptLoop can tell it has finished and join it without blocking.

--- a/src/cache/read_coalescer.h
+++ b/src/cache/read_coalescer.h
@@ -49,6 +49,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "common/config_dump.h"
 #include "common/kv_types.h"
 #include "common/status.h"
 
@@ -56,6 +57,11 @@ namespace dfkv {
 
 class ReadCoalescer {
  public:
+  // Force-resolve the coalescer's env knobs so they land in the startup config
+  // dump instead of waiting for the first coalesced read's lazy init. Called at
+  // server startup when read-coalescing is enabled.
+  static void RecordConfig() { (void)WaitMs(); (void)RecurMs(); }
+
   struct Key {
     uint64_t id;
     uint32_t index, ksize;
@@ -303,12 +309,14 @@ class ReadCoalescer {
   // liveness on that); 500 ms is ~2 orders above a healthy NVMe read.
   static int WaitMs() {
     static const int ms = [] {
+      int out = 500;
       const char* e = std::getenv("DFKV_READ_COALESCE_TIMEOUT_MS");
       if (e && *e) {
         long v = std::strtol(e, nullptr, 10);
-        if (v >= 10 && v <= 60000) return static_cast<int>(v);
+        if (v >= 10 && v <= 60000) out = static_cast<int>(v);
       }
-      return 500;
+      config_dump::RecordResolved("DFKV_READ_COALESCE_TIMEOUT_MS", std::to_string(out));
+      return out;
     }();
     return ms;
   }
@@ -320,12 +328,14 @@ class ReadCoalescer {
   // DFKV_READ_COALESCE_RECUR_MS overrides; 0 disables (v1 overlap-only gate).
   static int RecurMs() {
     static const int ms = [] {
+      int out = 1000;
       const char* e = std::getenv("DFKV_READ_COALESCE_RECUR_MS");
       if (e && *e) {
         long v = std::strtol(e, nullptr, 10);
-        if (v >= 0 && v <= 60000) return static_cast<int>(v);
+        if (v >= 0 && v <= 60000) out = static_cast<int>(v);
       }
-      return 1000;
+      config_dump::RecordResolved("DFKV_READ_COALESCE_RECUR_MS", std::to_string(out));
+      return out;
     }();
     return ms;
   }

--- a/src/cache/slab_allocator.cc
+++ b/src/cache/slab_allocator.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "common/config_dump.h"
 #include "utils/log.h"  // WARN guard on Remove-while-pinned (see header contract)
 
 namespace dfkv {
@@ -31,6 +32,10 @@ SlabAllocator::SlabAllocator(Options opt) : opt_(opt) {
       else cold_window_ = static_cast<uint64_t>(v);
     }
   }
+  config_dump::RecordResolved(
+      "DFKV_SLAB_COLD_STEAL_WINDOW",
+      !cold_steal_enabled_ ? std::string("disabled")
+          : (cold_window_ ? std::to_string(cold_window_) : std::string("auto")));
 }
 
 void SlabAllocator::PushFreeLocked(Class& C, uint32_t ext, uint32_t slot) {

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -18,6 +18,7 @@
 #include "utils/log.h"
 #include "utils/thread_name.h"
 #include "transport/transport_factory.h"
+#include "common/config_dump.h"
 
 namespace dfkv {
 
@@ -151,17 +152,22 @@ class FanoutPool {
   // grows from max(group) to sum(group)). Env-tunable (DFKV_FANOUT_THREADS,
   // clamped [1, 1024]) so high-concurrency clients can raise it; default
   // unchanged at 32.
+ public:
   static size_t MaxThreads() {
     static const size_t v = [] {
+      size_t out = 32;
       const char* e = std::getenv("DFKV_FANOUT_THREADS");
       if (e && *e) {
         long x = std::strtol(e, nullptr, 10);
-        if (x >= 1 && x <= 1024) return static_cast<size_t>(x);
+        if (x >= 1 && x <= 1024) out = static_cast<size_t>(x);
       }
-      return size_t{32};
+      config_dump::RecordResolved("DFKV_FANOUT_THREADS", std::to_string(out));
+      return out;
     }();
     return v;
   }
+
+ private:
   std::mutex mu_;
   std::condition_variable cv_;
   std::deque<std::shared_ptr<Job>> queue_;
@@ -176,10 +182,17 @@ void RunParallel(size_t n, size_t workers, const std::function<void(size_t)>& fn
 
 size_t EnvSize(const char* name, size_t dflt) {
   const char* v = std::getenv(name);
-  if (!v || !*v) return dflt;
-  char* end = nullptr;
-  unsigned long long x = std::strtoull(v, &end, 10);
-  return (end != v && x > 0) ? static_cast<size_t>(x) : dflt;
+  size_t out = dflt;
+  bool from_env = false;
+  if (v && *v) {
+    char* end = nullptr;
+    unsigned long long x = std::strtoull(v, &end, 10);
+    if (end != v && x > 0) { out = static_cast<size_t>(x); from_env = true; }
+  }
+  config_dump::Record(name, std::to_string(out),
+                      from_env ? config_dump::Source::kEnv
+                               : config_dump::Source::kDefault);
+  return out;
 }
 
 // Split each per-node read group into up to N shards so multiple connections
@@ -248,10 +261,41 @@ KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
   }
   // Opt-in active per-peer latency probe. Off unless DFKV_PROBE_INTERVAL_MS>0,
   // so default behavior is unchanged (no background traffic).
-  if (const char* pe = std::getenv("DFKV_PROBE_INTERVAL_MS")) {
-    int ms = std::atoi(pe);
-    if (ms > 0) StartProbe(ms);
+  int probe_ms = 0;
+  if (const char* pe = std::getenv("DFKV_PROBE_INTERVAL_MS")) probe_ms = std::atoi(pe);
+  if (probe_ms > 0) StartProbe(probe_ms);
+  // Record the resolved client env knobs (defaults included). FanoutPool's is a
+  // lazy static, so force it now rather than wait for the first fan-out.
+  {
+    namespace cd = dfkv::config_dump;
+    (void)FanoutPool::MaxThreads();  // records DFKV_FANOUT_THREADS
+    cd::RecordResolved("DFKV_BATCH_CONCURRENCY",
+                       std::to_string(batch_concurrency_.load(std::memory_order_relaxed)));
+    cd::RecordResolved("DFKV_PROBE_INTERVAL_MS", std::to_string(probe_ms));
+    cd::RecordResolved("DFKV_CLIENT_NODE_DEDUP", dedup_ ? "on" : "off");
   }
+  // Startup config dump: once per process (a process usually opens one client;
+  // env knobs are the same for any others, and Emit clears the registry). Shows
+  // the opened geometry — model_hash above all, the isolation identity — plus
+  // the transport and every set DFKV_* env knob (folded in by Emit).
+  static std::once_flag dump_once;
+  std::call_once(dump_once, [this] {
+    namespace cd = dfkv::config_dump;
+    // Geometry is caller-provided (dfkv_open args / the ValueHeader a tool
+    // builds) — externally specified, but not a CLI flag; label it arg. The
+    // client cannot see whether the caller in turn defaulted a field.
+    cd::Record("model_hash", std::to_string(self_hdr_.model_hash), cd::Source::kArg);
+    cd::Record("page_size", std::to_string(self_hdr_.page_size), cd::Source::kArg);
+    cd::Record("dtype_tag", std::to_string(self_hdr_.dtype_tag), cd::Source::kArg);
+    cd::Record("tp_size", std::to_string(self_hdr_.tp_size), cd::Source::kArg);
+    cd::Record("tp_rank", std::to_string(self_hdr_.tp_rank), cd::Source::kArg);
+    cd::Record("layer_num", std::to_string(self_hdr_.layer_num), cd::Source::kArg);
+    cd::Record("head_num", std::to_string(self_hdr_.head_num), cd::Source::kArg);
+    cd::Record("head_dim", std::to_string(self_hdr_.head_dim), cd::Source::kArg);
+    cd::Record("is_mla", self_hdr_.is_mla() ? "1" : "0", cd::Source::kArg);
+    cd::Record("transport", transport_reason_, cd::Source::kArg);
+    cd::Emit("client");
+  });
 }
 
 void KVClient::AdoptRing(ConHash ring, std::map<std::string, std::string> addr) {

--- a/src/common/config_dump.cc
+++ b/src/common/config_dump.cc
@@ -1,0 +1,136 @@
+#include "common/config_dump.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "utils/log.h"
+
+extern char** environ;
+
+namespace dfkv {
+namespace config_dump {
+namespace {
+
+struct Entry {
+  std::string value;
+  Source src;
+};
+
+std::mutex g_mu;
+// Keyed + sorted by name; last write wins so a re-resolved knob does not
+// duplicate. Ordered map => stable, alphabetical Emit output.
+std::map<std::string, Entry> g_entries;
+
+const char* SourceLabel(Source s) {
+  switch (s) {
+    case Source::kFlag: return "flag";
+    case Source::kEnv: return "env";
+    case Source::kArg: return "arg";
+    case Source::kDefault: return "default";
+  }
+  return "?";
+}
+
+// Only DFKV_-namespaced vars are dfkv knobs; other env (PATH, etc.) is noise.
+bool IsDfkvEnv(const char* kv) { return std::strncmp(kv, "DFKV_", 5) == 0; }
+
+}  // namespace
+
+void Record(const std::string& name, const std::string& value, Source src) {
+  std::lock_guard<std::mutex> lk(g_mu);
+  g_entries[name] = Entry{value, src};
+}
+
+void RecordResolved(const std::string& name, const std::string& value) {
+  Record(name, value,
+         std::getenv(name.c_str()) ? Source::kEnv : Source::kDefault);
+}
+
+std::string EnvStr(const char* name, const std::string& def) {
+  const char* e = std::getenv(name);
+  bool set = (e != nullptr && *e != '\0');
+  std::string val = set ? std::string(e) : def;
+  Record(name, val, set ? Source::kEnv : Source::kDefault);
+  return val;
+}
+
+int64_t EnvI64(const char* name, int64_t def) {
+  const char* e = std::getenv(name);
+  int64_t val = def;
+  Source src = Source::kDefault;
+  if (e != nullptr && *e != '\0') {
+    char* end = nullptr;
+    long long parsed = std::strtoll(e, &end, 10);
+    if (end != e) { val = static_cast<int64_t>(parsed); src = Source::kEnv; }
+  }
+  Record(name, std::to_string(val), src);
+  return val;
+}
+
+uint64_t EnvU64(const char* name, uint64_t def) {
+  const char* e = std::getenv(name);
+  uint64_t val = def;
+  Source src = Source::kDefault;
+  if (e != nullptr && *e != '\0') {
+    char* end = nullptr;
+    unsigned long long parsed = std::strtoull(e, &end, 10);
+    if (end != e) { val = static_cast<uint64_t>(parsed); src = Source::kEnv; }
+  }
+  Record(name, std::to_string(val), src);
+  return val;
+}
+
+bool EnvBool(const char* name, bool def) {
+  const char* e = std::getenv(name);
+  bool val = def;
+  Source src = Source::kDefault;
+  if (e != nullptr && *e != '\0') {
+    std::string s(e);
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    val = !(s == "0" || s == "false" || s == "no" || s == "off");
+    src = Source::kEnv;
+  }
+  Record(name, val ? "1" : "0", src);
+  return val;
+}
+
+void Emit(const std::string& section) {
+  std::lock_guard<std::mutex> lk(g_mu);
+  // Fold in DFKV_* env vars that no component recorded, so a set-but-unwired
+  // knob is still visible (marked env). Recorded entries are authoritative.
+  for (char** ep = environ; ep && *ep; ++ep) {
+    if (!IsDfkvEnv(*ep)) continue;
+    const char* eq = std::strchr(*ep, '=');
+    if (!eq) continue;
+    std::string name(*ep, eq - *ep);
+    if (name == "DFKV_LOG") continue;  // logger level, echoed by the logger
+    if (g_entries.find(name) == g_entries.end())
+      g_entries[name] = Entry{std::string(eq + 1), Source::kEnv};
+  }
+  if (g_entries.empty()) return;
+  DFKV_LOG_INFO("effective config (" + section + "): " +
+                std::to_string(g_entries.size()) + " parameter(s)");
+  size_t width = 0;
+  for (const auto& kv : g_entries) width = std::max(width, kv.first.size());
+  for (const auto& kv : g_entries) {
+    std::string pad(width - kv.first.size(), ' ');
+    DFKV_LOG_INFO("  " + kv.first + pad + " = " + kv.second.value +
+                  "  (" + SourceLabel(kv.second.src) + ")");
+  }
+  g_entries.clear();
+}
+
+void ResetForTest() {
+  std::lock_guard<std::mutex> lk(g_mu);
+  g_entries.clear();
+}
+
+}  // namespace config_dump
+}  // namespace dfkv

--- a/src/common/config_dump.h
+++ b/src/common/config_dump.h
@@ -1,0 +1,61 @@
+/* Startup effective-config recorder.
+ *
+ * Goal: from the log alone, see EVERY parameter a dfkv process is actually
+ * running with — flag, env var, or built-in default — instead of guessing which
+ * of the ~40 DFKV_* env knobs took effect on a given node.
+ *
+ * Model: components record each parameter as they resolve it (the Env* helpers
+ * both read the env AND record the resolved value + its source), and the process
+ * entrypoint (server / mds main, or the KVClient ctor for the client) calls
+ * Emit() once startup config has settled. Emit() also scans `environ` so any
+ * DFKV_* env var that is set but not explicitly recorded still shows up — a knob
+ * is never silently missing. Explicitly-recorded entries win over the scan (they
+ * carry the resolved value, incl. defaults, and the precise source).
+ *
+ * Not on the hot path; all state is process-global and mutex-guarded.
+ */
+#ifndef DFKV_CONFIG_DUMP_H_
+#define DFKV_CONFIG_DUMP_H_
+
+#include <cstdint>
+#include <string>
+
+namespace dfkv {
+namespace config_dump {
+
+// Where a resolved parameter came from. kFlag/kEnv/kArg are all EXTERNALLY
+// specified (CLI flag / env var / caller-passed API arg); kDefault is the
+// process's built-in default (the operator set nothing).
+enum class Source { kFlag, kEnv, kArg, kDefault };
+
+// Record a resolved parameter (last write wins per name). Thread-safe.
+void Record(const std::string& name, const std::string& value, Source src);
+
+// Record an already-computed EFFECTIVE value for env knob `name`; the source is
+// env when `name` is present in the environment, else default. For sites that
+// keep their own (clamping/validating) parse and just want the true effective
+// value in the dump — one line, no parse duplication, no drift.
+void RecordResolved(const std::string& name, const std::string& value);
+
+// Env helpers: read env `name`, record (value + kEnv/kDefault source), and
+// return the resolved value. An unset OR empty env string yields `def` (the
+// `e && *e` convention that dominates the codebase). Numeric helpers parse
+// base-10 via strtoll/strtoull; an unparseable value falls back to `def`.
+std::string EnvStr(const char* name, const std::string& def = "");
+int64_t     EnvI64(const char* name, int64_t def);
+uint64_t    EnvU64(const char* name, uint64_t def);
+// Truthy iff set and not one of {0,false,no,off} (case-insensitive).
+bool        EnvBool(const char* name, bool def);
+
+// Log all records at INFO under a `<section>` header (one line per parameter,
+// `name = value (source)`, sorted by name), folding in any un-recorded DFKV_*
+// env vars from `environ`, then clear the registry. No-op if nothing to emit.
+void Emit(const std::string& section);
+
+// Test/reset hook: drop all records without emitting.
+void ResetForTest();
+
+}  // namespace config_dump
+}  // namespace dfkv
+
+#endif  // DFKV_CONFIG_DUMP_H_

--- a/src/mds/dfkv_mds_main.cc
+++ b/src/mds/dfkv_mds_main.cc
@@ -11,6 +11,7 @@
 #include "mds/mds_server.h"
 #include "utils/metrics_http.h"
 #include "common/version.h"
+#include "common/config_dump.h"
 
 namespace {
 volatile sig_atomic_t g_stop = 0;
@@ -50,6 +51,17 @@ int main(int argc, char** argv) {
                  args.error().c_str());
     return 2;
   }
+  {
+    namespace cd = dfkv::config_dump;
+    auto src = [&](const char* flag) {
+      return args.Has(flag) ? cd::Source::kFlag : cd::Source::kDefault;
+    };
+    cd::Record("etcd", etcd, src("--etcd"));
+    cd::Record("listen", std::to_string(port), src("--listen"));
+    cd::Record("metrics_port", std::to_string(metrics_port), src("--metrics-port"));
+    cd::Record("metrics_bind", metrics_bind.empty() ? "(any)" : metrics_bind,
+               src("--metrics-bind"));
+  }
   dfkv::MdsServer srv(etcd);
   std::signal(SIGINT, OnSig);
   std::signal(SIGTERM, OnSig);
@@ -62,11 +74,9 @@ int main(int argc, char** argv) {
   // instead of running "up" while every registration silently fails. Window is
   // env-tunable (tests use a short one); default 30 s.
   {
-    int probe_ms = 30000;
-    if (const char* e = std::getenv("DFKV_MDS_ETCD_PROBE_MS")) {
-      int v = std::atoi(e);
-      if (v >= 0) probe_ms = v;
-    }
+    int probe_ms = static_cast<int>(
+        dfkv::config_dump::EnvI64("DFKV_MDS_ETCD_PROBE_MS", 30000));
+    if (probe_ms < 0) probe_ms = 30000;  // negative => default (unchanged)
     bool up = false;
     auto t0 = std::chrono::steady_clock::now();
     for (;;) {
@@ -95,6 +105,7 @@ int main(int argc, char** argv) {
       std::printf("dfkv_mds /metrics on port %d\n", mhttp->port());
     std::fflush(stdout);
   }
+  dfkv::config_dump::Emit("mds");
   // poll flag from normal context (matches dfkv_server_main.cc)
   while (!g_stop) { struct timespec ts{0, 50 * 1000 * 1000}; nanosleep(&ts, nullptr); }
   if (mhttp) mhttp->Stop();

--- a/src/mds/mds_member_poller.cc
+++ b/src/mds/mds_member_poller.cc
@@ -21,6 +21,11 @@ namespace {
 // same-poll failure burst (a 64-node ring trips only below 32 survivors) while
 // catching the etcd NOSPACE / lease-mass-expiry signature. 0 disables.
 int ShrinkGuardPct() {
+  // NOTE: this is a CLIENT-side MDS-discovery knob, read when the poller is
+  // built during StartMdsDiscovery — after the client's startup config dump has
+  // already emitted. It is therefore not recorded here (the record would land
+  // in an already-cleared registry). If set via env it still shows in the dump
+  // via Emit()'s environ scan; only its unset default is not surfaced.
   if (const char* v = std::getenv("DFKV_MDS_SHRINK_GUARD_PCT")) {
     const long p = std::atol(v);
     if (p >= 0 && p <= 99) return static_cast<int>(p);

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -1,3 +1,4 @@
+#include "common/config_dump.h"
 #include "mds/mds_server.h"
 
 #include <cstdlib>
@@ -102,6 +103,10 @@ void MdsServer::AcceptLoop() {
     const long m = std::atol(v);
     if (m > 0) max_conns = static_cast<size_t>(m);
   }
+  // Recorded from the accept thread's prologue (runs at Start, before main
+  // reaches Emit after its network etcd probe) so the dump shows these defaults.
+  config_dump::RecordResolved("DFKV_MDS_IO_TIMEOUT_S", std::to_string(tmo_s));
+  config_dump::RecordResolved("DFKV_MDS_MAX_CONNS", std::to_string(max_conns));
   while (running_) {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
     if (fd < 0) { if (!running_) break; continue; }

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -1,3 +1,4 @@
+#include "common/config_dump.h"
 #include "transport/rdma_transport.h"
 
 #include <unistd.h>
@@ -126,6 +127,8 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
   }
   const char* d = std::getenv("DFKV_RDMA_DEPTH");  // pipeline depth (must be <= server's)
   if (d && *d) { long v = std::strtol(d, nullptr, 10); if (v >= 1 && v <= 256) depth_ = (size_t)v; }
+  config_dump::RecordResolved("DFKV_RDMA_DEV", list.empty() ? "(auto)" : list);
+  config_dump::RecordResolved("DFKV_RDMA_DEPTH", std::to_string(depth_));
   connect_ms_ = EnvInt("DFKV_RDMA_CONNECT_MS", 3000);
   io_ms_ = EnvInt("DFKV_RDMA_IO_MS", 10000);
   // Datapath completion timeout. EnvInt maps non-positive => default; treat an
@@ -140,6 +143,8 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
     const char* v = std::getenv("DFKV_RDMA_BATCH_OP_TIMEOUT_MS");
     if (v && *v) { long x = std::strtol(v, nullptr, 10); if (x > 0) batch_op_timeout_ms_ = static_cast<int>(x); }
   }
+  config_dump::RecordResolved("DFKV_RDMA_OP_TIMEOUT_MS", std::to_string(op_timeout_ms_));
+  config_dump::RecordResolved("DFKV_RDMA_BATCH_OP_TIMEOUT_MS", std::to_string(batch_op_timeout_ms_));
   }
   // Idle-connection pool cap. The pool naturally bounds at peak concurrency
   // (each thread holds <=1 conn); this only guards against a thread-count spike

--- a/test/common/config_dump_test.cc
+++ b/test/common/config_dump_test.cc
@@ -1,0 +1,134 @@
+#include "common/config_dump.h"
+
+#include <cstdlib>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace dfkv {
+namespace {
+namespace cd = config_dump;
+
+class ConfigDumpTest : public ::testing::Test {
+ protected:
+  void SetUp() override { cd::ResetForTest(); }
+  void TearDown() override {
+    cd::ResetForTest();
+    for (const char* k : {"DFKV_TEST_I", "DFKV_TEST_U", "DFKV_TEST_B",
+                          "DFKV_TEST_S", "DFKV_TEST_SCAN"})
+      ::unsetenv(k);
+  }
+};
+
+TEST_F(ConfigDumpTest, EnvI64SetEmptyUnsetMalformed) {
+  ::unsetenv("DFKV_TEST_I");
+  EXPECT_EQ(cd::EnvI64("DFKV_TEST_I", 7), 7);   // unset -> default
+  ::setenv("DFKV_TEST_I", "", 1);
+  EXPECT_EQ(cd::EnvI64("DFKV_TEST_I", 7), 7);   // empty -> default
+  ::setenv("DFKV_TEST_I", "42", 1);
+  EXPECT_EQ(cd::EnvI64("DFKV_TEST_I", 7), 42);  // set
+  ::setenv("DFKV_TEST_I", "-5", 1);
+  EXPECT_EQ(cd::EnvI64("DFKV_TEST_I", 7), -5);  // negative ok
+  ::setenv("DFKV_TEST_I", "abc", 1);
+  EXPECT_EQ(cd::EnvI64("DFKV_TEST_I", 7), 7);   // malformed -> default
+}
+
+TEST_F(ConfigDumpTest, EnvU64StrBool) {
+  ::setenv("DFKV_TEST_U", "1000", 1);
+  EXPECT_EQ(cd::EnvU64("DFKV_TEST_U", 1), 1000u);
+  ::unsetenv("DFKV_TEST_U");
+  EXPECT_EQ(cd::EnvU64("DFKV_TEST_U", 9), 9u);
+
+  ::setenv("DFKV_TEST_S", "hello", 1);
+  EXPECT_EQ(cd::EnvStr("DFKV_TEST_S", "def"), "hello");
+  ::unsetenv("DFKV_TEST_S");
+  EXPECT_EQ(cd::EnvStr("DFKV_TEST_S", "def"), "def");
+
+  for (const char* t : {"1", "true", "yes", "on", "TRUE"}) {
+    ::setenv("DFKV_TEST_B", t, 1);
+    EXPECT_TRUE(cd::EnvBool("DFKV_TEST_B", false)) << t;
+  }
+  for (const char* f : {"0", "false", "no", "off", "OFF"}) {
+    ::setenv("DFKV_TEST_B", f, 1);
+    EXPECT_FALSE(cd::EnvBool("DFKV_TEST_B", true)) << f;
+  }
+  ::unsetenv("DFKV_TEST_B");
+  EXPECT_TRUE(cd::EnvBool("DFKV_TEST_B", true));    // unset -> default
+  EXPECT_FALSE(cd::EnvBool("DFKV_TEST_B", false));
+}
+
+TEST_F(ConfigDumpTest, EmitShowsRecordsWithSourceAndFoldsEnvScan) {
+  cd::Record("model_hash", "81", cd::Source::kFlag);
+  ::setenv("DFKV_TEST_SCAN", "scanned", 1);  // not recorded -> scan folds it in
+  testing::internal::CaptureStderr();
+  cd::Emit("client");
+  const std::string out = testing::internal::GetCapturedStderr();
+  EXPECT_NE(out.find("effective config (client)"), std::string::npos);
+  EXPECT_NE(out.find("model_hash"), std::string::npos);
+  EXPECT_NE(out.find("81  (flag)"), std::string::npos);
+  EXPECT_NE(out.find("DFKV_TEST_SCAN"), std::string::npos);
+  EXPECT_NE(out.find("scanned  (env)"), std::string::npos);
+}
+
+TEST_F(ConfigDumpTest, ExplicitRecordWinsOverEnvScan) {
+  // A clamped knob: raw env 16 but effective 4 recorded — dump must show 4.
+  ::setenv("DFKV_TEST_SCAN", "16", 1);
+  cd::Record("DFKV_TEST_SCAN", "4", cd::Source::kEnv);
+  testing::internal::CaptureStderr();
+  cd::Emit("server");
+  const std::string out = testing::internal::GetCapturedStderr();
+  EXPECT_NE(out.find("DFKV_TEST_SCAN = 4"), std::string::npos);
+  EXPECT_EQ(out.find("DFKV_TEST_SCAN = 16"), std::string::npos);
+}
+
+TEST_F(ConfigDumpTest, EmitClearsRegistry) {
+  cd::Record("uniqkey_zzz", "1", cd::Source::kFlag);
+  testing::internal::CaptureStderr();
+  cd::Emit("a");
+  EXPECT_NE(testing::internal::GetCapturedStderr().find("uniqkey_zzz"),
+            std::string::npos);
+  // Second Emit: the key was cleared, so it must not reappear (robust to any
+  // ambient DFKV_* env the test host may carry).
+  testing::internal::CaptureStderr();
+  cd::Emit("b");
+  EXPECT_EQ(testing::internal::GetCapturedStderr().find("uniqkey_zzz"),
+            std::string::npos);
+}
+
+TEST_F(ConfigDumpTest, SourceLabelsDistinguishExternalFromDefault) {
+  cd::Record("a_flag", "1", cd::Source::kFlag);
+  cd::Record("a_arg", "81", cd::Source::kArg);
+  cd::Record("a_default", "8", cd::Source::kDefault);
+  testing::internal::CaptureStderr();
+  cd::Emit("mix");
+  const std::string out = testing::internal::GetCapturedStderr();
+  // Names are right-padded for alignment, so match on the stable " = value
+  // (source)" tail rather than the name-to-equals spacing.
+  EXPECT_NE(out.find(" = 1  (flag)"), std::string::npos);
+  EXPECT_NE(out.find(" = 81  (arg)"), std::string::npos);
+  EXPECT_NE(out.find(" = 8  (default)"), std::string::npos);
+}
+
+TEST_F(ConfigDumpTest, RecordResolvedSourceFollowsEnvPresence) {
+  ::unsetenv("DFKV_TEST_SCAN");
+  cd::RecordResolved("DFKV_TEST_SCAN", "4");        // env unset -> default
+  ::setenv("DFKV_TEST_S", "x", 1);
+  cd::RecordResolved("DFKV_TEST_S", "buffered");    // env set -> env (effective value)
+  testing::internal::CaptureStderr();
+  cd::Emit("srv");
+  const std::string out = testing::internal::GetCapturedStderr();
+  EXPECT_NE(out.find(" = 4  (default)"), std::string::npos);
+  EXPECT_NE(out.find(" = buffered  (env)"), std::string::npos);
+}
+
+TEST_F(ConfigDumpTest, DfkvLogEnvIsNotFoldedIn) {
+  ::setenv("DFKV_LOG", "info", 1);
+  cd::Record("uniqkey_zzz", "1", cd::Source::kFlag);
+  testing::internal::CaptureStderr();
+  cd::Emit("x");
+  const std::string out = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(out.find("DFKV_LOG"), std::string::npos);  // logger's own knob, skipped
+}
+
+}  // namespace
+}  // namespace dfkv


### PR DESCRIPTION
## Motivation

Neither the server, MDS, nor client logged the parameters it actually started with. On a production node you could not tell **from the log** which of the ~40 `DFKV_*` env knobs took effect — shards 8 or 16? read-coalesce on? which RDMA rails? `model_hash` set or 0? — you had to scrape `/metrics` or guess. This bit the recent bench / rollout investigations more than once.

## What it does

Adds a collector (`src/common/config_dump.{h,cc}`) and emits an `effective config (<section>)` block at INFO once startup config settles. **Every line is labelled with its source, so the dump separates externally-specified from built-in-default values:**

| label | meaning |
|---|---|
| `flag` | passed on the command line |
| `env` | set via a `DFKV_*` env var |
| `arg` | provided by the caller (`dfkv_open` geometry / a tool's header) |
| `default` | the process's built-in default — the operator set nothing |

Example (server started with only `--dir`/`--cap`):
```
[INFO] dfkv: effective config (server): 11 parameter(s)
[INFO] dfkv:   cap          = 1073741824  (flag)     <- externally specified
[INFO] dfkv:   dir          = /tmp/...     (flag)
[INFO] dfkv:   weight       = 1            (default)  <- built-in default
[INFO] dfkv:   port         = 0            (default)
[INFO] dfkv:   DFKV_RAM_TIER_SHARDS = 4    (env)      <- effective, post-clamp
```

Wiring:
- **server main** — direct flags recorded as `flag` **only when actually passed** (`args.Has`), else `default`. Env-facade flags reach `environ` via `setenv`, folded in by the scan as `env`.
- **mds main** — its flags (flag-vs-default by presence) + `etcd-probe-ms`.
- **KVClient ctor** — opened geometry: **`model_hash`** (isolation identity) + `page_size/dtype/tp/layer/head/is_mla` + transport, as `arg`; once per process. **All three Python connectors reach this via `dfkv_open`**, so hicache/vllm/lmcache get the client dump with no Python change.

## Mechanism (accurate, low-drift)

- `Env{Str,I64,U64,Bool}()` read an env var **and** record the resolved value with its source (`env` vs `default`), so even an **unset** knob shows its built-in **default**.
- `Emit()` scans `environ` for `DFKV_*` and folds in any **set-but-unrecorded** knob — never silently missing — then clears the registry.
- **Explicitly-recorded entries win over the scan**: `ram_tier` records the **effective** (post-clamp) shard count, so `DFKV_RAM_TIER_SHARDS=16` that clamps to 4 shows `4`, not the misleading raw `16`.

Default-on at INFO (values are not sensitive). A few MDS/slab internals read on background threads show via the scan when set; their unset defaults are the only gap.

## Tests

`test/common/config_dump_test.cc`: parse fallbacks, **source labels (flag/arg/default)**, env-scan fold-in, explicit-record-wins, clear-on-emit, `DFKV_LOG` skip. Full suite **383/383**; smoke-verified server (flag vs default) + client (arg) dumps.