### PR TITLE
feat(connectors): surface C-client ring/MDS health on the vLLM connector's Prometheus scrape

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -342,7 +342,9 @@ vllm serve <model> \
 3. server 侧 `dfkvctl stat --all` 或 `/metrics` 看 get 命中、写入量。
 
 不命中排查顺序：`PYTHONHASHSEED` → MDS 可达（或静态 `members` 端口是否 rdma-port）→
-`nvidia-peermem` → `model_hash`/几何是否一致（§5）。
+`nvidia-peermem` → `model_hash`/几何是否一致（§5）。**空环 / MDS 不可达**可直接在 vLLM `/metrics`
+上看：`vllm:dfkv_client_ring_members==0`（写无处可去）或 `vllm:dfkv_client_mds_reachable==0`
+（[METRICS.md](METRICS.md) §3.5），不必翻客户端日志。
 
 ### 3.3 环境变量（每个 vLLM 引擎进程）
 
@@ -356,6 +358,7 @@ vllm serve <model> \
 | `DFKV_RDMA_NUMA` | `0` | 多 NUMA 大机 `1` | §1.2 |
 | `DFKV_LIB` / `DFKV_BUILD` | — | so 路径 | 被 extra_config `lib` 覆盖 |
 | `DFKV_ACCESS_LOG_*` | 关 | 排查时开 | §1.6；vLLM 侧记 `batch_get_auto_sg`/`batch_put_sg`/`batch_exist`/`register_memory` |
+| `DFKV_CLIENT_STATS_POLL_S` | `15` | 默认即可 | 后台轮询把环/MDS 健康镜像到 vLLM `/metrics`（`vllm:dfkv_client_ring_members`/`mds_reachable`/`mds_unreachable_polls_total`/`transport_info`）；`0`=关。见 [METRICS.md](METRICS.md) §3.5 |
 | `DFKV_METRICS_ENABLED` / `DFKV_TRACING_ENABLED` | 关 | 按需 | §1.6；vLLM 连接器 telemetry **只认 env**（不读 extra_config） |
 
 ### 3.4 `kv_connector_extra_config`

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -154,6 +154,17 @@ C 客户端快照里还含传输级（RDMA 构建）：`dfkv_rdma_client_conns_o
 
 > 逐 peer 延迟由 C++ 客户端主动探测（`DFKV_PROBE_INTERVAL_MS`）：SGLang HiCache 开 metrics 即自动开；vLLM/LMCache 需手动 `export DFKV_PROBE_INTERVAL_MS=5000`。
 
+### 3.5 vLLM 连接器客户端健康（`dfkv-vllm` /metrics，经 prometheus_client，pull）
+§3.4 是 OTLP **push**（opt-in）；此外 vLLM 连接器后台轮询线程读同一 C 客户端快照（`DFKV_CLIENT_STATS_POLL_S`，默认 15s，0=关），把**环/MDS 健康**镜像为带 `{tp_rank}` 的 Gauge，直接落在 vLLM 自带 `/metrics` 上（**无需开 telemetry**）。这样"空环（写无处可去、ok=0）/ MDS 不可达"在 scrape 上可见，而非只在客户端日志里——正是一次生产事故（静默空环）的教训。
+| 指标 | 类型 | 标签 | 含义 |
+|---|---|---|---|
+| `vllm:dfkv_client_ring_members` | gauge | `tp_rank` | 客户端看到的环成员数（`0` = 空环） |
+| `vllm:dfkv_client_mds_reachable` | gauge | `tp_rank` | 上次发现轮询 MDS 是否可达（`1`/`0`） |
+| `vllm:dfkv_client_mds_unreachable_polls_total` | gauge | `tp_rank` | 无法连上 MDS 的发现轮询次数（镜像 C 端计数器） |
+| `vllm:dfkv_client_transport_info` | gauge | `tp_rank`,`transport` | 恒为 `1`，`transport` 标 live 传输（`rdma`/`tcp`） |
+
+> 源快照名（C 端无 `vllm:` 前缀）为 `dfkv_client_ring_members` / `dfkv_client_mds_reachable` / `dfkv_client_mds_unreachable_polls_total`（PR#207），与 SGLang HiCache §3.3 同源；vLLM 侧加 `vllm:` 前缀入连接器命名空间。
+
 ## 4. 性能保证
 
 - 热路径计数：`std::atomic` relaxed `fetch_add`，零锁零分配（与既有模式一致）。

--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -48,6 +48,7 @@ vLLM engine process — each DP rank is its own process.
 | `DFKV_ACCESS_LOG_ENABLED` | `0` | `1` turns on the per-op access log (one line per dfkv client op: `batch_get_auto_sg`/`batch_put_sg`/`batch_exist`/…). Off ⇒ ~100 ns/call no-op; on ⇒ async (background thread), ~µs on the hot path. |
 | `DFKV_ACCESS_LOG_PATH` | (stderr) | access-log file path; empty ⇒ stderr. |
 | `DFKV_ACCESS_LOG_THRESHOLD_US` | `0` | only log ops slower than this many µs (`0` = log every call). Set e.g. `1000` to surface only ≥1 ms ops. |
+| `DFKV_CLIENT_STATS_POLL_S` | `15` | cadence (seconds) of the background poller that mirrors the C client's ring/MDS health onto Prometheus (`vllm:dfkv_client_ring_members`, `vllm:dfkv_client_mds_reachable`, `vllm:dfkv_client_mds_unreachable_polls_total`, `vllm:dfkv_client_transport_info`). Sleeping daemon thread, off the request path. `0` disables. |
 
 The access log shares the same env vars and line format as the dfkv HiCache /
 LMCache connector access logs, so one setting covers every integration. Format:

--- a/integration/vllm/src/dfkv_vllm/_cabi.py
+++ b/integration/vllm/src/dfkv_vllm/_cabi.py
@@ -109,6 +109,12 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_transport_mode.restype = c_char_p
     lib.dfkv_transport_mode.argtypes = [c_void_p]
 
+    # u64 = dfkv_stats_snapshot(c, buf, cap): Prometheus-text dump of the C
+    # client's observed counters (ring size, MDS reachability, per-peer health).
+    # Call with buf=NULL/cap=0 to size, then fetch. Off the request path.
+    lib.dfkv_stats_snapshot.restype = c_uint64
+    lib.dfkv_stats_snapshot.argtypes = [c_void_p, c_char_p, c_uint64]
+
     # const char* dfkv_version(void) -> libdfkv.so version (process-global).
     lib.dfkv_version.restype = c_char_p
     lib.dfkv_version.argtypes = []

--- a/integration/vllm/src/dfkv_vllm/client_stats.py
+++ b/integration/vllm/src/dfkv_vllm/client_stats.py
@@ -1,0 +1,152 @@
+"""Mirror the C client's ring/MDS health snapshot onto Prometheus.
+
+Why: the vLLM connector's per-op metrics (``vllm:dfkv_store_*`` in metrics.py)
+flow through vLLM's KVConnectorStats reduction on the frontend, but they cannot
+express the client's *membership* health -- an empty ring (writes routed
+nowhere, ok=0) or an unreachable ``mds_endpoint``. Those live only in the C
+client (per worker process) and, before this, surfaced on vLLM only in the
+client log. This poller re-exports the ring size + MDS reachability the C client
+already publishes so the failure is visible on the SCRAPE (ring_members==0 /
+mds_reachable==0), matching the production incident class of a silent empty ring.
+
+The snapshot text is the C client's Prometheus-format dump (``dfkv_stats_snapshot``
+in _cabi.py). The parsing + poll loop mirror the SGLang HiCache poller in
+integration/hicache/dfkv_metrics.py (ClientStatsPoller); it ships as a separate
+package, so the minimal parser is copied here rather than imported across
+integration packages.
+
+Metrics (labels: tp_rank), ``vllm:`` prefix per the connector convention:
+  vllm:dfkv_client_ring_members                 ring size the client sees (0 = empty ring)
+  vllm:dfkv_client_mds_reachable                1 if the MDS answered the last poll, else 0
+  vllm:dfkv_client_mds_unreachable_polls_total  MDS discovery polls that failed (mirrors the C counter)
+  vllm:dfkv_client_transport_info               1, labeled with the live transport (rdma/tcp)
+"""
+import ctypes
+import threading
+
+try:
+    from prometheus_client import Gauge as _PromGauge
+    _HAVE_PROM = True
+except Exception:  # prometheus_client absent -> in-process gauges only
+    _HAVE_PROM = False
+
+# Snapshot metric name (unprefixed, as the C client emits it) -> exported name.
+_GAUGE_SPECS = [
+    ("dfkv_client_ring_members", "vllm:dfkv_client_ring_members",
+     "ring members the dfkv client sees (0 = empty ring)"),
+    ("dfkv_client_mds_reachable", "vllm:dfkv_client_mds_reachable",
+     "1 if the MDS answered the last discovery poll, else 0"),
+    ("dfkv_client_mds_unreachable_polls_total",
+     "vllm:dfkv_client_mds_unreachable_polls_total",
+     "MDS discovery polls that could not reach the MDS (mirrors the C counter)"),
+]
+_SOURCE_NAMES = frozenset(src for src, _, _ in _GAUGE_SPECS)
+
+# Prometheus Gauges are process-global singletons (re-creating a name raises), so
+# build them once at import and reuse across the per-process client instances.
+_PROM = {}
+_TRANSPORT_PROM = None
+if _HAVE_PROM:
+    try:
+        for _src, _name, _help in _GAUGE_SPECS:
+            # 'liveall' keeps each live rank's current value under SGLang/vLLM
+            # multiprocess metrics mode (PROMETHEUS_MULTIPROC_DIR); tp_rank labels them.
+            _PROM[_src] = _PromGauge(_name, _help, ["tp_rank"],
+                                     multiprocess_mode="liveall")
+        _TRANSPORT_PROM = _PromGauge(
+            "vllm:dfkv_client_transport_info",
+            "dfkv client live transport (value is always 1)",
+            ["tp_rank", "transport"], multiprocess_mode="liveall")
+    except Exception:
+        _HAVE_PROM = False
+        _PROM = {}
+        _TRANSPORT_PROM = None
+
+
+def read_snapshot(lib, h) -> str:
+    """Read the C client's Prometheus metrics snapshot (size query, then fetch).
+    Mirrors integration/hicache/dfkv_hicache.py:_read_snapshot."""
+    need = int(lib.dfkv_stats_snapshot(h, None, 0))
+    if need <= 0:
+        return ""
+    buf = ctypes.create_string_buffer(need + 1)
+    lib.dfkv_stats_snapshot(h, buf, need + 1)
+    return buf.value.decode("utf-8", "replace")
+
+
+class ClientStatsPoller:
+    """Polls the C client's Prometheus-text snapshot and mirrors the ring/MDS
+    gauges onto Prometheus. One sleeping daemon thread, off the request path."""
+
+    def __init__(self, get_text, tp_rank, transport="", interval_s=15.0):
+        self._get_text = get_text
+        self._rank = str(int(tp_rank))
+        self._transport = transport or ""
+        self._interval = float(interval_s)
+        self._gauges = {src: 0 for src in _SOURCE_NAMES}  # last-seen (tests/debug)
+        self._stop = threading.Event()
+        self._thread = None
+        self._warned = False
+
+    @staticmethod
+    def _parse(text):
+        # Copied from integration/hicache/dfkv_metrics.py:ClientStatsPoller._parse.
+        out = {}
+        for line in text.splitlines():
+            if not line or line[0] == "#":
+                continue
+            sp = line.rfind(" ")
+            if sp <= 0:
+                continue
+            name = line[:sp]
+            brace = name.find("{")
+            if brace != -1:
+                name = name[:brace]
+            if name in _SOURCE_NAMES:
+                try:
+                    out[name] = out.get(name, 0) + int(line[sp + 1:])
+                except ValueError:
+                    pass
+        return out
+
+    def poll_once(self):
+        vals = self._parse(self._get_text() or "")
+        for src in _SOURCE_NAMES:
+            v = vals.get(src, 0)
+            self._gauges[src] = v
+            if _HAVE_PROM and src in _PROM:
+                _PROM[src].labels(self._rank).set(v)
+
+    def gauges(self):
+        return dict(self._gauges)
+
+    def _loop(self):
+        while not self._stop.wait(self._interval):
+            try:
+                self.poll_once()
+            except Exception:
+                if not self._warned:  # log once, never let it kill the thread
+                    self._warned = True
+                    import warnings
+                    warnings.warn("dfkv client stats poll failed (further errors "
+                                  "suppressed)", stacklevel=2)
+
+    def start(self):
+        if self._interval <= 0:
+            return  # disabled
+        # transport is static per client; publish it once up front.
+        if _HAVE_PROM and _TRANSPORT_PROM is not None and self._transport:
+            _TRANSPORT_PROM.labels(self._rank, self._transport).set(1)
+        try:
+            self.poll_once()  # immediate first read
+        except Exception:
+            pass
+        self._thread = threading.Thread(target=self._loop, name="dfkv-client-stats",
+                                        daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -19,6 +19,7 @@ import os
 from typing import Optional, Sequence
 
 from ._cabi import load_lib, native_version
+from .client_stats import ClientStatsPoller, read_snapshot
 from . import access_log as _alog
 from .access_log import access_log
 from . import _hot_config
@@ -140,6 +141,20 @@ class DfkvDeviceClient:
         _alog.configure({}, tp_rank=_env_rank())
         _hot_config.register("access_log", _alog.apply_hot)
         _hot_config.start({}, tp_rank=_env_rank())
+        # Surface the C client's ring/MDS health on Prometheus so an empty ring
+        # (writes routed nowhere) or an unreachable MDS is visible on the scrape,
+        # not just in the client log. Sleeping daemon thread off the request path;
+        # DFKV_CLIENT_STATS_POLL_S=0 disables. Mirrors the HiCache stats poller.
+        self._stats_poller = None
+        try:
+            poll_s = float(os.environ.get("DFKV_CLIENT_STATS_POLL_S", 15))
+        except (TypeError, ValueError):
+            poll_s = 15.0
+        if poll_s > 0:
+            self._stats_poller = ClientStatsPoller(
+                lambda: read_snapshot(self._lib, self._h), _env_rank(),
+                transport=self.transport_mode, interval_s=poll_s)
+            self._stats_poller.start()
 
     @property
     def transport_mode(self) -> str:
@@ -326,6 +341,12 @@ class DfkvDeviceClient:
             return res
 
     def close(self) -> None:
+        try:
+            if getattr(self, "_stats_poller", None):
+                self._stats_poller.stop()
+                self._stats_poller = None
+        except Exception:
+            pass
         try:
             _hot_config.stop()
         except Exception:

--- a/integration/vllm/tests/test_client_stats.py
+++ b/integration/vllm/tests/test_client_stats.py
@@ -1,0 +1,92 @@
+"""ClientStatsPoller parses the C client snapshot into ring/MDS health gauges.
+
+Pure Python: feeds a canned Prometheus-text snapshot to the poller (no libdfkv,
+no GPU) and asserts the parsed values, then — when prometheus_client is present —
+that the vllm:dfkv_client_* gauges carry them on the scrape."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from dfkv_vllm.client_stats import ClientStatsPoller
+
+# A healthy snapshot: 5-member ring, MDS reachable, no failed polls. Includes
+# HELP/TYPE comment lines, a labeled per-peer series, and an unrelated metric the
+# parser must ignore.
+_HEALTHY = """\
+# HELP dfkv_client_ring_members ring size
+# TYPE dfkv_client_ring_members gauge
+dfkv_client_ring_members 5
+dfkv_client_mds_reachable 1
+dfkv_client_mds_unreachable_polls_total 0
+dfkv_client_ops_served_total 123456
+dfkv_client_peer_latency_seconds{peer="10.0.0.1"} 0.0012
+"""
+
+# The production incident: empty ring, MDS unreachable, failed polls piling up.
+_EMPTY_RING = """\
+dfkv_client_ring_members 0
+dfkv_client_mds_reachable 0
+dfkv_client_mds_unreachable_polls_total 7
+"""
+
+
+def test_parses_healthy_snapshot():
+    p = ClientStatsPoller(lambda: _HEALTHY, tp_rank=0, interval_s=0)
+    p.poll_once()
+    g = p.gauges()
+    assert g["dfkv_client_ring_members"] == 5
+    assert g["dfkv_client_mds_reachable"] == 1
+    assert g["dfkv_client_mds_unreachable_polls_total"] == 0
+
+
+def test_parses_empty_ring_snapshot():
+    p = ClientStatsPoller(lambda: _EMPTY_RING, tp_rank=3, interval_s=0)
+    p.poll_once()
+    g = p.gauges()
+    assert g["dfkv_client_ring_members"] == 0
+    assert g["dfkv_client_mds_reachable"] == 0
+    assert g["dfkv_client_mds_unreachable_polls_total"] == 7
+
+
+def test_missing_lines_default_to_zero():
+    p = ClientStatsPoller(lambda: "dfkv_client_ring_members 2\n", tp_rank=0, interval_s=0)
+    p.poll_once()
+    g = p.gauges()
+    assert g["dfkv_client_ring_members"] == 2
+    assert g["dfkv_client_mds_reachable"] == 0
+
+
+def test_empty_and_malformed_text_never_raises():
+    for txt in ("", None, "garbage-with-no-space\n", "dfkv_client_ring_members notanint\n"):
+        p = ClientStatsPoller(lambda t=txt: t, tp_rank=0, interval_s=0)
+        p.poll_once()
+        assert p.gauges()["dfkv_client_ring_members"] == 0
+
+
+def test_zero_interval_disables_thread():
+    p = ClientStatsPoller(lambda: _HEALTHY, tp_rank=0, interval_s=0)
+    p.start()
+    assert p._thread is None
+    p.stop()  # must be safe even when never started
+
+
+def test_prometheus_gauges_reflect_snapshot():
+    prometheus_client = pytest.importorskip("prometheus_client")
+    p = ClientStatsPoller(lambda: _HEALTHY, tp_rank=1,
+                          transport="rdma", interval_s=60)
+    p.start()  # publishes transport_info + an immediate poll; loop won't fire in 60s
+    reg = prometheus_client.REGISTRY
+    assert reg.get_sample_value(
+        "vllm:dfkv_client_ring_members", {"tp_rank": "1"}) == 5
+    assert reg.get_sample_value(
+        "vllm:dfkv_client_mds_reachable", {"tp_rank": "1"}) == 1
+    assert reg.get_sample_value(
+        "vllm:dfkv_client_mds_unreachable_polls_total", {"tp_rank": "1"}) == 0
+    assert reg.get_sample_value(
+        "vllm:dfkv_client_transport_info",
+        {"tp_rank": "1", "transport": "rdma"}) == 1
+    p.stop()


### PR DESCRIPTION
## Problem
The vLLM `DfkvStoreConnector` exposes per-op counters (`vllm:dfkv_store_*`) but never the C client's **membership** health. On vLLM an **empty ring** (placement ring unpopulated → every `put`/`get` routes nowhere, reports `ok=0`) or an **unreachable `mds_endpoint`** is invisible on the scrape and shows only in the client log — the silent-empty-ring class that cost a multi-hour misdiagnosis in a GLM-5.2 bring-up. The C client already publishes `dfkv_client_ring_members` / `dfkv_client_mds_reachable` / `dfkv_client_mds_unreachable_polls_total` via `dfkv_stats_snapshot` (#207) and HiCache mirrors them, but the vLLM connector never read the snapshot (the symbol wasn't even bound in its `_cabi.py`).

## Changes
**New poller** (`client_stats.py`) — a daemon thread reads the C client's Prometheus-text snapshot every `DFKV_CLIENT_STATS_POLL_S` seconds (default 15, `0` disables) and mirrors, labeled by `tp_rank`:
- `vllm:dfkv_client_ring_members` (gauge; `0` = empty ring)
- `vllm:dfkv_client_mds_reachable` (gauge `1`/`0`)
- `vllm:dfkv_client_mds_unreachable_polls_total` (gauge mirroring the C counter)
- `vllm:dfkv_client_transport_info` (gauge `1`, labeled with the live `rdma`/`tcp` transport)

The parser is copied from the HiCache `dfkv_metrics.py` poller (integrations ship as separate packages, so no cross-package import) with a provenance comment.

**Wiring** — bound `dfkv_stats_snapshot` in `_cabi.py` (as HiCache binds it); started after `dfkv_open` in `DfkvDeviceClient`, stopped on `close()`. Off the request path, daemon thread, poll body wrapped so a transient error never kills the thread or the engine.

**Tests** — `test_client_stats.py` (pure Python, no libdfkv/GPU): canned snapshots → asserts parsed values + `vllm:dfkv_client_*` gauges on the registry.

**Docs** — env var + metrics in `integration/vllm/README.md`, `docs/CONNECTORS.md` §3.2/§3.3, `docs/METRICS.md` §3.5.

Suggested alert: `vllm:dfkv_client_ring_members == 0` or `vllm:dfkv_client_mds_reachable == 0` sustained.

## Notes
- Pure-Python change; no C/C++ edits. No data-path behavior change.
- `DFKV_CLIENT_STATS_POLL_S=0` fully disables the poller.
- Validated live on an 8×GPU GLM-5.2-NVFP4 vLLM deployment against a v1.37.0 single-node ring (the startup first-poll `adopted EMPTY membership` window is exactly the state these gauges make visible).
