### PR TITLE
test(disk-slab): deflake ReclaimTickGrowsHotClassFromColdDonor (disable watermark eviction)

### DIFF
--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -464,10 +464,16 @@ TEST_F(DiskSlabTest, BackgroundReclaimerFreesSlotsOnFullStore) {
 // with one extent's worth of survivors); the reclaim tick must instead grow B
 // from the idle A donor so the whole burst stays readable.
 TEST_F(DiskSlabTest, ReclaimTickGrowsHotClassFromColdDonor) {
+  // Watermark eviction OFF: on a >92%-full store it returns cold extents to
+  // the pool each tick, and a non-empty pool disables the donor-steal grow
+  // (B then grows via pool grabs, rebalanced_extents stays 0). This test
+  // targets the donor-steal path specifically, so isolate it.
+  ::setenv("DFKV_SLAB_EVICT_HIGH_PCT", "0", 1);
   bool ok = false;
   auto o = Opts(16 << 20, 1 << 20, 4096);  // 16 extents x 1 MiB
   o.reclaim_interval_ms = 1;
   DiskSlabStore s(o, &ok);
+  ::unsetenv("DFKV_SLAB_EVICT_HIGH_PCT");
   ASSERT_TRUE(ok);
   std::string a(4000, 'a');
   for (uint64_t i = 0; i < 4096; ++i)  // 16 extents x 256 slots: fill class A


### PR DESCRIPTION
Deflakes the failure seen on main run [29981121006](https://github.com/dingodb/dfkv/actions/runs/29981121006) (clang++ job) that blocked the v1.38.0 release.

**Root cause**: the test fills the store 100% with class A — above the default 92% watermark. Each reclaim tick runs proactive watermark eviction *first*, returning cold extents to the pool; a non-empty pool disables the donor-steal grow path (`disk_slab_store.cc` grow condition requires `PoolExtents() == 0`), so class B grows via pool grabs in `Cache()` instead. Whether `rebalanced_extents > 0` is a scheduling race between the two growth paths. On the failed run the pool path won: `retained` stayed high, only the `rebalanced_extents` EXPECT fired — matching the log exactly.

**Fix**: the test targets the donor-steal path specifically, so isolate it — disable watermark eviction with `DFKV_SLAB_EVICT_HIGH_PCT=0` for this store (same setenv pattern as `ram_tier_wiring_test.cc`). Test-only change, same class as #211.

**Verification**: 50× repeat + 20× pinned to a single CPU (`taskset -c 0`), all green; full DiskSlabTest suite passes.