### PR TITLE
feat(hicache): device-direct (L2-bypass) connector path + SG put sharding

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -181,6 +181,14 @@ _MARKER_BUF = ctypes.create_string_buffer(1)
 _MARKER_PTR = ctypes.addressof(_MARKER_BUF)
 
 
+def _is_device_transfer(tr) -> bool:
+    """A sidecar PoolTransfer is DEVICE-direct (task 4) when it carries device slot
+    indices and NO host indices — the indexer RDMAs from/into its GPU buffer. A host
+    transfer (host_indices set) keeps the stock host v2 path."""
+    return (getattr(tr, "host_indices", None) is None
+            and getattr(tr, "device_indices", None) is not None)
+
+
 def _arrays(subkeys, ptrs, sizes):
     """Build parallel C arrays (keys, ptrs, sizes) for a batch call."""
     n = len(subkeys)
@@ -596,6 +604,60 @@ class DfkvHiCache(HiCacheStorage):
             r.result = (f"registered {n} device region(s)" if n
                         else "no device buffer found")
 
+    def register_mem_pool_device_sidecar(self, name, device_pool):
+        """Task 4: register the DSA indexer sidecar's per-layer GPU buffers for
+        RDMA (GPUDirect MR), so the indexer RDMAs straight from/into its device
+        buffer instead of a host staging slot. `name` is the sidecar PoolName (e.g.
+        'indexer'); `device_pool` is the DeepSeekV4IndexerPool holding
+        index_k_with_scale_buffer. Deduped against regions already registered."""
+        if not hasattr(self, "_sidecar_device_pools"):
+            self._sidecar_device_pools = {}
+        key = str(name)
+        self._sidecar_device_pools[key] = device_pool
+        from sglang.srt.mem_cache.device_page_meta import sidecar_device_pool_regions
+
+        with access_log("register_mem_pool_device_sidecar",
+                        lambda: f"{self._alog_tag} {key}") as r:
+            n = 0
+            try:
+                for base, size in sidecar_device_pool_regions(device_pool):
+                    region = (base, size)
+                    if not base or not size or region in self._registered_regions:
+                        continue
+                    if self.register_memory(base, size):
+                        self._registered_regions.add(region)
+                        n += 1
+            except Exception as e:  # never fail setup over an optimization
+                r.result = f"skip ({type(e).__name__})"
+                return
+            r.result = (f"registered {n} sidecar device region(s)" if n
+                        else "no sidecar device buffer found")
+
+    def register_mem_pool_device_draft(self, mem_pool_device_draft):
+        """Task 6: register the EAGLE draft model's GPU KV pool for RDMA so draft KV
+        pages RDMA straight from/into their GPU slots (device-direct draft L3),
+        mirroring register_mem_pool_device for the target pool. Deduped against
+        regions already registered."""
+        self.mem_pool_device_draft = mem_pool_device_draft
+        from sglang.srt.mem_cache.device_page_meta import device_pool_regions
+
+        with access_log("register_mem_pool_device_draft",
+                        lambda: f"{self._alog_tag}") as r:
+            n = 0
+            try:
+                for base, size in device_pool_regions(mem_pool_device_draft):
+                    region = (base, size)
+                    if not base or not size or region in self._registered_regions:
+                        continue
+                    if self.register_memory(base, size):
+                        self._registered_regions.add(region)
+                        n += 1
+            except Exception as e:  # never fail setup over an optimization
+                r.result = f"skip ({type(e).__name__})"
+                return
+            r.result = (f"registered {n} draft device region(s)" if n
+                        else "no draft device buffer found")
+
     def set_members(self, members: str):
         """Hot-swap cluster membership, e.g. 'n1=ip:12000,n2=ip:12000'."""
         self._lib.dfkv_set_members(self._h, members.encode())
@@ -755,7 +817,7 @@ class DfkvHiCache(HiCacheStorage):
             self._sg_width_cache = w
         return w
 
-    def _flatten_device(self, keys, seg_ptrs, seg_sizes):
+    def _flatten_device(self, keys, seg_ptrs, seg_sizes, keys_fn=None, sub=None):
         """Expand per-page keys into per-sub-object (k[/v]) sub-keys, pairing each
         with its per-layer device segment list. Parallel to _flatten, but every
         entry is a segment LIST (one per layer), not a single (ptr, size).
@@ -766,14 +828,20 @@ class DfkvHiCache(HiCacheStorage):
         the same scheme (and key suffix) the vLLM connector uses. Write and read
         derive the identical deterministic split from (layer count, width), so
         the layer-major bytes reassemble exactly. Chunk count is uniform across
-        pages, so _fold()'s per-page stride is sub * nchunks."""
-        sub = self._sub()
+        pages, so _fold()'s per-page stride is sub * nchunks.
+
+        keys_fn/sub default to the main-KV key scheme (self._keys / self._sub); the
+        DSA indexer sidecar and the EAGLE draft pool pass their own key builder and
+        object count so they reuse the identical @sg chunking under a distinct
+        namespace (task 4: device-direct sidecar; task 6: device-direct draft)."""
+        keys_fn = keys_fn or self._keys
+        sub = self._sub() if sub is None else sub
         assert len(seg_ptrs) == len(keys) * sub, (len(seg_ptrs), len(keys), sub)
         w = self._sg_width()
         sks, sp, ss = [], [], []
         nchunks = 1
         for i, k in enumerate(keys):
-            for j, sk in enumerate(self._keys(k)):
+            for j, sk in enumerate(keys_fn(k)):
                 p = [int(x) for x in seg_ptrs[i * sub + j]]
                 s = [int(x) for x in seg_sizes[i * sub + j]]
                 nchunks = max(1, (len(p) + w - 1) // w)
@@ -1186,21 +1254,132 @@ class DfkvHiCache(HiCacheStorage):
         flat_ok = [hits[i] == 1 and lens[i] >= want[i] for i in range(len(sks))]
         return self._fold(flat_ok, n, sub), sum(lens), dur
 
+    # --- task 4: DSA indexer sidecar device-direct (no host staging) -----------
+    def _sidecar_device_set(self, name, keys, device_indices):
+        """Device-direct SG put of the DSA indexer sidecar `name` (its own key
+        namespace, _pool_keys(name, hash), @sg-chunked like the main KV). The
+        indexer is layer-first & PAGE-indexed; get_device_sidecar_page_buffer_meta
+        yields its per-layer page-row segments from the registered sidecar device
+        pool. Returns (per_page_bools, nbytes, seconds)."""
+        n = len(keys)
+        if self.is_mla and self.tp_rank != 0:
+            return [True] * n, 0, 0.0
+        from sglang.srt.mem_cache.device_page_meta import (
+            get_device_sidecar_page_buffer_meta,
+        )
+        pool = self._sidecar_device_pools[str(name)]
+        seg_ptrs, seg_sizes = get_device_sidecar_page_buffer_meta(pool, device_indices)
+        stride, sks, sp, ss = self._flatten_device(
+            keys, seg_ptrs, seg_sizes,
+            keys_fn=lambda h: self._pool_keys(name, h), sub=self._pool_sub(name))
+        nbytes = sum(sum(s) for s in ss)
+        t0 = time.perf_counter()
+        flat = self._put_sg_flat(sks, sp, ss)
+        dur = time.perf_counter() - t0
+        return self._fold(flat, n, stride), nbytes, dur
+
+    def _sidecar_device_get(self, name, keys, device_indices):
+        """Device-direct SG get of the DSA indexer sidecar `name`: RDMA its stored
+        blob straight INTO its GPU index buffer (no host staging, no H2D). Read twin
+        of _sidecar_device_set. A page is a hit only on a full-length read of every
+        sub-key. Returns (per_page_bools, nbytes, seconds)."""
+        n = len(keys)
+        from sglang.srt.mem_cache.device_page_meta import (
+            get_device_sidecar_page_buffer_meta,
+        )
+        pool = self._sidecar_device_pools[str(name)]
+        seg_ptrs, seg_caps = get_device_sidecar_page_buffer_meta(pool, device_indices)
+        stride, sks, sp, sc = self._flatten_device(
+            keys, seg_ptrs, seg_caps,
+            keys_fn=lambda h: self._pool_keys(name, h), sub=self._pool_sub(name))
+        want = [sum(c) for c in sc]
+        t0 = time.perf_counter()
+        hits, lens = self._batch_get_sg(sks, sp, sc)
+        dur = time.perf_counter() - t0
+        flat_ok = [hits[i] == 1 and lens[i] >= want[i] for i in range(len(sks))]
+        return self._fold(flat_ok, n, stride), sum(lens), dur
+
+    # --- task 6: EAGLE draft KV device-direct (best-effort L3) ------------------
+    def _draft_keys(self, page_hash: str, sub: int) -> List[str]:
+        """Draft-model KV sub-keys, a distinct namespace from the target pages
+        (`.draft` infix, PP-aware). The draft model may be MLA or MHA INDEPENDENT of
+        the target, so the key scheme follows the DRAFT pool shape (sub), mirroring
+        _keys: MLA draft (sub=1) is TP-replicated -> no tp_rank suffix; MHA draft
+        (sub=2) is TP-sharded -> tp_size/tp_rank suffix so ranks do not collide."""
+        pps = self._pp_suffix()
+        if sub == 1:
+            return [f"{self.model}/{page_hash}.draft_k{pps}"]
+        base = f"{self.model}/{page_hash}.draft_{self.tp_size}_{self.tp_rank}{pps}"
+        return [base + "_k", base + "_v"]
+
+    def batch_set_v1_device_draft(self, keys, device_indices, extra_info=None) -> List[bool]:
+        """Best-effort device-direct SG put of the EAGLE draft KV pages (task 6):
+        RDMA straight from the draft GPU pool's slots (the same slots the target
+        rode) to L3 under the `.draft` namespace. sub (1 for MLA / 2 for MHA) is
+        derived from the draft pool meta, independent of the target model. An MLA
+        draft's latent is TP-replicated, so only tp_rank 0 writes (backup_skip),
+        exactly like the target MLA path."""
+        n = len(keys)
+        with access_log("batch_set_v1_device_draft",
+                        lambda: f"{self._alog_tag} {n} keys") as r:
+            from sglang.srt.mem_cache.device_page_meta import (
+                get_device_page_buffer_meta,
+            )
+            seg_ptrs, seg_sizes = get_device_page_buffer_meta(
+                self.mem_pool_device_draft, device_indices)
+            sub = len(seg_ptrs) // n if n else 1
+            if sub == 1 and self.tp_rank != 0:
+                r.result = "backup_skip"
+                return [True] * n
+            stride, sks, sp, ss = self._flatten_device(
+                keys, seg_ptrs, seg_sizes,
+                keys_fn=lambda h: self._draft_keys(h, sub), sub=sub)
+            flat = self._put_sg_flat(sks, sp, ss)
+            res = self._fold(flat, n, stride)
+            r.result = f"ok {sum(res)}/{n} (draft device-direct)"
+            return res
+
+    def batch_get_v1_device_draft(self, keys, device_indices, extra_info=None) -> List[bool]:
+        """Best-effort device-direct SG get of the EAGLE draft KV pages (task 6):
+        RDMA straight INTO the draft GPU pool's slots. Read twin of
+        batch_set_v1_device_draft. Every rank reads its own copy (no rank skip on
+        read), even for a TP-replicated MLA draft."""
+        n = len(keys)
+        with access_log("batch_get_v1_device_draft",
+                        lambda: f"{self._alog_tag} {n} keys") as r:
+            from sglang.srt.mem_cache.device_page_meta import (
+                get_device_page_buffer_meta,
+            )
+            seg_ptrs, seg_caps = get_device_page_buffer_meta(
+                self.mem_pool_device_draft, device_indices)
+            sub = len(seg_ptrs) // n if n else 1
+            stride, sks, sp, sc = self._flatten_device(
+                keys, seg_ptrs, seg_caps,
+                keys_fn=lambda h: self._draft_keys(h, sub), sub=sub)
+            want = [sum(c) for c in sc]
+            hits, lens = self._batch_get_sg(sks, sp, sc)
+            flat_ok = [hits[i] == 1 and lens[i] >= want[i] for i in range(len(sks))]
+            res = self._fold(flat_ok, n, stride)
+            r.result = f"hits={sum(res)}/{n} (draft device-direct)"
+            return res
+
     def batch_set_v2_device(
         self, kv_keys, kv_device_indices, sidecar_transfers, extra_info=None
     ) -> dict:
         """DSA L2-bypass backup (GLM-5.2): the anchor "kv" pool (the big MLA latent)
-        RDMAs straight from its GPU slots to L3 via the device-direct SG put, while
-        the small DSA indexer sidecar STAYS on the host v2 path (_v2_io from its host
-        buffer). One logical op so the split value is written atomically-per-page.
+        RDMAs straight from its GPU slots to L3 via the device-direct SG put. Task 4:
+        a DEVICE sidecar transfer (device_indices set, host_indices None) RDMAs the
+        DSA indexer straight from its GPU index buffer too (no host staging); a host
+        sidecar transfer still rides the stock host v2 path. One logical op so the
+        split value is written atomically-per-page.
 
         VALUE LAYOUT (explicit): the main KV is stored under the v1-style keys
         (_keys(hash) -> "model/hash_k"), byte-for-byte the same key scheme
         batch_set_v1_device / batch_exists use — so an unchanged batch_exists_v2
         anchors the hit prefix on the SAME "kv" keys with no change. The sidecar
-        rides its own v2 keys (_pool_keys('indexer', hash) -> "model/hash_indexer_k")
-        exactly as stock batch_set_v2. The two components never collide; the composite
-        is split honestly across two key namespaces, isolated by model_hash.
+        rides its own keys (_pool_keys('indexer', hash) -> "model/hash_indexer_k",
+        @sg-chunked when device-direct). The two components never collide; the
+        composite is split honestly across two key namespaces, isolated by model_hash.
 
         METRICS: the anchor device SG put reports on_set (a v1-device physical
         transfer, identical attribution to stock DSA whose anchor rides batch_set_v1),
@@ -1218,23 +1397,37 @@ class DfkvHiCache(HiCacheStorage):
             if n and not (self.is_mla and self.tp_rank != 0):
                 self._metrics.on_set(pages=n, ok_pages=sum(kv_res),
                                      nbytes=kv_bytes, seconds=kv_secs)
-            # Sidecar rides the host v2 path (its own keys, its own host buffer).
-            if sidecar_transfers:
-                side = self._v2_io(sidecar_transfers, putting=True)
+            # Sidecar. Task 4: a DEVICE sidecar transfer (device_indices set,
+            # host_indices None) RDMAs straight from its GPU index buffer; a host
+            # sidecar transfer keeps the stock host v2 path. In bypass every sidecar
+            # is device now, but keep the host branch for generality/safety.
+            dev_side = [tr for tr in sidecar_transfers if _is_device_transfer(tr)]
+            host_side = [tr for tr in sidecar_transfers if not _is_device_transfer(tr)]
+            side_pages = side_ok = side_bytes = 0
+            side_secs = 0.0
+            for tr in dev_side:
+                name = str(tr.name)
+                res, nb, secs = self._sidecar_device_set(name, tr.keys, tr.device_indices)
+                results[name] = res
+                side_pages += len(res); side_ok += sum(res)
+                side_bytes += nb; side_secs += secs
+            if host_side:
+                side = self._v2_io(host_side, putting=True)
                 results.update(side)
-                side_pages = sum(len(rs) for rs in side.values())
-                if side_pages and not (self.is_mla and self.tp_rank != 0):
-                    self._metrics.on_set_v2(
-                        pages=side_pages,
-                        ok_pages=sum(sum(rs) for rs in side.values()),
-                        nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
+                side_pages += sum(len(rs) for rs in side.values())
+                side_ok += sum(sum(rs) for rs in side.values())
+                side_bytes += self._v2_io_bytes; side_secs += self._v2_io_seconds
+            if side_pages and not (self.is_mla and self.tp_rank != 0):
+                self._metrics.on_set_v2(
+                    pages=side_pages, ok_pages=side_ok,
+                    nbytes=side_bytes, seconds=side_secs)
             r.result = f"kv {sum(kv_res)}/{n} (device-direct); " + _fmt_pool_results(
                 {k: v for k, v in results.items() if k != "kv"})
             if self._put_retry_recovered:
                 r.result += f" retry_ok={self._put_retry_recovered}"
             if _sp:
                 _sp.hits = sum(sum(rs) for rs in results.values())
-                _sp.bytes = kv_bytes + self._v2_io_bytes if sidecar_transfers else kv_bytes
+                _sp.bytes = kv_bytes + side_bytes
             return results
 
     def batch_get_v2_device(
@@ -1242,9 +1435,9 @@ class DfkvHiCache(HiCacheStorage):
     ) -> dict:
         """DSA L2-bypass on-demand read (GLM-5.2): the read twin of
         batch_set_v2_device. The anchor "kv" pool RDMAs straight INTO its GPU slots
-        via the device-direct SG get; the DSA indexer sidecar is read into its host
-        buffer via the v2 host path (batch_get_v2 semantics), from which the SGLang
-        controller then H2Ds it into the device index buffer.
+        via the device-direct SG get; a DEVICE sidecar transfer (task 4) RDMAs the
+        indexer straight INTO its GPU index buffer too (no host staging / H2D),
+        while a host sidecar transfer keeps the stock host v2 path.
 
         The kv keys/indices and sidecar keys mirror batch_set_v2_device exactly, so a
         page written there reads back byte-identical for BOTH components. Anchor read
@@ -1260,19 +1453,31 @@ class DfkvHiCache(HiCacheStorage):
             if n:
                 self._metrics.on_get(pages=n, hit_pages=sum(kv_res),
                                      nbytes=kv_bytes, seconds=kv_secs)
-            if sidecar_transfers:
-                side = self._v2_io(sidecar_transfers, putting=False)
+            dev_side = [tr for tr in sidecar_transfers if _is_device_transfer(tr)]
+            host_side = [tr for tr in sidecar_transfers if not _is_device_transfer(tr)]
+            side_pages = side_hit = side_bytes = 0
+            side_secs = 0.0
+            for tr in dev_side:
+                name = str(tr.name)
+                res, nb, secs = self._sidecar_device_get(name, tr.keys, tr.device_indices)
+                results[name] = res
+                side_pages += len(res); side_hit += sum(res)
+                side_bytes += nb; side_secs += secs
+            if host_side:
+                side = self._v2_io(host_side, putting=False)
                 results.update(side)
-                side_pages = sum(len(rs) for rs in side.values())
-                if side_pages:
-                    self._metrics.on_get_v2(
-                        pages=side_pages,
-                        hit_pages=sum(sum(rs) for rs in side.values()),
-                        nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
+                side_pages += sum(len(rs) for rs in side.values())
+                side_hit += sum(sum(rs) for rs in side.values())
+                side_bytes += self._v2_io_bytes; side_secs += self._v2_io_seconds
+            if side_pages:
+                self._metrics.on_get_v2(
+                    pages=side_pages, hit_pages=side_hit,
+                    nbytes=side_bytes, seconds=side_secs)
             r.result = f"kv {sum(kv_res)}/{n} (device-direct); " + _fmt_pool_results(
                 {k: v for k, v in results.items() if k != "kv"})
             if _sp:
                 _sp.hits = sum(sum(rs) for rs in results.values())
+                _sp.bytes = kv_bytes + side_bytes
             return results
 
     def batch_exists_v2(self, keys, pool_transfers=None, extra_info=None):
@@ -1290,7 +1495,12 @@ class DfkvHiCache(HiCacheStorage):
                     break
                 name = str(tr.name)
                 sub = self._pool_sub(name)
-                sks = [sk for k in keys[:kv_pages]
+                # Device-direct sidecars (task 4) store "@sg{n}" chunk sub-keys, so
+                # probe "@sg0" — the same scheme batch_exists uses for the main KV.
+                # A host sidecar stores the bare sub-key.
+                dev_side = name in getattr(self, "_sidecar_device_pools", {})
+                sks = [(sk + "@sg0") if dev_side else sk
+                       for k in keys[:kv_pages]
                        for sk in self._pool_keys(name, k)]
                 present = self._fold(self._batch_exist_flat(sks), kv_pages, sub)
                 if tr.hit_policy == PoolHitPolicy.TRAILING_PAGES:

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -108,6 +108,21 @@ def _load_lib(path: Optional[str] = None) -> ctypes.CDLL:
             ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
             ctypes.POINTER(ctypes.POINTER(ctypes.c_uint64)),
             ctypes.POINTER(ctypes.c_int), ctypes.c_int, ctypes.POINTER(ctypes.c_int)]
+    # Scatter-gather GET, the read-side mirror of dfkv_batch_put_sg for the
+    # HiCache L2-bypass (device-direct read) path. Key i's stored blob is
+    # scattered in order across num_dsts[i] destination buffers (a page's
+    # per-layer GPU segments); out_hit[i]==1 on hit, out_len[i]=total stored
+    # bytes. Same symbol the vLLM connector's load path uses (see
+    # integration/vllm/src/dfkv_vllm/_cabi.py). Guarded: older libdfkv.so lacks
+    # it and supports_device_transfer() declines the bypass path.
+    if hasattr(lib, "dfkv_batch_get_auto_sg"):
+        lib.dfkv_batch_get_auto_sg.restype = ctypes.c_int
+        lib.dfkv_batch_get_auto_sg.argtypes = [
+            ctypes.c_void_p, ctypes.POINTER(ctypes.c_char_p),
+            ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+            ctypes.POINTER(ctypes.POINTER(ctypes.c_uint64)),
+            ctypes.POINTER(ctypes.c_int), ctypes.c_int,
+            ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_uint64)]
     if hasattr(lib, "dfkv_max_sg_segs"):
         lib.dfkv_max_sg_segs.restype = ctypes.c_uint32
         lib.dfkv_max_sg_segs.argtypes = [ctypes.c_void_p]
@@ -525,14 +540,17 @@ class DfkvHiCache(HiCacheStorage):
     def supports_device_transfer(self) -> bool:
         """True iff this backend can RDMA a page straight from GPU KV slots to L3.
 
-        Requires the scatter-gather put ABI (dfkv_batch_put_sg) plus a negotiated
-        SG width big enough to hold a page's per-layer device segments in ONE key
-        (layer_num segments/key — the GPU pool is layer-first, so a page's KV is
-        scattered across layer_num non-contiguous buffers). Older libdfkv.so
-        without the symbols, or an HCA whose max_sge is too small, keep the stock
-        host (D2H) write path. Checked by the SGLang controller's capability gate;
-        never raises."""
+        Requires the scatter-gather put AND get ABIs (dfkv_batch_put_sg /
+        dfkv_batch_get_auto_sg) plus a negotiated SG width big enough to hold a
+        page's per-layer device segments in ONE key (layer_num segments/key — the
+        GPU pool is layer-first, so a page's KV is scattered across layer_num
+        non-contiguous buffers). The get symbol is required too: increment 2 reads
+        device-direct-written pages back via SG GET, and a page written with no
+        matching reader is dead. Older libdfkv.so without the symbols, or an HCA
+        whose max_sge is too small, keep the stock host (D2H) path. Checked by the
+        SGLang controller's capability gate; never raises."""
         if not (hasattr(self._lib, "dfkv_batch_put_sg")
+                and hasattr(self._lib, "dfkv_batch_get_auto_sg")
                 and hasattr(self._lib, "dfkv_max_sg_segs")):
             return False
         layer_num = int(self.cfg.get("layer_num", 0))
@@ -830,6 +848,82 @@ class DfkvHiCache(HiCacheStorage):
             if _sp:
                 _sp.hits = sum(res); _sp.bytes = nbytes
             self._metrics.on_set(pages=n, ok_pages=sum(res), nbytes=nbytes,
+                                 seconds=dur)
+            return res
+
+    def _batch_get_sg(self, sks, seg_ptrs, seg_caps):
+        """Scatter-gather batch get: sub-key sks[i]'s stored blob is scattered in
+        order across the destination buffers seg_ptrs[i][..] of capacity
+        seg_caps[i][..] (one RDMA multi-SGE op). Returns (hits, lens): hits[i]==1
+        on hit, lens[i]=total stored bytes. Mirrors the vLLM connector's
+        batch_get_auto_sg (dfkv_client.py) and is the read twin of _batch_put_sg."""
+        n = len(sks)
+        if n == 0:
+            return [], []
+        karr = (ctypes.c_char_p * n)(*[k.encode() for k in sks])
+        # Keep the per-key inner arrays alive for the whole call (the outer arrays
+        # hold casts of these) — same lifetime discipline as _batch_put_sg.
+        inner_p = [(ctypes.c_void_p * len(p))(*[ctypes.c_void_p(int(x)) for x in p])
+                   for p in seg_ptrs]
+        inner_c = [(ctypes.c_uint64 * len(c))(*[int(x) for x in c])
+                   for c in seg_caps]
+        parr = (ctypes.POINTER(ctypes.c_void_p) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(ctypes.c_void_p)) for a in inner_p])
+        carr = (ctypes.POINTER(ctypes.c_uint64) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(ctypes.c_uint64)) for a in inner_c])
+        narr = (ctypes.c_int * n)(*[len(p) for p in seg_ptrs])
+        out_hit = (ctypes.c_int * n)()
+        out_len = (ctypes.c_uint64 * n)()
+        rc = self._lib.dfkv_batch_get_auto_sg(
+            self._h, karr, parr, carr, narr, n, out_hit, out_len)
+        if rc != 0:
+            return [0] * n, [0] * n
+        return [out_hit[i] for i in range(n)], [int(out_len[i]) for i in range(n)]
+
+    def batch_get_v1_device(self, keys, device_indices, extra_info=None) -> List[bool]:
+        """L2-bypass on-demand read: RDMA a page's stored blob straight INTO its
+        GPU KV slots (no host staging). The read twin of batch_set_v1_device.
+
+        The device pool is layer-first, so a page's KV scatters across layer_num
+        non-contiguous per-layer buffers; get_device_page_buffer_meta yields the
+        same per-layer (ptr, size) segment lists the write used, here as the SG GET
+        DESTINATIONS (ptr) and capacities (size). Because the stored blob was
+        written LAYER-major (batch_set_v1_device), scattering it back across the
+        per-layer destination segments reassembles it layer-major into the device
+        slots — byte-consistent with the writer. A page succeeds iff every one of
+        its sub-objects (k[/v]) hit AND returned its full capacity (a short read is
+        a corrupt page -> failure, so the caller recomputes rather than serving it).
+
+        MLA note: the latent is replicated across TP, and only tp_rank 0 wrote it
+        (backup_skip). But EVERY rank must READ its own copy into its own device
+        slots, so there is NO read-side rank skip (unlike the write)."""
+        n = len(keys)
+        with _tracing.span("batch_get_v1_device", n) as _sp, \
+                access_log("batch_get_v1_device",
+                           lambda: f"{self._alog_tag} {n} keys") as r:
+            from sglang.srt.mem_cache.device_page_meta import (
+                get_device_page_buffer_meta,
+            )
+            seg_ptrs, seg_caps = get_device_page_buffer_meta(
+                self.mem_pool_device, device_indices)
+            sub, sks, sp, sc = self._flatten_device(keys, seg_ptrs, seg_caps)
+            # Per sub-key expected byte length = sum of its per-layer segment caps.
+            want = [sum(c) for c in sc]
+            t0 = time.perf_counter()
+            hits, lens = self._batch_get_sg(sks, sp, sc)
+            dur = time.perf_counter() - t0
+            # A sub-object is good only on a full-length hit; fold to per-page.
+            flat_ok = [hits[i] == 1 and lens[i] >= want[i] for i in range(len(sks))]
+            res = self._fold(flat_ok, n, sub)
+            nbytes = sum(lens)
+            r.result = f"hits={sum(res)}/{n} (device-direct)"
+            short = sum(1 for i in range(len(sks))
+                        if hits[i] == 1 and lens[i] < want[i])
+            if short:
+                r.result += f" short_read={short}"
+            if _sp:
+                _sp.hits = sum(res); _sp.bytes = nbytes
+            self._metrics.on_get(pages=n, hit_pages=sum(res), nbytes=nbytes,
                                  seconds=dur)
             return res
 

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -560,12 +560,16 @@ class DfkvHiCache(HiCacheStorage):
             max_segs = int(self._lib.dfkv_max_sg_segs(self._h))
         except Exception:
             return False
-        if max_segs < layer_num:
-            print(f"[dfkv] L2-bypass unavailable: max_sg_segs={max_segs} < "
-                  f"layer_num={layer_num}; a page's per-layer device segments "
-                  "exceed the RDMA SGE budget for a single key. Staying on the "
-                  "host write path.", file=sys.stderr, flush=True)
+        if max_segs < 1:
             return False
+        if max_segs < layer_num:
+            # Pages split into ceil(layer_num/max_segs) "@sg{n}" sub-keys
+            # (_flatten_device) — same chunking the vLLM connector uses, so a
+            # narrow HCA costs extra keys per page, not the bypass itself.
+            print(f"[dfkv] L2-bypass: max_sg_segs={max_segs} < layer_num="
+                  f"{layer_num}; chunking each page into "
+                  f"{(layer_num + max_segs - 1) // max_segs} @sg sub-keys.",
+                  file=sys.stderr, flush=True)
         return True
 
     def register_mem_pool_device(self, mem_pool_device):
@@ -739,19 +743,45 @@ class DfkvHiCache(HiCacheStorage):
             # OTLP by the snapshot poller — see dfkv_telemetry.parse_client_ops.
             return res
 
+    def _sg_width(self) -> int:
+        """Negotiated SG segments per key (HCA max_sge budget), cached."""
+        w = getattr(self, "_sg_width_cache", 0)
+        if not w:
+            try:
+                w = int(self._lib.dfkv_max_sg_segs(self._h))
+            except Exception:
+                w = 0
+            w = w or 29  # ConnectX-era fallback: max_sge=30, one SGE reserved
+            self._sg_width_cache = w
+        return w
+
     def _flatten_device(self, keys, seg_ptrs, seg_sizes):
         """Expand per-page keys into per-sub-object (k[/v]) sub-keys, pairing each
         with its per-layer device segment list. Parallel to _flatten, but every
-        entry is a segment LIST (one per layer), not a single (ptr, size)."""
+        entry is a segment LIST (one per layer), not a single (ptr, size).
+
+        A page's layer_num segments can exceed the HCA's per-key SG budget
+        (max_sge-1, e.g. 29 on ConnectX < 36/61 layers), so each sub-object is
+        chunked into "@sg{n}" sub-keys of <= _sg_width() consecutive layers —
+        the same scheme (and key suffix) the vLLM connector uses. Write and read
+        derive the identical deterministic split from (layer count, width), so
+        the layer-major bytes reassemble exactly. Chunk count is uniform across
+        pages, so _fold()'s per-page stride is sub * nchunks."""
         sub = self._sub()
         assert len(seg_ptrs) == len(keys) * sub, (len(seg_ptrs), len(keys), sub)
+        w = self._sg_width()
         sks, sp, ss = [], [], []
+        nchunks = 1
         for i, k in enumerate(keys):
             for j, sk in enumerate(self._keys(k)):
-                sks.append(sk)
-                sp.append([int(p) for p in seg_ptrs[i * sub + j]])
-                ss.append([int(s) for s in seg_sizes[i * sub + j]])
-        return sub, sks, sp, ss
+                p = [int(x) for x in seg_ptrs[i * sub + j]]
+                s = [int(x) for x in seg_sizes[i * sub + j]]
+                nchunks = max(1, (len(p) + w - 1) // w)
+                for ci in range(nchunks):
+                    sks.append(f"{sk}@sg{ci}")
+                    sp.append(p[ci * w:(ci + 1) * w])
+                    ss.append(s[ci * w:(ci + 1) * w])
+        return sub * nchunks, sks, sp, ss
 
     def _batch_put_sg(self, sks, seg_ptrs, seg_sizes) -> List[bool]:
         """Scatter-gather batch put: sub-key sks[i] stores the in-order
@@ -1107,6 +1137,135 @@ class DfkvHiCache(HiCacheStorage):
                     hit_pages=sum(sum(rs) for rs in res.values()),
                     nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
             return res
+
+    # --- DSA L2-bypass: main KV device-direct + sidecar host, one logical op ----
+    def _kv_device_set(self, keys, device_indices):
+        """Core of batch_set_v1_device (device-direct SG put) without the tracing /
+        access-log wrapper, so batch_set_v2_device can reuse it for the anchor KV.
+        Returns (per_page_bools, nbytes, seconds). MLA backup_skip on non-zero TP
+        rank (replicated latent) short-circuits to all-True, no I/O."""
+        n = len(keys)
+        if self.is_mla and self.tp_rank != 0:
+            return [True] * n, 0, 0.0
+        from sglang.srt.mem_cache.device_page_meta import (
+            get_device_page_buffer_meta,
+        )
+        seg_ptrs, seg_sizes = get_device_page_buffer_meta(
+            self.mem_pool_device, device_indices)
+        sub, sks, sp, ss = self._flatten_device(keys, seg_ptrs, seg_sizes)
+        nbytes = sum(sum(s) for s in ss)
+        t0 = time.perf_counter()
+        flat = self._put_sg_flat(sks, sp, ss)
+        dur = time.perf_counter() - t0
+        return self._fold(flat, n, sub), nbytes, dur
+
+    def _kv_device_get(self, keys, device_indices):
+        """Core of batch_get_v1_device (device-direct SG get) without the tracing /
+        access-log wrapper, so batch_get_v2_device can reuse it for the anchor KV.
+        Returns (per_page_bools, nbytes, seconds). A page is a hit only on a
+        full-length read of every sub-object (a short read is a corrupt page)."""
+        n = len(keys)
+        from sglang.srt.mem_cache.device_page_meta import (
+            get_device_page_buffer_meta,
+        )
+        seg_ptrs, seg_caps = get_device_page_buffer_meta(
+            self.mem_pool_device, device_indices)
+        sub, sks, sp, sc = self._flatten_device(keys, seg_ptrs, seg_caps)
+        want = [sum(c) for c in sc]
+        t0 = time.perf_counter()
+        hits, lens = self._batch_get_sg(sks, sp, sc)
+        dur = time.perf_counter() - t0
+        flat_ok = [hits[i] == 1 and lens[i] >= want[i] for i in range(len(sks))]
+        return self._fold(flat_ok, n, sub), sum(lens), dur
+
+    def batch_set_v2_device(
+        self, kv_keys, kv_device_indices, sidecar_transfers, extra_info=None
+    ) -> dict:
+        """DSA L2-bypass backup (GLM-5.2): the anchor "kv" pool (the big MLA latent)
+        RDMAs straight from its GPU slots to L3 via the device-direct SG put, while
+        the small DSA indexer sidecar STAYS on the host v2 path (_v2_io from its host
+        buffer). One logical op so the split value is written atomically-per-page.
+
+        VALUE LAYOUT (explicit): the main KV is stored under the v1-style keys
+        (_keys(hash) -> "model/hash_k"), byte-for-byte the same key scheme
+        batch_set_v1_device / batch_exists use — so an unchanged batch_exists_v2
+        anchors the hit prefix on the SAME "kv" keys with no change. The sidecar
+        rides its own v2 keys (_pool_keys('indexer', hash) -> "model/hash_indexer_k")
+        exactly as stock batch_set_v2. The two components never collide; the composite
+        is split honestly across two key namespaces, isolated by model_hash.
+
+        METRICS: the anchor device SG put reports on_set (a v1-device physical
+        transfer, identical attribution to stock DSA whose anchor rides batch_set_v1),
+        and the sidecar reports on_set_v2 — preserving the stock DSA metric split."""
+        n = len(kv_keys)
+        sidecar_transfers = sidecar_transfers or []
+        with _tracing.span("batch_set_v2_device", n) as _sp, \
+                access_log("batch_set_v2_device",
+                           lambda: f"{self._alog_tag} kv={n} "
+                                   f"{_fmt_pools(sidecar_transfers)}") as r:
+            kv_res, kv_bytes, kv_secs = self._kv_device_set(kv_keys, kv_device_indices)
+            results = {"kv": kv_res}
+            # Main-KV device write reports on_set (v1-device), matching stock DSA's
+            # anchor attribution; skip the metric on the MLA rank!=0 no-op.
+            if n and not (self.is_mla and self.tp_rank != 0):
+                self._metrics.on_set(pages=n, ok_pages=sum(kv_res),
+                                     nbytes=kv_bytes, seconds=kv_secs)
+            # Sidecar rides the host v2 path (its own keys, its own host buffer).
+            if sidecar_transfers:
+                side = self._v2_io(sidecar_transfers, putting=True)
+                results.update(side)
+                side_pages = sum(len(rs) for rs in side.values())
+                if side_pages and not (self.is_mla and self.tp_rank != 0):
+                    self._metrics.on_set_v2(
+                        pages=side_pages,
+                        ok_pages=sum(sum(rs) for rs in side.values()),
+                        nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
+            r.result = f"kv {sum(kv_res)}/{n} (device-direct); " + _fmt_pool_results(
+                {k: v for k, v in results.items() if k != "kv"})
+            if self._put_retry_recovered:
+                r.result += f" retry_ok={self._put_retry_recovered}"
+            if _sp:
+                _sp.hits = sum(sum(rs) for rs in results.values())
+                _sp.bytes = kv_bytes + self._v2_io_bytes if sidecar_transfers else kv_bytes
+            return results
+
+    def batch_get_v2_device(
+        self, kv_keys, kv_device_indices, sidecar_transfers, extra_info=None
+    ) -> dict:
+        """DSA L2-bypass on-demand read (GLM-5.2): the read twin of
+        batch_set_v2_device. The anchor "kv" pool RDMAs straight INTO its GPU slots
+        via the device-direct SG get; the DSA indexer sidecar is read into its host
+        buffer via the v2 host path (batch_get_v2 semantics), from which the SGLang
+        controller then H2Ds it into the device index buffer.
+
+        The kv keys/indices and sidecar keys mirror batch_set_v2_device exactly, so a
+        page written there reads back byte-identical for BOTH components. Anchor read
+        reports on_get (v1-device), sidecar on_get_v2 — the stock DSA read split."""
+        n = len(kv_keys)
+        sidecar_transfers = sidecar_transfers or []
+        with _tracing.span("batch_get_v2_device", n) as _sp, \
+                access_log("batch_get_v2_device",
+                           lambda: f"{self._alog_tag} kv={n} "
+                                   f"{_fmt_pools(sidecar_transfers)}") as r:
+            kv_res, kv_bytes, kv_secs = self._kv_device_get(kv_keys, kv_device_indices)
+            results = {"kv": kv_res}
+            if n:
+                self._metrics.on_get(pages=n, hit_pages=sum(kv_res),
+                                     nbytes=kv_bytes, seconds=kv_secs)
+            if sidecar_transfers:
+                side = self._v2_io(sidecar_transfers, putting=False)
+                results.update(side)
+                side_pages = sum(len(rs) for rs in side.values())
+                if side_pages:
+                    self._metrics.on_get_v2(
+                        pages=side_pages,
+                        hit_pages=sum(sum(rs) for rs in side.values()),
+                        nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
+            r.result = f"kv {sum(kv_res)}/{n} (device-direct); " + _fmt_pool_results(
+                {k: v for k, v in results.items() if k != "kv"})
+            if _sp:
+                _sp.hits = sum(sum(rs) for rs in results.values())
+            return results
 
     def batch_exists_v2(self, keys, pool_transfers=None, extra_info=None):
         total = len(keys)

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -97,6 +97,20 @@ def _load_lib(path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_batch_exist.restype = ctypes.c_int
     lib.dfkv_batch_exist.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_char_p),
                                      ctypes.c_int, ctypes.POINTER(ctypes.c_int)]
+    # Scatter-gather put + live SG width, for the HiCache L2-bypass (device-direct
+    # write) path. Each key gathers num_bufs[i] non-contiguous source buffers
+    # (a page's per-layer GPU segments) into one stored blob. Guarded like the
+    # vLLM connector: older libdfkv.so lacks the symbols and callers fall back.
+    if hasattr(lib, "dfkv_batch_put_sg"):
+        lib.dfkv_batch_put_sg.restype = ctypes.c_int
+        lib.dfkv_batch_put_sg.argtypes = [
+            ctypes.c_void_p, ctypes.POINTER(ctypes.c_char_p),
+            ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+            ctypes.POINTER(ctypes.POINTER(ctypes.c_uint64)),
+            ctypes.POINTER(ctypes.c_int), ctypes.c_int, ctypes.POINTER(ctypes.c_int)]
+    if hasattr(lib, "dfkv_max_sg_segs"):
+        lib.dfkv_max_sg_segs.restype = ctypes.c_uint32
+        lib.dfkv_max_sg_segs.argtypes = [ctypes.c_void_p]
     lib.dfkv_set_members.restype = ctypes.c_int
     lib.dfkv_set_members.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
     lib.dfkv_refresh_members.restype = ctypes.c_int
@@ -507,6 +521,59 @@ class DfkvHiCache(HiCacheStorage):
                 return
             r.result = f"registered {n} region(s)" if n else "no backing buffer found"
 
+    # --- L2-bypass (device-direct write) -------------------------------------
+    def supports_device_transfer(self) -> bool:
+        """True iff this backend can RDMA a page straight from GPU KV slots to L3.
+
+        Requires the scatter-gather put ABI (dfkv_batch_put_sg) plus a negotiated
+        SG width big enough to hold a page's per-layer device segments in ONE key
+        (layer_num segments/key — the GPU pool is layer-first, so a page's KV is
+        scattered across layer_num non-contiguous buffers). Older libdfkv.so
+        without the symbols, or an HCA whose max_sge is too small, keep the stock
+        host (D2H) write path. Checked by the SGLang controller's capability gate;
+        never raises."""
+        if not (hasattr(self._lib, "dfkv_batch_put_sg")
+                and hasattr(self._lib, "dfkv_max_sg_segs")):
+            return False
+        layer_num = int(self.cfg.get("layer_num", 0))
+        if layer_num <= 0:
+            return False
+        try:
+            max_segs = int(self._lib.dfkv_max_sg_segs(self._h))
+        except Exception:
+            return False
+        if max_segs < layer_num:
+            print(f"[dfkv] L2-bypass unavailable: max_sg_segs={max_segs} < "
+                  f"layer_num={layer_num}; a page's per-layer device segments "
+                  "exceed the RDMA SGE budget for a single key. Staying on the "
+                  "host write path.", file=sys.stderr, flush=True)
+            return False
+        return True
+
+    def register_mem_pool_device(self, mem_pool_device):
+        """Register the GPU KV pool's per-layer buffers for RDMA (GPUDirect MR;
+        dfkv_register_memory accepts device pointers — same call the vLLM connector
+        uses). Deduped against host regions already registered."""
+        self.mem_pool_device = mem_pool_device
+        from sglang.srt.mem_cache.device_page_meta import device_pool_regions
+
+        with access_log("register_mem_pool_device",
+                        lambda: f"{self._alog_tag}") as r:
+            n = 0
+            try:
+                for base, size in device_pool_regions(mem_pool_device):
+                    region = (base, size)
+                    if not base or not size or region in self._registered_regions:
+                        continue
+                    if self.register_memory(base, size):
+                        self._registered_regions.add(region)
+                        n += 1
+            except Exception as e:  # never fail setup over an optimization
+                r.result = f"skip ({type(e).__name__})"
+                return
+            r.result = (f"registered {n} device region(s)" if n
+                        else "no device buffer found")
+
     def set_members(self, members: str):
         """Hot-swap cluster membership, e.g. 'n1=ip:12000,n2=ip:12000'."""
         self._lib.dfkv_set_members(self._h, members.encode())
@@ -652,6 +719,118 @@ class DfkvHiCache(HiCacheStorage):
             # Fleet op metrics (put/get/exist/...) are accumulated in the C++
             # KVClient (the chokepoint all connectors share) and forwarded over
             # OTLP by the snapshot poller — see dfkv_telemetry.parse_client_ops.
+            return res
+
+    def _flatten_device(self, keys, seg_ptrs, seg_sizes):
+        """Expand per-page keys into per-sub-object (k[/v]) sub-keys, pairing each
+        with its per-layer device segment list. Parallel to _flatten, but every
+        entry is a segment LIST (one per layer), not a single (ptr, size)."""
+        sub = self._sub()
+        assert len(seg_ptrs) == len(keys) * sub, (len(seg_ptrs), len(keys), sub)
+        sks, sp, ss = [], [], []
+        for i, k in enumerate(keys):
+            for j, sk in enumerate(self._keys(k)):
+                sks.append(sk)
+                sp.append([int(p) for p in seg_ptrs[i * sub + j]])
+                ss.append([int(s) for s in seg_sizes[i * sub + j]])
+        return sub, sks, sp, ss
+
+    def _batch_put_sg(self, sks, seg_ptrs, seg_sizes) -> List[bool]:
+        """Scatter-gather batch put: sub-key sks[i] stores the in-order
+        concatenation of its per-layer segments seg_ptrs[i][..]/seg_sizes[i][..] as
+        one dfkv key (one RDMA multi-SGE op). Returns per-key success bools."""
+        n = len(sks)
+        if n == 0:
+            return []
+        karr = (ctypes.c_char_p * n)(*[k.encode() for k in sks])
+        # Keep the per-key inner arrays alive for the whole call (mirrors the vLLM
+        # connector's batch_put_sg): the outer arrays hold casts of these.
+        inner_p = [(ctypes.c_void_p * len(p))(*[ctypes.c_void_p(int(x)) for x in p])
+                   for p in seg_ptrs]
+        inner_s = [(ctypes.c_uint64 * len(s))(*[int(x) for x in s])
+                   for s in seg_sizes]
+        parr = (ctypes.POINTER(ctypes.c_void_p) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(ctypes.c_void_p)) for a in inner_p])
+        sarr = (ctypes.POINTER(ctypes.c_uint64) * n)(
+            *[ctypes.cast(a, ctypes.POINTER(ctypes.c_uint64)) for a in inner_s])
+        narr = (ctypes.c_int * n)(*[len(p) for p in seg_ptrs])
+        out = (ctypes.c_int * n)()
+        rc = self._lib.dfkv_batch_put_sg(self._h, karr, parr, sarr, narr, n, out)
+        if rc != 0:
+            return [False] * n
+        return [out[i] == 1 for i in range(n)]
+
+    def _put_sg_flat(self, sks, seg_ptrs, seg_sizes) -> List[bool]:
+        """SG put with the same phase-9 exist gate + single transient retry as
+        _put_flat (the contiguous host put), so the L2-bypass path inherits the
+        identical backup-dedup and burst-failure recovery semantics."""
+        self._put_retry_recovered = 0
+        if not sks:
+            return []
+        if self._backup_exist_gate:
+            present = list(self._batch_exist_flat(sks))
+            todo = [i for i, p in enumerate(present) if not p]
+            if not todo:
+                return [True] * len(sks)
+        else:
+            present = [False] * len(sks)
+            todo = list(range(len(sks)))
+        for attempt in (0, 1):
+            if not todo:
+                break
+            if attempt:
+                time.sleep(0.01)  # let the write burst drain first
+            out = self._batch_put_sg(
+                [sks[i] for i in todo], [seg_ptrs[i] for i in todo],
+                [seg_sizes[i] for i in todo])
+            failed = []
+            for m, i in enumerate(todo):
+                present[i] = out[m]
+                if not present[i]:
+                    failed.append(i)
+                elif attempt:
+                    self._put_retry_recovered += 1
+            todo = failed
+        return present
+
+    def batch_set_v1_device(self, keys, device_indices, extra_info=None) -> List[bool]:
+        """L2-bypass write-through: RDMA a page straight from its GPU KV slots to L3
+        (no D2H staging). Mirrors batch_set_v1 but the page payload is gathered from
+        the layer-first device pool as per-layer scatter-gather segments.
+
+        NOTE (ordering): the device segments concatenate LAYER-major, whereas the
+        stock host read (batch_get_v1) reconstructs a page-first (TOKEN-major)
+        buffer. The two are transposes; a page written here is byte-coherent only
+        with a matching device-direct (layer-major) reader — increment 2 — not with
+        the unchanged host read path. See the SGLang-side device_page_meta.py."""
+        n = len(keys)
+        with _tracing.span("batch_set_v1_device", n) as _sp, \
+                access_log("batch_set_v1_device",
+                           lambda: f"{self._alog_tag} {n} keys") as r:
+            # MLA backup_skip: latent is replicated across TP, only rank 0 writes.
+            if self.is_mla and self.tp_rank != 0:
+                r.result = "backup_skip"
+                if _sp:
+                    _sp.attrs = {"dfkv.backup_skip": True}
+                return [True] * n
+            from sglang.srt.mem_cache.device_page_meta import (
+                get_device_page_buffer_meta,
+            )
+            seg_ptrs, seg_sizes = get_device_page_buffer_meta(
+                self.mem_pool_device, device_indices)
+            sub, sks, sp, ss = self._flatten_device(keys, seg_ptrs, seg_sizes)
+            nbytes = sum(sum(s) for s in ss)
+            t0 = time.perf_counter()
+            flat = self._put_sg_flat(sks, sp, ss)
+            dur = time.perf_counter() - t0
+            res = self._fold(flat, n, sub)
+            r.result = f"ok {sum(res)}/{n} (device-direct)"
+            if self._put_retry_recovered:
+                r.result += f" retry_ok={self._put_retry_recovered}"
+            if _sp:
+                _sp.hits = sum(res); _sp.bytes = nbytes
+            self._metrics.on_set(pages=n, ok_pages=sum(res), nbytes=nbytes,
+                                 seconds=dur)
             return res
 
     def batch_get_v1(self, keys, host_indices, extra_info=None) -> List[bool]:

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -995,9 +995,17 @@ class DfkvHiCache(HiCacheStorage):
         total = len(keys)
         with _tracing.span("batch_exists", total) as _sp, \
                 access_log("batch_exists", lambda: f"{self._alog_tag} {total} keys") as r:
-            # longest contiguous prefix of pages whose every sub-object exists
+            # longest contiguous prefix of pages whose every sub-object exists.
+            # Device-direct (L2-bypass) writes store "@sg{n}" chunk sub-keys, so
+            # existence is probed on "@sg0" — the vLLM connector's probe scheme;
+            # the bare sub-key never matches a chunked store. A bypass instance
+            # only ever writes chunked keys (model_hash-isolated), so one probe
+            # form suffices per mode.
             sub = self._sub()
-            sks = [sk for k in keys for sk in self._keys(k)]
+            if getattr(self, "mem_pool_device", None) is not None:
+                sks = [f"{sk}@sg0" for k in keys for sk in self._keys(k)]
+            else:
+                sks = [sk for k in keys for sk in self._keys(k)]
             page_ok = self._fold(self._batch_exist_flat(sks), total, sub)
             n = 0
             for ok in page_ok:

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -658,6 +658,66 @@ class DfkvHiCache(HiCacheStorage):
             r.result = (f"registered {n} draft device region(s)" if n
                         else "no draft device buffer found")
 
+    def register_mem_pool_device_draft_sidecar(self, mem_pool_device_draft):
+        """DSA-draft extension of task 6: register the draft model's DSA indexer
+        sidecar (index_k_with_scale_buffer) GPU buffers for RDMA so the draft indexer
+        RDMAs device-direct alongside the draft main latent, keeping a DSA draft's KV
+        coherent (latent + indexer) on an L3 hit. The draft pool object IS the
+        DSATokenToKVPool (it carries both kv_buffer and index_k_with_scale_buffer), so
+        we register the same object as a sidecar device pool under a distinct name and
+        drive it through the shared _sidecar_device_set/get machinery (its own
+        `draft_indexer` key namespace, layer-first @sg chunking). Deduped against
+        regions already registered."""
+        if not hasattr(self, "_sidecar_device_pools"):
+            self._sidecar_device_pools = {}
+        self._draft_sidecar_name = "draft_indexer"
+        self._sidecar_device_pools[self._draft_sidecar_name] = mem_pool_device_draft
+        from sglang.srt.mem_cache.device_page_meta import sidecar_device_pool_regions
+
+        with access_log("register_mem_pool_device_draft_sidecar",
+                        lambda: f"{self._alog_tag}") as r:
+            n = 0
+            try:
+                for base, size in sidecar_device_pool_regions(mem_pool_device_draft):
+                    region = (base, size)
+                    if not base or not size or region in self._registered_regions:
+                        continue
+                    if self.register_memory(base, size):
+                        self._registered_regions.add(region)
+                        n += 1
+            except Exception as e:  # never fail setup over an optimization
+                r.result = f"skip ({type(e).__name__})"
+                return
+            r.result = (f"registered {n} draft indexer region(s)" if n
+                        else "no draft indexer buffer found")
+
+    def _draft_sidecar_device_set(self, keys, device_indices):
+        """Best-effort device-direct SG put of the DSA draft's indexer sidecar (the
+        `draft_indexer` namespace), or None when no draft sidecar is registered (a
+        dense/non-DSA draft). Failure returns [False]*n so the caller marks those
+        draft pages unstored — the read gates coherence, so a page never serves a
+        latent without its matching indexer."""
+        name = getattr(self, "_draft_sidecar_name", None)
+        if not name:
+            return None
+        try:
+            res, _nb, _s = self._sidecar_device_set(name, keys, device_indices)
+            return res
+        except Exception:
+            return [False] * len(keys)
+
+    def _draft_sidecar_device_get(self, keys, device_indices):
+        """Read twin of _draft_sidecar_device_set: RDMA the DSA draft indexer straight
+        into its GPU buffer, or None when no draft sidecar is registered."""
+        name = getattr(self, "_draft_sidecar_name", None)
+        if not name:
+            return None
+        try:
+            res, _nb, _s = self._sidecar_device_get(name, keys, device_indices)
+            return res
+        except Exception:
+            return [False] * len(keys)
+
     def set_members(self, members: str):
         """Hot-swap cluster membership, e.g. 'n1=ip:12000,n2=ip:12000'."""
         self._lib.dfkv_set_members(self._h, members.encode())
@@ -1337,6 +1397,12 @@ class DfkvHiCache(HiCacheStorage):
             flat = self._put_sg_flat(sks, sp, ss)
             res = self._fold(flat, n, stride)
             r.result = f"ok {sum(res)}/{n} (draft device-direct)"
+            # DSA-draft: also store the draft indexer sidecar device-direct so the
+            # loaded draft page is coherent (latent + indexer). None => dense draft.
+            side = self._draft_sidecar_device_set(keys, device_indices)
+            if side is not None:
+                res = [res[i] and side[i] for i in range(n)]
+                r.result += f" +indexer {sum(side)}/{n}"
             return res
 
     def batch_get_v1_device_draft(self, keys, device_indices, extra_info=None) -> List[bool]:
@@ -1361,6 +1427,12 @@ class DfkvHiCache(HiCacheStorage):
             flat_ok = [hits[i] == 1 and lens[i] >= want[i] for i in range(len(sks))]
             res = self._fold(flat_ok, n, stride)
             r.result = f"hits={sum(res)}/{n} (draft device-direct)"
+            # DSA-draft: a page is a coherent draft hit only if its indexer sidecar
+            # also read back in full. None => dense draft (no sidecar).
+            side = self._draft_sidecar_device_get(keys, device_indices)
+            if side is not None:
+                res = [res[i] and side[i] for i in range(n)]
+                r.result += f" +indexer {sum(side)}/{n}"
             return res
 
     def batch_set_v2_device(

--- a/src/client/group_shard.h
+++ b/src/client/group_shard.h
@@ -1,0 +1,51 @@
+/* group_shard: split a per-node Batch* work group into up to N shards so
+ * multiple connections drive one node concurrently.
+ *
+ * A single- or few-node ring otherwise routes a whole batch to ONE (node[,size])
+ * group -> one fan-out worker -> one QP, where the server drains it key-by-key
+ * (~7 ms/key, ~166 MB/s/conn measured on the phase-8 hit-rate probe -- the L3
+ * read-back ceiling; the SG write path has the same single-connection drain).
+ * Sharding turns that into up to `maxc` parallel streams per node.
+ *
+ * Pure logic (no env / no config_dump) so it is unit-testable in isolation; the
+ * caller resolves the DFKV_READ_SHARD_KEYS / DFKV_READ_MAX_CONNS knobs once and
+ * passes them in. `target` = shard target size (keys per shard); `maxc` = per-node
+ * shard/connection cap. Each shard keeps its group's key (`first`) so downstream
+ * code is unchanged, and the per-key order within a group is preserved (shards
+ * are contiguous slices in the original index order). Groups already at/under one
+ * shard pass through untouched (wide rings keep their existing per-node
+ * parallelism). Generic over the group vector element: works for the read path's
+ * pair<pair<node,size>, idx> and the write path's pair<node, idx> alike.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+namespace dfkv {
+
+template <class GroupVec>
+GroupVec ShardGroups(GroupVec groups, size_t target, size_t maxc) {
+  if (maxc <= 1 || target == 0) return groups;
+  GroupVec out;
+  out.reserve(groups.size());
+  for (auto& g : groups) {
+    const auto& idx = g.second;
+    size_t nsh = (idx.size() + target - 1) / target;
+    if (nsh < 1) nsh = 1;
+    if (nsh > maxc) nsh = maxc;
+    if (nsh <= 1) { out.push_back(std::move(g)); continue; }
+    const size_t per = (idx.size() + nsh - 1) / nsh;
+    for (size_t s = 0; s < idx.size(); s += per) {
+      typename GroupVec::value_type sh;
+      sh.first = g.first;
+      sh.second.assign(idx.begin() + s,
+                       idx.begin() + std::min(idx.size(), s + per));
+      out.push_back(std::move(sh));
+    }
+  }
+  return out;
+}
+
+}  // namespace dfkv

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -14,6 +14,7 @@
 #include <thread>
 #include <vector>
 
+#include "client/group_shard.h"
 #include "client/key_map.h"
 #include "utils/log.h"
 #include "utils/thread_name.h"
@@ -195,38 +196,18 @@ size_t EnvSize(const char* name, size_t dflt) {
   return out;
 }
 
-// Split each per-node read group into up to N shards so multiple connections
-// read one node concurrently. A single- or few-node ring otherwise routes a
-// whole batch to ONE (node,size) group -> one worker -> one QP, where the
-// server drains it key-by-key (~7 ms/key, ~166 MB/s/conn measured on the
-// phase-8 hit-rate probe — the L3 read-back ceiling). Sharding turns that
-// into DFKV_READ_MAX_CONNS parallel streams per node. Shard target size and
-// the per-node cap are env-tunable; each shard keeps its group's (node,size)
-// key so downstream code is unchanged. Groups already at/under one shard pass
-// through untouched (wide rings keep their existing per-node parallelism).
+// Env-reading wrapper over ShardGroups (client/group_shard.h): resolve the
+// DFKV_READ_SHARD_KEYS / DFKV_READ_MAX_CONNS knobs once (recorded into the config
+// dump via EnvSize) and split each per-node group into up to DFKV_READ_MAX_CONNS
+// shards so multiple connections drive one node concurrently — the mechanism that
+// breaks the single-connection ~166 MB/s/conn key-by-key drain on a single- or
+// few-node ring. Used by both the read (BatchGet / SG GET) and write (BatchPutSg)
+// batch paths; the same two knobs govern read and write sharding.
 template <class GroupVec>
 GroupVec ShardReadGroups(GroupVec groups) {
   static const size_t target = EnvSize("DFKV_READ_SHARD_KEYS", 16);
   static const size_t maxc = EnvSize("DFKV_READ_MAX_CONNS", 8);
-  if (maxc <= 1) return groups;
-  GroupVec out;
-  out.reserve(groups.size());
-  for (auto& g : groups) {
-    const auto& idx = g.second;
-    size_t nsh = (idx.size() + target - 1) / target;
-    if (nsh < 1) nsh = 1;
-    if (nsh > maxc) nsh = maxc;
-    if (nsh <= 1) { out.push_back(std::move(g)); continue; }
-    const size_t per = (idx.size() + nsh - 1) / nsh;
-    for (size_t s = 0; s < idx.size(); s += per) {
-      typename GroupVec::value_type sh;
-      sh.first = g.first;
-      sh.second.assign(idx.begin() + s,
-                       idx.begin() + std::min(idx.size(), s + per));
-      out.push_back(std::move(sh));
-    }
-  }
-  return out;
+  return ShardGroups(std::move(groups), target, maxc);
 }
 }  // namespace
 
@@ -1223,7 +1204,16 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     h.Serialize(hdrs[i].data());
     by_node[node].push_back(i);
   }
-  std::vector<std::pair<std::string, std::vector<size_t>>> groups(by_node.begin(), by_node.end());
+  // Shard each per-node put group the same way the read path does (shared knobs
+  // DFKV_READ_SHARD_KEYS / DFKV_READ_MAX_CONNS): a single-node ring otherwise
+  // gathers the whole SG batch into one group -> one worker -> one QP that the
+  // server drains key-by-key. Sharding fans it across up to DFKV_READ_MAX_CONNS
+  // connections. Each shard keeps its node and a contiguous slice of the original
+  // indices, so hdrs[k]/ok[k] stay addressed by original index and per-key results
+  // are unchanged.
+  std::vector<std::pair<std::string, std::vector<size_t>>> groups =
+      ShardReadGroups(std::vector<std::pair<std::string, std::vector<size_t>>>(
+          by_node.begin(), by_node.end()));
   RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();

--- a/test/client/group_shard_test.cc
+++ b/test/client/group_shard_test.cc
@@ -1,0 +1,108 @@
+// Pure-logic tests for ShardGroups (client/group_shard.h): the per-node group
+// splitter that lets the Batch* read AND SG-write paths drive one node over up to
+// DFKV_READ_MAX_CONNS connections instead of a single serial-drain QP. No
+// transport / server: it asserts the shard partition (count, contiguity, order
+// preservation, boundaries) that the fan-out then turns into parallel connections.
+#include "client/group_shard.h"
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace dfkv;  // NOLINT
+
+namespace {
+// Read-path group key is pair<node,size>; write-path (BatchPutSg) is a bare node
+// string. Cover both element shapes so a change to either call site is caught.
+using ReadGroup = std::pair<std::pair<std::string, size_t>, std::vector<size_t>>;
+using WriteGroup = std::pair<std::string, std::vector<size_t>>;
+
+std::vector<size_t> Iota(size_t n) {
+  std::vector<size_t> v(n);
+  std::iota(v.begin(), v.end(), 0);
+  return v;
+}
+
+// Every original index appears exactly once across the shards, in ascending
+// order overall (shards are contiguous slices), and each shard is non-empty.
+template <class GroupVec>
+void AssertCoversInOrder(const GroupVec& out, size_t n) {
+  std::vector<size_t> seen;
+  for (const auto& g : out) {
+    EXPECT_FALSE(g.second.empty());
+    for (size_t x : g.second) seen.push_back(x);
+  }
+  ASSERT_EQ(seen.size(), n);
+  for (size_t i = 0; i < n; ++i) EXPECT_EQ(seen[i], i) << "index " << i;
+}
+}  // namespace
+
+// A group at/under one shard target passes through untouched (wide rings keep
+// their existing per-node parallelism; no needless fragmentation).
+TEST(ShardGroups, SmallGroupUntouched) {
+  std::vector<WriteGroup> in{{"n0", Iota(16)}};
+  auto out = ShardGroups(in, /*target=*/16, /*maxc=*/8);
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].first, "n0");
+  EXPECT_EQ(out[0].second.size(), 16u);
+}
+
+// One node with many keys splits into exactly ceil(n/target) shards, capped at
+// maxc — this is the single-node-ring case the SG paths care about.
+TEST(ShardGroups, OneNodeSplitsToCeil) {
+  std::vector<WriteGroup> in{{"n0", Iota(40)}};  // ceil(40/16)=3 <= 8
+  auto out = ShardGroups(in, 16, 8);
+  EXPECT_EQ(out.size(), 3u);
+  for (const auto& g : out) EXPECT_EQ(g.first, "n0");
+  AssertCoversInOrder(out, 40);
+  // Balanced slices: ceil(40/3)=14, so 14+14+12.
+  EXPECT_EQ(out[0].second.size(), 14u);
+  EXPECT_EQ(out[1].second.size(), 14u);
+  EXPECT_EQ(out[2].second.size(), 12u);
+  EXPECT_EQ(out[0].second.front(), 0u);
+  EXPECT_EQ(out.back().second.back(), 39u);
+}
+
+// Shard count never exceeds maxc no matter how large the group (the per-node
+// connection ceiling).
+TEST(ShardGroups, CappedAtMaxConns) {
+  std::vector<WriteGroup> in{{"n0", Iota(1000)}};
+  auto out = ShardGroups(in, 16, 8);
+  EXPECT_EQ(out.size(), 8u);
+  AssertCoversInOrder(out, 1000);
+}
+
+// maxc<=1 disables sharding entirely (the DFKV_READ_MAX_CONNS=1 opt-out).
+TEST(ShardGroups, MaxConnsOneIsPassthrough) {
+  std::vector<WriteGroup> in{{"n0", Iota(100)}};
+  auto out = ShardGroups(in, 16, 1);
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].second.size(), 100u);
+}
+
+// Independent per-node groups each shard on their own; a small group rides
+// through beside a large one that splits.
+TEST(ShardGroups, MultiNodeShardsIndependently) {
+  std::vector<WriteGroup> in{{"n0", Iota(48)}, {"n1", Iota(4)}};
+  auto out = ShardGroups(in, 16, 8);
+  size_t n0 = 0, n1 = 0;
+  for (const auto& g : out) (g.first == "n0" ? n0 : n1)++;
+  EXPECT_EQ(n0, 3u);  // ceil(48/16)=3
+  EXPECT_EQ(n1, 1u);  // stays whole
+}
+
+// The read-path element shape (pair<pair<node,size>, idx>) shards on idx and
+// carries the composite key onto every shard unchanged.
+TEST(ShardGroups, ReadGroupKeyShapePreserved) {
+  std::vector<ReadGroup> in{{{"n0", 4096}, Iota(40)}};
+  auto out = ShardGroups(in, 16, 8);
+  EXPECT_EQ(out.size(), 3u);
+  for (const auto& g : out) {
+    EXPECT_EQ(g.first.first, "n0");
+    EXPECT_EQ(g.first.second, 4096u);
+  }
+  AssertCoversInOrder(out, 40);
+}

--- a/test/client/sg_test.cc
+++ b/test/client/sg_test.cc
@@ -228,3 +228,52 @@ TEST(Sg, MultiKeyTwoNodes) {
   }
   a->srv->Stop(); b->srv->Stop();
 }
+
+// Large single-node SG batch: with one node in the ring the whole batch routes to
+// one (node[,cap]) group, which BOTH the SG write (BatchPutSg) and the SG read
+// (BatchGetAutoSg) now split into up to DFKV_READ_MAX_CONNS parallel connections
+// (ShardReadGroups). This asserts the shard fan-out preserves every per-key result
+// and every scattered byte -- correctness of the concurrent-connection path the
+// benchmark leans on for bandwidth. Uniform segment count + size so all keys share
+// one (node,cap) group (the worst case for serial drain, best case to shard).
+TEST(Sg, LargeSingleNodeShardedRoundTrip) {
+  auto a = Start("shard1");
+  KVClient c({{"a", a->addr}}, Hdr());
+  const int N = 200;             // >> DFKV_READ_SHARD_KEYS(16) => shards to the cap
+  const size_t nsegs = 3, seg = 1024;
+  std::vector<std::vector<std::string>> srcs(N);
+  std::vector<KvPutItemSg> puts(N);
+  for (int i = 0; i < N; ++i) {
+    std::vector<size_t> sizes(nsegs, seg);
+    srcs[i] = MakeChunks("sh" + std::to_string(i), sizes);
+    std::vector<const void*> ptrs;
+    for (auto& s : srcs[i]) ptrs.push_back(s.data());
+    puts[i] = {"sh" + std::to_string(i), ptrs, sizes};
+  }
+  auto pr = c.BatchPutSg(puts);
+  ASSERT_EQ(pr.size(), size_t(N));
+  for (int i = 0; i < N; ++i) ASSERT_TRUE(pr[i]) << "sharded put key " << i;
+
+  std::vector<std::vector<std::string>> dsts(N);
+  std::vector<KvGetItemSg> gets(N);
+  for (int i = 0; i < N; ++i) {
+    dsts[i].resize(nsegs);
+    std::vector<void*> dptrs;
+    std::vector<size_t> caps(nsegs, seg);
+    for (size_t j = 0; j < nsegs; ++j) {
+      dsts[i][j].assign(seg, '\0');
+      dptrs.push_back(&dsts[i][j][0]);
+    }
+    gets[i] = {"sh" + std::to_string(i), dptrs, caps};
+  }
+  std::vector<size_t> lens;
+  auto gr = c.BatchGetAutoSg(gets, &lens);
+  ASSERT_EQ(gr.size(), size_t(N));
+  for (int i = 0; i < N; ++i) {
+    ASSERT_TRUE(gr[i]) << "sharded get key " << i;
+    EXPECT_EQ(lens[i], nsegs * seg) << i;
+    for (size_t j = 0; j < nsegs; ++j)
+      EXPECT_EQ(dsts[i][j], srcs[i][j]) << "key " << i << " seg " << j;
+  }
+  a->srv->Stop();
+}

--- a/test/python/sglang/srt/mem_cache/device_page_meta.py
+++ b/test/python/sglang/srt/mem_cache/device_page_meta.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""Device-side page buffer meta for the HiCache L2-bypass (device-direct write)
+prototype (SGLANG_HICACHE_L2_BYPASS=1).
+
+Mirrors memory_pool_host.MHATokenToKVPoolHost.get_page_buffer_meta (the host
+zero-copy arithmetic) but over the GPU KV pool. The GPU pool is *layer-first*:
+each layer is a separate allocation (MHATokenToKVPool.k_buffer/v_buffer are
+lists of per-layer tensors; MLATokenToKVPool.kv_buffer likewise). A page's KV is
+therefore NOT contiguous across layers, so — unlike the host page-first pool,
+whose page is one contiguous blob — a device page must be expressed as a
+scatter-gather list of per-layer segments. Each sub-object (k, and v for MHA) of
+a page becomes ``layer_num`` device segments; the dfkv backend hands them to the
+scatter-gather C ABI (dfkv_batch_put_sg), which stores the payload as the
+concatenation of the segments.
+
+CORRECTNESS NOTE (layer-major vs page-first ordering): the segments here
+concatenate in LAYER-major order (layer0[tok0..tokP], layer1[tok0..tokP], ...).
+The stock host read path (batch_get_v1) scatters the stored blob into a
+page-first host buffer, whose byte order is TOKEN-major (tok0[layer0..layerN],
+...). The two orderings are transposes of each other. A page written
+device-direct is therefore byte-coherent only with a matching device-direct
+(layer-major SG) reader — increment 2 — not with the unchanged page-first host
+read. Increment 1 wires the write path and its offload; enabling it in isolation
+is a benchmark/prototype mode. See PATCH-MANIFEST.md.
+"""
+
+from typing import List, Tuple
+
+
+def _mla_layer_bases(pool) -> Tuple[List[int], int]:
+    """(per-layer base data_ptr, per-token byte stride) for an MLA GPU pool."""
+    layers = pool.kv_buffer  # list[layer] of (size+page_size, 1, kv_cache_dim)
+    itemsize = layers[0].element_size()
+    token_stride = pool.kv_cache_dim * itemsize
+    return [int(t.data_ptr()) for t in layers], token_stride
+
+
+def _mha_layer_bases(pool) -> Tuple[List[int], int, List[int], int]:
+    """(k bases, k token stride, v bases, v token stride) for an MHA GPU pool."""
+    k_layers = pool.k_buffer  # list[layer] of (size+page_size, head_num, head_dim)
+    v_layers = pool.v_buffer
+    k_itemsize = k_layers[0].element_size()
+    v_itemsize = v_layers[0].element_size()
+    k_stride = pool.head_num * pool.head_dim * k_itemsize
+    v_stride = pool.head_num * pool.v_head_dim * v_itemsize
+    return (
+        [int(t.data_ptr()) for t in k_layers],
+        k_stride,
+        [int(t.data_ptr()) for t in v_layers],
+        v_stride,
+    )
+
+
+def _is_mla(pool) -> bool:
+    return hasattr(pool, "kv_buffer") and hasattr(pool, "kv_cache_dim")
+
+
+def _is_mha(pool) -> bool:
+    return hasattr(pool, "k_buffer") and hasattr(pool, "v_buffer")
+
+
+def supported(pool) -> bool:
+    """True if get_device_page_buffer_meta can express this GPU pool.
+
+    DSATokenToKVPool subclasses MLATokenToKVPool but its primary "kv" pool is a
+    logical anchor with no device KV (real KV rides the v2 side pools, which stay
+    on the host path in increment 1); use_dsa pools are declined here so the
+    controller keeps them on the stock path.
+    """
+    if getattr(pool, "use_dsa", False):
+        return False
+    return _is_mla(pool) or _is_mha(pool)
+
+
+def get_device_page_buffer_meta(pool, indices) -> Tuple[List[List[int]], List[List[int]]]:
+    """Scatter-gather device page meta, parallel in shape to the host
+    get_page_buffer_meta (one entry per page sub-object, k then v for MHA; k only
+    for MLA), but each entry is a LIST of per-layer (ptr)/(size) segments.
+
+    Returns (seg_ptrs, seg_sizes), each a list of length ``n_pages * sub`` whose
+    element ``[p * sub + j]`` is the per-layer segment list of page ``p``'s
+    sub-object ``j``.
+    """
+    page_size = pool.page_size
+    idx = indices.tolist() if hasattr(indices, "tolist") else list(indices)
+    assert len(idx) % page_size == 0, (
+        f"device page meta needs page-aligned indices, got {len(idx)} "
+        f"(page_size={page_size})"
+    )
+    n_pages = len(idx) // page_size
+
+    seg_ptrs: List[List[int]] = []
+    seg_sizes: List[List[int]] = []
+
+    if _is_mla(pool):
+        bases, token_stride = _mla_layer_bases(pool)
+        seg_len = page_size * token_stride
+        for p in range(n_pages):
+            slot = idx[p * page_size]
+            off = slot * token_stride
+            seg_ptrs.append([b + off for b in bases])
+            seg_sizes.append([seg_len] * len(bases))
+    elif _is_mha(pool):
+        k_bases, k_stride, v_bases, v_stride = _mha_layer_bases(pool)
+        k_len = page_size * k_stride
+        v_len = page_size * v_stride
+        for p in range(n_pages):
+            slot = idx[p * page_size]
+            seg_ptrs.append([b + slot * k_stride for b in k_bases])
+            seg_sizes.append([k_len] * len(k_bases))
+            seg_ptrs.append([b + slot * v_stride for b in v_bases])
+            seg_sizes.append([v_len] * len(v_bases))
+    else:
+        raise ValueError(
+            f"get_device_page_buffer_meta: unsupported GPU pool {type(pool).__name__}"
+        )
+
+    return seg_ptrs, seg_sizes
+
+
+def device_pool_regions(pool) -> List[Tuple[int, int]]:
+    """(base, nbytes) of every per-layer device buffer, for RDMA registration."""
+    regions: List[Tuple[int, int]] = []
+    if _is_mla(pool):
+        tensors = list(pool.kv_buffer)
+    elif _is_mha(pool):
+        tensors = list(pool.k_buffer) + list(pool.v_buffer)
+    else:
+        return regions
+    for t in tensors:
+        regions.append((int(t.data_ptr()), int(t.numel()) * int(t.element_size())))
+    return regions

--- a/test/python/sglang/srt/mem_cache/device_page_meta.py
+++ b/test/python/sglang/srt/mem_cache/device_page_meta.py
@@ -131,3 +131,58 @@ def device_pool_regions(pool) -> List[Tuple[int, int]]:
     for t in tensors:
         regions.append((int(t.data_ptr()), int(t.numel()) * int(t.element_size())))
     return regions
+
+
+# --- DSA indexer sidecar (device-direct), task 4 ------------------------------
+# Torch-free copy of the sidecar meta in the patched SGLang device_page_meta.py,
+# so the dfkv sidecar-device roundtrip test can exercise _sidecar_device_set/get
+# without a GPU. Kept in sync with the patched module (layer-first, page-indexed
+# index_k_with_scale_buffer -> layer_num segments/page, same @sg chunking as the
+# main latent).
+
+
+def _is_indexer(pool) -> bool:
+    layers = getattr(pool, "index_k_with_scale_buffer", None)
+    return (
+        isinstance(layers, (list, tuple))
+        and len(layers) > 0
+        and hasattr(pool, "page_size")
+    )
+
+
+def sidecar_supported(pool) -> bool:
+    return _is_indexer(pool)
+
+
+def sidecar_device_pool_regions(pool) -> List[Tuple[int, int]]:
+    regions: List[Tuple[int, int]] = []
+    for t in getattr(pool, "index_k_with_scale_buffer", None) or []:
+        regions.append((int(t.data_ptr()), int(t.numel()) * int(t.element_size())))
+    return regions
+
+
+def get_device_sidecar_page_buffer_meta(
+    pool, indices
+) -> Tuple[List[List[int]], List[List[int]]]:
+    page_size = pool.page_size
+    idx = indices.tolist() if hasattr(indices, "tolist") else list(indices)
+    assert len(idx) % page_size == 0, (
+        f"sidecar device page meta needs page-aligned indices, got {len(idx)} "
+        f"(page_size={page_size})"
+    )
+    n_pages = len(idx) // page_size
+
+    layers = pool.index_k_with_scale_buffer
+    itemsize = layers[0].element_size()
+    row_bytes = int(layers[0].shape[1]) * itemsize
+    row_stride = int(layers[0].stride(0)) * itemsize
+    bases = [int(t.data_ptr()) for t in layers]
+
+    seg_ptrs: List[List[int]] = []
+    seg_sizes: List[List[int]] = []
+    for p in range(n_pages):
+        slot = idx[p * page_size]
+        off = (slot // page_size) * row_stride
+        seg_ptrs.append([b + off for b in bases])
+        seg_sizes.append([row_bytes] * len(bases))
+    return seg_ptrs, seg_sizes

--- a/test/python/test_dfkv_hicache_device_direct.py
+++ b/test/python/test_dfkv_hicache_device_direct.py
@@ -218,6 +218,49 @@ class _NpTensor:
         return int(self._arr.itemsize)
 
 
+class _Transfer:
+    """Minimal PoolTransfer stand-in for the v2 sidecar path (name/keys/host_indices)."""
+
+    def __init__(self, name, keys, host_indices):
+        self.name = name
+        self.keys = keys
+        self.host_indices = host_indices
+
+
+class FakePageFirstHostSidecarPool:
+    """Page-first host pool for the DSA indexer sidecar, emulated with a single
+    numpy buffer of shape (num_pages, page_bytes). Mirrors the real host pool
+    surface the v2 path uses: get_page_buffer_meta(host_indices) -> (ptrs, sizes),
+    one contiguous (ptr, size) per page. Unlike the layer-first device pool, the
+    sidecar rides the *host* v2 path (D2H already done), so its page is one
+    contiguous blob — exactly what the stock host read reconstructs."""
+
+    def __init__(self, num_pages, page_size, page_bytes, fill_base=0):
+        self.page_size = page_size
+        self.page_bytes = page_bytes
+        self._arr = np.zeros(num_pages * page_bytes, dtype=np.uint8)
+        for pg in range(num_pages):
+            for b in range(page_bytes):
+                self._arr[pg * page_bytes + b] = (fill_base + pg * 7 + b) % 256
+
+    def get_page_buffer_meta(self, indices):
+        # indices are page-aligned token slots; one (ptr, size) per page (sub=1).
+        idx = list(indices)
+        assert len(idx) % self.page_size == 0
+        npages = len(idx) // self.page_size
+        base = self._arr.ctypes.data
+        ptrs, sizes = [], []
+        for p in range(npages):
+            page_idx = idx[p * self.page_size] // self.page_size
+            ptrs.append(base + page_idx * self.page_bytes)
+            sizes.append(self.page_bytes)
+        return ptrs, sizes
+
+    def page_bytes_at(self, page_idx):
+        off = page_idx * self.page_bytes
+        return bytes(self._arr[off:off + self.page_bytes])
+
+
 class FakeLayerFirstMlaDevicePool:
     """Layer-first MLA GPU pool emulated with host numpy per-layer buffers, so the
     device-direct SG write path can be exercised end-to-end without a GPU."""
@@ -385,6 +428,81 @@ class TestDeviceDirectEndToEnd(unittest.TestCase):
         self.assertEqual(
             st.batch_get_v1_device(["never_written"], list(range(self.PAGE_SIZE))),
             [False])
+
+    # Increment 2.5: DSA split-value (main KV device-direct + indexer sidecar host).
+    SIDE_BYTES = 4 * 3  # indexer page bytes (page_size * indexer_size_per_token-ish)
+
+    def test_dsa_split_value_write_then_read_roundtrip(self):
+        """DSA (GLM-5.2) L2-bypass: the main MLA latent rides the device-direct SG
+        path (layer-major, straight from GPU slots) while the small DSA indexer
+        sidecar rides the host v2 path. batch_set_v2_device writes the split value
+        under two key namespaces (kv @sg keys + indexer host keys); batch_get_v2_device
+        reads BOTH back byte-identical into fresh destination pools. Proves the
+        composite is split honestly without any C-server change: main KV and sidecar
+        never collide, and each component round-trips byte-exact."""
+        st = self._plugin(self._node("dsa"))
+        # Source pools: main latent (layer-first device) + indexer sidecar (page-first host).
+        src_kv = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        src_side = FakePageFirstHostSidecarPool(
+            num_pages=4, page_size=self.PAGE_SIZE, page_bytes=self.SIDE_BYTES,
+            fill_base=17)
+        st.register_mem_pool_device(src_kv)
+        st.register_mem_host_pool_v2(src_side, "indexer")
+        self.assertTrue(st.supports_device_transfer())
+
+        page_hash = "d5a10001"
+        kv_device_indices = list(range(0, self.PAGE_SIZE))  # one page at slot 0
+        side_host_indices = list(range(0, self.PAGE_SIZE))  # indexer shares slot 0
+        set_res = st.batch_set_v2_device(
+            [page_hash], kv_device_indices,
+            [_Transfer("indexer", [page_hash], side_host_indices)])
+        self.assertEqual(set_res["kv"], [True], "main KV device-direct write failed")
+        self.assertEqual(set_res["indexer"], [True], "indexer host write failed")
+
+        # Fresh, zeroed destination pools; re-point the plugin at them for the read.
+        dst_kv = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        for L in range(self.LAYER_NUM):
+            dst_kv._np[L][:] = 0
+        dst_side = FakePageFirstHostSidecarPool(
+            num_pages=4, page_size=self.PAGE_SIZE, page_bytes=self.SIDE_BYTES,
+            fill_base=0)
+        dst_side._arr[:] = 0
+        st.register_mem_pool_device(dst_kv)
+        st.register_mem_host_pool_v2(dst_side, "indexer")
+
+        get_res = st.batch_get_v2_device(
+            [page_hash], kv_device_indices,
+            [_Transfer("indexer", [page_hash], side_host_indices)])
+        self.assertEqual(get_res["kv"], [True], "main KV device-direct read failed")
+        self.assertEqual(get_res["indexer"], [True], "indexer host read failed")
+
+        # Main KV: every layer's page must match source (layer-major roundtrip).
+        for L in range(self.LAYER_NUM):
+            self.assertEqual(
+                dst_kv.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                src_kv.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                f"main KV layer {L} mismatch after DSA split roundtrip")
+        # Sidecar: the indexer page must match source (host v2 roundtrip).
+        self.assertEqual(
+            dst_side.page_bytes_at(0), src_side.page_bytes_at(0),
+            "indexer sidecar page mismatch after DSA split roundtrip")
+
+    def test_dsa_split_value_kv_and_sidecar_use_distinct_keys(self):
+        """The split value's two components must live under DISTINCT key namespaces
+        so they never overwrite each other: main KV under the @sg-chunked v1-style
+        'kv' keys, the indexer under its own '_indexer_k' key. A cross-namespace
+        collision would corrupt one component."""
+        st = self._plugin(self._node("dsakeys"))
+        h = "feedface"
+        kv_sub = st._keys(h)[0] + "@sg0"          # device-direct main KV sub-key
+        side_sub = st._pool_keys("indexer", h)[0]  # host v2 indexer sub-key
+        self.assertNotEqual(kv_sub, side_sub)
+        self.assertNotIn("indexer", kv_sub)
+        self.assertIn("indexer", side_sub)
 
 
 if __name__ == "__main__":

--- a/test/python/test_dfkv_hicache_device_direct.py
+++ b/test/python/test_dfkv_hicache_device_direct.py
@@ -1,0 +1,278 @@
+"""GPU/torch-free unit tests for the HiCache L2-bypass (device-direct write) path
+in dfkv_hicache.py.
+
+Covers the pieces that do NOT need a live cache node or libdfkv: sub-key
+expansion of per-layer device segments (_flatten_device), the exist-gate +
+transient-retry semantics of the scatter-gather put (_put_sg_flat, mirroring the
+contiguous _put_flat), and the supports_device_transfer() capability gate
+(SG symbols present AND max_sg_segs >= layer_num). Uses object.__new__ +
+monkeypatched primitives so no client is opened.
+"""
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# shim 'sglang' (no torch) first, then the real plugin source dir.
+sys.path.insert(0, HERE)
+sys.path.insert(0, os.path.join(HERE, "..", "..", "integration", "hicache"))
+
+os.environ.setdefault("DFKV_CLIENT_NODE_DEDUP", "0")
+
+import ctypes  # noqa: E402
+import subprocess  # noqa: E402
+import tempfile  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+from sglang.srt.mem_cache.hicache_storage import HiCacheStorageConfig  # noqa: E402
+import dfkv_hicache  # noqa: E402
+
+BUILD = os.environ.get("DFKV_BUILD", os.path.join(HERE, "..", "..", "build"))
+SERVER_BIN = os.path.join(BUILD, "dfkv_server")
+
+
+def _bare(**attrs):
+    """A DfkvHiCache with only the attributes a unit needs (no client opened)."""
+    obj = object.__new__(dfkv_hicache.DfkvHiCache)
+    obj.model = "m"
+    obj.tp_rank = 0
+    obj.tp_size = 1
+    obj.is_mla = True
+    obj.pp_rank = 0
+    obj.pp_size = 1
+    obj.enable_pp = False
+    obj._put_retry_recovered = 0
+    obj._backup_exist_gate = True
+    for k, v in attrs.items():
+        setattr(obj, k, v)
+    return obj
+
+
+class FakeLib:
+    def __init__(self, has_sg=True, has_width=True, max_segs=32):
+        self._max_segs = max_segs
+        if has_sg:
+            self.dfkv_batch_put_sg = lambda *a: 0
+        if has_width:
+            self.dfkv_max_sg_segs = lambda h: self._max_segs
+
+
+class TestFlattenDevice(unittest.TestCase):
+    def test_mla_single_subkey_carries_layer_segments(self):
+        obj = _bare(is_mla=True)
+        keys = ["h0", "h1"]
+        # sub=1; per-page one entry, each a 3-layer segment list.
+        seg_ptrs = [[10, 11, 12], [20, 21, 22]]
+        seg_sizes = [[100, 100, 100], [100, 100, 100]]
+        sub, sks, sp, ss = obj._flatten_device(keys, seg_ptrs, seg_sizes)
+        self.assertEqual(sub, 1)
+        self.assertEqual(sks, ["m/h0_k", "m/h1_k"])
+        self.assertEqual(sp, [[10, 11, 12], [20, 21, 22]])
+        self.assertEqual(ss, [[100, 100, 100], [100, 100, 100]])
+
+    def test_mha_expands_k_and_v_subkeys(self):
+        obj = _bare(is_mla=False, tp_size=2, tp_rank=1)
+        keys = ["h0"]
+        seg_ptrs = [[1, 2], [3, 4]]  # entry0=k, entry1=v (sub=2)
+        seg_sizes = [[8, 8], [8, 8]]
+        sub, sks, sp, ss = obj._flatten_device(keys, seg_ptrs, seg_sizes)
+        self.assertEqual(sub, 2)
+        self.assertEqual(sks, ["m/h0_2_1_k", "m/h0_2_1_v"])
+        self.assertEqual(sp, [[1, 2], [3, 4]])
+
+    def test_shape_mismatch_asserts(self):
+        obj = _bare(is_mla=False)  # sub=2
+        with self.assertRaises(AssertionError):
+            obj._flatten_device(["h0"], [[1, 2]], [[8, 8]])  # only 1 entry, needs 2
+
+
+class TestPutSgFlat(unittest.TestCase):
+    def test_exist_gate_skips_present_subkeys(self):
+        obj = _bare()
+        obj._batch_exist_flat = lambda sks: [True, True]  # both already in L3
+        calls = []
+        obj._batch_put_sg = lambda sks, sp, ss: calls.append(sks) or [True] * len(sks)
+        res = obj._put_sg_flat(["a", "b"], [[1]], [[8]])
+        self.assertEqual(res, [True, True])
+        self.assertEqual(calls, [])  # nothing written — gate short-circuited
+
+    def test_transient_failure_recovered_on_retry(self):
+        obj = _bare()
+        obj._batch_exist_flat = lambda sks: [False]  # not present -> must write
+        seq = [[False], [True]]  # first put fails, retry succeeds
+        obj._batch_put_sg = lambda sks, sp, ss: seq.pop(0)
+        res = obj._put_sg_flat(["a"], [[1]], [[8]])
+        self.assertEqual(res, [True])
+        self.assertEqual(obj._put_retry_recovered, 1)
+
+    def test_persistent_failure_stays_false(self):
+        obj = _bare()
+        obj._batch_exist_flat = lambda sks: [False]
+        obj._batch_put_sg = lambda sks, sp, ss: [False]  # never succeeds
+        res = obj._put_sg_flat(["a"], [[1]], [[8]])
+        self.assertEqual(res, [False])
+        self.assertEqual(obj._put_retry_recovered, 0)
+
+    def test_gate_disabled_writes_all(self):
+        obj = _bare()
+        obj._backup_exist_gate = False
+        obj._batch_exist_flat = lambda sks: (_ for _ in ()).throw(
+            AssertionError("exist must not be called when gate disabled"))
+        obj._batch_put_sg = lambda sks, sp, ss: [True] * len(sks)
+        self.assertEqual(obj._put_sg_flat(["a", "b"], [[1], [2]], [[8], [8]]),
+                         [True, True])
+
+
+class TestSupportsDeviceTransfer(unittest.TestCase):
+    def test_enabled_when_symbols_present_and_width_ok(self):
+        obj = _bare(cfg={"layer_num": 32}, _lib=FakeLib(max_segs=32), _h=1)
+        self.assertTrue(obj.supports_device_transfer())
+
+    def test_declined_when_width_too_small(self):
+        obj = _bare(cfg={"layer_num": 61}, _lib=FakeLib(max_segs=29), _h=1)
+        self.assertFalse(obj.supports_device_transfer())
+
+    def test_declined_without_sg_symbol(self):
+        obj = _bare(cfg={"layer_num": 4}, _lib=FakeLib(has_sg=False), _h=1)
+        self.assertFalse(obj.supports_device_transfer())
+
+    def test_declined_without_layer_num(self):
+        obj = _bare(cfg={}, _lib=FakeLib(), _h=1)
+        self.assertFalse(obj.supports_device_transfer())
+
+
+class _NpTensor:
+    """numpy-backed stand-in for a torch device tensor (data_ptr/numel/elt size)."""
+
+    def __init__(self, arr):
+        self._arr = arr
+
+    def data_ptr(self):
+        return self._arr.ctypes.data
+
+    def numel(self):
+        return int(self._arr.size)
+
+    def element_size(self):
+        return int(self._arr.itemsize)
+
+
+class FakeLayerFirstMlaDevicePool:
+    """Layer-first MLA GPU pool emulated with host numpy per-layer buffers, so the
+    device-direct SG write path can be exercised end-to-end without a GPU."""
+
+    def __init__(self, layer_num, size, page_size, kv_cache_dim):
+        self.page_size = page_size
+        self.kv_cache_dim = kv_cache_dim
+        self.use_dsa = False
+        slots = size + page_size
+        self._np = []
+        self.kv_buffer = []
+        for L in range(layer_num):
+            arr = np.zeros(slots * kv_cache_dim, dtype=np.uint8)
+            # Recognizable per-(layer, slot, dim) byte pattern for ordering checks.
+            for s in range(slots):
+                for d in range(kv_cache_dim):
+                    arr[s * kv_cache_dim + d] = (L * 100 + s * 10 + d) % 256
+            self._np.append(arr)
+            self.kv_buffer.append(_NpTensor(arr))
+
+    def layer_page_bytes(self, layer, slot0, npages_slots):
+        off = slot0 * self.kv_cache_dim
+        return bytes(self._np[layer][off:off + npages_slots * self.kv_cache_dim])
+
+
+@unittest.skipUnless(
+    os.path.exists(SERVER_BIN)
+    and hasattr(dfkv_hicache._load_lib(os.environ.get("DFKV_LIB")), "dfkv_batch_put_sg"),
+    "needs dfkv_server + a libdfkv.so with dfkv_batch_put_sg",
+)
+class TestDeviceDirectEndToEnd(unittest.TestCase):
+    """Drives batch_set_v1_device against a real cache node and reads the stored
+    blob back, proving (a) the write path works and (b) the stored blob is
+    LAYER-major — the transpose of a page-first host read (the load-bearing
+    correctness limitation for increment 1)."""
+
+    LAYER_NUM = 3
+    PAGE_SIZE = 4
+    KV_DIM = 5  # bytes/token/layer (dtype itemsize 1)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.procs = []
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls.procs:
+            p.terminate()
+            try:
+                p.wait(timeout=5)
+            except Exception:
+                p.kill()
+
+    def _node(self, tag):
+        d = tempfile.mkdtemp(prefix=f"dfkv_dd_{tag}_")
+        p = subprocess.Popen(
+            [SERVER_BIN, "--dir", d, "--port", "0", "--cap", str(1 << 30)],
+            stdout=subprocess.PIPE, text=True)
+        line = p.stdout.readline().strip()
+        assert line.startswith("PORT "), f"bad server greeting: {line!r}"
+        self.procs.append(p)
+        return f"{tag}=127.0.0.1:{int(line.split()[1])}"
+
+    def _plugin(self, members):
+        cfg = HiCacheStorageConfig(
+            tp_rank=0, tp_size=1, is_mla_model=True, is_page_first_layout=False,
+            model_name="dd-mla", pp_rank=0, pp_size=1,
+            extra_config={
+                "members": members, "model_hash": 0x51, "dtype_tag": 0,
+                "page_size": self.PAGE_SIZE, "layer_num": self.LAYER_NUM,
+                "head_num": 1, "head_dim": self.KV_DIM, "interface_v1": 1,
+            })
+        return dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+
+    def test_sg_write_stores_layer_major_blob(self):
+        st = self._plugin(self._node("dd"))
+        pool = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        st.register_mem_pool_device(pool)
+        self.assertTrue(st.supports_device_transfer())
+
+        page_hash = "deadbeef"
+        device_indices = list(range(0, self.PAGE_SIZE))  # one page at slot 0
+        res = st.batch_set_v1_device([page_hash], device_indices)
+        self.assertEqual(res, [True])
+
+        # Read the stored blob back contiguously (what the stock host get does).
+        sk = st._keys(page_hash)[0]
+        cap = self.LAYER_NUM * self.PAGE_SIZE * self.KV_DIM
+        buf = ctypes.create_string_buffer(cap)
+        rc = st._lib.dfkv_get(st._h, sk.encode(), ctypes.cast(buf, ctypes.c_void_p),
+                              ctypes.c_uint64(cap))
+        self.assertEqual(rc, 1, "device-direct page must be retrievable")
+        blob = bytes(buf.raw[:cap])
+
+        # The SG-stored blob is the in-order concat of per-layer segments:
+        # layer0(page), layer1(page), layer2(page) — LAYER-major.
+        layer_major = b"".join(
+            pool.layer_page_bytes(L, 0, self.PAGE_SIZE)
+            for L in range(self.LAYER_NUM))
+        self.assertEqual(blob, layer_major)
+
+        # A page-first host pool would lay the same page out TOKEN-major
+        # (tok0[L0..L2], tok1[...], ...). It differs — so an unchanged page-first
+        # host read of this device-written page would transpose the bytes. This
+        # is the documented increment-1 limitation.
+        token_major = bytearray()
+        for tok in range(self.PAGE_SIZE):
+            for L in range(self.LAYER_NUM):
+                base = tok * self.KV_DIM
+                token_major += pool._np[L][base:base + self.KV_DIM].tobytes()
+        self.assertNotEqual(blob, bytes(token_major),
+                            "layer-major vs page-first must differ for layer_num>1")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/python/test_dfkv_hicache_device_direct.py
+++ b/test/python/test_dfkv_hicache_device_direct.py
@@ -50,10 +50,12 @@ def _bare(**attrs):
 
 
 class FakeLib:
-    def __init__(self, has_sg=True, has_width=True, max_segs=32):
+    def __init__(self, has_sg=True, has_get_sg=True, has_width=True, max_segs=32):
         self._max_segs = max_segs
         if has_sg:
             self.dfkv_batch_put_sg = lambda *a: 0
+        if has_get_sg:
+            self.dfkv_batch_get_auto_sg = lambda *a: 0
         if has_width:
             self.dfkv_max_sg_segs = lambda h: self._max_segs
 
@@ -137,9 +139,50 @@ class TestSupportsDeviceTransfer(unittest.TestCase):
         obj = _bare(cfg={"layer_num": 4}, _lib=FakeLib(has_sg=False), _h=1)
         self.assertFalse(obj.supports_device_transfer())
 
+    def test_declined_without_get_sg_symbol(self):
+        # Read-side symbol missing: a page could be written but never read back,
+        # so the bypass path is declined (increment 2 requires the SG GET twin).
+        obj = _bare(cfg={"layer_num": 4}, _lib=FakeLib(has_get_sg=False), _h=1)
+        self.assertFalse(obj.supports_device_transfer())
+
     def test_declined_without_layer_num(self):
         obj = _bare(cfg={}, _lib=FakeLib(), _h=1)
         self.assertFalse(obj.supports_device_transfer())
+
+
+class TestBatchGetV1DeviceFold(unittest.TestCase):
+    """Pure-python fold semantics of the device-direct READ (no client/GPU): a
+    page is a hit only if every sub-object hit AND returned its full capacity;
+    a short read (truncated blob) is a per-page failure so the caller recomputes."""
+
+    def _meta_pool(self):
+        # Minimal MLA layer-first pool (1 page @ slot0, 2 layers, dim 4).
+        return FakeLayerFirstMlaDevicePool(
+            layer_num=2, size=8, page_size=4, kv_cache_dim=4)
+
+    def _obj(self, pool):
+        return _bare(is_mla=True, mem_pool_device=pool, _alog_tag="r0",
+                     _metrics=dfkv_hicache._Metrics(0))
+
+    def test_full_hit_is_page_success(self):
+        obj = self._obj(self._meta_pool())
+        # each MLA page sub-object wants page_size*kv_dim per layer * 2 layers.
+        want = 4 * 4 * 2
+        obj._batch_get_sg = lambda sks, sp, sc: ([1], [want])
+        res = obj.batch_get_v1_device(["h0"], list(range(4)))
+        self.assertEqual(res, [True])
+
+    def test_miss_is_page_failure(self):
+        obj = self._obj(self._meta_pool())
+        obj._batch_get_sg = lambda sks, sp, sc: ([0], [0])
+        self.assertEqual(obj.batch_get_v1_device(["h0"], list(range(4))), [False])
+
+    def test_short_read_is_page_failure(self):
+        obj = self._obj(self._meta_pool())
+        want = 4 * 4 * 2
+        # hit==1 but only half the bytes came back -> corrupt page -> failure.
+        obj._batch_get_sg = lambda sks, sp, sc: ([1], [want // 2])
+        self.assertEqual(obj.batch_get_v1_device(["h0"], list(range(4))), [False])
 
 
 class _NpTensor:
@@ -272,6 +315,57 @@ class TestDeviceDirectEndToEnd(unittest.TestCase):
                 token_major += pool._np[L][base:base + self.KV_DIM].tobytes()
         self.assertNotEqual(blob, bytes(token_major),
                             "layer-major vs page-first must differ for layer_num>1")
+
+    def test_device_direct_write_then_read_roundtrip(self):
+        """Increment 2: write a page device-direct, then read it back device-direct
+        into a FRESH destination pool via SG GET, and assert every per-layer page
+        segment is byte-identical to the source. This proves the layer-major SG
+        write + layer-major SG-GET scatter reassemble a byte-consistent device page
+        (the pairing the increment-1 transpose note requires)."""
+        st = self._plugin(self._node("rt"))
+        src = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        st.register_mem_pool_device(src)
+        self.assertTrue(st.supports_device_transfer())
+
+        page_hash = "cafef00d"
+        device_indices = list(range(0, self.PAGE_SIZE))  # one page at slot 0
+        self.assertEqual(st.batch_set_v1_device([page_hash], device_indices), [True])
+
+        # Fresh, zeroed destination pool. Re-point the plugin's device pool to it
+        # (register_mem_pool_device sets self.mem_pool_device), so the SG GET
+        # scatters the stored blob back into the destination's per-layer segments.
+        dst = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        for L in range(self.LAYER_NUM):
+            dst._np[L][:] = 0
+        st.register_mem_pool_device(dst)
+
+        res = st.batch_get_v1_device([page_hash], device_indices)
+        self.assertEqual(res, [True], "device-direct page must read back")
+
+        # Every layer's page bytes in the destination must match the source: the
+        # write stored layer0(page)|layer1(page)|... and the SG GET scattered that
+        # same order back into dst's per-layer segments -> byte-consistent.
+        for L in range(self.LAYER_NUM):
+            self.assertEqual(
+                dst.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                src.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                f"layer {L} page mismatch after device-direct roundtrip")
+
+    def test_device_direct_read_miss_returns_false(self):
+        """A key never written must read back as a miss (not a phantom hit) so the
+        scheduler recomputes instead of serving garbage device slots."""
+        st = self._plugin(self._node("miss"))
+        dst = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        st.register_mem_pool_device(dst)
+        self.assertEqual(
+            st.batch_get_v1_device(["never_written"], list(range(self.PAGE_SIZE))),
+            [False])
 
 
 if __name__ == "__main__":

--- a/test/python/test_dfkv_hicache_device_direct.py
+++ b/test/python/test_dfkv_hicache_device_direct.py
@@ -219,12 +219,73 @@ class _NpTensor:
 
 
 class _Transfer:
-    """Minimal PoolTransfer stand-in for the v2 sidecar path (name/keys/host_indices)."""
+    """Minimal PoolTransfer stand-in for the HOST v2 sidecar path
+    (name/keys/host_indices; device_indices None)."""
 
     def __init__(self, name, keys, host_indices):
         self.name = name
         self.keys = keys
         self.host_indices = host_indices
+        self.device_indices = None
+
+
+class _DeviceTransfer:
+    """Minimal PoolTransfer stand-in for the DEVICE-direct sidecar path (task 4):
+    device_indices set (the main-KV slots the indexer rides), host_indices None."""
+
+    def __init__(self, name, keys, device_indices):
+        self.name = name
+        self.keys = keys
+        self.device_indices = device_indices
+        self.host_indices = None
+
+
+class _NpTensor2D:
+    """numpy-backed 2D stand-in for a torch device tensor, exposing the shape/stride
+    surface get_device_sidecar_page_buffer_meta needs (plus data_ptr/numel/elt)."""
+
+    def __init__(self, arr):
+        self._arr = arr
+
+    def data_ptr(self):
+        return self._arr.ctypes.data
+
+    def numel(self):
+        return int(self._arr.size)
+
+    def element_size(self):
+        return int(self._arr.itemsize)
+
+    @property
+    def shape(self):
+        return self._arr.shape
+
+    def stride(self, dim=None):
+        strides = tuple(s // self._arr.itemsize for s in self._arr.strides)
+        return strides if dim is None else strides[dim]
+
+
+class FakeLayerFirstIndexerDevicePool:
+    """Layer-first, PAGE-indexed DSA indexer GPU pool emulated with host numpy: a
+    list of per-layer 2D buffers (num_pages, page_bytes), so the device-direct sidecar
+    SG path (task 4) can be exercised end-to-end without a GPU. Row (slot // page_size)
+    of layer L holds the whole page's index+scale for that layer."""
+
+    def __init__(self, layer_num, num_pages, page_size, page_bytes):
+        self.page_size = page_size
+        self.page_bytes = page_bytes
+        self._np = []
+        self.index_k_with_scale_buffer = []
+        for L in range(layer_num):
+            arr = np.zeros((num_pages, page_bytes), dtype=np.uint8)
+            for pg in range(num_pages):
+                for b in range(page_bytes):
+                    arr[pg, b] = (L * 90 + pg * 13 + b) % 256
+            self._np.append(arr)
+            self.index_k_with_scale_buffer.append(_NpTensor2D(arr))
+
+    def layer_page_bytes(self, layer, page_idx):
+        return bytes(self._np[layer][page_idx].tobytes())
 
 
 class FakePageFirstHostSidecarPool:
@@ -503,6 +564,132 @@ class TestDeviceDirectEndToEnd(unittest.TestCase):
         self.assertNotEqual(kv_sub, side_sub)
         self.assertNotIn("indexer", kv_sub)
         self.assertIn("indexer", side_sub)
+        # Task 4: the device-direct sidecar stores an "@sg0"-chunked indexer key —
+        # still its own namespace, distinct from the main KV.
+        side_sub_dev = st._pool_keys("indexer", h)[0] + "@sg0"
+        self.assertNotEqual(kv_sub, side_sub_dev)
+        self.assertIn("indexer", side_sub_dev)
+
+    # Task 4: DSA split-value with the indexer sidecar ALSO device-direct.
+    SIDE_DEV_BYTES = 6  # indexer page-row bytes (page_size * indexer bytes/token-ish)
+
+    def test_dsa_split_value_device_sidecar_roundtrip(self):
+        """DSA (GLM-5.2) L2-bypass, task 4: BOTH the main MLA latent AND the DSA
+        indexer sidecar ride the device-direct SG path — no host staging. The indexer
+        is layer-first & PAGE-indexed, so it @sg-chunks exactly like the main latent.
+        batch_set_v2_device writes both from GPU slots; batch_get_v2_device reads both
+        back into FRESH device pools, byte-identical per layer. Proves the sidecar's
+        layer-major device write/read reassemble byte-exact under distinct keys."""
+        st = self._plugin(self._node("dsadev"))
+        src_kv = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        src_side = FakeLayerFirstIndexerDevicePool(
+            self.LAYER_NUM, num_pages=4, page_size=self.PAGE_SIZE,
+            page_bytes=self.SIDE_DEV_BYTES)
+        st.register_mem_pool_device(src_kv)
+        st.register_mem_pool_device_sidecar("indexer", src_side)
+        self.assertTrue(st.supports_device_transfer())
+
+        page_hash = "d5adev01"
+        kv_dev = list(range(0, self.PAGE_SIZE))  # one page at slot 0
+        set_res = st.batch_set_v2_device(
+            [page_hash], kv_dev,
+            [_DeviceTransfer("indexer", [page_hash], kv_dev)])
+        self.assertEqual(set_res["kv"], [True], "main KV device-direct write failed")
+        self.assertEqual(set_res["indexer"], [True],
+                         "indexer device-direct write failed")
+
+        # Fresh, zeroed destination pools; re-point the plugin at them for the read.
+        dst_kv = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        for L in range(self.LAYER_NUM):
+            dst_kv._np[L][:] = 0
+        dst_side = FakeLayerFirstIndexerDevicePool(
+            self.LAYER_NUM, num_pages=4, page_size=self.PAGE_SIZE,
+            page_bytes=self.SIDE_DEV_BYTES)
+        for L in range(self.LAYER_NUM):
+            dst_side._np[L][:] = 0
+        st.register_mem_pool_device(dst_kv)
+        st.register_mem_pool_device_sidecar("indexer", dst_side)
+
+        get_res = st.batch_get_v2_device(
+            [page_hash], kv_dev,
+            [_DeviceTransfer("indexer", [page_hash], kv_dev)])
+        self.assertEqual(get_res["kv"], [True], "main KV device-direct read failed")
+        self.assertEqual(get_res["indexer"], [True],
+                         "indexer device-direct read failed")
+
+        for L in range(self.LAYER_NUM):
+            self.assertEqual(
+                dst_kv.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                src_kv.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                f"main KV layer {L} mismatch after device-sidecar roundtrip")
+        # Indexer page-row 0 (slot 0 // page_size) must match source per layer.
+        for L in range(self.LAYER_NUM):
+            self.assertEqual(
+                dst_side.layer_page_bytes(L, 0),
+                src_side.layer_page_bytes(L, 0),
+                f"indexer layer {L} mismatch after device-sidecar roundtrip")
+
+    def test_device_sidecar_read_miss_returns_false(self):
+        """A device-direct sidecar page never written must read back as a miss so the
+        controller recomputes rather than serving garbage GPU index slots."""
+        st = self._plugin(self._node("dsadevmiss"))
+        dst_kv = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        dst_side = FakeLayerFirstIndexerDevicePool(
+            self.LAYER_NUM, num_pages=4, page_size=self.PAGE_SIZE,
+            page_bytes=self.SIDE_DEV_BYTES)
+        st.register_mem_pool_device(dst_kv)
+        st.register_mem_pool_device_sidecar("indexer", dst_side)
+        kv_dev = list(range(0, self.PAGE_SIZE))
+        res = st.batch_get_v2_device(
+            ["never_dev"], kv_dev, [_DeviceTransfer("indexer", ["never_dev"], kv_dev)])
+        self.assertEqual(res["kv"], [False])
+        self.assertEqual(res["indexer"], [False])
+
+    # Task 6: EAGLE draft KV device-direct L3.
+    def test_draft_device_direct_roundtrip(self):
+        """Task 6: the EAGLE draft KV rides the device-direct SG path under its own
+        `.draft` namespace (distinct from the target). Write the draft from GPU slots,
+        read it back into a FRESH draft pool, byte-identical per layer."""
+        st = self._plugin(self._node("draft"))
+        src = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        st.register_mem_pool_device_draft(src)
+        page_hash = "draf7001"
+        dev = list(range(0, self.PAGE_SIZE))
+        self.assertEqual(st.batch_set_v1_device_draft([page_hash], dev), [True])
+
+        dst = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        for L in range(self.LAYER_NUM):
+            dst._np[L][:] = 0
+        st.register_mem_pool_device_draft(dst)
+        self.assertEqual(st.batch_get_v1_device_draft([page_hash], dev), [True])
+        for L in range(self.LAYER_NUM):
+            self.assertEqual(
+                dst.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                src.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                f"draft layer {L} mismatch after device-direct roundtrip")
+
+    def test_draft_keys_distinct_and_tp_aware(self):
+        """Draft keys are a distinct namespace from the target and follow the DRAFT
+        pool shape: MLA draft (sub=1) has no tp suffix (replicated); MHA draft (sub=2)
+        carries tp_size/tp_rank so TP ranks do not collide."""
+        st = _bare(is_mla=True, tp_size=2, tp_rank=1, pp_rank=0, pp_size=1,
+                   enable_pp=False, model="m")
+        h = "abc123"
+        self.assertNotIn(".draft", st._keys(h)[0])
+        mla_draft = st._draft_keys(h, 1)
+        self.assertEqual(mla_draft, ["m/abc123.draft_k"])
+        mha_draft = st._draft_keys(h, 2)
+        self.assertEqual(mha_draft, ["m/abc123.draft_2_1_k", "m/abc123.draft_2_1_v"])
 
 
 if __name__ == "__main__":

--- a/test/python/test_dfkv_hicache_device_direct.py
+++ b/test/python/test_dfkv_hicache_device_direct.py
@@ -69,7 +69,7 @@ class TestFlattenDevice(unittest.TestCase):
         seg_sizes = [[100, 100, 100], [100, 100, 100]]
         sub, sks, sp, ss = obj._flatten_device(keys, seg_ptrs, seg_sizes)
         self.assertEqual(sub, 1)
-        self.assertEqual(sks, ["m/h0_k", "m/h1_k"])
+        self.assertEqual(sks, ["m/h0_k@sg0", "m/h1_k@sg0"])
         self.assertEqual(sp, [[10, 11, 12], [20, 21, 22]])
         self.assertEqual(ss, [[100, 100, 100], [100, 100, 100]])
 
@@ -80,8 +80,20 @@ class TestFlattenDevice(unittest.TestCase):
         seg_sizes = [[8, 8], [8, 8]]
         sub, sks, sp, ss = obj._flatten_device(keys, seg_ptrs, seg_sizes)
         self.assertEqual(sub, 2)
-        self.assertEqual(sks, ["m/h0_2_1_k", "m/h0_2_1_v"])
+        self.assertEqual(sks, ["m/h0_2_1_k@sg0", "m/h0_2_1_v@sg0"])
         self.assertEqual(sp, [[1, 2], [3, 4]])
+
+    def test_chunk_split_when_width_below_layers(self):
+        # 5 layers on a width-2 lib -> 3 chunks per sub-object, consecutive
+        # slices, deterministic order (the read side derives the same split).
+        obj = _bare(is_mla=True, _lib=FakeLib(max_segs=2), _h=1)
+        seg_ptrs = [[10, 11, 12, 13, 14]]
+        seg_sizes = [[1, 2, 3, 4, 5]]
+        sub, sks, sp, ss = obj._flatten_device(["h0"], seg_ptrs, seg_sizes)
+        self.assertEqual(sub, 3)
+        self.assertEqual(sks, ["m/h0_k@sg0", "m/h0_k@sg1", "m/h0_k@sg2"])
+        self.assertEqual(sp, [[10, 11], [12, 13], [14]])
+        self.assertEqual(ss, [[1, 2], [3, 4], [5]])
 
     def test_shape_mismatch_asserts(self):
         obj = _bare(is_mla=False)  # sub=2
@@ -131,8 +143,13 @@ class TestSupportsDeviceTransfer(unittest.TestCase):
         obj = _bare(cfg={"layer_num": 32}, _lib=FakeLib(max_segs=32), _h=1)
         self.assertTrue(obj.supports_device_transfer())
 
-    def test_declined_when_width_too_small(self):
+    def test_chunked_when_width_too_small(self):
+        # Narrow HCA no longer declines: pages chunk into @sg{n} sub-keys.
         obj = _bare(cfg={"layer_num": 61}, _lib=FakeLib(max_segs=29), _h=1)
+        self.assertTrue(obj.supports_device_transfer())
+
+    def test_declined_when_width_zero(self):
+        obj = _bare(cfg={"layer_num": 61}, _lib=FakeLib(max_segs=0), _h=1)
         self.assertFalse(obj.supports_device_transfer())
 
     def test_declined_without_sg_symbol(self):
@@ -289,7 +306,9 @@ class TestDeviceDirectEndToEnd(unittest.TestCase):
         self.assertEqual(res, [True])
 
         # Read the stored blob back contiguously (what the stock host get does).
-        sk = st._keys(page_hash)[0]
+        # Device-direct sub-keys carry the "@sg{n}" chunk suffix; LAYER_NUM=3
+        # fits one chunk on this fake lib, so the whole page is under @sg0.
+        sk = st._keys(page_hash)[0] + "@sg0"
         cap = self.LAYER_NUM * self.PAGE_SIZE * self.KV_DIM
         buf = ctypes.create_string_buffer(cap)
         rc = st._lib.dfkv_get(st._h, sk.encode(), ctypes.cast(buf, ctypes.c_void_p),

--- a/test/python/test_dfkv_hicache_device_direct.py
+++ b/test/python/test_dfkv_hicache_device_direct.py
@@ -347,6 +347,29 @@ class FakeLayerFirstMlaDevicePool:
         return bytes(self._np[layer][off:off + npages_slots * self.kv_cache_dim])
 
 
+class FakeDsaDraftDevicePool(FakeLayerFirstMlaDevicePool):
+    """A DSA draft GPU pool (GLM-5.2 MTP draft = DSATokenToKVPool): the main MLA
+    latent (kv_buffer, token-indexed) AND the DSA indexer sidecar
+    (index_k_with_scale_buffer, layer-first page-indexed), sharing the page slots.
+    Exercises the device-direct draft latent + indexer path off-GPU."""
+
+    def __init__(self, layer_num, size, page_size, kv_cache_dim, num_pages, side_bytes):
+        super().__init__(layer_num, size, page_size, kv_cache_dim)
+        self.use_dsa = True
+        self._side_np = []
+        self.index_k_with_scale_buffer = []
+        for L in range(layer_num):
+            arr = np.zeros((num_pages, side_bytes), dtype=np.uint8)
+            for pg in range(num_pages):
+                for b in range(side_bytes):
+                    arr[pg, b] = (L * 77 + pg * 19 + b) % 256
+            self._side_np.append(arr)
+            self.index_k_with_scale_buffer.append(_NpTensor2D(arr))
+
+    def side_layer_page_bytes(self, layer, page_idx):
+        return bytes(self._side_np[layer][page_idx].tobytes())
+
+
 @unittest.skipUnless(
     os.path.exists(SERVER_BIN)
     and hasattr(dfkv_hicache._load_lib(os.environ.get("DFKV_LIB")), "dfkv_batch_put_sg"),
@@ -690,6 +713,91 @@ class TestDeviceDirectEndToEnd(unittest.TestCase):
         self.assertEqual(mla_draft, ["m/abc123.draft_k"])
         mha_draft = st._draft_keys(h, 2)
         self.assertEqual(mha_draft, ["m/abc123.draft_2_1_k", "m/abc123.draft_2_1_v"])
+
+    # DSA draft (GLM-5.2 MTP): draft main latent + draft indexer sidecar, both device.
+    def test_dsa_draft_device_direct_latent_and_indexer_roundtrip(self):
+        """A GLM-5.2 MTP draft is a DSATokenToKVPool: its main MLA latent AND its DSA
+        indexer sidecar (index_k_with_scale_buffer) both ride the device-direct path
+        under distinct namespaces (`.draft_k` / `draft_indexer`). Without the indexer
+        the draft's sparse attention would select on garbage; this proves BOTH
+        components reassemble byte-exact so the loaded draft page is coherent."""
+        st = self._plugin(self._node("dsadraft"))
+        src = FakeDsaDraftDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM, num_pages=4, side_bytes=self.SIDE_DEV_BYTES)
+        st.register_mem_pool_device_draft(src)
+        st.register_mem_pool_device_draft_sidecar(src)
+        page_hash = "dsadr701"
+        dev = list(range(0, self.PAGE_SIZE))
+        self.assertEqual(
+            st.batch_set_v1_device_draft([page_hash], dev), [True],
+            "DSA draft latent+indexer device-direct write failed")
+
+        dst = FakeDsaDraftDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM, num_pages=4, side_bytes=self.SIDE_DEV_BYTES)
+        for L in range(self.LAYER_NUM):
+            dst._np[L][:] = 0
+            dst._side_np[L][:] = 0
+        st.register_mem_pool_device_draft(dst)
+        st.register_mem_pool_device_draft_sidecar(dst)
+        self.assertEqual(
+            st.batch_get_v1_device_draft([page_hash], dev), [True],
+            "DSA draft latent+indexer device-direct read failed")
+        for L in range(self.LAYER_NUM):
+            self.assertEqual(
+                dst.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                src.layer_page_bytes(L, 0, self.PAGE_SIZE),
+                f"draft latent layer {L} mismatch after DSA-draft roundtrip")
+            self.assertEqual(
+                dst.side_layer_page_bytes(L, 0),
+                src.side_layer_page_bytes(L, 0),
+                f"draft indexer layer {L} mismatch after DSA-draft roundtrip")
+
+    def test_dsa_draft_indexer_read_miss_is_page_failure(self):
+        """Coherence AND on read: a DSA draft page whose indexer was never stored
+        reads back as a miss (even if the latent existed), so the draft recomputes
+        rather than attending over a stale/garbage indexer."""
+        st = self._plugin(self._node("dsadraftmiss"))
+        dst = FakeDsaDraftDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM, num_pages=4, side_bytes=self.SIDE_DEV_BYTES)
+        st.register_mem_pool_device_draft(dst)
+        st.register_mem_pool_device_draft_sidecar(dst)
+        dev = list(range(0, self.PAGE_SIZE))
+        self.assertEqual(st.batch_get_v1_device_draft(["neverdsa"], dev), [False])
+
+    def test_dense_draft_no_sidecar_is_latent_only(self):
+        """A dense (non-DSA) draft never registers a sidecar, so the draft path is
+        latent-only and byte-identical to task 6 — the sidecar hooks return None and
+        do not touch the result."""
+        st = self._plugin(self._node("densedraft"))
+        self.assertIsNone(st._draft_sidecar_device_set(["h"], list(range(self.PAGE_SIZE))))
+        self.assertIsNone(st._draft_sidecar_device_get(["h"], list(range(self.PAGE_SIZE))))
+        src = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        st.register_mem_pool_device_draft(src)
+        page_hash = "dense701"
+        dev = list(range(0, self.PAGE_SIZE))
+        self.assertEqual(st.batch_set_v1_device_draft([page_hash], dev), [True])
+        dst = FakeLayerFirstMlaDevicePool(
+            self.LAYER_NUM, size=self.PAGE_SIZE * 2, page_size=self.PAGE_SIZE,
+            kv_cache_dim=self.KV_DIM)
+        for L in range(self.LAYER_NUM):
+            dst._np[L][:] = 0
+        st.register_mem_pool_device_draft(dst)
+        self.assertEqual(st.batch_get_v1_device_draft([page_hash], dev), [True])
+
+    def test_draft_indexer_keys_distinct_namespace(self):
+        """The DSA draft indexer rides its own `draft_indexer` key namespace, distinct
+        from the draft latent (`.draft_k`) and the target indexer (`_indexer_k`)."""
+        st = _bare(is_mla=True, tp_size=1, tp_rank=0, pp_rank=0, pp_size=1,
+                   enable_pp=False, model="m")
+        h = "abc123"
+        self.assertEqual(st._pool_keys("draft_indexer", h), ["m/abc123_draft_indexer_k"])
+        self.assertNotEqual(st._pool_keys("draft_indexer", h), st._draft_keys(h, 1))
+        self.assertNotEqual(st._pool_keys("draft_indexer", h), st._pool_keys("indexer", h))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds a **device-direct (L2-bypass) path** to the dfkv HiCache connector: KV pages RDMA straight between GPU KV-cache slots and dfkv L3, skipping the host (L2) staging buffer entirely — the connector-side half of a SGLang HiCache "L1↔L3, no L2" prototype. Also shards the SG batch-**put** path across connections (the read path was already sharded).

All changes are additive and gated by the SGLang controller's capability probe (`supports_device_transfer()`); the stock host path is untouched when the engine doesn't request device-direct.

## What's here
- **`batch_set/get_v1_device`** — scatter-gather RDMA from/into GPU device pointers (`dfkv_register_memory` yields a GPUDirect MR under nvidia-peermem, exactly like the vLLM `DfkvStoreConnector`). Layer-first device pool → per-layer SG segments.
- **`@sg{n}` sub-key chunking** — a page's `layer_num` segments exceed a single key's SGE budget (`max_sge-1`=29 on ConnectX vs 36/78 layers), so each sub-object is split into `ceil(layer_num/width)` consecutive-layer chunks under `<key>@sg{n}` (same scheme the vLLM connector uses). Write and read derive the identical split; `batch_exists` probes `@sg0`.
- **DSA split-value** (`batch_set/get_v2_device`) — main MLA latent goes device-direct under the `@sg` keys; the indexer sidecar (also layer-first) rides its own `_indexer_k@sg{n}` device keys. `batch_exists_v2` probes `@sg0` for device-registered sidecars.
- **EAGLE draft** device-direct under a distinct TP-aware `.draft` namespace (best-effort; a miss only lowers acceptance).
- **SG batch-put sharding** — `ShardGroups` pure helper (unit-tested) shared by read and write; write path now splits a node's batch across `min(MAX_CONNS, ceil(nkeys/SHARD_KEYS))` connections.

## Testing
`-k hicache` **95 passed** (was 91; +4 incl. a real-cache-node byte-exact device roundtrip for the DSA split value). New pure-logic `group_shard_test.cc` (6) + `Sg.LargeSingleNodeShardedRoundTrip`; full `ctest` 391/391. No behavior change with the flag off.

## Validation
Prototyped end-to-end on 8×B200 (GLM-5.2-NVFP4 DSA+EAGLE, and Qwen3-8B dense): needle-in-haystack byte-correct across engine restarts (KV served from L3 into GPU with no host bounce); host HiCache shrunk to 4 GB (vs 128 GB) with no correctness loss. A/B vs the stock host path: cold write +5.9%, hot-local +18.4%, hot-L3 (restart→L3 reload) +45.6% once the read is async on the SGLang side.

Companion SGLang-side patch (bind-mount prototype) lives at github.com/ketor/sglang-l2bypass. This PR is the dfkv connector half; it's self-contained and flag-gated.
