### PR TITLE
obs(hicache): diagnostics for device-direct read rejects (write/exist/read key triangle + client snapshot)

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -20,6 +20,7 @@ HiCacheStorage; the test harness supplies a no-torch shim with the same surface.
 from __future__ import annotations
 
 import ctypes
+import logging
 import os
 import sys
 import time
@@ -35,6 +36,12 @@ import dfkv_hot_config as _hot_config
 from dfkv_metrics import Metrics as _Metrics, ClientStatsPoller as _ClientStatsPoller
 from dfkv_telemetry import metrics as _push_metrics, config as _tcfg
 from dfkv_telemetry import tracing as _tracing
+
+# The module carries no logger of its own historically (observability rides the
+# access log / tracing spans). One is added here for the read-reject diagnostic,
+# which must land in the ENGINE log next to SGLang's "0 pages verified across
+# ranks" line to be readable as a pair.
+_log = logging.getLogger(__name__)
 
 _FLAG_IS_MLA = 0x1
 
@@ -1312,7 +1319,40 @@ class DfkvHiCache(HiCacheStorage):
         hits, lens = self._batch_get_sg(sks, sp, sc)
         dur = time.perf_counter() - t0
         flat_ok = [hits[i] == 1 and lens[i] >= want[i] for i in range(len(sks))]
+        if not all(flat_ok):
+            self._log_read_reject(sks, hits, lens, want, flat_ok, len(sks))
         return self._fold(flat_ok, n, sub), sum(lens), dur
+
+    def _log_read_reject(self, sks, hits, lens, want, flat_ok, nmain):
+        """Say WHY a device read rejected sub-objects, throttled to one line/30s.
+
+        Motivation (2026-07-25): SGLang's promotion drops whole loads with
+        `0 pages verified across ranks` 24-56 times per hot-L3 round even on a
+        clean baseline — exist reports the pages ARE in L3, yet the read is not
+        accepted. Without this line the two candidate causes are indistinguishable
+        from the outside:
+
+          * MISS  (hits[i] != 1)        — the sub-key is not there at all, i.e. an
+                                          exist/read key-scheme disagreement;
+          * SHORT (lens[i] < want[i])   — it is there but returned fewer bytes than
+                                          the destination expects, i.e. a layout /
+                                          @sg-chunking / capacity disagreement.
+
+        Reports the first offender's numbers so `want` vs `got` can be compared
+        directly against the page geometry."""
+        now = time.monotonic()
+        if now - getattr(self, "_read_reject_logged", 0.0) < 30.0:
+            return
+        self._read_reject_logged = now
+        miss = sum(1 for i in range(nmain) if hits[i] != 1)
+        short = sum(1 for i in range(nmain)
+                    if hits[i] == 1 and lens[i] < want[i])
+        first = next(i for i in range(nmain) if not flat_ok[i])
+        _log.warning(
+            "dfkv device read rejected %d/%d sub-objects (%d MISS, %d SHORT); "
+            "first offender: key=%s hit=%s got=%d want=%d",
+            nmain - sum(flat_ok), nmain, miss, short,
+            sks[first], hits[first], lens[first], want[first])
 
     # --- task 4: DSA indexer sidecar device-direct (no host staging) -----------
     def _sidecar_device_set(self, name, keys, device_indices):

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -1301,7 +1301,29 @@ class DfkvHiCache(HiCacheStorage):
         t0 = time.perf_counter()
         flat = self._put_sg_flat(sks, sp, ss)
         dur = time.perf_counter() - t0
+        self._log_write_keys(sks, flat, len(sks))
         return self._fold(flat, n, sub), nbytes, dur
+
+    def _log_write_keys(self, sks, flat, nmain):
+        """Print the FIRST key actually WRITTEN, throttled to one line/30s.
+
+        Completes the write/exist/read key triangle. Measured 2026-07-25 on one
+        run: 75.0% of pages write OK (47615/63528) yet device reads hit
+        0.0% (0/20746) and exist mostly reports 0/N. Pages that are written but
+        unreadable point at the key, not at capacity — and the write side was the
+        one leg of the triangle never printed. If this first_key does not share
+        the hash space of _log_exist_probe / _log_read_reject, the write path and
+        the exist/read path are hashing the same tokens differently."""
+        if not sks:
+            return
+        now = time.monotonic()
+        if now - getattr(self, "_write_keys_logged", 0.0) < 30.0:
+            return
+        self._write_keys_logged = now
+        ok = sum(1 for i in range(nmain) if flat[i])
+        _log.warning(
+            "dfkv write keys: ok=%d/%d first_key=%s last_key=%s",
+            ok, nmain, sks[0], sks[nmain - 1])
 
     def _kv_device_get(self, keys, device_indices):
         """Core of batch_get_v1_device (device-direct SG get) without the tracing /

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -1148,6 +1148,7 @@ class DfkvHiCache(HiCacheStorage):
                     break
                 n += 1
             r.result = f"prefix={n}/{total}"
+            self._log_exist_probe(sks, n, total)
             if _sp:
                 _sp.hits = n
             return n
@@ -1322,6 +1323,28 @@ class DfkvHiCache(HiCacheStorage):
         if not all(flat_ok):
             self._log_read_reject(sks, hits, lens, want, flat_ok, len(sks))
         return self._fold(flat_ok, n, sub), sum(lens), dur
+
+    def _log_exist_probe(self, sks, n, total):
+        """Print the FIRST key exist actually probed, throttled to one line/30s.
+
+        Pairs with _log_read_reject to settle a sharp contradiction seen on
+        2026-07-25: exist reports prefix=1562/1562 (every candidate page present)
+        while the device GET that follows reports 4686/4686 sub-objects MISS —
+        and 4686 = 1562 x 3 chunks, so the two are talking about the same NUMBER
+        of pages. Same key scheme on both sides (`{model}/{hash}_k@sg0`), so if
+        the strings still differ it can only be the page_hash itself: exist hashes
+        the candidate token sequence, while the GET uses the marker nodes'
+        hash_value. Printing both first-keys makes that comparison direct instead
+        of inferential."""
+        if not sks:
+            return
+        now = time.monotonic()
+        if now - getattr(self, "_exist_probe_logged", 0.0) < 30.0:
+            return
+        self._exist_probe_logged = now
+        _log.warning(
+            "dfkv exist probe: prefix=%d/%d first_key=%s last_key=%s",
+            n, total, sks[0], sks[-1])
 
     def _log_read_reject(self, sks, hits, lens, want, flat_ok, nmain):
         """Say WHY a device read rejected sub-objects, throttled to one line/30s.

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -1389,6 +1389,20 @@ class DfkvHiCache(HiCacheStorage):
         if now - getattr(self, "_read_reject_logged", 0.0) < 30.0:
             return
         self._read_reject_logged = now
+        # 整批全 MISS 时把 C 客户端快照一并 dump：服务端侧显示 cache_miss=0、
+        # cache_hit 几乎不涨(失败轮 +196/+3515 vs 成功轮 +799,744)，说明请求很可能
+        # 根本没到服务端。ops served / IO 错误 / peer 健康只存在于 C 客户端快照里，
+        # Prometheus 侧并未导出这些计数器，事后无从追溯 —— 必须当场抓。
+        if all(h != 1 for h in hits[:nmain]):
+            try:
+                snap = _read_snapshot(self._lib, self._h)
+                keep = [ln for ln in snap.splitlines()
+                        if any(k in ln for k in ("ops_served", "io_error", "unhealthy",
+                                                 "peer_", "ring_", "mds_"))]
+                _log.warning("dfkv client snapshot @full-miss: %s",
+                             " | ".join(keep[:12]) or "(快照无相关行)")
+            except Exception as e:
+                _log.warning("dfkv client snapshot @full-miss 读取失败: %r", e)
         miss = sum(1 for i in range(nmain) if hits[i] != 1)
         short = sum(1 for i in range(nmain)
                     if hits[i] == 1 and lens[i] < want[i])

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -1396,11 +1396,15 @@ class DfkvHiCache(HiCacheStorage):
         if all(h != 1 for h in hits[:nmain]):
             try:
                 snap = _read_snapshot(self._lib, self._h)
+                # 过滤掉 # HELP / # TYPE 注释行 —— 第一版没排除它们，12 个名额被注释
+                # 占满，按 peer 的错误分布和 busy_suppressed 全被截掉了。
                 keep = [ln for ln in snap.splitlines()
-                        if any(k in ln for k in ("ops_served", "io_error", "unhealthy",
-                                                 "peer_", "ring_", "mds_"))]
+                        if not ln.startswith("#")
+                        and any(k in ln for k in ("ops_served", "io_error", "unhealthy",
+                                                  "peer_", "ring_", "mds_", "busy_suppressed",
+                                                  "health_checks"))]
                 _log.warning("dfkv client snapshot @full-miss: %s",
-                             " | ".join(keep[:12]) or "(快照无相关行)")
+                             " | ".join(keep[:16]) or "(快照无相关行)")
             except Exception as e:
                 _log.warning("dfkv client snapshot @full-miss 读取失败: %r", e)
         miss = sum(1 for i in range(nmain) if hits[i] != 1)


### PR DESCRIPTION
Observability only — **no functional change** (+103 lines, one file: `integration/hicache/dfkv_hicache.py`).

## Why

Chasing an intermittent **0% L3 read-hit** failure on the L2-bypass path (xb01, GLM-5.2 NVFP4, 8×B200), the outside view was uninformative: `exist` reported the pages were present, the read returned nothing, and SGLang logged only `0 pages verified across ranks`. Nothing said *which* leg was lying.

These five commits print the three legs of the key triangle plus the C client's own counters, which is what finally made the root cause findable.

## What each commit adds

| Commit | Adds |
|---|---|
| `say WHY a device read rejects` | Splits rejects into **MISS** (`hits[i] != 1`) vs **SHORT** (`lens[i] < want[i]`) — distinguishes "not there" from "there but truncated" |
| `print the first key exist actually probed` | The exist leg of the triangle |
| `print the first key actually written` | The write leg — previously the only leg never printed |
| `dump the C client snapshot on a full-miss read` | `ops_served / io_errors / peer health / ring_members` at the moment of a full miss; these live only in the C client and are not exported to Prometheus, so they were unrecoverable after the fact |
| `full-miss dump was swallowed by HELP/TYPE lines` | Fix: the first version's 12 slots were eaten by `# HELP` / `# TYPE` comment lines |

All logging is throttled to one line / 30 s and only fires on a reject, so steady-state output is unchanged.

## What it found

The failure was **not** in storage, key scheme, eviction, or response parsing — it was the RDMA connection handshake. The snapshot showed `io_errors=16 / ops_served=18` with the server reporting `cache_miss=0`; that contradiction is what redirected the search to the transport, and from there to `Acquire → qpframe` timeouts. Root cause: the client does not declare its max block size, so the server pre-registers `qd × max_msg (64 MiB)` per connection while real transfers average 437 KiB.

## Notes

- Rebased onto current `main`; the two conflicts were mechanical (`nmain` → `len(sks)` after the sub-key refactor, and the `_kv_device_get` signature). Resolved to upstream's structure; call sites verified present after resolution.
- `python3 -m py_compile` clean.