### PR TITLE
fix(ci): scope the FetchContent cache key to the repository (unblocks all PRs after the rename)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,14 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build/_deps
-          key: deps-${{ runner.os }}-${{ matrix.compiler }}-gtest-1.12.1
+          # Scope the key to the repository: build/_deps holds googletest-subbuild,
+          # a CMake scratch tree that bakes in ABSOLUTE paths under
+          # /home/runner/work/<repo>/<repo>. Restoring it into a differently named
+          # checkout makes CMake refuse to configure ("The current CMakeCache.txt
+          # directory ... is different"), which is exactly what the dfkv ->
+          # DingoCache rename triggered. github.repository fully determines that
+          # path on hosted runners, so keying on it makes the cache rename-proof.
+          key: deps-${{ runner.os }}-${{ matrix.compiler }}-${{ github.repository }}-gtest-1.12.1
 
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
**Blocks every PR on the repo right now** — one-line change, self-validating (this PR's own CI runs with the fixed key).

## Symptom

Both `build & test` matrix jobs fail at **Configure in ~20 s**:

```
CMake Error: The current CMakeCache.txt directory
  /home/runner/work/DingoCache/DingoCache/build/_deps/googletest-subbuild/CMakeCache.txt
  is different from the directory ... where CMakeCache.txt was created
CMake Error at FetchContent.cmake:1906 (message):
  CMake step for googletest failed: 1
```

## Cause

```yaml
path: build/_deps
key: deps-${{ runner.os }}-${{ matrix.compiler }}-gtest-1.12.1
```

`build/_deps` contains `googletest-subbuild`, a CMake scratch tree that bakes in **absolute paths** under `/home/runner/work/<repo>/<repo>`. The key contained nothing path-derived, so the cache written under the old `dfkv/dfkv` checkout path is restored into the new `DingoCache/DingoCache` one, and CMake refuses to configure.

What pins it on the cache rather than on any source change: **every job that does not restore this cache passed** on the same run — RDMA build (compile-check), RDMA datapath (Soft-RoCE + TSan), ThreadSanitizer, portable static artifacts. Only the two jobs with the cache step failed, and they failed before compiling a single file.

## Fix

Add `${{ github.repository }}` to the key. On hosted runners the checkout path is fully determined by the repository name, so the cache now invalidates exactly when the path changes and never otherwise — rename-proof from here on.

## Follow-up worth considering (not in this PR)

Caching `build/_deps` is fragile by construction: it stores a CMake scratch tree, not just downloaded sources. A sturdier setup caches only the fetched sources (e.g. a shared `FETCHCONTENT_BASE_DIR` holding `*-src` and pointing `FETCHCONTENT_SOURCE_DIR_GOOGLETEST` at it) so nothing path-bound is ever restored. Left out here to keep the unblocking change reviewable in one line.