### PR TITLE
obs(rdma): report observed max block size; stop failing silently on an under-sized DFKV_RDMA_MAX_BLOCK_BYTES

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -551,7 +551,7 @@ std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
   // cost every sibling its cache hit.
   std::vector<char> bad(n, 0);
   for (size_t i = 0; i < n; ++i)
-    if (dsts[i].n > OpBound()) bad[i] = 1;
+    if (NoteBlock(dsts[i].n)) bad[i] = 1;
 
   // 2-attempt loop: retry a stale pooled conn once on a fresh one. Range is a read
   // (idempotent) and the scatter lands in the caller's buffers, so replaying the
@@ -648,7 +648,7 @@ std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
   std::vector<char> bad(n, 0);
   for (size_t i = 0; i < n; ++i) {
     const CacheSrc& s = srcs[i];
-    if (s.header_len > control_cap_ - kReqPrefix || s.payload_len > OpBound()) bad[i] = 1;
+    if (NoteBlock(s.payload_len) || s.header_len > control_cap_ - kReqPrefix) bad[i] = 1;
   }
 
   // 2-attempt loop: retry a stale pooled conn once on a fresh one. Cache is
@@ -757,7 +757,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       const auto& s = srcs[i];
       size_t total = 0;
       for (const auto& p : s.payloads) total += p.second;
-      if (s.header_len > control_cap_ - kReqPrefix || total > OpBound() ||
+      if (NoteBlock(total) || s.header_len > control_cap_ - kReqPrefix ||
           s.payloads.size() > max_payload_segs) {
         bad[i] = 1;
         res[i] = Status::kInvalid;
@@ -836,6 +836,42 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   return res;
 }
 
+// Records n as a high-water candidate and reports whether it exceeds the
+// declaration. Two problems this closes, both observed on a B200 node:
+//
+//  1. Sizing DFKV_RDMA_MAX_BLOCK_BYTES was guesswork. The declaration decides
+//     how much the SERVER pins per connection -- qd x (ValueHeader + declared),
+//     ~1 GiB per connection at qd=32/16MiB measured -- so an over-generous
+//     value is not free: it is server memory multiplied by every connection in
+//     the fleet. The only figure an operator could see was the AVERAGE transfer
+//     size (437 KiB there), which says nothing about the peak that must fit.
+//
+//  2. An UNDER-sized declaration failed silently. Oversized blocks become
+//     kInvalid, which the client's health accounting deliberately ignores, so
+//     upstream they are indistinguishable from an ordinary cache miss: no error,
+//     no log, no counter -- just a hit rate quietly capped for large pages.
+//     Anyone tuning this down would have had no signal that they went too far.
+bool RdmaTransport::NoteBlock(size_t n) const {
+  uint64_t prev = max_block_seen_.load(std::memory_order_relaxed);
+  while (n > prev &&
+         !max_block_seen_.compare_exchange_weak(prev, n, std::memory_order_relaxed)) {
+  }
+  if (n > prev) {  // new high-water mark: the number needed to size the declaration
+    DFKV_LOG_INFO("rdma: max block observed " + std::to_string(n) + "B (" +
+                  std::to_string(n / 1024) + " KiB); declared bound " +
+                  std::to_string(OpBound()) + "B");
+  }
+  const size_t bound = OpBound();
+  if (n <= bound) return false;
+  const uint64_t k = oversize_rejects_.fetch_add(1, std::memory_order_relaxed);
+  if (k == 0 || (k & 0x3FFu) == 0)  // first, then every 1024th
+    DFKV_LOG_WARN("rdma: block " + std::to_string(n) + "B exceeds the declared bound " +
+                  std::to_string(bound) + "B -> kInvalid, which reads as a cache MISS "
+                  "upstream (not an error). Raise DFKV_RDMA_MAX_BLOCK_BYTES. rejects=" +
+                  std::to_string(k + 1));
+  return true;
+}
+
 std::vector<Status> RdmaTransport::RangeIntoMulti(
     const std::string& node, const std::vector<BlockKey>& keys,
     const std::vector<RangeDstMulti>& dsts, size_t header_size,
@@ -868,7 +904,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     for (size_t i = 0; i < n; ++i) {
       size_t cap = 0;
       for (const auto& p : dsts[i].payloads) cap += p.second;
-      if (cap > OpBound() || dsts[i].payloads.size() > max_payload_segs) {
+      if (NoteBlock(cap) || dsts[i].payloads.size() > max_payload_segs) {
         bad[i] = 1;
         res[i] = Status::kInvalid;
       }

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -118,6 +118,18 @@ class RdmaTransport : public Transport {
   size_t OpBound() const {  // per-op payload bound honoring the declaration
     return declared_ ? static_cast<size_t>(declared_) : max_payload_;
   }
+  // Largest block this client has actually handed to the transport. Sizing
+  // DFKV_RDMA_MAX_BLOCK_BYTES is otherwise guesswork: the declaration decides
+  // how much the SERVER pins per connection (qd x (ValueHeader + declared)),
+  // which at qd=32 is ~1 GiB per connection measured on a B200 node -- yet the
+  // only figure available to an operator was the average transfer size. This
+  // reports the actual high-water mark so the declaration can be set from
+  // evidence with a deliberate margin.
+  mutable std::atomic<uint64_t> max_block_seen_{0};
+  mutable std::atomic<uint64_t> oversize_rejects_{0};
+  // Records n as a candidate high-water mark and reports whether it exceeds the
+  // declaration. Returns true for an oversized block (caller marks it kInvalid).
+  bool NoteBlock(size_t n) const;
   size_t control_cap_;
   size_t depth_;
   int connect_ms_ = 3000;             // bootstrap TCP connect timeout (DFKV_RDMA_CONNECT_MS)


### PR DESCRIPTION
Observability only — same items rejected, same statuses. 2 files, ~45 lines.

## Why this knob is load-bearing at cluster scale

`DFKV_RDMA_MAX_BLOCK_BYTES` decides how much the **server** pins per connection: `qd × (ValueHeader + declared)`, allocated **eagerly at handshake**. Measured on a B200 node (qd=32, declared 16 MiB): **≈1.02 GB per connection**, and one 8-rank inference instance opens **~135 connections** to a single server.

So the declaration is server memory multiplied by every connection in the fleet:

| concurrent instances | conns/server | qd=32 | qd=8 |
|---|---|---|---|
| 1 | ~135 | 138 GB | 34 GB |
| 10 | ~1280 | 1.3 TB | 320 GB |

Getting this value right is not a micro-optimization — it decides whether a ring node fits in RAM.

## The two problems

**1. No way to size it.** The only figure an operator could observe was the *average* transfer (437 KiB on that node), which says nothing about the peak that must fit. Everything else was arithmetic on model geometry.

**2. Setting it too small failed silently — this is the dangerous one.** An oversized block is marked `kInvalid`, and `kInvalid` is *deliberately* excluded from the client's health accounting (`Only a real reply (hit or logical miss) is "good"`). Upstream it surfaces as `hits[i] != 1`, i.e. **indistinguishable from an ordinary cache miss**: no error, no log, no counter. The hit rate is quietly capped for large pages and every signal points somewhere else.

## What this adds

- `NoteBlock(n)` records a high-water mark and logs each new maximum:
  `rdma: max block observed 2949120B (2880 KiB); declared bound 16777216B`
  → the number needed to set the declaration from evidence.
- Oversized rejects now warn (first, then every 1024th), naming the size, the bound, and the knob:
  `rdma: block ...B exceeds the declared bound ...B -> kInvalid, which reads as a cache MISS upstream (not an error). Raise DFKV_RDMA_MAX_BLOCK_BYTES. rejects=N`

The four per-item bound checks (`RangeIntoMulti` and the three SG paths) call `NoteBlock` instead of comparing against `OpBound()` directly. **`NoteBlock` is placed on the LEFT of the `||` conditions** so short-circuit evaluation cannot skip the recording when another check also trips.

## Verification

- `cmake -DDFKV_WITH_RDMA=ON` builds clean, no new warnings
- `ctest`: **391/391 pass**
- Both new log strings present in the built `libdfkv.so`

Depends on #222 for CI to run green.