### PR TITLE
fix(rdma): read back the SGE width the QP actually granted (and flag a keyspace hazard it exposes)

### DIFF
--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -269,6 +269,40 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib
   qp_ = ibv_create_qp(pd_, &qa);
   if (!qp_) { Close(); return false; }
 
+  // ibv_create_qp rewrites qa.cap with what the driver ACTUALLY granted, which
+  // until now was discarded: max_sge_ came from the device attribute we derived
+  // the *request* from, not from the answer. Two reasons to read it back:
+  //
+  //  - Defence. The spec says a grant is >= the request (or the call fails), so
+  //    a smaller grant "cannot happen" -- but if it ever did, every scatter-gather
+  //    post would build an SGL the QP cannot accept and fail at post time, far
+  //    from the cause. Clamping here turns that into one line at Open().
+  //  - Visibility. A grant LARGER than the request is real headroom: fewer @sg
+  //    chunks per page, so bigger blocks and fewer RDMA ops. It was invisible.
+  //
+  // Deliberately NOT adopted when larger. sg_payload_segs_ (= max_sge_ - 1)
+  // selects the "@sg{n}" sub-key chunking, so the width is part of the KEY
+  // LAYOUT, not just a local transport detail: two clients that pick different
+  // widths hash the same page into different sub-keys and can never share a
+  // cache entry. Widening on whatever a particular driver happens to grant would
+  // silently partition the keyspace across a heterogeneous fleet. Raising it is
+  // a deliberate, fleet-wide decision (kMaxSge), so this only reports the room.
+  {
+    const size_t granted = std::min<size_t>(qa.cap.max_send_sge, qa.cap.max_recv_sge);
+    if (granted < max_sge_) {
+      DFKV_LOG_WARN("rdma: QP granted max_sge=" + std::to_string(granted) +
+                    " below the requested " + std::to_string(max_sge_) +
+                    " (device reported more); clamping to the grant");
+      max_sge_ = granted < 2 ? 2 : granted;
+    } else if (granted > max_sge_) {
+      DFKV_LOG_INFO("rdma: QP granted max_sge=" + std::to_string(granted) +
+                    ", above the requested " + std::to_string(max_sge_) +
+                    "; keeping the requested width (it selects the @sg key "
+                    "chunking, so it must stay uniform across the fleet). "
+                    "Raise kMaxSge to use the headroom.");
+    }
+  }
+
   // QP -> INIT
   ibv_qp_attr at{};
   at.qp_state = IBV_QPS_INIT;


### PR DESCRIPTION
One file, ~30 lines, all of it after `ibv_create_qp`. No behavior change on hardware where the grant equals the request.

## What was wrong

`ibv_create_qp` rewrites `qp_init_attr.cap` with what the driver **actually granted**. That answer was discarded — `max_sge_` came from the `ibv_query_device` attribute the *request* was derived from, never from the grant.

Two things that costs:

- **Defence.** Per spec a grant is `>=` the request (or the call fails), so a smaller grant "cannot happen". If it ever did, every scatter-gather post would build an SGL the QP cannot accept and fail at post time — far from the cause and hard to read. Clamping at `Open()` turns that into one warning line.
- **Visibility.** A grant *larger* than the request is real headroom: a wider SGL means fewer `@sg` chunks per page, so bigger blocks and fewer RDMA ops. There was no way to see the card had room to give.

## What this deliberately does NOT do

It does not adopt a larger grant. `sg_payload_segs_` (`= max_sge_ - 1`) selects the `@sg{n}` sub-key chunking — the connector reads it through `dfkv_max_sg_segs()` and splits each page into `ceil(layer_num / width)` sub-keys. **The width is therefore part of the key layout, not a local transport detail.** Two clients that pick different widths hash the same page into different sub-keys and can never share a cache entry.

Adopting whatever a given driver happens to grant would silently partition the keyspace across a heterogeneous fleet. Widening stays a deliberate, fleet-wide decision (`kMaxSge`); this change only *reports* the room.

## ⚠️ A pre-existing hazard this makes visible

The same reasoning applies to what is already there:

```cpp
max_sge_ = std::min(kMaxSge, dev_attr.max_sge);   // device-dependent
```

**The `@sg` key layout already depends on the HCA's reported `max_sge`.** A fleet mixing cards that report different values would compute different chunkings and silently never share L3 entries — no error, just a hit rate that never materialises. Today `kMaxSge = 30` masks this on any card reporting `>= 30`, but a narrower card would diverge.

Worth deciding separately whether the SG width should be **pinned by configuration** (uniform by construction, validated against the local cap) rather than derived from local hardware. Not changed here — it affects key layout and deserves its own discussion.

## Measured on the target hardware

ConnectX, fw 28.47.2526: `ibv_query_device` reports `max_sge=30`, `kMaxSge=30`, QP grant `=30`. Request equals grant, so this PR is a no-op there and simply makes the equality observable.

## Verification

- `cmake -DDFKV_WITH_RDMA=ON` builds clean (the one remaining `-Wmissing-field-initializers` at `rdma_verbs.cc:80` is pre-existing and unrelated)
- `ctest`: **391/391 pass**