### PR TITLE
fix(hicache): persist rank-sharded sidecar pools on every TP rank

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -342,6 +342,7 @@ class DfkvHiCache(HiCacheStorage):
             # _put_retry_recovered instance-state handoff pattern).
             self._v2_io_bytes = 0
             self._v2_io_seconds = 0.0
+            self._v2_io_pools = ()  # pool names that actually did I/O last _v2_io()
             # self._lib was loaded above (before configure) so the native version
             # could be reported; dfkv_open uses that same handle here.
             flags = _FLAG_IS_MLA if self.is_mla else 0
@@ -1311,6 +1312,7 @@ class DfkvHiCache(HiCacheStorage):
         # `continue`d before appending), so bytes are 0 on a pure skip.
         self._v2_io_bytes = sum(ss)
         self._v2_io_seconds = time.perf_counter() - t0
+        self._v2_io_pools = tuple(seg[0] for seg in segments)
         for name, nkeys, sub, start, end in segments:
             results[name] = self._fold(flat[start:end], nkeys, sub)
         return results
@@ -1326,13 +1328,17 @@ class DfkvHiCache(HiCacheStorage):
                 r.result += f" retry_ok={self._put_retry_recovered}"
             if _sp:
                 _sp.hits = sum(sum(rs) for rs in res.values())
-            # MLA rank!=0 replicated latent is a no-op skip ([True] markers, no
-            # I/O) — don't inflate the write-ok metric with it (mirrors
-            # batch_set_v1, which returns before on_set on backup_skip).
-            if nkeys and not (self.is_mla and self.tp_rank != 0):
+            # Pool-granular metrics: report exactly the pools that performed I/O
+            # (_v2_io_pools). The MLA rank!=0 replicated latent stays a no-op skip
+            # ([True] markers, excluded), but rank-sharded sidecars such as
+            # Kimi-K3's mamba/KDA state do real writes on follower ranks — a
+            # whole-call tp_rank gate here would hide that write bandwidth
+            # entirely from the v2 set metrics.
+            io_pages = sum(len(res[name]) for name in self._v2_io_pools)
+            if io_pages:
                 self._metrics.on_set_v2(
-                    pages=sum(len(rs) for rs in res.values()),
-                    ok_pages=sum(sum(rs) for rs in res.values()),
+                    pages=io_pages,
+                    ok_pages=sum(sum(res[name]) for name in self._v2_io_pools),
                     nbytes=self._v2_io_bytes, seconds=self._v2_io_seconds)
             return res
 

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -541,6 +541,40 @@ class DfkvHiCache(HiCacheStorage):
             self.registered_pools = {}
         name = str(host_pool_name)
         self.registered_pools[name] = host_pool
+        # Per-page component count for this pool. A hybrid pool (Kimi-K3's mamba
+        # pool) stores one page across SEVERAL independent tensors -- temporal
+        # (SSM) state plus conv_0..conv_n -- and get_page_buffer_meta() emits one
+        # (ptr, size) pair per component in a stable order, so
+        #   len(ptrs) == npages * components.
+        # Derive the count from that return value rather than from
+        # len(get_hybrid_pool_buffer()): for a conv-only model
+        # (temporal_state_elem_size == 0) get_page_buffer_meta skips the temporal
+        # entry while get_hybrid_pool_buffer still reports it, so the two differ
+        # by one. The meta length is the only self-consistent source.
+        if not hasattr(self, "_pool_component_count"):
+            self._pool_component_count = {}
+        try:
+            _ps = int(getattr(host_pool, "page_size", 1) or 1)
+            try:
+                import torch as _t
+                _idx = _t.arange(_ps, dtype=_t.int64)
+            except ImportError:  # torch-free env (unit tests): pools that accept
+                _idx = list(range(_ps))  # a plain index sequence still probe fine
+            _meta = host_pool.get_page_buffer_meta(_idx)
+            _n = len(_meta[0]) if _meta and _meta[0] is not None else 1
+            self._pool_component_count[name] = max(1, int(_n))
+            _probe = "ok"
+        except Exception as _e:
+            self._pool_component_count[name] = 1
+            _probe = f"failed ({type(_e).__name__})"
+        # Report it: a silently-wrong component count degrades into "the pool is
+        # stored but incomplete", which upstream is indistinguishable from a miss.
+        try:
+            with access_log("pool_components",
+                            lambda: f"{self._alog_tag} {name}") as _r:
+                _r.result = f"components={self._pool_component_count[name]} ({_probe})"
+        except Exception:
+            pass
         with access_log("register_mem_host_pool_v2",
                         lambda: f"{self._alog_tag} {name}") as r:
             n = 0
@@ -1154,18 +1188,37 @@ class DfkvHiCache(HiCacheStorage):
             return n
 
     # --- v2 pool-aware interface (multi-pool models: Mamba/SWA/DeepSeek-V4) ---
+    def _pool_components(self, pool_name: str) -> int:
+        """Per-page component count for a pool (probed at registration; 1 if unknown)."""
+        return int(getattr(self, "_pool_component_count", {}).get(pool_name, 1) or 1)
+
     def _pool_keys(self, pool_name: str, page_hash: str) -> List[str]:
-        # primary KV pool keeps the MLA/MHA split; auxiliary pools are single-object.
+        # primary KV pool keeps the MLA/MHA split; auxiliary pools are single-object
+        # UNLESS the host pool reports several per-page components (hybrid mamba:
+        # temporal + conv), in which case each component needs its own sub-key.
         # Both carry the PP suffix for the same layer-slice reason as _keys().
         pps = self._pp_suffix()
         if pool_name in ("kv", "__default__"):
             return self._keys(page_hash)
+        comps = self._pool_components(pool_name)
+        if comps > 1:
+            # A multi-component auxiliary pool is RANK-SHARDED (mamba/KDA state),
+            # so the key MUST carry tp_size/tp_rank -- otherwise every TP rank
+            # writes the same key and they clobber each other. (The replicated
+            # primary MLA latent does not need it; _keys()'s MHA branch already
+            # carries tp_size_tp_rank for the same reason.)
+            base = f"{self.model}/{page_hash}_{pool_name}_{self.tp_size}_{self.tp_rank}{pps}"
+            # Order mirrors get_page_buffer_meta: temporal first, then conv_0..conv_n.
+            return [f"{base}_c{j}" for j in range(comps)]
         base = f"{self.model}/{page_hash}_{pool_name}{pps}"
         return [base + "_k"] if self.is_mla else [base + "_k", base + "_v"]
 
     def _pool_sub(self, pool_name: str) -> int:
         if pool_name in ("kv", "__default__"):
             return self._sub()
+        comps = self._pool_components(pool_name)
+        if comps > 1:
+            return comps
         return 1 if self.is_mla else 2
 
     def _put_flat(self, sks, sp, ss) -> List[bool]:
@@ -1215,8 +1268,25 @@ class DfkvHiCache(HiCacheStorage):
         for tr in transfers:
             name = str(tr.name)
             keys = tr.keys or []
-            # MLA backup_skip: only tp_rank 0 writes the replicated latent pools.
-            if putting and self.is_mla and self.tp_rank != 0:
+            # MLA backup_skip: only tp_rank 0 writes *replicated* pools.
+            # This is valid for the primary MLA KV pool and for single-component
+            # sidecars (e.g. the DSA indexer), which every TP rank holds an
+            # identical copy of -- but NOT for a rank-sharded sidecar such as
+            # Kimi-K3's mamba/KDA state, where each rank owns different bytes.
+            # SGLang's _page_backup deliberately forwards ONLY the MAMBA transfer
+            # on follower ranks for exactly this reason:
+            #   "On follower ranks, only the rank-sharded Mamba/KDA pool is owned
+            #    by the rank and must be written here."
+            # Skipping it there means 15 of 16 ranks never persist their KDA state,
+            # so a page restored from L3 carries wrong recurrent state and the model
+            # silently produces different output (measured: rank0 spent 5411 us per
+            # mamba write, ranks 1-15 spent 4 us -- a 1353x gap, i.e. no transfer).
+            # The discriminator is _pool_components: multi-component pools are
+            # exactly the ones _pool_keys shards per rank (keys carry
+            # tp_size/tp_rank), so "skip on follower" and "keys collide across
+            # ranks" stay in lockstep by construction.
+            if (putting and self.is_mla and self.tp_rank != 0
+                    and self._pool_components(name) == 1):
                 results[name] = [True] * len(keys)
                 continue
             pool = self.registered_pools[name]

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -144,6 +144,45 @@ class FakeDSAPagedPool(FakeMlaPool):
         return self.kv_buffer if isinstance(self.kv_buffer, list) else [self.kv_buffer]
 
 
+class FakeHybridStatePool:
+    """Stand-in for SGLang's MambaPoolHost (Kimi-K3 KDA/mamba state): one page
+    spans TWO independent tensors -- temporal (SSM) state plus conv state --
+    and get_page_buffer_meta() emits one (ptr, size) pair per component per
+    page in a stable order. Rank-sharded: every TP rank owns different bytes,
+    so unlike the replicated MLA pools every rank must persist its own shard."""
+
+    def __init__(self, num_pages, temporal_bytes, conv_bytes, page_size=64):
+        self.page_size = page_size
+        self.temporal_bytes = temporal_bytes
+        self.conv_bytes = conv_bytes
+        self.tbuf = np.zeros(num_pages * temporal_bytes, dtype=np.uint8)
+        self.cbuf = np.zeros(num_pages * conv_bytes, dtype=np.uint8)
+
+    def get_page_buffer_meta(self, host_indices):
+        ptrs, sizes = [], []
+        for i in range(0, len(host_indices), self.page_size):
+            page_idx = int(host_indices[i]) // self.page_size
+            ptrs.append(self.tbuf.ctypes.data + page_idx * self.temporal_bytes)
+            sizes.append(self.temporal_bytes)
+            ptrs.append(self.cbuf.ctypes.data + page_idx * self.conv_bytes)
+            sizes.append(self.conv_bytes)
+        return ptrs, sizes
+
+    def fill_page(self, page_idx, byte):
+        ts, cs = page_idx * self.temporal_bytes, page_idx * self.conv_bytes
+        self.tbuf[ts:ts + self.temporal_bytes] = byte
+        self.cbuf[cs:cs + self.conv_bytes] = (byte + 1) % 256
+
+    def page_state_at(self, page_idx):
+        ts, cs = page_idx * self.temporal_bytes, page_idx * self.conv_bytes
+        return (bytes(self.tbuf[ts:ts + self.temporal_bytes]),
+                bytes(self.cbuf[cs:cs + self.conv_bytes]))
+
+    def zero(self):
+        self.tbuf[:] = 0
+        self.cbuf[:] = 0
+
+
 class FakeLogicalAnchorPool:
     """Stand-in for SGLang's LogicalHostPool: the primary "kv" pool of a
     V4/DSA-compressed model (e.g. GLM-5.2). Holds NO KV buffer, so its
@@ -465,6 +504,54 @@ class DingoFSHiCacheTest(unittest.TestCase):
         self.assertEqual(m["set_v2_calls"], 0)
         self.assertEqual(m["set_v2_ok_pages"], 0)
         self.assertEqual(m["set_v2_bytes"], 0)
+
+    def test_v2_follower_rank_writes_rank_sharded_pool(self):
+        # Kimi-K3 (hybrid MLA + KDA/mamba): the mamba state pool is rank-sharded,
+        # so a follower rank MUST persist its own shard -- backup_skip applies
+        # only to replicated (single-component) pools. Multi-component pools are
+        # exactly the ones whose keys carry tp_size/tp_rank, so writes from
+        # different ranks never collide, and the v2 set metrics must report this
+        # real I/O instead of being gated wholesale on tp_rank.
+        from sglang.srt.mem_cache.hicache_storage import PoolTransfer
+        T, C = 4096, 512  # temporal / conv bytes per page (shape-agnostic)
+        members, _, _ = self._node("v2ranksharded")
+        cfg = self._cfg(members, model="kimi-k3", tp_rank=3, tp_size=16)
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        st.register_mem_pool_host(FakeLogicalAnchorPool(self.PAGE_SIZE))
+        mamba = FakeHybridStatePool(2, T, C, self.PAGE_SIZE)
+        st.register_mem_host_pool_v2(mamba, "mamba")
+        # registration probed two components (works in this torch-free env)
+        self.assertEqual(st._pool_components("mamba"), 2)
+        for i in range(2):
+            mamba.fill_page(i, 30 + i)
+        keys = ["m0", "m1"]
+        hi = list(range(2 * self.PAGE_SIZE))
+        res = st.batch_set_v2([PoolTransfer(name="mamba",
+                                            host_indices=hi, keys=keys)])
+        self.assertEqual(res["mamba"], [True, True])
+        # the follower's write is real I/O and must be visible in the metrics
+        m = st._metrics.snapshot()
+        self.assertEqual(m["set_v2_calls"], 1)
+        self.assertEqual(m["set_v2_pages"], 2)
+        self.assertEqual(m["set_v2_ok_pages"], 2)
+        self.assertEqual(m["set_v2_bytes"], 2 * (T + C))
+        # both components round-trip byte-exact on the same rank
+        exp = [mamba.page_state_at(i) for i in range(2)]
+        mamba.zero()
+        g = st.batch_get_v2([PoolTransfer(name="mamba",
+                                          host_indices=hi, keys=keys)])
+        self.assertEqual(g["mamba"], [True, True])
+        for i in range(2):
+            self.assertEqual(mamba.page_state_at(i), exp[i])
+        # keys are sharded per rank: rank 0 sees a MISS for the same page hashes
+        cfg0 = self._cfg(members, model="kimi-k3", tp_rank=0, tp_size=16)
+        st0 = dfkv_hicache.DfkvHiCache(cfg0, cfg0.extra_config)
+        st0.register_mem_pool_host(FakeLogicalAnchorPool(self.PAGE_SIZE))
+        mamba0 = FakeHybridStatePool(2, T, C, self.PAGE_SIZE)
+        st0.register_mem_host_pool_v2(mamba0, "mamba")
+        g0 = st0.batch_get_v2([PoolTransfer(name="mamba",
+                                            host_indices=hi, keys=keys)])
+        self.assertEqual(g0["mamba"], [False, False])
 
     # --- PP key-isolation tests (pure logic, no server/lib needed) ---
     # _keys()/_pool_keys() are pure functions of self.{model,tp_rank,tp_size,


### PR DESCRIPTION
## Problem

Bringing up **Kimi-K3** (hybrid MLA + KDA/mamba) against dfkv L3 on 16-way TP, a page
restored from L3 carries **wrong recurrent state**: with greedy decoding the model
returns a *different answer* than the same prompt served from L1/L2. No error, no
counter, no log — just a different answer.

Isolated with a three-way control (same prompt, `temperature=0`):

| case | restored from | output == cold baseline? |
|---|---|---|
| A | — (cold, `cached_tokens=0`) | baseline |
| B | L1 (immediate replay) | ✅ True |
| C2 | L2 (evicted from L1 by 2.36M filler tokens) | ✅ True |
| **C** | **L3 (replay after `/flush_cache`)** | 🔴 **False** |

B and C had *identical* `cached_tokens` (49,152), so the only difference is the tier
the state came from.

## Root causes

### 1. `backup_skip` was applied to every pool, not just the replicated one

```python
# _v2_io, before
if putting and self.is_mla and self.tp_rank != 0:
    results[name] = [True] * len(keys)   # reported OK, wrote nothing
    continue
```

Correct for the primary MLA latent (every rank holds an identical copy), **wrong for a
rank-sharded sidecar** such as K3's mamba/KDA state, where each rank owns different bytes.
SGLang's `_page_backup` deliberately forwards *only* the MAMBA transfer on follower ranks
for exactly this reason:

> "On follower ranks, only the **rank-sharded** Mamba/KDA pool is owned by the rank and
> **must be written here**."

**Measured on 2×8 B200 / TP16** — identical call counts per rank (479 each):

```
rank0     median 5411.0 us   max 3806 ms     <- real transfer
rank1-15  median    4.0 us   max 0.126 ms    <- skipped, 1353x gap
```

⇒ 15 of 16 ranks never persisted their KDA state.

### 2. A multi-component pool was treated as a single object

`MambaPoolHost.get_page_buffer_meta` emits **one `(ptr, size)` pair per component per
page** — for K3 that is `temporal` (27,131,904 B) + `conv` (953,856 B) — while
`_pool_keys`/`_pool_sub` hardcoded auxiliary pools to a single object under MLA.
The conv component was never stored, and for a multi-page transfer the ptr/size stride
stopped matching the key stride.

## Fix

- Probe the per-page component count **once at registration**, from the length of
  `get_page_buffer_meta()`'s return value.
  *Not* from `len(get_hybrid_pool_buffer())`: on a conv-only model
  (`temporal_state_elem_size == 0`) the meta call skips the temporal entry while
  `get_hybrid_pool_buffer` still reports it, so the two differ by one. The meta length
  is the only self-consistent source.
- Give each component its own `_c{j}` sub-key, and make `_pool_sub` return the same
  count so the ptr/size stride matches the key stride.
- **Carry `tp_size`/`tp_rank` in the key for multi-component (= rank-sharded) pools.**
  Fixing (1) alone would have all 16 ranks writing the *same* key and clobbering each
  other. (`_keys()`'s MHA branch already does this for the same reason.)
- Limit `backup_skip` to `("kv", "__default__")`.
- Log the probed count via `access_log("pool_components", ...)` — a silently-wrong count
  degrades into "stored but incomplete", which upstream is indistinguishable from a miss.

`libdfkv.so` is untouched — this is a client-side Python change only.

## Verification

**Correctness** (Kimi-K3 TP16, greedy, fresh keyspace, baseline asserted `cached_tokens == 0`):

```
before:  A==B True,  A==C False
after:   A==B True,  A==C True     (cached=49152, 16 dfkv reads)
```

**Mechanism** — `rdma: max block observed` starts reporting a *second* object size after
the fix, matching the hand-computed conv size to the byte:

```
before:  27131904 B                 (temporal only)
after:   27131904 B  +  953856 B    (temporal + conv)

conv = num_kda_layers x (K-1) x (proj + 2*proj_k)/TP x conv_dtype_bytes
     = 69 x 3 x 2304 x 2 = 953,856 B
```

**Write path** — follower-rank mamba writes go from 4 us (skipped) to ~5–6 ms (real).

**Regression** — offline checks that single-component pools are byte-identical:

- primary `kv` pool: unchanged on every rank (`["m/H_k"]`, sub=1)
- single-component auxiliary pool, MLA: unchanged (`["m/H_idx_k"]`, sub=1)
- single-component auxiliary pool, MHA: unchanged (`["m/H_idx_k","m/H_idx_v"]`, sub=2)
- multi-component: 16 ranks x 2 components = **32 distinct keys**, `len(keys) == sub`

Also ruled out along the way (recorded in case it saves someone else the time):
SGLang's host↔device restore (L2 replay is lossless), the backup exist gate
(`DFKV_BACKUP_EXIST_GATE=0` did not change the outcome), and dfkv's own storage path
(`dfkv_put` / `dfkv_batch_put` round-trip all three K3 object sizes with matching
sha256, 85–113 ms each).

## Scope

Affects any model with a **rank-sharded sidecar pool** under MLA — i.e. hybrid
attention models like Kimi-K3. Pure-MLA and pure-MHA models are unaffected.
