### PR TITLE
test(vllm-connector): DCP key-space lookup hit-geometry regression + README note

### DIFF
--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -88,6 +88,13 @@ instead of share, give each a distinct `served-model-name` / `model_hash`.
 - **GPU buffers use the batch path only.** The single `dfkv_get_auto` computes a
   CRC over the destination on the CPU and segfaults on device memory; the batch
   `dfkv_batch_get_auto` is zero-copy and GPU-safe.
+- **DCP (`--decode-context-parallel-size > 1`) needs client >= v1.10.0**.
+  Older builds run the put_step stride under the replicated-KV assumption and
+  store only 1/dcp_size of each rank's shard, so external prefix hits
+  collapse to ~1/dcp (field-reported "low dfkv hit rate with DCP"). v1.10.0
+  (#70) shrinks the stride by dcp_size; coverage under the default
+  token-level interleave is guarded by
+  `tests/test_dcp_lookup_geometry.py`.
 - **GPUDirect needs nvidia-peermem loaded** on the GPU node (`lsmod | grep
   nvidia_peermem`).
 - **First request per DP rank pays a one-time ~2s Triton JIT** (resumed-prefill +

--- a/integration/vllm/tests/test_dcp_lookup_geometry.py
+++ b/integration/vllm/tests/test_dcp_lookup_geometry.py
@@ -1,0 +1,137 @@
+"""DCP key-space hit-geometry regression test (issue #70 follow-up).
+
+Under DCP (Decode Context Parallelism) the MLA KV is SHARDED across dcp
+ranks:  rank r stores its shard chunks under keys tagged ``@dcp{r}``
+(worker.py KeyMetadata), while the scheduler-side lookup (worker.py
+``DfkvStoreWorker.lookup``) probes candidates from worker-rank-0's metadata,
+i.e. ``@dcp0``, with tp_count=min(tp_size, num_kv_head)=1 probes per chunk.
+
+This file drives the REAL lookup against synthetic dfkv key-space contents
+modelling the two save geometries, so the coverage contract survives
+refactors instead of living only in tribal knowledge:
+
+* geometry A (post-#70, default cp_kv_cache_interleave_size=1):
+  every rank stores every chunk under its own ``@dcp{r}`` namespace (each
+  rank holds 1/dcp of every block's tokens - the shard is per-chunk, not
+  per-token-range).  ``@dcp0`` keys therefore exist for every chunk and the
+  lookup reports the FULL prefix.
+* geometry B (pre-#70 put_step=tp_size stride, fixed by #70/v1.10.0):
+  chunk c is stored only by the single rank c%dcp under ``@dcp{c%dcp}``.
+  The lookup sees only the dcp=0 quarter/eighth -> the external hit
+  collapses to ~1/dcp of the prompt.  This is the field-reported
+  "low dfkv hit rate with DCP"; deploys on < v1.10.0 show exactly it.
+
+Variation B is asserted as a DOCUMENTED NEGATIVE: if a future change
+reintroduces a store stride (or block-grain interleave keyed per owning
+rank) without teaching lookup about dcp ownership, A must not silently
+degrade into B-like coverage.
+
+Runs in the engine image (vllm + torch provided by it -- see
+integration/vllm/pyproject.toml). No GPU or dfkv server needed: the client
+is faked, only the pure-python key/lookup math is exercised.
+"""
+
+import hashlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch  # noqa: F401  (spec dtype; provided by the runtime image)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
+
+from dfkv_vllm.coordinator import DfkvStoreCoordinator
+from dfkv_vllm.data import KeyMetadata, PoolKey
+from dfkv_vllm.worker import DfkvStoreWorker, SG_MAX_SEGS, _sg_group_key
+
+BLOCK = 64
+NCHUNK = 64
+DCP = 8
+
+_METADATA = {
+    "model_name": "m",
+    "tp_rank": 0,
+    "pcp_rank": 0,
+    "pp_rank": 0,
+    "group_id": 0,
+}
+
+
+def _md(dcp_rank: int) -> KeyMetadata:
+    return KeyMetadata(**{**_METADATA, "dcp_rank": dcp_rank})
+
+
+def _onewire_key(md: KeyMetadata, h: BlockHash) -> str:
+    # Same on-wire form lookup probes and the save path store: group-0 SG key.
+    return _sg_group_key(PoolKey(md, h.hex()).to_string(), 0, SG_MAX_SEGS)
+
+
+def _make_store(geometry: str, hashes: list[BlockHash]) -> set[str]:
+    store: set[str] = set()
+    for r in range(DCP):
+        for c, h in enumerate(hashes):
+            if geometry == "A" or (geometry == "B" and r == c % DCP):
+                store.add(_onewire_key(_md(r), h))
+    return store
+
+
+def _lookup_hit_tokens(store: set[str], hashes: list[BlockHash]) -> int:
+    class _FakeClient:
+        _sg_segs_cache = SG_MAX_SEGS
+
+        def __init__(self, present: set[str]):
+            self._present = present
+
+        def batch_exist(self, keys):
+            return [1 if k in self._present else 0 for k in keys]
+
+    spec = FullAttentionSpec(
+        block_size=BLOCK,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+    )
+    groups = [KVCacheGroupSpec([f"layer{i}" for i in range(43)], spec)]
+    coord = DfkvStoreCoordinator(
+        groups, scheduler_block_size=BLOCK, hash_block_size=BLOCK
+    )
+    self_ = SimpleNamespace(
+        coord=coord,
+        token_dbs=[SimpleNamespace(metadata=_md(0), block_size=BLOCK)],
+        client=_FakeClient(store),
+        tp_size=8,
+        num_kv_head=1,
+        pp_size=1,
+        _kv_cache_groups=groups,
+        _record_kv_connector_operation=lambda *a, **k: None,
+    )
+    return DfkvStoreWorker.lookup(self_, NCHUNK * BLOCK, hashes)
+
+
+def _hashes() -> list[BlockHash]:
+    return [BlockHash(hashlib.sha256(f"{i}".encode()).digest()) for i in range(NCHUNK)]
+
+
+def test_post_70_geometry_lookup_full_prefix():
+    """Every rank stores every chunk (@dcp{r}): rank-0 lookup must report
+    the complete prefix, i.e. DCP on >= v1.10.0 has full L3 hit coverage."""
+    hashes = _hashes()
+    store = _make_store("A", hashes)
+    assert len(store) == DCP * NCHUNK
+    hit = _lookup_hit_tokens(store, hashes)
+    assert hit == NCHUNK * BLOCK, f"expected full prefix, got {hit}/{NCHUNK * BLOCK}"
+
+
+def test_pre_70_geometry_lookup_collapses():
+    """Negative control: chunk c only under @dcp{c%dcp} (the pre-#70 stride
+    or a block-grain interleave) truncates the lookup to ~1/dcp. If this
+    ever turns into a full hit the incident class deserves a fresh look."""
+    hashes = _hashes()
+    store = _make_store("B", hashes)
+    hit = _lookup_hit_tokens(store, hashes)
+    assert 0 < hit < NCHUNK * BLOCK // 2, (
+        f"documented-negative geometry should truncate badly, got {hit}"
+    )


### PR DESCRIPTION
## 背景

现场反馈：vLLM 推理 GLM-5.2 开启 DCP（Decode Context Parallelism）时，dfkv 直连 connector 的缓存命中率偏低。

## 根因判定

定位为 **部署侧 dfkv client < v1.10.0**（缺 #70）。#70 之前的 put_step 去重 stride 假设 TP 间 KV 复制，DCP 下各 rank 持有的是各自唯一的 shard（key 带 `@dcp{r}`），stride 会丢掉每 rank `~(1-1/dcp_size)` 的 shard → scheduler 侧 lookup（从 worker rank0 探测 `@dcp0`）只能覆盖一小部分 chunk → 外部命中率塌缩到 ~1/dcp。

该原始 bug 已由 #70 修复（2026-07-01，含于 v1.10.0+，含验证数据 7.1% → 46.6% == no-DCP baseline）。本 PR **不含行为改动**：补齐防回退回归测试 + 版本要求文档。

## 此 PR

1. `integration/vllm/tests/test_dcp_lookup_geometry.py` — 驱动**真实** `DfkvStoreWorker.lookup`，喂合成 key-space：
   - geometry A（post-#70 全 shard 存储, 默认 token 级 interleave）→ 断言 **100% 命中前缀**
   - geometry B（pre-#70 stride / 块粒度 interleave 语义）→ 断言命中**显著截断**（负样本对照，文档化）
   纯 CPU、无需 GPU/无需 dfkv server（client 打桩，只测 key/lookup 数学）
2. `integration/vllm/README.md` Gotchas 新增：DCP 要求 client ≥ v1.10.0

## 验证

- 引擎镜像 vllm/vllm-openai:glm52 内 `pytest`：**2 passed**，分别对本分支源码和线上部署的 connector
- 实测基线（xb01-gpu-200b-0064, 8×B200, dfkv L3 ring v1.37+, DfkvStoreConnector 直连）：
  - GLM-5.2-NVFP4 与 DeepSeek-V4-Flash，TP8+EP，DCP-off 热轮：**96 次 batch_get 全部 1248/1248 = 100% hit**（TTFT 中位 2.1–3.1× 改善）

## 备注（非本 PR 范围）

本节点（B200 + dspark/glm52 引擎镜像）**e2e 启动 DCP 被 vLLM 侧挡住**（FlashInferMLASparseImpl LSE-for-decode gate + `DCP not support fp8 kvcache`），非 dfkv 问题；同实例 DCP 的端到端复测建议在引擎支持 DSA+DCP 的环境（如 H800 fleet）执行。