### PR TITLE
fix(vllm-connector): vLLM 0.26 compat for ExternalCachedBlockPool hit-lookup

### DIFF
--- a/integration/vllm/src/dfkv_vllm/coordinator.py
+++ b/integration/vllm/src/dfkv_vllm/coordinator.py
@@ -26,13 +26,38 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 _DUMMY_BLOCK_HASH = BlockHash(b"\x00" * 32)
 
 
+def _unwrap_hit_blocks(res):
+    """vLLM >= 0.26: SingleTypeKVCacheManager.find_longest_cache_hit returns
+    ``(blocks_per_group, hit_length_tokens)``; older versions return just
+    ``blocks_per_group``. Accept both. hit_length is always re-derived from
+    the returned block lists, so the manager-side value is not needed here.
+    """
+    if (
+        isinstance(res, tuple)
+        and len(res) == 2
+        and isinstance(res[0], tuple)
+        and isinstance(res[1], int)
+    ):
+        return res[0]
+    return res
+
+
 class ExternalCachedBlockPool:
     """Duck-typed BlockPool backed by a ``(group_id, hash)`` exists set."""
 
-    def __init__(self, exists: set[tuple[int, bytes]] | None = None) -> None:
+    def __init__(
+        self,
+        exists: set[tuple[int, bytes]] | None = None,
+        hash_block_size: int | None = None,
+    ) -> None:
         # ``exists=None`` is used on the recv side where hit_length is already
         # determined and we just want each spec's manager to apply its own mask.
         self._exists = exists
+        # vLLM >= 0.26: SingleTypeKVCacheManager.find_longest_cache_hit reads
+        # ``block_pool.hash_block_size`` for partial-hash-chain math. None here
+        # means "not yet stamped" -- the coordinator stamps it from its own
+        # scheduler-side value before dispatching into manager code.
+        self.hash_block_size = hash_block_size
         self.null_block = KVCacheBlock(block_id=0)
         # Dummy ID 1 for present block for duck-typing.
         self._present_block = KVCacheBlock(block_id=1)
@@ -131,6 +156,12 @@ class DfkvStoreCoordinator:
         already reflects the eagle-pruned hit length and a second pop would
         leave the trailing block unloaded.
         """
+        # vLLM >= 0.26 compat: the single-type managers consult
+        # ``block_pool.hash_block_size``; stamp it from the scheduler-side
+        # value the coordinator was built with. Idempotent across the
+        # convergence loop and across store_mask's template pool.
+        if getattr(cached_block_pool, "hash_block_size", None) is None:
+            cached_block_pool.hash_block_size = self.hash_block_size
         blocks_per_group, hit_length = self._find_hit_blocks(
             block_hashes, max_length, cached_block_pool, apply_eagle=apply_eagle
         )
@@ -226,7 +257,7 @@ class DfkvStoreCoordinator:
         if len(self.attention_groups) == 1:
             spec, group_ids, manager_cls = self.attention_groups[0]
             hashes = self.block_hashes_for_spec(block_hashes, spec)
-            hit_blocks = manager_cls.find_longest_cache_hit(
+            hit_blocks = _unwrap_hit_blocks(manager_cls.find_longest_cache_hit(
                 block_hashes=hashes,
                 max_length=max_length,
                 kv_cache_group_ids=group_ids,
@@ -234,7 +265,7 @@ class DfkvStoreCoordinator:
                 kv_cache_spec=spec,
                 drop_eagle_block=(0 in eagle_indices),
                 alignment_tokens=spec.block_size,
-            )
+            ))
             num_groups = len(self.kv_cache_groups)
             blocks_by_group: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
             for gid, blks in zip(group_ids, hit_blocks, strict=True):
@@ -266,7 +297,7 @@ class DfkvStoreCoordinator:
                 if drop_eagle_block:
                     _max_length = min(curr_hit_length + spec.block_size, max_length)
                 hashes = self.block_hashes_for_spec(block_hashes, spec)
-                hit_blocks = manager_cls.find_longest_cache_hit(
+                hit_blocks = _unwrap_hit_blocks(manager_cls.find_longest_cache_hit(
                     block_hashes=hashes,
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
@@ -274,7 +305,7 @@ class DfkvStoreCoordinator:
                     kv_cache_spec=spec,
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self.lcm_block_size,
-                )
+                ))
                 _new_hit_length = len(hit_blocks[0]) * spec.block_size
                 if drop_eagle_block:
                     eagle_verified.add(idx)


### PR DESCRIPTION
## Problem

Bringing up DeepSeek-V4-Flash-0731 on `vllm/vllm-openai:v0.26.0-cu129` with `DfkvStoreConnector`: **the first remote KV lookup kills the worker's `process_request` thread**; all subsequent requests wedge the engine (0% GPU utilization, `shm_broadcast` stalls on every DP rank).

Two delta-vs-0.26 breakages in `coordinator.py`, both in the `manager_cls.find_longest_cache_hit` dispatch:

1. `'ExternalCachedBlockPool' object has no attribute 'hash_block_size'` — vLLM 0.26 single-type managers now consult `block_pool.hash_block_size` for partial-hash-chain math; the duck-typed external pool never had it.
2. `ValueError: zip() argument 2 is longer than argument 1` — 0.26 managers return `(blocks_per_group, hit_length_tokens)`; the connector expected just `blocks_per_group`.

## Fix

- Make `hash_block_size` first-class on `ExternalCachedBlockPool` and stamp it from the scheduler-side value the coordinator was built with, at the single choke point (`find_longest_cache_hit`), idempotently (also covers `store_mask`'s template pool and the recv-side no-arg pool).
- Shape-unwrap both dispatch sites via `_unwrap_hit_blocks` (accepts both old/new manager return layouts; hit length is still re-derived from the returned block lists, so semantics are unchanged on older vLLM).

## Verification

- In-container (`vllm/vllm-openai:v0.26.0-cu129-ubuntu2404`), `integration/vllm/tests/test_dcp_lookup_geometry.py` fails pre-fix (AttributeError → ValueError as above), **passes post-fix** (both A/B geometries).
- Full CPU suite: `pytest integration/vllm/tests` → **20 passed, 1 skipped** (`test_determinism_guard` needs a GPU-config fixture; unrelated).
- Field repro→fix loop at the actual scene: 8×B200 node, dfkv ring 1.40.1, DeepSeek-V4-Flash-0731 DP8+EP 1M-ctx serving; remote lookups return real hits end-to-end after the patch.

## Not in this PR

MDS-discovery empty-ring adoption on 1.40.1 (client adopts `EMPTY membership` when MDS was recently restarted and never re-adopts even after the ring re-forms; the static `members` path is unaffected). Still being characterized; will come as its own issue/PR.
