### PR TITLE
feat(hicache): namespace SG chunk keys by negotiated width (@sgw{W}.{n})

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -321,7 +321,9 @@ HiCache 维持常规路径即可：
 ### 2.7 L2-bypass（L1↔L3 device 直连，绕过 host 池）
 
 把 SGLang 的 L2（host pinned 池）从数据路径上摘掉，GPU 显存与 dfkv 之间直接 GPUDirect RDMA。
-省掉一次 device↔host 拷贝和整个 host 池的驻留内存，代价是块被 SGE 宽度切成 `@sg{n}` 子键。
+省掉一次 device↔host 拷贝和整个 host 池的驻留内存，代价是块被 SGE 宽度切成 `@sg{n}` 子键
+（非默认宽为独立命名空间 `@sgw{W}.{n}`：宽度进 key 身份，混型 HCA 环上跨宽客户端互相 miss
+而非错读——一宽一空间，与 vLLM 连接器同一策略）。
 
 #### 客户端（SGLang 侧）
 

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -45,6 +45,15 @@ _log = logging.getLogger(__name__)
 
 _FLAG_IS_MLA = 0x1
 
+# Historical/default SG width: ConnectX-era max_sge=30, SGE[0] carries the
+# request/value header, leaving 29 payload segments per scatter-gather key.
+# The live width comes from dfkv_max_sg_segs (negotiated per HCA); this
+# constant is the fallback AND the key-namespace compat anchor — the default
+# width keeps the historical "@sg{n}" so previously cached data stays
+# reachable. Mirrors integration/vllm worker.py SG_MAX_SEGS (same value,
+# same reasoning).
+SG_DEFAULT_WIDTH = 29
+
 
 def _truthy(v) -> bool:
     if isinstance(v, str):
@@ -919,6 +928,20 @@ class DfkvHiCache(HiCacheStorage):
             self._sg_width_cache = w
         return w
 
+    def _sg_group_key(self, sk: str, ci: int) -> str:
+        """Chunk sub-key for SG group ci. The grouping WIDTH is part of a key's
+        identity: the same "@sg1" under different widths carries different
+        consecutive-layer spans, and a variable-size GET whose total cap happens
+        to fit would scatter the WRONG bytes with no error signal. Non-default
+        widths therefore get their own namespace ("@sgw{W}.{n}"); the default
+        width keeps the historical "@sg{n}" so existing cached data stays
+        reachable across this upgrade. Same policy (and constant) as the vLLM
+        connector's _sg_group_key/SG_MAX_SEGS."""
+        w = self._sg_width()
+        if w == SG_DEFAULT_WIDTH:
+            return f"{sk}@sg{ci}"
+        return f"{sk}@sgw{w}.{ci}"
+
     def _flatten_device(self, keys, seg_ptrs, seg_sizes, keys_fn=None, sub=None):
         """Expand per-page keys into per-sub-object (k[/v]) sub-keys, pairing each
         with its per-layer device segment list. Parallel to _flatten, but every
@@ -930,7 +953,10 @@ class DfkvHiCache(HiCacheStorage):
         the same scheme (and key suffix) the vLLM connector uses. Write and read
         derive the identical deterministic split from (layer count, width), so
         the layer-major bytes reassemble exactly. Chunk count is uniform across
-        pages, so _fold()'s per-page stride is sub * nchunks.
+        pages, so _fold()'s per-page stride is sub * nchunks. The WIDTH is part
+        of a key's identity: non-default widths are namespaced "@sgw{W}.{n}"
+        (see _sg_group_key), so clients that negotiated different widths miss
+        (cold) instead of reading mis-split bytes.
 
         keys_fn/sub default to the main-KV key scheme (self._keys / self._sub); the
         DSA indexer sidecar and the EAGLE draft pool pass their own key builder and
@@ -948,7 +974,7 @@ class DfkvHiCache(HiCacheStorage):
                 s = [int(x) for x in seg_sizes[i * sub + j]]
                 nchunks = max(1, (len(p) + w - 1) // w)
                 for ci in range(nchunks):
-                    sks.append(f"{sk}@sg{ci}")
+                    sks.append(self._sg_group_key(sk, ci))
                     sp.append(p[ci * w:(ci + 1) * w])
                     ss.append(s[ci * w:(ci + 1) * w])
         return sub * nchunks, sks, sp, ss
@@ -1166,14 +1192,15 @@ class DfkvHiCache(HiCacheStorage):
         with _tracing.span("batch_exists", total) as _sp, \
                 access_log("batch_exists", lambda: f"{self._alog_tag} {total} keys") as r:
             # longest contiguous prefix of pages whose every sub-object exists.
-            # Device-direct (L2-bypass) writes store "@sg{n}" chunk sub-keys, so
-            # existence is probed on "@sg0" — the vLLM connector's probe scheme;
-            # the bare sub-key never matches a chunked store. A bypass instance
-            # only ever writes chunked keys (model_hash-isolated), so one probe
-            # form suffices per mode.
+            # Device-direct (L2-bypass) writes store "@sg{n}"/"@sgw{W}.{n}" chunk
+            # sub-keys, so existence is probed on group 0 via _sg_group_key() —
+            # the bare sub-key never matches a chunked store, and a *different*
+            # negotiated width lands in a different namespace (miss, not corrupt).
+            # A bypass instance only ever writes chunked keys (model_hash-
+            # isolated), so one probe form suffices per mode.
             sub = self._sub()
             if getattr(self, "mem_pool_device", None) is not None:
-                sks = [f"{sk}@sg0" for k in keys for sk in self._keys(k)]
+                sks = [self._sg_group_key(sk, 0) for k in keys for sk in self._keys(k)]
             else:
                 sks = [sk for k in keys for sk in self._keys(k)]
             page_ok = self._fold(self._batch_exist_flat(sks), total, sub)
@@ -1746,11 +1773,12 @@ class DfkvHiCache(HiCacheStorage):
                     break
                 name = str(tr.name)
                 sub = self._pool_sub(name)
-                # Device-direct sidecars (task 4) store "@sg{n}" chunk sub-keys, so
-                # probe "@sg0" — the same scheme batch_exists uses for the main KV.
+                # Device-direct sidecars (task 4) store "@sg{n}"/"@sgw{W}.{n}"
+                # chunk sub-keys, so probe group 0 via _sg_group_key() — the
+                # same scheme batch_exists uses for the main KV.
                 # A host sidecar stores the bare sub-key.
                 dev_side = name in getattr(self, "_sidecar_device_pools", {})
-                sks = [(sk + "@sg0") if dev_side else sk
+                sks = [self._sg_group_key(sk, 0) if dev_side else sk
                        for k in keys[:kv_pages]
                        for sk in self._pool_keys(name, k)]
                 present = self._fold(self._batch_exist_flat(sks), kv_pages, sub)

--- a/integration/hicache/tests/test_sg_width_namespace.py
+++ b/integration/hicache/tests/test_sg_width_namespace.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SG-width key namespacing in the HiCache backend.
+
+Regression: `_flatten_device` used to always emit "@sg{n}" regardless of the
+negotiated SG width. Two instances on one ring that negotiate DIFFERENT
+widths (e.g. mixed HCA fleet) would read each other's chunk keys and
+silently reassemble the wrong bytes — same key string, different layer
+spans, no error signal. Non-default widths now use "@sgw{W}.{n}"; the
+historical default (29) keeps "@sg{n}" so existing cached pages stay
+reachable. Mirrors the vLLM connector's `_sg_group_key` policy.
+
+These tests run WITHOUT SGLang/torch: a minimal shim module is installed so
+the plugin's import surface is satisfied, and DfkvHiCache is exercised via
+``__new__`` + attribute injection instead of the heavyweight ``__init__``.
+
+Run:
+    python3 -m pytest integration/hicache/tests/test_sg_width_namespace.py -v
+or standalone:
+    python3 integration/hicache/tests/test_sg_width_namespace.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import types
+import unittest
+
+# Make the plugin importable from the repo without install (sibling modules
+# dfkv_access_log / dfkv_hot_config / dfkv_metrics / dfkv_telemetry live in
+# integration/hicache/).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Minimal sglang shim (import-time surface only)
+# ---------------------------------------------------------------------------
+
+
+def _install_sglang_shim() -> None:
+    class HiCacheStorage:  # base class stand-in
+        pass
+
+    class HiCacheStorageConfig:
+        pass
+
+    hicache_storage = types.ModuleType("sglang.srt.mem_cache.hicache_storage")
+    hicache_storage.HiCacheStorage = HiCacheStorage
+    hicache_storage.HiCacheStorageConfig = HiCacheStorageConfig
+    mem_cache = types.ModuleType("sglang.srt.mem_cache")
+    mem_cache.hicache_storage = hicache_storage
+    srt = types.ModuleType("sglang.srt")
+    srt.mem_cache = mem_cache
+    sglang = types.ModuleType("sglang")
+    sglang.srt = srt
+    sys.modules.setdefault("sglang", sglang)
+    sys.modules.setdefault("sglang.srt", srt)
+    sys.modules.setdefault("sglang.srt.mem_cache", mem_cache)
+    sys.modules["sglang.srt.mem_cache.hicache_storage"] = hicache_storage
+
+
+_install_sglang_shim()
+
+import dfkv_hicache as H  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Harness stubs (access log / tracing spans ride module-level functions)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpan:
+    def __init__(self):
+        self.hits = 0
+        self.attrs = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeALCtx:
+    def __init__(self):
+        self.result = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _stub_observability() -> None:
+    H.access_log = lambda name, fn: _FakeALCtx()
+    H._tracing.span = lambda *a, **k: _FakeSpan()
+
+
+_stub_observability()
+
+
+class _FakeLib:
+    """dfkv_max_sg_segs is the only handle _sg_width() needs."""
+
+    def __init__(self, width: int):
+        self._width = width
+
+    def dfkv_max_sg_segs(self, _h) -> int:
+        return self._width
+
+
+class _FakeMetrics:
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+
+
+def _mk_instance(width: int, mla: bool = True):
+    inst = H.DfkvHiCache.__new__(H.DfkvHiCache)
+    inst._lib = _FakeLib(width)
+    inst._h = 1
+    inst.model = "GLM-TEST"
+    inst.is_mla = mla
+    inst.tp_rank = 3
+    inst.tp_size = 8
+    inst.enable_pp = False
+    inst.pp_rank = 0
+    inst.mem_pool_device = object()  # non-None → device (L2-bypass) mode
+    inst._metrics = _FakeMetrics()
+    inst._alog_tag = "test"
+    inst._log_exist_probe = lambda *a, **k: None
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSgGroupKey(unittest.TestCase):
+    def test_default_width_keeps_legacy_suffix(self):
+        inst = _mk_instance(29)
+        self.assertEqual(inst._sg_group_key("K", 0), "K@sg0")
+        self.assertEqual(inst._sg_group_key("K", 2), "K@sg2")
+
+    def test_nondefault_width_gets_own_namespace(self):
+        inst = _mk_instance(4)
+        self.assertEqual(inst._sg_group_key("K", 0), "K@sgw4.0")
+        inst63 = _mk_instance(63)
+        self.assertEqual(inst63._sg_group_key("K", 1), "K@sgw63.1")
+
+    def test_width_detect_failure_falls_back_to_legacy_namespace(self):
+        class _DeadLib:
+            def dfkv_max_sg_segs(self, _h):
+                raise RuntimeError("old lib")
+
+        inst = _mk_instance(29)
+        inst._lib = _DeadLib()
+        self.assertEqual(inst._sg_group_key("K", 0), "K@sg0")
+
+
+class TestFlattenDeviceKeyNames(unittest.TestCase):
+    """layer_num=13 under width 4 → 4 chunks (4+4+4+1); under 29 → 1 chunk."""
+
+    @staticmethod
+    def _seglists(nlayers: int):
+        ptrs = [1000 * (i + 1) for i in range(nlayers)]
+        sizes = [512] * nlayers
+        return ptrs, sizes
+
+    def test_legacy_namespace_when_default_width(self):
+        inst = _mk_instance(29)
+        nl = 13
+        ptrs, sizes = self._seglists(nl)
+        stride, sks, sp, ss = inst._flatten_device(["hash0"], [ptrs], [sizes])
+        self.assertEqual(sks, ["GLM-TEST/hash0_k@sg0"])
+        self.assertEqual(stride, 1)
+        self.assertEqual(len(sp[0]), nl)  # single chunk holds all layers
+
+    def test_namespaced_chunking_when_narrow(self):
+        inst = _mk_instance(4)
+        nl = 13
+        ptrs, sizes = self._seglists(nl)
+        stride, sks, sp, ss = inst._flatten_device(["hash0"], [ptrs], [sizes])
+        self.assertEqual(
+            sks,
+            ["GLM-TEST/hash0_k@sgw4.0", "GLM-TEST/hash0_k@sgw4.1",
+             "GLM-TEST/hash0_k@sgw4.2", "GLM-TEST/hash0_k@sgw4.3"],
+        )
+        self.assertEqual(stride, 4)
+        # chunk segment slicing must follow the same width
+        self.assertEqual([len(p) for p in sp], [4, 4, 4, 1])
+        self.assertEqual(sp[0], ptrs[0:4])
+        self.assertEqual(sp[3], ptrs[12:13])
+
+    def test_mha_pp_composition(self):
+        inst = _mk_instance(4, mla=False)
+        inst.enable_pp = True
+        inst.pp_rank = 1
+        nl = 3
+        ptrs, sizes = self._seglists(nl)
+        stride, sks, sp, ss = inst._flatten_device(
+            ["hash0"], [ptrs, ptrs], [sizes, sizes])
+        self.assertEqual(
+            sks,
+            ["GLM-TEST/hash0_8_3_pp1_k@sgw4.0", "GLM-TEST/hash0_8_3_pp1_v@sgw4.0"],
+        )
+        self.assertEqual(stride, 2)  # sub=2 objects, one chunk each
+
+
+class TestCrossWidthIsolation(unittest.TestCase):
+    """The actual failure mode: width-4 writer vs width-29 reader over a
+    shared ring must MISS (cold cache), never return mis-split bytes."""
+
+    @staticmethod
+    def _ring_from(inst, hash_name: str, nlayers: int, width: int):
+        """Simulate a "ring": the set of key strings `inst` would have written."""
+        ptrs = [1000 * (i + 1) for i in range(nlayers)]
+        sizes = [512] * nlayers
+        _, sks, _, _ = inst._flatten_device([hash_name], [ptrs], [sizes])
+        return set(sks)
+
+    def _probe(self, inst, hashes):
+        """Run batch_exists with a capture harness; return (probe_keys, hits)."""
+        captured = {}
+        ring = getattr(inst, "_ring", set())
+
+        def fake_exist(sks):
+            captured["sks"] = list(sks)
+            return [k in ring for k in sks]
+
+        inst._batch_exist_flat = fake_exist
+        hits = inst.batch_exists(hashes)
+        return captured["sks"], hits
+
+    def test_cross_width_is_a_miss_not_a_corrupt_read(self):
+        writer29 = _mk_instance(29)
+        ring = self._ring_from(writer29, "hashX", 13, 29)
+
+        reader4 = _mk_instance(4)
+        reader4._ring = ring  # sole key universe contains only @sg{n} keys
+
+        sks, hits = self._probe(reader4, ["hashX"])
+        # the reader probes its own namespace (@sgw4.0) → nothing matches
+        self.assertEqual(sks, ["GLM-TEST/hashX_k@sgw4.0"])
+        self.assertEqual(hits, 0)
+
+    def test_same_width_hits(self):
+        writer = _mk_instance(4)
+        ring = self._ring_from(writer, "hashX", 13, 4)
+
+        reader = _mk_instance(4)
+        reader._ring = ring
+        sks, hits = self._probe(reader, ["hashX"])
+        self.assertEqual(sks, ["GLM-TEST/hashX_k@sgw4.0"])
+        self.assertEqual(hits, 1)
+
+    def test_default_width_still_finds_legacy_cached_pages(self):
+        writer = _mk_instance(29)
+        ring = self._ring_from(writer, "hashX", 13, 29)
+
+        reader = _mk_instance(29)
+        reader._ring = ring
+        sks, hits = self._probe(reader, ["hashX"])
+        self.assertEqual(sks, ["GLM-TEST/hashX_k@sg0"])
+        self.assertEqual(hits, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### Problem

Mixed-HCA rings can pair two HiCache instances that negotiated different scatter-gather widths (HCA `max_sge` budgets differ across CX generations and other vendors). `_flatten_device` used to always emit `@sg{n}` regardless of the width, so width-4 clients and width-29 clients shared **one** key namespace — the same key string then carries *different* consecutive-layer spans, and a variable-size GET whose total capacity happens to fit would scatter the **wrong** bytes with no error signal.

### Fix

The SG grouping width is now part of a key's identity:

- non-default widths get their own namespace `@sgw{W}.{n}`;
- the historical default width (29, ConnectX-era `max_sge=30` minus the `SGE[0]` header) keeps `@sg{n}`, so previously cached pages stay reachable across this upgrade.

Same policy (and constant) as the vLLM connector's `_sg_group_key`/`SG_MAX_SEGS`, applied at all three construction points: `_flatten_device` (write+read), `batch_exists` probe, and the device sidecar probe — so a mixed-width fleet now MISSES (cold) instead of reading mis-split bytes.

### Tests

New: `integration/hicache/tests/test_sg_width_namespace.py` (9 tests, no torch/sglang needed — shim module), covering:

- legacy suffix retained at the default width;
- namespaced chunking at widths 4/63 with correct segment slicing;
- MHA+PP key composition;
- **cross-width isolation: width-4 writer vs width-29 reader over one ring → miss, never a corrupt read**;
- legacy cached pages still found at the default width;
- detection-failure fallback to the legacy namespace.

All 9 tests pass; ring-level semantics confirmed against a live dfkv deployment (isolation/probe parity/legacy compat).