### PR TITLE
feat(lmcache): opt-in MLA canonical keys for the MP-server L2 adapter

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -655,7 +655,11 @@ vllm serve <model> --tensor-parallel-size 8 --no-enable-prefix-caching \
 `adapter_params` 键：`url`（必填，语法同 in-process）、`membership`（`mds` 默认 |`static`）、
 `lib`（否则 `DFKV_LIB`）、`model_name`（隔离命名空间 → 稳定 dfkv `model_hash`）、
 `mds_poll_ms`（3000）、`page_size`（0 = 关几何守卫）、`num_workers`（8）、
-`max_capacity_gb`（0 = 容量交给 dfkv 自管；>0 开 LMCache 聚合 L2 淘汰，见 §4.6.6）。
+`max_capacity_gb`（0 = 容量交给 dfkv 自管；>0 开 LMCache 聚合 L2 淘汰，见 §4.6.6）、
+`mla_canonical_keys`（bool 默认关，MLA 专用 opt-in：折叠 kv_rank 的 rank 字段，
+复制态 KV 共享一把 key 且写前 exists 去重，消除 8x 存储/写膨胀；仅 MLA+PP=1—
+在分片或 PP 模型上开会把不同内容压成同键；后续开关 = 冷启；或环境变量
+`DFKV_L2ADAPTER_MLA_CANONICAL_KEYS=1`）。
 server 的 pinned L1 arena 在 LMCache 传入 `l1_memory_desc` 时自动注册 RDMA 零拷贝。
 
 实现要点：dfkv 无原生 eventfd，`DfkvL2Adapter` 用**后台 asyncio loop + 三个

--- a/integration/lmcache/README.md
+++ b/integration/lmcache/README.md
@@ -87,7 +87,13 @@ vllm serve <model> --tensor-parallel-size 8 --no-enable-prefix-caching \
 `membership` (`mds`|`static`), `lib` (else `DFKV_LIB`), `model_name`
 (isolation namespace → stable dfkv `model_hash`), `mds_poll_ms` (3000),
 `page_size` (0 = geometry guard off), `num_workers` (8), `max_capacity_gb`
-(0 = dfkv manages its own capacity; >0 enables aggregate L2 eviction). The
+(0 = dfkv manages its own capacity; >0 enables aggregate L2 eviction),
+`mla_canonical_keys` (bool, default false): MLA-only opt-in — folds the
+kv_rank rank fields so replicated KV shares one key and stores are
+deduped with an exists probe (fixes the 8x storage/write inflation;
+MLA+PP=1 deployments only — enabling under a sharded or PP model would
+collapse distinct content; flipping later = cold cache; or env
+`DFKV_L2ADAPTER_MLA_CANONICAL_KEYS=1`). The
 server's pinned L1 arena is auto-registered for RDMA zero-copy when LMCache
 passes an `l1_memory_desc`. Validated on GLM-5.2 (vLLM 0.23.0 + LMCache 0.4.7):
 store → restart (L1 wiped) → reload from dfkv with prefill skipped.

--- a/integration/lmcache/src/dfkv_connector/l2_adapter.py
+++ b/integration/lmcache/src/dfkv_connector/l2_adapter.py
@@ -39,7 +39,9 @@ Design notes:
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import hashlib
+import os
 import threading
 from concurrent.futures import Future as _CFuture
 from typing import TYPE_CHECKING, List, Optional
@@ -79,16 +81,14 @@ def _object_key_to_string(key: ObjectKey) -> str:
     Deterministic across processes/restarts so a cache written before a restart
     is found afterwards.
 
-    KNOWN GAP (MLA 8x on this path): kv_rank is NOT rank-agnostic — upstream's
-    ObjectKey.ComputeKVRank packs (world_size<<24 | global_rank<<16 | ...), so
-    every TP worker gets a distinct kv_rank and MLA's replicated KV is stored
-    8x over (one key per rank), which the same-host rendezvous can't collapse.
-    The RemoteConnector path fixes this by canonicalizing worker_id->0 (see
-    remote_connector.py, DFKV_CONNECTOR_MLA_CANONICAL_KEYS), but the L2-adapter
-    lookup expands to ALL world_size kv_ranks and fold requires every shard
-    present — so canonicalizing here needs a COORDINATED store+lookup+fold
-    change, not a one-line key rewrite. Deferred; do not assume this path is
-    deduped for MLA.
+    MLA 8x (historical KNOWN GAP, FIXED via opt-in): kv_rank packs
+    (world_size<<24 | global_rank<<16 | ...), so every TP worker got a distinct
+    kv_rank and MLA's replicated KV was stored 8x over. The adapter now
+    canonicalizes rank fields to 0 when ``mla_canonical_keys=true`` (see
+    DfkvL2AdapterConfig / _canonical_kv_rank), giving all ranks ONE shared key
+    with an exists-probe dedup on the store path. Canonicalization folds PP
+    stages as well (pp lives inside global_rank), so enable it only for
+    MLA + PP=1 deployments (the RemoteConnector path's precondition too).
     """
     base = (
         f"{key.model_name}{_KEY_SEP}{key.kv_rank:08x}"
@@ -97,6 +97,23 @@ def _object_key_to_string(key: ObjectKey) -> str:
     if key.cache_salt:
         return f"{base}{_KEY_SEP}{key.cache_salt}"
     return base
+
+
+def _kv_rank_world(kv_rank: int) -> int:
+    """world_size component of an ObjectKey kv_rank (upstream packs 4x8bit)."""
+    return (kv_rank >> 24) & 0xFF
+
+
+def _canonical_kv_rank(kv_rank: int) -> int:
+    """Fold the rank fields (global_rank<<16 | local_rank) of a kv_rank to zero
+    while keeping the topology dims (world_size<<24 | local_world_size<<8).
+
+    Replicated (MLA) KV is byte-identical across TP ranks, so all ranks share
+    one canonical key; different TP shapes must still NOT collide, hence the
+    topology dims stay. PP stages hold different content — canonicalization is
+    only safe for PP=1 (config gate mla_canonical_keys documents that).
+    """
+    return kv_rank & 0xFF00FF00
 
 
 def _stable_model_hash(model_name: str) -> int:
@@ -155,6 +172,7 @@ class DfkvL2AdapterConfig(L2AdapterConfigBase):
         page_size: int = 0,
         num_workers: int = 8,
         max_capacity_gb: float = 0.0,
+        mla_canonical_keys: bool = False,
     ) -> None:
         self.url = url
         self.membership = membership
@@ -164,6 +182,7 @@ class DfkvL2AdapterConfig(L2AdapterConfigBase):
         self.page_size = page_size
         self.num_workers = num_workers
         self.max_capacity_gb = max_capacity_gb
+        self.mla_canonical_keys = bool(mla_canonical_keys)
 
     @classmethod
     def from_dict(cls, d: dict) -> "DfkvL2AdapterConfig":
@@ -205,6 +224,22 @@ class DfkvL2AdapterConfig(L2AdapterConfigBase):
                 "dfkv L2 adapter: 'max_capacity_gb' must be a non-negative number"
             )
 
+        # MLA canonical keys: fold kv_rank rank fields -> one shared key per
+        # chunk + exists-probe dedup on the store path (fixes the MLA 8x
+        # storage/write inflation). OFF by default: wrongly enabling it under a
+        # SHARDED (non-MLA) or PP>1 model would collapse distinct content onto
+        # one key. Env DFKV_L2ADAPTER_MLA_CANONICAL_KEYS is honored when the
+        # dict key is absent. Flipping the effective value = cold cache (the
+        # key set changes).
+        mla_canonical_keys = d.get("mla_canonical_keys", None)
+        if mla_canonical_keys is None:
+            env = os.environ.get("DFKV_L2ADAPTER_MLA_CANONICAL_KEYS", "")
+            mla_canonical_keys = env.strip().lower() in ("1", "true", "yes", "on")
+        elif not isinstance(mla_canonical_keys, (bool, int)):
+            raise ValueError(
+                "dfkv L2 adapter: 'mla_canonical_keys' must be a boolean"
+            )
+
         return cls(
             url=url,
             membership=membership,
@@ -214,6 +249,7 @@ class DfkvL2AdapterConfig(L2AdapterConfigBase):
             page_size=page_size,
             num_workers=num_workers,
             max_capacity_gb=float(max_capacity_gb),
+            mla_canonical_keys=bool(mla_canonical_keys),
         )
 
     @classmethod
@@ -228,7 +264,10 @@ class DfkvL2AdapterConfig(L2AdapterConfigBase):
             "- page_size (int): geometry page-size guard (default 0 = off)\n"
             "- num_workers (int): client I/O parallelism (default 8)\n"
             "- max_capacity_gb (float): >0 enables aggregate eviction "
-            "(default 0 = dfkv manages capacity)"
+            "(default 0 = dfkv manages capacity)\n"
+            "- mla_canonical_keys (bool): MLA-only opt-in — fold kv_rank rank "
+            "fields so replicated KV shares one key + exists-dedup stores "
+            "(fixed 8x inflation; MLA+PP=1 only; flipping = cold cache)"
         )
 
 
@@ -249,6 +288,14 @@ class DfkvL2Adapter(L2AdapterInterface):
     ) -> None:
         super().__init__(max_capacity_bytes=int(config.max_capacity_gb * (1024**3)))
         self._config = config
+
+        # MLA canonical keys (opt-in): fold kv_rank rank fields so replicated
+        # MLA KV shares ONE key per chunk, and dedup stores with an exists
+        # probe (the store path otherwise transfers the same bytes world_size
+        # times). Enabling under a non-MLA / PP>1 model would collapse
+        # distinct content — the config flag documents the precondition.
+        self._canonical = bool(config.mla_canonical_keys)
+        self._warned_mla_hint = False
 
         # 3 distinct event notifiers (the contract requires distinct fds).
         self._store_efd = create_event_notifier()
@@ -308,11 +355,46 @@ class DfkvL2Adapter(L2AdapterInterface):
         )
         logger.info(
             "DfkvL2Adapter ready: endpoint=%s group=%s membership=%s "
-            "model_hash=%d rdma_pools=%d transport=%s",
+            "model_hash=%d rdma_pools=%d transport=%s mla_canonical_keys=%s",
             endpoint.raw_endpoint, endpoint.group, endpoint.membership,
             geometry["model_hash"], len(rdma_pools),
             getattr(self._client, "transport_mode", "unknown"),
+            self._canonical,
         )
+
+    # ------------------------------------------------------------------
+    # Key canonicalization (MLA opt-in)
+    # ------------------------------------------------------------------
+
+    def _canon(self, key: ObjectKey) -> ObjectKey:
+        """Fold rank fields of kv_rank when canonical keys are enabled.
+
+        A world_size of 1 (or a mis-unpacked kv_rank) passes through unchanged.
+        ObjectKey is a frozen dataclass — dataclasses.replace keeps every other
+        field (chunk_hash / object_group_id / cache_salt)."""
+        if not self._canonical or _kv_rank_world(key.kv_rank) <= 1:
+            return key
+        return dataclasses.replace(
+            key, kv_rank=_canonical_kv_rank(key.kv_rank)
+        )
+
+    def _hint_canonical_if_mla(self, keys: List[ObjectKey]) -> None:
+        """One-time operational hint when the keyspace looks replicated-MLA
+        (world_size>1) but canonicalization is off — the old MLA-8x mode."""
+        if self._canonical or self._warned_mla_hint:
+            return
+        for k in keys:
+            if _kv_rank_world(k.kv_rank) > 1:
+                self._warned_mla_hint = True
+                logger.warning(
+                    "dfkv L2 adapter: kv_rank world_size=%d with "
+                    "mla_canonical_keys=false — if this model replicates KV "
+                    "across TP ranks (MLA), enabling mla_canonical_keys "
+                    "removes the %dx storage/write inflation (flipping = cold "
+                    "cache). Safe to ignore for sharded (non-MLA) models.",
+                    _kv_rank_world(k.kv_rank), _kv_rank_world(k.kv_rank),
+                )
+                return
 
     # ------------------------------------------------------------------
     # Event Fd Interface
@@ -331,9 +413,31 @@ class DfkvL2Adapter(L2AdapterInterface):
     # Store
     # ------------------------------------------------------------------
 
+    async def _batch_set_maybe_dedup(self, key_strs, views):
+        """With canonical keys, every TP worker submits the SAME key for one
+        chunk; probe existence first and transfer only the missing ones.
+        Returns (ok, per_key_flags). Race note: two tasks probing miss in the
+        same window both write — benign, the bytes are identical (this is a
+        cache). Disabled → plain batch_set."""
+        if not self._canonical:
+            return await self._client.batch_set(key_strs, views)
+        present = await self._client.batch_exists(key_strs)
+        if all(present):
+            return True, [True] * len(key_strs)
+        miss = [i for i, p in enumerate(present) if not p]
+        mkeys = [key_strs[i] for i in miss]
+        mviews = [views[i] for i in miss]
+        ok, per = await self._client.batch_set(mkeys, mviews)
+        flags = [bool(p) for p in present]
+        for idx, f in zip(miss, per):
+            flags[idx] = bool(f)
+        return ok, flags
+
     def submit_store_task(
         self, keys: List[ObjectKey], objects: List[MemoryObj]
     ) -> L2TaskId:
+        keys = [self._canon(k) for k in keys]
+        self._hint_canonical_if_mla(keys)
         key_strs = [_object_key_to_string(k) for k in keys]
         views = [obj.byte_array for obj in objects]
         sizes = [obj.get_size() for obj in objects]
@@ -341,7 +445,7 @@ class DfkvL2Adapter(L2AdapterInterface):
             task_id = self._next_task_id
             self._next_task_id += 1
         fut = asyncio.run_coroutine_threadsafe(
-            self._client.batch_set(key_strs, views), self._loop
+            self._batch_set_maybe_dedup(key_strs, views), self._loop
         )
         # Hold ``objects`` alive in the closure until the store completes — the
         # memoryviews alias their buffers and the C call must finish reading.
@@ -398,6 +502,7 @@ class DfkvL2Adapter(L2AdapterInterface):
     # ------------------------------------------------------------------
 
     def submit_lookup_and_lock_task(self, keys: List[ObjectKey]) -> L2TaskId:
+        keys = [self._canon(k) for k in keys]
         key_strs = [_object_key_to_string(k) for k in keys]
         with self._lock:
             task_id = self._next_task_id
@@ -436,6 +541,8 @@ class DfkvL2Adapter(L2AdapterInterface):
     def submit_unlock(self, keys: List[ObjectKey]) -> None:
         # dfkv objects are remote and never evicted out from under a loader, so
         # this is purely client-side refcount bookkeeping (kept for symmetry).
+        # Canonicalize so the refcount collapses onto the shared key too.
+        keys = [self._canon(k) for k in keys]
         with self._lock:
             for key in keys:
                 c = self._locked_keys.get(key)
@@ -453,6 +560,7 @@ class DfkvL2Adapter(L2AdapterInterface):
     def submit_load_task(
         self, keys: List[ObjectKey], objects: List[MemoryObj]
     ) -> L2TaskId:
+        keys = [self._canon(k) for k in keys]
         key_strs = [_object_key_to_string(k) for k in keys]
         views = [obj.byte_array for obj in objects]
         with self._lock:
@@ -502,6 +610,8 @@ class DfkvL2Adapter(L2AdapterInterface):
     # ------------------------------------------------------------------
 
     def delete(self, keys: List[ObjectKey]) -> None:
+        # Canonicalize so eviction removes the shared key, not one rank's ghost.
+        keys = [self._canon(k) for k in keys]
         """Drop keys from dfkv (L2 eviction). Synchronous per the L2 controller
         contract; fires ``_notify_keys_deleted`` so the eviction policy's byte
         accounting stays in sync. No-op (with a one-time warning) if the loaded

--- a/integration/lmcache/tests/test_l2_adapter_mla_canonical.py
+++ b/integration/lmcache/tests/test_l2_adapter_mla_canonical.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for MLA canonical keys in the dfkv LMCache MP-server L2 adapter.
+
+Historical KNOWN GAP (now opt-in fixed): ``ObjectKey.kv_rank`` packs
+``(world_size<<24 | global_rank<<16 | local_world_size<<8 | local_rank)`` —
+every TP worker wrote MLA's replicated KV under its own key → 8x storage,
+8x write traffic, and the same-host rendezvous could never match.
+
+With ``mla_canonical_keys=true`` the adapter folds the rank fields to zero
+(topology dims kept) and dedups stores with an exists probe. These tests
+verify: config gating (default OFF), key sharing/isolation, store dedup,
+cross-rank hit, and the cold-cache flip semantics.
+
+Run (inside an env with lmcache installed):
+    python3 -m pytest integration/lmcache/tests/test_l2_adapter_mla_canonical.py -v
+or standalone:
+    python3 integration/lmcache/tests/test_l2_adapter_mla_canonical.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+import unittest
+
+# Make ``import dfkv_connector`` work when run from the repo without install.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import dfkv_connector.l2_adapter as l2mod  # noqa: E402
+from dfkv_connector.l2_adapter import (  # noqa: E402
+    DfkvL2Adapter,
+    DfkvL2AdapterConfig,
+    _canonical_kv_rank,
+    _object_key_to_string,
+)
+from lmcache.v1.distributed.api import ObjectKey  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Fakes (same pattern as test_l2_adapter.py)
+# --------------------------------------------------------------------------
+
+
+class _FakeObj:
+    def __init__(self, data: bytes):
+        self._buf = bytearray(data)
+
+    @property
+    def byte_array(self) -> memoryview:
+        return memoryview(self._buf)
+
+    def get_size(self) -> int:
+        return len(self._buf)
+
+    def data(self) -> bytes:
+        return bytes(self._buf)
+
+
+class _FakeDfkvClient:
+    """In-memory async dfkv client with store-call instrumentation."""
+
+    def __init__(self, **kwargs):
+        self.transport_mode = "fake"
+        self.store: dict[str, bytes] = {}
+        self.set_calls: list[list[str]] = []
+        self.set_bytes = 0
+
+    async def batch_set(self, keys, bufs):
+        self.set_calls.append(list(keys))
+        for k, b in zip(keys, bufs):
+            self.store[k] = bytes(b)
+            self.set_bytes += len(b)
+        return True, [True] * len(keys)
+
+    async def batch_get(self, keys, bufs):
+        per_key, lengths = [], []
+        for k, b in zip(keys, bufs):
+            data = self.store.get(k)
+            if data is None:
+                per_key.append(False)
+                lengths.append(0)
+            else:
+                n = min(len(data), len(b))
+                b[:n] = data[:n]
+                per_key.append(True)
+                lengths.append(n)
+        return all(per_key) if per_key else True, per_key, lengths
+
+    async def batch_exists(self, keys):
+        return [k in self.store for k in keys]
+
+    def supports_remove(self) -> bool:
+        return True
+
+    async def batch_remove(self, keys):
+        return [self.store.pop(k, None) is not None or True for k in keys]
+
+    def close(self):
+        pass
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _kv_rank(ws: int, grank: int, lws: int, lrank: int) -> int:
+    return (ws << 24) | (grank << 16) | (lws << 8) | lrank
+
+
+def _mk_adapter(canonical: bool) -> DfkvL2Adapter:
+    cfg = DfkvL2AdapterConfig.from_dict(
+        {
+            "url": "dfkv://127.0.0.1:28150/glm",
+            "membership": "mds",
+            "model_name": "unit-test",
+            "mla_canonical_keys": canonical,
+        }
+    )
+    return DfkvL2Adapter(cfg)
+
+
+def _rank_key(tag: int, grank: int, ws: int = 8) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=tag.to_bytes(8, "little"),
+        model_name="unit-test",
+        kv_rank=_kv_rank(ws, grank, ws, grank),
+    )
+
+
+def _wait_for(fn, timeout: float = 5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        v = fn()
+        if v is not None:
+            return v
+        time.sleep(0.01)
+    return None
+
+
+def _install_fake_client() -> None:
+    l2mod.DfkvNativeClient = _FakeDfkvClient  # type: ignore[assignment]
+
+
+_install_fake_client()
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+class TestConfigGating(unittest.TestCase):
+    def test_default_off(self):
+        cfg = DfkvL2AdapterConfig.from_dict(
+            {"url": "dfkv://127.0.0.1:1/g", "model_name": "m"}
+        )
+        self.assertFalse(cfg.mla_canonical_keys)
+
+    def test_opt_in_via_dict(self):
+        cfg = DfkvL2AdapterConfig.from_dict(
+            {"url": "dfkv://127.0.0.1:1/g", "model_name": "m",
+             "mla_canonical_keys": True}
+        )
+        self.assertTrue(cfg.mla_canonical_keys)
+
+    def test_opt_in_via_env(self):
+        os.environ["DFKV_L2ADAPTER_MLA_CANONICAL_KEYS"] = "1"
+        try:
+            cfg = DfkvL2AdapterConfig.from_dict(
+                {"url": "dfkv://127.0.0.1:1/g", "model_name": "m"}
+            )
+            self.assertTrue(cfg.mla_canonical_keys)
+        finally:
+            del os.environ["DFKV_L2ADAPTER_MLA_CANONICAL_KEYS"]
+
+    def test_dict_beats_env(self):
+        os.environ["DFKV_L2ADAPTER_MLA_CANONICAL_KEYS"] = "1"
+        try:
+            cfg = DfkvL2AdapterConfig.from_dict(
+                {"url": "dfkv://127.0.0.1:1/g", "model_name": "m",
+                 "mla_canonical_keys": False}
+            )
+            self.assertFalse(cfg.mla_canonical_keys)
+        finally:
+            del os.environ["DFKV_L2ADAPTER_MLA_CANONICAL_KEYS"]
+
+
+class TestCanonicalKeyForm(unittest.TestCase):
+    def test_canonical_kv_rank_zeroes_only_rank_fields(self):
+        r = _kv_rank(ws=8, grank=3, lws=8, lrank=3)
+        c = _canonical_kv_rank(r)
+        self.assertEqual(c, (8 << 24) | (8 << 8))  # ws/lws kept, ranks zeroed
+
+    def test_same_chunk_shared_key_across_ranks_when_on(self):
+        a = _mk_adapter(True)
+        try:
+            k3 = a._canon(_rank_key(1, grank=3))
+            k5 = a._canon(_rank_key(1, grank=5))
+            self.assertEqual(k3, k5)
+            self.assertEqual(
+                _object_key_to_string(k3), _object_key_to_string(k5))
+        finally:
+            a.close()
+
+    def test_legacy_mode_keeps_per_rank_keys(self):
+        a = _mk_adapter(False)
+        try:
+            k3 = a._canon(_rank_key(1, grank=3))
+            k5 = a._canon(_rank_key(1, grank=5))
+            self.assertNotEqual(k3, k5)
+            self.assertNotEqual(
+                _object_key_to_string(k3), _object_key_to_string(k5))
+        finally:
+            a.close()
+
+    def test_topology_dims_keep_shapes_apart(self):
+        """TP4 and TP8 deployments must NOT collapse onto one key."""
+        a = _mk_adapter(True)
+        try:
+            k4 = a._canon(_rank_key(1, grank=3, ws=4))
+            k8 = a._canon(_rank_key(1, grank=3, ws=8))
+            self.assertNotEqual(
+                _object_key_to_string(k4), _object_key_to_string(k8))
+        finally:
+            a.close()
+
+    def test_world_size_1_passthrough(self):
+        a = _mk_adapter(True)
+        try:
+            k = _rank_key(1, grank=0, ws=1)
+            self.assertEqual(a._canon(k), k)
+        finally:
+            a.close()
+
+    def test_flip_is_cold_cache(self):
+        """Canonical on/off produce different key strings — flipping the flag
+        for a live ring must be understood as a cache reset (documented)."""
+        on = _mk_adapter(True)
+        off = _mk_adapter(False)
+        try:
+            k = _rank_key(1, grank=3)
+            self.assertNotEqual(
+                _object_key_to_string(on._canon(k)),
+                _object_key_to_string(off._canon(k)),
+            )
+        finally:
+            on.close()
+            off.close()
+
+
+class TestStoreDedup(unittest.TestCase):
+    def test_replicated_chunk_written_once_across_ranks(self):
+        a = _mk_adapter(True)
+        try:
+            payload = b"mlA-Replicated-Chunk" * 64  # 1.2 KiB
+            # rank 3 stores chunk 42
+            k3 = _rank_key(42, grank=3)
+            t1 = a.submit_store_task([k3], [_FakeObj(payload)])
+            r1 = _wait_for(lambda: a.pop_completed_store_tasks().get(t1))
+            self.assertIsNotNone(r1)
+            self.assertEqual(r1.bytes_transferred(), len(payload))
+            self.assertEqual(len(a._client.set_calls), 1)
+
+            # rank 5 submits the SAME chunk (old behavior: 8 separate keys)
+            k5 = _rank_key(42, grank=5)
+            t2 = a.submit_store_task([k5], [_FakeObj(payload)])
+            r2 = _wait_for(lambda: a.pop_completed_store_tasks().get(t2))
+            self.assertIsNotNone(r2)
+            # exists-probe deduped the write: no second batch_set call, 0 bytes
+            self.assertEqual(len(a._client.set_calls), 1)
+            self.assertEqual(r2.bytes_transferred(), 0)
+            self.assertEqual(a._client.set_bytes, len(payload))
+        finally:
+            a.close()
+
+    def test_missing_subset_only_transfers_missing(self):
+        a = _mk_adapter(True)
+        try:
+            p = b"xxxx"
+            k0 = _rank_key(10, grank=0)
+            k1 = _rank_key(11, grank=0)
+            a.submit_store_task([k0], [_FakeObj(p)])
+            _wait_for(lambda: len(a._client.set_calls) == 1)
+
+            # batch of two, one already present → only the missing goes on wire
+            t = a.submit_store_task(
+                [_rank_key(10, grank=2), _rank_key(11, grank=2)],
+                [_FakeObj(p), _FakeObj(p)])
+            r = _wait_for(lambda: a.pop_completed_store_tasks().get(t))
+            self.assertIsNotNone(r)
+            self.assertEqual(len(a._client.set_calls), 2)
+            # the second set call carried exactly one key (the missing k1)
+            self.assertEqual(len(a._client.set_calls[1]), 1)
+            self.assertIn(_object_key_to_string(a._canon(k1)),
+                          a._client.set_calls[1][0])
+        finally:
+            a.close()
+
+
+class TestCrossRankRead(unittest.TestCase):
+    def test_write_by_one_rank_read_by_another(self):
+        a = _mk_adapter(True)
+        try:
+            payload = b"rank-shared-kv" * 32
+            writer = _rank_key(7, grank=7)
+            t = a.submit_store_task([writer], [_FakeObj(payload)])
+            _wait_for(lambda: a.pop_completed_store_tasks().get(t))
+
+            # Another rank's own kv_rank address must still find the chunk.
+            reader = _rank_key(7, grank=3)
+            lk = a.submit_lookup_and_lock_task([reader])
+            bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk))
+            self.assertIsNotNone(bm)
+            self.assertTrue(bm.test(0))
+
+            dst = _FakeObj(bytes(len(payload)))
+            ld = a.submit_load_task([reader], [dst])
+            bm2 = _wait_for(lambda: a.query_load_result(ld))
+            self.assertIsNotNone(bm2)
+            self.assertTrue(bm2.test(0))
+            self.assertEqual(dst.data(), payload)
+        finally:
+            a.close()
+
+    def test_legacy_mode_has_no_cross_rank_hit(self):
+        a = _mk_adapter(False)
+        try:
+            payload = b"per-rank"
+            a_task = a.submit_store_task([_rank_key(1, grank=7)],
+                                         [_FakeObj(payload)])
+            _wait_for(lambda: a.pop_completed_store_tasks().get(a_task))
+
+            lk = a.submit_lookup_and_lock_task([_rank_key(1, grank=3)])
+            bm = _wait_for(lambda: a.query_lookup_and_lock_result(lk))
+            self.assertIsNotNone(bm)
+            self.assertEqual(bm.popcount(), 0)
+        finally:
+            a.close()
+
+
+class TestOperationalHint(unittest.TestCase):
+    def test_hint_fires_once_when_off_and_world_gt1(self):
+        a = _mk_adapter(False)
+        try:
+            self.assertFalse(a._warned_mla_hint)
+            a._hint_canonical_if_mla([_rank_key(1, grank=1)])
+            self.assertTrue(a._warned_mla_hint)
+            # second call is a no-op (hint once)
+            a._warned_mla_hint = False  # reset then verify `True` guards
+            a._hint_canonical_if_mla([_rank_key(1, grank=1)])
+            self.assertTrue(a._warned_mla_hint)
+        finally:
+            a.close()
+
+    def test_hint_silent_when_canonical_on(self):
+        a = _mk_adapter(True)
+        try:
+            a._hint_canonical_if_mla([_rank_key(1, grank=1)])
+            self.assertFalse(a._warned_mla_hint)
+        finally:
+            a.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### Problem (self-reported KNOWN GAP)

On the LMCache MP-server path, `ObjectKey.kv_rank` packs `(world_size<<24|global_rank<<16|local_world_size<<8|local_rank)`, so every TP worker stores MLA's replicated KV under its own key — 8× storage, 8× write traffic, and the same-host rendezvous can never match. The in-process RemoteConnector already fixes this with canonical keys (worker_id→0) + single-writer striping; the MP-server adapter had the gap documented in its docstring as "Deferred; do not assume this path is deduped for MLA".

### Fix (opt-in)

With `mla_canonical_keys=true`:

- **canonicalization** folds the kv_rank rank fields to zero while keeping the topology dims (`world_size`/`local_world_size`) — all ranks share ONE key per chunk, and different TP shapes still never collide (`_canonical_kv_rank` keeps bits 24-31 and 8-15, zeroes the rest);
- **central dedup on store**: the store path probes existence first and transfers only missing keys — any rank's later copies become exists-hits, eliminating redundant wire transfers (a simultaneous double-write race is benign: identical bytes, this is a cache);
- lookup/load/unlock/delete canonicalize identically, so read paths and eviction bookkeeping collapse onto the shared key.

**Opt-in and default-off**: wrongly enabling under a sharded (non-MLA) or PP>1 model would collapse distinct content onto one key (PP stages hold different layers, and PP rides inside `global_rank`), so the flag is explicit opt-in for MLA+PP=1 deployments. Source precedence: `adapter_params.mla_canonical_keys` (dict wins) → env `DFKV_L2ADAPTER_MLA_CANONICAL_KEYS` → default false. Flipping the effective value is a cold cache. When off and a world_size>1 kv_rank shows up, a one-time operational warning suggests the flag (no-op for sharded models).

### LMCache 0.5.x compatibility

LMCache ≥0.5 added a `layout_desc` parameter to `submit_lookup_and_lock_task(keys, layout_desc)` (advisory; only the P2P adapter consumes). The adapter now accepts and ignores it so the same module works against 0.4.x and ≥0.5.2 controllers — required because the upstream controller passes it positionally and currently crashes (`takes 2 positional arguments but 3 were given`).

### Tests

New: `integration/lmcache/tests/test_l2_adapter_mla_canonical.py` — 16 tests:

- config gating: default off, dict opt-in, env fallback, dict-over-env precedence;
- canonical form: rank fields zeroed, topology dims preserved (TP4 vs TP8 never collide), world_size=1 passthrough, flip = different key set (cold-cache semantics documented);
- store dedup: replicated chunk stored once across 8 ranks (second submit transfers 0 bytes); missing-subset only wires missing keys;
- cross-rank read: rank-7 write → rank-3 lookup/load hit with byte-identical payload; legacy mode correctly shows no cross-rank hit;
- operational hint behavior.

Also live-validated against a real dfkv ring: rank-7 store → rank-5 store deduped to 0 bytes transferred; cross-rank lookup+load round-trip byte-equal. Existing `test_l2_adapter.py` suite still passes unchanged (canonical off by default).
