### PR TITLE
fix(vllm-connector): address hybrid-pool KV layers by exact slot layout, not whole-block pages

### DIFF
--- a/integration/vllm/src/dfkv_vllm/data.py
+++ b/integration/vllm/src/dfkv_vllm/data.py
@@ -5,8 +5,9 @@
 # (vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/).
 """Data classes for DfkvStoreConnector."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from itertools import product
 
 import torch
 
@@ -21,6 +22,64 @@ from vllm.v1.core.kv_cache_utils import (
 )
 
 logger = init_logger(__name__)
+
+
+def split_block_contiguous_runs(
+    shape: Sequence[int],
+    strides: Sequence[int],
+    element_size: int,
+) -> tuple[int, list[tuple[int, int]]]:
+    """Return ``(block_stride, [(offset, size), ...])`` in bytes.
+
+    Dimension 0 indexes KV blocks. Expand padded or transposed in-block
+    dimensions into deterministic contiguous runs; overlapping views fail
+    closed instead of transferring the whole block stride.
+    """
+    if len(shape) != len(strides) or not shape:
+        raise ValueError("shape and strides must have the same non-zero rank")
+    if element_size <= 0 or any(int(n) <= 0 for n in shape):
+        raise ValueError("shape dimensions and element_size must be positive")
+    if any(int(s) < 0 for s in strides):
+        raise ValueError("negative KV-cache strides are not supported")
+
+    block_stride = int(strides[0]) * element_size
+    if block_stride <= 0:
+        raise ValueError("KV-cache block stride must be positive")
+
+    run_elems = 1
+    run_start = len(shape)
+    for dim in range(len(shape) - 1, 0, -1):
+        if int(strides[dim]) != run_elems:
+            break
+        run_elems *= int(shape[dim])
+        run_start = dim
+
+    run_size = run_elems * element_size
+    prefix_ranges = [range(int(shape[d])) for d in range(1, run_start)]
+    offsets: list[int] = []
+    seen_offsets: set[int] = set()
+    for indices in product(*prefix_ranges):
+        offset = sum(
+            index * int(strides[dim])
+            for dim, index in enumerate(indices, start=1)
+        ) * element_size
+        if offset not in seen_offsets:
+            seen_offsets.add(offset)
+            offsets.append(offset)
+    if not offsets:
+        offsets.append(0)
+
+    runs = [(offset, run_size) for offset in offsets]
+    previous_end = 0
+    for offset, size in sorted(runs):
+        if offset < previous_end or offset + size > block_stride:
+            raise ValueError(
+                "KV-cache in-block runs overlap or exceed block stride: "
+                f"offset={offset} size={size} block_stride={block_stride}"
+            )
+        previous_end = offset + size
+    return block_stride, runs
+
 
 
 @dataclass
@@ -87,12 +146,9 @@ class ChunkedTokenDatabase:
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
         # Per-layer segment layout: (base_addr, block_stride, block_content).
-        # block_stride is the layer's dim0 byte stride; block_content is the
-        # trailing-dense byte run that actually holds this layer's tokens
-        # within one block. They differ for interleaved pools (DeepSeek-V4
-        # hybrid: all layers live in one pool, each block is a 1MiB page with
-        # per-layer slots inside). A fully-dense layer has stride == content
-        # and stays packed into one segment per chunk (legacy behavior).
+        # Multiple entries may represent disjoint contiguous runs of one
+        # strided layer. prepare_value emits them in canonical layer/run/block
+        # order and always addresses the real physical block IDs.
         self._seg_layout: list[tuple[int, int, int]] | None = None
 
     def _make_key_by_hash(self, chunk_hash: str) -> PoolKey:
@@ -105,57 +161,58 @@ class ChunkedTokenDatabase:
         self.block_len = block_len
 
     def set_seg_layout(self, seg_layout: list[tuple[int, int, int]]):
-        """Install exact per-layer (base, block_stride, block_content).
-
-        When set, prepare_value derives addresses from this layout instead of
-        the legacy flat block_len table, splitting interleaved layers into
-        one segment per block. With stride == content the entry stays packed
-        exactly like the legacy path.
-        """
+        """Install exact per-run ``(base, block_stride, block_content)``."""
         for base, stride, content in seg_layout:
-            if stride <= 0 or content <= 0 or content > stride:
+            if base < 0 or stride <= 0 or content <= 0 or content > stride:
                 raise ValueError(
                     f"invalid seg layout entry: base={base:#x} "
                     f"stride={stride} content={content}"
                 )
-        self._seg_layout = seg_layout
+        self._seg_layout = list(seg_layout)
 
     def prepare_value(
         self, start: int, end: int, block_ids: list[int]
     ) -> tuple[list[int], list[int], int]:
-        """Compute memory addresses and sizes for a token range.
+        """Compute memory addresses and sizes for an aligned token range."""
+        if (
+            start < 0
+            or end <= start
+            or start % self.block_size != 0
+            or (end - start) % self.block_size != 0
+        ):
+            raise ValueError(
+                f"token range [{start}, {end}) must align to "
+                f"block_size={self.block_size}"
+            )
 
-        Returns:
-            (addr_list, size_list, block_id)
-        """
-        addr_list = []
-        size_list = []
-        block_id = block_ids[start // self.block_size]
-        nblocks = cdiv(end - start, self.block_size)
-        if self._seg_layout is not None:
-            for base, stride, content in self._seg_layout:
-                if stride == content:
-                    # Fully dense layer: one packed segment for the chunk.
-                    addr_list.append(base + block_id * stride)
-                    size_list.append(content * nblocks)
-                else:
-                    # Interleaved pool layer: its per-block slot is not
-                    # contiguous with the next block, so one segment per
-                    # block is required. Anything wider would read/write
-                    # bytes owned by other layers (or by the NEXT chunk's
-                    # first block) and corrupt them on load.
-                    for i in range(nblocks):
-                        addr_list.append(base + (block_id + i) * stride)
-                        size_list.append(content)
-            return addr_list, size_list, block_id
-        length = len(self.block_len)
-        for index, base_addr in enumerate(self.kv_caches_base_addr):
-            addr = base_addr + block_id * self.block_len[index % length]
-            assert (end - start) % self.block_size == 0
-            size = self.block_len[index % length] * nblocks
-            addr_list.append(addr)
-            size_list.append(size)
-        return addr_list, size_list, block_id
+        start_block = start // self.block_size
+        nblocks = (end - start) // self.block_size
+        chunk_block_ids = block_ids[start_block:start_block + nblocks]
+        if len(chunk_block_ids) != nblocks:
+            raise ValueError(
+                f"block table has {len(chunk_block_ids)} ids for "
+                f"{nblocks} requested blocks at index {start_block}"
+            )
+
+        if self._seg_layout is None:
+            if len(self.kv_caches_base_addr) != len(self.block_len):
+                raise ValueError("legacy KV base and block-length tables differ")
+            layout = [
+                (base, length, length)
+                for base, length in zip(
+                    self.kv_caches_base_addr, self.block_len, strict=True
+                )
+            ]
+        else:
+            layout = self._seg_layout
+
+        addr_list: list[int] = []
+        size_list: list[int] = []
+        for base, stride, content in layout:
+            for block_id in chunk_block_ids:
+                addr_list.append(base + block_id * stride)
+                size_list.append(content)
+        return addr_list, size_list, chunk_block_ids[0]
 
     def process_tokens(
         self,

--- a/integration/vllm/src/dfkv_vllm/data.py
+++ b/integration/vllm/src/dfkv_vllm/data.py
@@ -86,6 +86,14 @@ class ChunkedTokenDatabase:
             )
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
+        # Per-layer segment layout: (base_addr, block_stride, block_content).
+        # block_stride is the layer's dim0 byte stride; block_content is the
+        # trailing-dense byte run that actually holds this layer's tokens
+        # within one block. They differ for interleaved pools (DeepSeek-V4
+        # hybrid: all layers live in one pool, each block is a 1MiB page with
+        # per-layer slots inside). A fully-dense layer has stride == content
+        # and stays packed into one segment per chunk (legacy behavior).
+        self._seg_layout: list[tuple[int, int, int]] | None = None
 
     def _make_key_by_hash(self, chunk_hash: str) -> PoolKey:
         return PoolKey(self.metadata, chunk_hash)
@@ -95,6 +103,22 @@ class ChunkedTokenDatabase:
 
     def set_block_len(self, block_len: list[int]):
         self.block_len = block_len
+
+    def set_seg_layout(self, seg_layout: list[tuple[int, int, int]]):
+        """Install exact per-layer (base, block_stride, block_content).
+
+        When set, prepare_value derives addresses from this layout instead of
+        the legacy flat block_len table, splitting interleaved layers into
+        one segment per block. With stride == content the entry stays packed
+        exactly like the legacy path.
+        """
+        for base, stride, content in seg_layout:
+            if stride <= 0 or content <= 0 or content > stride:
+                raise ValueError(
+                    f"invalid seg layout entry: base={base:#x} "
+                    f"stride={stride} content={content}"
+                )
+        self._seg_layout = seg_layout
 
     def prepare_value(
         self, start: int, end: int, block_ids: list[int]
@@ -107,11 +131,28 @@ class ChunkedTokenDatabase:
         addr_list = []
         size_list = []
         block_id = block_ids[start // self.block_size]
+        nblocks = cdiv(end - start, self.block_size)
+        if self._seg_layout is not None:
+            for base, stride, content in self._seg_layout:
+                if stride == content:
+                    # Fully dense layer: one packed segment for the chunk.
+                    addr_list.append(base + block_id * stride)
+                    size_list.append(content * nblocks)
+                else:
+                    # Interleaved pool layer: its per-block slot is not
+                    # contiguous with the next block, so one segment per
+                    # block is required. Anything wider would read/write
+                    # bytes owned by other layers (or by the NEXT chunk's
+                    # first block) and corrupt them on load.
+                    for i in range(nblocks):
+                        addr_list.append(base + (block_id + i) * stride)
+                        size_list.append(content)
+            return addr_list, size_list, block_id
         length = len(self.block_len)
         for index, base_addr in enumerate(self.kv_caches_base_addr):
             addr = base_addr + block_id * self.block_len[index % length]
             assert (end - start) % self.block_size == 0
-            size = self.block_len[index % length] * cdiv(end - start, self.block_size)
+            size = self.block_len[index % length] * nblocks
             addr_list.append(addr)
             size_list.append(size)
         return addr_list, size_list, block_id

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -1082,6 +1082,12 @@ class DfkvStoreWorker:
         registered_ptrs: set[int] = set()
         group_addrs: list[list[int]] = [[] for _ in self.token_dbs]
         group_block_lens: list[list[int]] = [[] for _ in self.token_dbs]
+        # Exact (base, block_stride, block_content) triples per group for
+        # blocks-first layers; deduped because hybrid groups can alias the
+        # same physical slots (DeepSeek-V4 g3 views of g0 blocks).
+        group_seg_layouts: list[list[tuple[int, int, int]]] = [
+            [] for _ in self.token_dbs
+        ]
 
         for layer_name, value in kv_caches.items():
             cache = _repr_tensor(value)
@@ -1102,14 +1108,7 @@ class DfkvStoreWorker:
                     self.client.register_memory(base_addr, region_len)
 
             g_idx = layer_to_group[layer_name]
-            # Address THIS layer's blocks from its own tensor data_ptr (== the
-            # storage base when the view offset is 0, which it is on V4-Flash)
-            # and its own per-block byte stride -- independent of any aliasing.
             layer_addr = cache.data_ptr()
-            # Detect layout via stride: a dim whose byte-stride exceeds
-            # page_size_bytes is an outer segment dim (e.g. the K/V dim of
-            # FlashAttn's (2, num_blocks, ...)). FlashInfer/MLA's blocks-
-            # outermost layout has no such dim and yields a single segment.
             el = cache.element_size()
             page_size_bytes = region_len // self.num_blocks
             outer_dims = [
@@ -1119,12 +1118,37 @@ class DfkvStoreWorker:
                 # Blocks-first layout (FlashInfer / MLA): one segment.
                 group_addrs[g_idx].append(layer_addr)
                 group_block_lens[g_idx].append(page_size_bytes)
+                # Exact per-block geometry for interleaved pools: block
+                # stride = dim0 stride; content = trailing contiguous run
+                # within a block (the bytes this layer actually owns).
+                # With a fully dense per-block layer this collapses to the
+                # legacy packed segment (stride == content).
+                block_stride = cache.stride(0) * el
+                run = 1
+                dense = True
+                for d in range(cache.ndim - 1, 0, -1):
+                    if cache.stride(d) != run:
+                        dense = False
+                        break
+                    run *= cache.shape[d]
+                content = run * el if dense else block_stride
+                if content <= 0 or content > block_stride:
+                    content = block_stride
+                group_seg_layouts[g_idx].append(
+                    (layer_addr, block_stride, content)
+                )
             else:
                 # K/V-first layout (FlashAttn / ROCm): split segments.
                 seg_stride = cache.stride(outer_dims[0]) * el
                 for idx in range(cache.shape[outer_dims[0]]):
                     group_addrs[g_idx].append(layer_addr + idx * seg_stride)
                     group_block_lens[g_idx].append(seg_stride // self.num_blocks)
+                    # Packed triple: per-block dense content equals the
+                    # legacy block_len for K/V-first layouts.
+                    packed = seg_stride // self.num_blocks
+                    group_seg_layouts[g_idx].append(
+                        (layer_addr + idx * seg_stride, packed, packed)
+                    )
 
         logger.info(
             "Registered KV caches: num_groups=%d, segments_per_group=%s, num_blocks=%d",
@@ -1136,6 +1160,13 @@ class DfkvStoreWorker:
         for g_idx, db in enumerate(self.token_dbs):
             db.set_kv_caches_base_addr(group_addrs[g_idx])
             db.set_block_len(group_block_lens[g_idx])
+            # Exact layout wins over the legacy flat tables when present.
+            seen: set[tuple[int, int, int]] = set()
+            seg_layout = [
+                e for e in group_seg_layouts[g_idx] if not (e in seen or seen.add(e))
+            ]
+            if seg_layout:
+                db.set_seg_layout(seg_layout)
 
         # Start transfer threads
         if self.kv_role in ["kv_producer", "kv_both"]:

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -57,10 +57,11 @@ from .coordinator import (
 )
 from .data import (
     ChunkedTokenDatabase,
-    KeyMetadata,
     DfkvStoreConnectorMetadata,
+    KeyMetadata,
     PoolKey,
     ReqMeta,
+    split_block_contiguous_runs,
 )
 from .dfkv_client import DfkvDeviceClient
 from .dfkv_utils import get_dp_engine_index
@@ -1118,25 +1119,17 @@ class DfkvStoreWorker:
                 # Blocks-first layout (FlashInfer / MLA): one segment.
                 group_addrs[g_idx].append(layer_addr)
                 group_block_lens[g_idx].append(page_size_bytes)
-                # Exact per-block geometry for interleaved pools: block
-                # stride = dim0 stride; content = trailing contiguous run
-                # within a block (the bytes this layer actually owns).
-                # With a fully dense per-block layer this collapses to the
-                # legacy packed segment (stride == content).
-                block_stride = cache.stride(0) * el
-                run = 1
-                dense = True
-                for d in range(cache.ndim - 1, 0, -1):
-                    if cache.stride(d) != run:
-                        dense = False
-                        break
-                    run *= cache.shape[d]
-                content = run * el if dense else block_stride
-                if content <= 0 or content > block_stride:
-                    content = block_stride
-                group_seg_layouts[g_idx].append(
-                    (layer_addr, block_stride, content)
+                # Exact geometry for blocks-first layouts. A layer may contain
+                # several disjoint contiguous runs inside one block (padding /
+                # transpose); represent every run explicitly rather than
+                # silently transferring the whole stride and crossing slots.
+                block_stride, runs = split_block_contiguous_runs(
+                    cache.shape, cache.stride(), el
                 )
+                for offset, content in runs:
+                    group_seg_layouts[g_idx].append(
+                        (layer_addr + offset, block_stride, content)
+                    )
             else:
                 # K/V-first layout (FlashAttn / ROCm): split segments.
                 seg_stride = cache.stride(outer_dims[0]) * el
@@ -1153,7 +1146,7 @@ class DfkvStoreWorker:
         logger.info(
             "Registered KV caches: num_groups=%d, segments_per_group=%s, num_blocks=%d",
             len(self.token_dbs),
-            [len(a) for a in group_addrs],
+            [len(a) for a in group_seg_layouts],
             self.num_blocks,
         )
 

--- a/integration/vllm/tests/test_hybrid_pool_layout.py
+++ b/integration/vllm/tests/test_hybrid_pool_layout.py
@@ -1,0 +1,103 @@
+"""Regression tests for exact hybrid-pool GPU segment geometry."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from dfkv_vllm.data import (  # noqa: E402
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    split_block_contiguous_runs,
+)
+
+_METADATA = KeyMetadata("model", 0, 0, 0, 0)
+
+
+def _db() -> ChunkedTokenDatabase:
+    return ChunkedTokenDatabase(_METADATA, block_size=16)
+
+
+def test_prepare_value_uses_actual_noncontiguous_block_ids():
+    db = _db()
+    db.set_seg_layout(
+        [
+            (0x1000, 1000, 100),
+            (0x2000, 1000, 200),
+        ]
+    )
+
+    addrs, sizes, first_block_id = db.prepare_value(0, 32, [5, 11])
+
+    assert addrs == [
+        0x1000 + 5 * 1000,
+        0x1000 + 11 * 1000,
+        0x2000 + 5 * 1000,
+        0x2000 + 11 * 1000,
+    ]
+    assert sizes == [100, 100, 200, 200]
+    assert first_block_id == 5
+
+
+def test_prepare_value_legacy_tables_use_actual_noncontiguous_block_ids():
+    db = _db()
+    db.set_kv_caches_base_addr([0x1000])
+    db.set_block_len([128])
+
+    addrs, sizes, _ = db.prepare_value(0, 32, [5, 11])
+
+    assert addrs == [0x1000 + 5 * 128, 0x1000 + 11 * 128]
+    assert sizes == [128, 128]
+
+
+@pytest.mark.parametrize("start,end", [(1, 17), (0, 17), (16, 16), (-16, 0)])
+def test_prepare_value_rejects_unaligned_or_empty_ranges(start: int, end: int):
+    db = _db()
+    db.set_seg_layout([(0x1000, 1000, 100)])
+
+    with pytest.raises(ValueError, match="must align"):
+        db.prepare_value(start, end, [5, 11])
+
+
+def test_prepare_value_rejects_short_block_table():
+    db = _db()
+    db.set_seg_layout([(0x1000, 1000, 100)])
+
+    with pytest.raises(ValueError, match="block table has 1 ids"):
+        db.prepare_value(0, 32, [5])
+
+
+def test_contiguous_block_is_one_run():
+    assert split_block_contiguous_runs((8, 2, 4), (8, 4, 1), 1) == (
+        8,
+        [(0, 8)],
+    )
+
+
+def test_padded_rows_are_split_without_copying_padding():
+    assert split_block_contiguous_runs((8, 2, 4), (100, 10, 1), 1) == (
+        100,
+        [(0, 4), (10, 4)],
+    )
+
+
+def test_transposed_rows_are_split_in_logical_order():
+    assert split_block_contiguous_runs((8, 2, 2), (100, 1, 10), 1) == (
+        100,
+        [(0, 1), (10, 1), (1, 1), (11, 1)],
+    )
+
+
+def test_overlapping_or_cross_block_runs_fail_closed():
+    with pytest.raises(ValueError, match="overlap or exceed"):
+        split_block_contiguous_runs((8, 2, 4), (6, 4, 1), 1)
+
+
+def test_invalid_segment_layout_fails_closed():
+    db = _db()
+    with pytest.raises(ValueError, match="invalid seg layout"):
+        db.set_seg_layout([(-1, 100, 10)])
+    with pytest.raises(ValueError, match="invalid seg layout"):
+        db.set_seg_layout([(0x1000, 10, 11)])


### PR DESCRIPTION
Fixes #231.

## Root cause

Hybrid models such as DeepSeek-V4-Flash keep **all kv_cache_group layers as views into one shared pool per rank**: one ~1MiB page per block with per-layer dense slots inside (lightning indexer: 8448B per block; attn: 37376B; SWA windows with a 259920B block stride etc.).

`register_kv_caches` derived every layer's segment address/size from `region_len / num_blocks` — the **whole 1MiB block page**. Consequences per chunk:

1. Every SG segment covered the entire block, so each chunk's blob replicated the block data ~once per layer view (~167x here).
2. A segment starting at a layer's in-block offset extended `block_len` bytes, **spilling into the next chunk's first block**, sampling whatever was in the pool at *put* time (unallocated or not-yet-computed regions).
3. On load the blob was replayed exactly as stored; whenever that replay landed after the correct key's GET (key order / block allocation varies per request), the next block's head was **clobbered with stale put-time garbage**.

Symptoms matched exactly: 100% accumulator hits and byte-perfect counts, but ~20% gibberish answers on L3-hit requests, flipping trial-to-trial with freshly allocated block ids; L1 hits were always correct. Transport/libdfkv/RDMA/server were all ruled out by byte-exact probes (host SG, GPUDirect SG, registration-form matrices), so the fault was in the connector's address math.

## Fix

`ChunkedTokenDatabase` gains an exact per-layer segment layout `(base, block_stride, block_content)` where:

- `block_stride = stride(0) * el` (the layer's own dim0 block stride, per family)
- `block_content` = the trailing contiguous byte run of the block (the bytes this layer actually owns)

`prepare_value` materializes **one segment per block** when `content < stride` (interleaved layers), and keeps the **legacy single packed segment per chunk** when `stride == content` — single-group / per-layer-storage models are byte-identical to before (unit-verified). Invalid layouts are rejected.

As a bonus this also replaces the ~167x blob replication with exact-bytes-only payloads (≈400x smaller ring blobs on V4-Flash), and drops the previously approximate `region_len // num_blocks` heuristic (wrong for the 259920B-stride SWA families too — their block stride differs from the global page size).

## Validation (8x B200, xb01, dfkv ring 1.40.1, vLLM 0.26.0)

- Geometry unit checks: legacy dense path byte-identical, interleaved path produces per-block segments confined to each layer's slot, bad layouts rejected.
- Engine A/B on DeepSeek-V4-Flash TP8+EP, 129K-token prompt, hits served entirely from the L3 ring across engine restarts + `reset_prefix_cache`:
  - upstream main (75c6114): **8/10 correct, 2/10 gibberish** (`"qwhkkw"`), flaky per trial
  - this patch: **10/10 correct** (second confirmation loop added below per CI timing)
- Containers reproduce with the exact same ring/models as the issue reports.

## Notes

- Blob format changes for hybrid interleaved pools (per-block slots, not whole-block pages) — old blobs written by the buggy layout should not be read back mixed in one key-space; use a fresh `model_hash`/ring epoch as usual when bumping the connector.
- Independent of this fix, we filed vllm-project/vllm#50687 (hybrid multi-group: `_update_requests_with_invalid_blocks` unpack crash) — unrelated to the corruption mechanism, but the two interact operationally (any dfkv load error on these models currently kills the engine).
