### PR TITLE
feat(rdma): add negotiated zero-copy v2 transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ list(FILTER DFKV_SRCS EXCLUDE REGEX "_main\\.cc$")
 if(NOT DFKV_WITH_RDMA)
   list(REMOVE_ITEM DFKV_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/transport/rdma_verbs.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/transport/rdma_topology.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/transport/rdma_transport.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cache/rdma_server.cc)
 endif()
@@ -138,6 +139,7 @@ if(DFKV_BUILD_TESTS)
   # rdma_loopback_test needs the RDMA transport/server symbols -> RDMA build only.
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)
+  list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_topology_test.cc)
   foreach(t ${DFKV_TESTS})
     get_filename_component(name ${t} NAME_WE)
     add_executable(${name} ${t})
@@ -161,6 +163,9 @@ if(DFKV_BUILD_TESTS)
     add_executable(qp_depth_negotiation_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)
     target_link_libraries(qp_depth_negotiation_test PRIVATE dfkv_core GTest::gtest_main)
     gtest_discover_tests(qp_depth_negotiation_test)
+    add_executable(rdma_topology_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_topology_test.cc)
+    target_link_libraries(rdma_topology_test PRIVATE dfkv_core GTest::gtest_main)
+    gtest_discover_tests(rdma_topology_test)
   endif()
 
   # Python plugin test (ctypes -> libdfkv.so -> dfkv_server). No GPU/torch.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ three engines through thin adapters over one portable core:
   object per page, no tp_rank suffix, `backup_skip` (only tp_rank 0 writes).
 
 ## Design in one breath
-SGLang HiCache (zero-copy v1) → `dfkv_hicache.py` (ctypes) → `libdfkv` client
+SGLang HiCache (zero-copy `interface_v1`) → `dfkv_hicache.py` (ctypes) →
+`libdfkv` client
 (Ketama route + header wrap/verify) → TCP/RDMA → `dfkv_server` → optional RAM hot
 tier → DiskCacheGroup over N NVMe (per-disk `StoreEngine`: `file` or `slab`), LRU.
 Distributed = client-side consistent hashing; no replication (regenerable KV →
@@ -175,23 +176,29 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
   share + each node's **self-reported version/config** — engine, capacity, RAM tier,
   RDMA dev — carried on register/heartbeat, so fleet-wide version/config audit is one
   command, no per-node ssh) and `dfkvctl stat --all` (per-node metrics + aggregate) via MDS.
-- **RDMA transport** (gated `-DDFKV_WITH_RDMA=ON`, native libibverbs RC): device
-  selected **by name** (`DFKV_RDMA_DEV=ib7s400p0`, comma-list = multi-rail), QP
-  bootstrapped over a tiny TCP channel so the 400G data fabric needs no IP and may
-  be separate from the IP network. **Automatic TCP fallback** when no device or
-  `DFKV_RDMA` unset. Validated on 400G InfiniBand.
-- **Zero-copy GET both ends**: the server reads the block straight into the send
-  buffer; the client scatters the payload directly into the caller's buffer (e.g.
-  a SGLang HiCache registered host page) — no intermediate copies.
+- **RDMA transport v2** (gated `-DDFKV_WITH_RDMA=ON`, native libibverbs RC):
+  with no device override each host chooses its first `ACTIVE` local HCA and
+  sends an empty device selector to its peer. An explicit comma whitelist opts
+  into multi-rail round-robin and therefore must name the intended fabric on
+  both hosts. QPs bootstrap over a tiny TCP channel, so the data fabric needs no
+  IP. A v2 capability probe falls back connection-by-connection to the v1
+  SEND/RECV path for rolling upgrades; unset `DFKV_RDMA` still selects TCP.
+- **Mixed zero-copy data plane**: control descriptors/status use small 4-KiB
+  SEND/RECV buffers. PUT payloads RDMA-WRITE into leases from one process-wide,
+  pre-registered receive segment; GET payloads RDMA-WRITE directly into the
+  caller's registered buffer. No connection-sized block buffers or payload copy
+  remain on v2.
 - **Optional pipelining** (`DFKV_RDMA_DEPTH=K`): K requests in flight per connection.
   A network-latency hider, **not a throughput knob** — GET and PUT are both
   depth-flat (the per-connection serve loop is in-order; benchmarked GET ~1.24 GB/s at
   depth 1 == 32). The throughput levers are **multi-connection fan-out**
   (`batch_concurrency`) and **fewer/larger keys**. See `docs/datapath-perf-notes.md`.
-- **NUMA-aware rail selection** (`DFKV_RDMA_NUMA=1`): pins buffers/serve-threads to
-  the rail's NUMA node AND, with a multi-rail `DFKV_RDMA_DEV`, picks a NUMA-local
-  rail per connection (falls back to round-robin over all rails when no local rail
-  exists). Off by default; vendor-neutral (sysfs + `sched_getcpu`, no libnuma/CUDA).
+- **NUMA-aware rail selection** (`DFKV_RDMA_NUMA=1`): with an explicit
+  multi-rail whitelist, prefers an `ACTIVE` rail local to the calling thread,
+  then round-robins the listed healthy rails. Server threads follow their QP's
+  rail NUMA node; the single shared receive segment is registered on each
+  selected rail but is not separately NUMA-allocated per rail. Off by default;
+  vendor-neutral (sysfs + `sched_getcpu`, no libnuma/CUDA).
 - **HiCache v2** (PoolTransfer) for multi-pool models (Mamba/SWA/DeepSeek-V4).
 - **Packaging**: CPack (deb/rpm/tgz) + Dockerfile; **graceful shutdown**; leveled logging.
 
@@ -200,16 +207,16 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
 Validated on a 5-node ring (8×B200 hosts, 6× Gen4 NVMe + 8×400G IB per node,
 128 GiB RAM arena): cold read 97 → **156 GB/s**, hot read 48 → **97 GB/s**
 single-pair / **147 GB/s** mesh, cold-read p99 0.9–2.2 s → **~50 ms**.
-Every knob below defaults to the historical behavior — this section is what to
-*change*, not what happens out of the box.
+Defaults are safe for a single-fabric node; production overrides below make
+fabric selection and capacity explicit.
 
 **Server** (per cache node):
 
 | Knob | Recommended | Why |
 |---|---|---|
-| `--rdma-dev` | comma list of **all** local rails (e.g. `ib7s400p0,...,ib7s400p7`) | v1.34 pins one anchor per listed device at startup (arena MRs registered once, logged); without it, idle reclaim of a rail's last connection drops the device and the next burst pays a serialized re-registration storm. First entry = default for legacy clients. Startup pays N× arena registration (~8 s each for 128 GiB). |
+| `--rdma-dev` | leave unset for one local HCA; list the fabric explicitly for multi-rail | Unset selects the first `ACTIVE` local HCA (peer names may differ). A comma list opts into multi-rail, anchors only listed active devices, and requires compatible names/fabric on both hosts; inactive entries are rejected. |
 | `DFKV_DISK_HASH_WEIGHT` | `10` | Flattens the intra-server disk ring share from ±20 % to ±3 % so the hottest disk stops gating the whole node (+5–6 % cold read, ~2× lower p99). **Re-routes existing keys** (cache miss + refill) — flip together with a restart/upgrade window. |
-| `--rdma-depth` | `4` (keep) | Deeper is not a throughput knob (see datapath notes); it only grows pinned memory. |
+| `--rdma-depth` | `4` (keep) | Deeper is not itself a throughput knob. On v2 it consumes more slots from the fixed shared receive segment; on v1 fallback it also grows per-connection pinned buffers. |
 | `--ram-tier` / `--ram-tier-bytes` / `--ram-tier-shards` | on / sized to the node / `16` for ≥100 GiB arenas | Large arenas contend on the shard locks under mixed load (+40 % mixed R/W at 16 shards on a 128 GiB arena); small (≤16 GiB) arenas are fine at the default 8. |
 | `--store-engine` | `slab` | Index rebuilds on restart; removes file-per-block hazards. |
 
@@ -217,7 +224,7 @@ Every knob below defaults to the historical behavior — this section is what to
 
 | Knob | Recommended | Why |
 |---|---|---|
-| `DFKV_RDMA_DEV` | best: **rail affinity per rank** — inject `ib7s400p{local_rank}` per process; simpler: the full comma list + `DFKV_RDMA_NUMA=1` | Each rank uses the NIC closest to its GPU; the bootstrap dev frame makes the server answer on the same rail automatically. Verify the device names exist inside the container first. |
+| `DFKV_RDMA_DEV` | best: **rail affinity per rank** — inject the matching local/server HCA name per process; simpler on symmetric hosts: the full comma list + `DFKV_RDMA_NUMA=1` | Explicit values are sent to the peer, so verify those names exist on both hosts/containers. Leave unset to let each host select its own first ACTIVE HCA when names differ. |
 | `DFKV_RDMA_DEPTH` | `4` | Pairs with the server's posted depth (window = min of both, negotiated). |
 | `DFKV_FANOUT_THREADS` | unset (default 32) | Only wide single-process clients (benchmarks, many concurrent Batch* callers) need more. |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,25 +91,52 @@ is unaffected.
 
 ## 4. Wire protocol
 
-Fixed-prefix binary frames (`src/transport/wire.h`), protocol version 1:
+`src/transport/wire.h` defines two deliberately distinct transports:
 
-| | request | response |
-|-|---------|----------|
-| prefix bytes | 42 | 10 |
+| path | request/control frame | response/control frame | payload |
+|---|---:|---:|---|
+| TCP and RDMA fallback v1 | 42-byte fixed prefix + inline payload | 10-byte prefix + inline payload | two-sided SEND/RECV (RDMA) or stream (TCP) |
+| negotiated RDMA transport v2 | 42-byte prefix; GET adds 8 bytes + 16 bytes per destination | 10-byte prefix + small header | PUT `WRITE_WITH_IMM` into a leased server slot; GET server `RDMA_WRITE` into client MRs |
 
-Both prefixes start with a 1-byte protocol version so a mixed-version deploy
-**fails fast** (an unknown version is rejected and the connection dropped)
-instead of mis-parsing. Replies are paired to requests by strict FIFO order —
-on TCP that order is the stream's; on RDMA the RC transport guarantees reliable
-in-order delivery in hardware.
+Both prefixes start with an explicit 1-byte protocol version. RDMA v2 is
+negotiated during the TCP bootstrap before QPs exchange frames; an unknown or
+unexpected version fails fast instead of being mis-parsed. Replies remain strict
+FIFO on each RC QP. The legacy `kMembers` discovery response deliberately uses a
+dedicated v1 control QP because a membership list may exceed the 4-KiB v2
+control frame; production MDS discovery is unaffected.
 
-> History: v1.7.0/v1.7.1 shipped an experimental opt-in "wire v2" (a request
-> `seq` echoed in the reply, `DFKV_WIRE_VERSION=2`). It was **removed in
-> v1.7.2** as speculative: the RDMA data path — where production traffic runs —
-> already gets ordering + ICRC from RC hardware and never supported v2 (its
-> zero-copy receive posts the scatter split before the version is known), and no
-> deployment used it on TCP. If out-of-order replies are ever needed, a
-> request-id echo will be designed for that purpose then.
+> Historical name collision: v1.7.0/v1.7.1 shipped an unrelated experimental
+> TCP "wire v2" (`DFKV_WIRE_VERSION=2`) that only echoed a request `seq`. It was
+> removed in v1.7.2 and that environment variable remains a no-op. The current
+> **RDMA transport v2** is a different, bootstrap-negotiated one-sided data plane;
+> it does not resurrect the retired TCP sequence protocol.
+
+### 4.1 RDMA v2 resource and fallback invariants
+
+- `RdmaServer::Start` allocates one aligned `RecvSegment` per process, then
+  registers it once on every anchored rail's shared PD. Every endpoint on that
+  rail reuses the same MR; endpoint close drops only its shared-device reference.
+- DCP2 advertises the client's exact `DFKV_RDMA_MAX_BLOCK_BYTES` (or the explicit
+  legacy DCP1 cap). The server validates it against `--max-msg`, negotiates
+  `qd=min(client depth, server depth)`, and leases `qd` contiguous slots. The
+  connection keeps that lease—including while idle in the client pool—until QP
+  teardown or idle reclaim.
+- Slot geometry is `align4K(4096 + ValueHeader::kSize + max(declared_block, 4096))`.
+  Segment sizing must cover every live and pooled data/control QP across all
+  client ranks/processes, not only currently in-flight operations. Exhaustion
+  rejects that v2 bootstrap cleanly; the client reconnects the operation over v1.
+- Client host/device pools are registered once per rail at declaration time.
+  Buffers outside those pools use operation-scoped MRs and are deregistered only
+  after the corresponding completion; no cached MR may outlive caller-owned
+  `std::string` or transient buffers.
+- With an empty device selector each side chooses its own first ACTIVE local HCA,
+  so host-local names may differ. An explicit comma list is a cross-host
+  whitelist and therefore requires the same names/fabric on both peers.
+
+`dfkv_rdma_v2_ready`, receive-segment total/free bytes, registered-rail count,
+v1/v2 opened connections, and v2 PUT/GET WRITE counters make each invariant
+observable. See [CONNECTORS.md](CONNECTORS.md) §1.2.1 for capacity arithmetic and
+[DEPLOY.md](DEPLOY.md) §3 for rollout settings.
 
 ---
 
@@ -179,21 +206,21 @@ the allocator's pin count — this is why the allocator was built media-agnostic
 | state | pin holders | evictable? |
 |-------|-------------|------------|
 | RAM_ONLY (flush pending) | flush-pin | no |
-| in-flight (RDMA send reading arena) | send-pin | no |
+| in-flight (RDMA transfer reading arena) | transfer-pin | no |
 | DURABLE & idle | none (refcount 0) | **yes** |
 
 - **flush-pin** — taken on `Put`, released when the async flush reaches disk.
-- **send-pin** — taken on `GetPrep` (an RDMA send reads the shared arena in
-  place), released on the send completion (`IBV_WC_SEND`).
+- **transfer-pin** — taken on `GetPrep`, released only after the completion that
+  fences the payload transfer (`IBV_WC_SEND`).
 
-**RDMA zero-copy serve**: the arena is registered once as a pool MR on each
-connection's PD (`RegisterMemory`). On a RAM hit the serve loop scatter-sends
-`[response | arena bytes]` straight from the arena MR and records the send-pin's
-release token in `release_on_send[]` (mirrors the existing `rearm_on_send[]`);
-the pin is released when that send's `IBV_WC_SEND` fires. Connection teardown
-releases any outstanding pins, so a torn-down connection never leaks a pinned
-slot. When the RAM tier is off, none of this path is wired and the serve loop is
-byte-identical to before.
+**RDMA zero-copy serve**: the arena is registered once on each selected device's
+shared PD; all endpoint QPs on that rail reuse the pool MR. On a v2 RAM hit the
+server RDMA-WRITEs arena bytes directly into the client's advertised targets,
+then sends the small status response. Its signaled SEND completion fences the
+preceding WRITEs and releases the transfer-pin. A v1 fallback QP instead
+scatter-SENDs `[response | arena bytes]` and releases the same token on that
+SEND completion. Connection teardown releases any outstanding pins, so a dead
+QP cannot leak an allocator pin. With RAM tier off none of this path is wired.
 
 **Backpressure & durability**: if the arena fills with non-evictable
 (flush-pending / in-flight) slots, `Put` declines and the caller takes the normal
@@ -210,16 +237,17 @@ enabled) — see [METRICS.md](METRICS.md).
 
 ## 7. Configuration matrix (feature defaults)
 
-Every subsystem added by the storage/protocol rework is **off by default** —
-a stock `v1.7.0` node behaves exactly like `v1.6.x`.
+Storage engines remain opt-in. RDMA itself still requires `DFKV_RDMA=1`; once
+selected, peers negotiate mixed v2 by default and fall back per connection.
 
 | Feature | Enable with | Default | Notes |
 |---------|-------------|---------|-------|
 | slab storage engine | `--store-engine=slab` / `DFKV_STORE_ENGINE=slab` | `file` | needs clean-disk cold start |
 | RAM hot tier | `DFKV_RAM_TIER=1` (+ `DFKV_RAM_TIER_BYTES`) | off | write-through + RDMA zero-copy GET |
 | RAM tier lock shards | `--ram-tier-shards` / `DFKV_RAM_TIER_SHARDS` | 8 | 1-64; per-shard lock is the >8-connection concurrency ceiling; auto-halved while a shard would hold <32 extents |
-| RDMA transport | build `-DDFKV_WITH_RDMA=ON`, `DFKV_RDMA=1` | TCP | device by name `DFKV_RDMA_DEV` |
-| io_uring async GET | build `-DDFKV_WITH_URING`, `DFKV_SERVER_URING=1` | off | disk-read path only |
+| RDMA transport | build `-DDFKV_WITH_RDMA=ON`, `DFKV_RDMA=1` | TCP | active-HCA discovery; `DFKV_RDMA_DEV` is an optional whitelist |
+| RDMA mixed v2 | `DFKV_RDMA_PROTOCOL=auto-v2` | auto-v2 with per-connection v1 fallback | 4-KiB control buffers + shared registered receive segment; server rollback `DFKV_RDMA_SERVER_PROTOCOL=1` |
+| io_uring async GET | build `-DDFKV_WITH_URING`; `DFKV_SERVER_URING=0` disables | on when built, unavailable otherwise | disk-read path; applies to RDMA v1/v2 |
 
 ---
 
@@ -227,7 +255,8 @@ a stock `v1.7.0` node behaves exactly like `v1.6.x`.
 
 ```
 src/common/     ValueHeader, BlockKey, Status — portable shared types
-src/transport/  wire.h (wire frames) · tcp_transport · rdma_transport / rdma_verbs
+src/transport/  wire.h (v1/v2 frames) · rdma_protocol / rdma_recv_segment ·
+                rdma_topology · tcp_transport · rdma_transport / rdma_verbs
 src/cache/      store_engine.h (interface) · kv_store (file) ·
                 slab_allocator + disk_slab_store (slab) · ram_tier (RAM hot tier) ·
                 disk_cache_group (per-disk routing) · kv_node_server · rdma_server ·

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -41,6 +41,11 @@ README "Recommended tuning"）：TP-N 各 rank 独立进程重复读同页时，
 合并/晋升——客户端观察到的效果是**同页重复冷读与重放显著变快**（xb01 实测每重复页盘读
 8→~2.4 次、晋升页复读零盘），无任何客户端配置或行为变化。
 
+**RDMA transport v2（本轮 Phase 2）**是另一类兼容性变更：新 client 先做能力
+probe，新 server 同时接 v1/v2；新旧组合按连接回到 v1。只有新 client + 新
+server 才使用共享 receive segment 与 one-sided payload。实际路径以
+`dfkv_rdma_{v1,v2}_conns_opened_total` 为准，不能只看环境变量。
+
 ---
 
 ## 1. 通用客户端配置（跨连接器 env / config 总表）
@@ -74,19 +79,49 @@ tp_rank=..,ver=<lib>`（无 `role`——HiCache 是前缀 L3 缓存，无生产/
 | env | 默认 | 推荐 | 说明 |
 |-----|------|------|------|
 | `DFKV_RDMA` | 未设 = TCP | `1` | 选 native-verbs RDMA 传输；未设则 TCP 回退 |
-| `DFKV_RDMA_DEV` | — | 最佳：**按 rank 轨亲和**（每进程注入 `ib7s400p{local_rank}`）；简化：本机所有 400G 口逗号列表 + `DFKV_RDMA_NUMA=1` | RDMA 轨；逗号列表 = 多轨。🔴 **必须显式设置且与 server 服务轨同一 IB fabric**。留空 = 客户端拿本机**枚举第一个**设备——多 fabric 主机（计算轨 + 存储轨共存）上第一个设备常是另一张网（如 200G 存储卡 `ib6s200p0`），与 server 的 400G 轨物理不通 → **跨轨 RC 黑洞**：bootstrap/QP 建连全部成功，数据 op 秒级重传超时死亡、连接池熔断后续秒拒（2026-07-20 xb01 实测签名：服务端 conn+1 但零完成、客户端首 op ~3.7s 失败后批量瞬败）。设备名不同的异构场景也一样：选一个**确认在 server fabric 上**的本机设备显式写上，不要赌枚举顺序 |
+| `DFKV_RDMA_DEV` | 首个 `ACTIVE` 本地 HCA | 留空让两端各自选本地首口；多轨才显式写同 fabric 白名单 | 留空时 bootstrap 不发送设备名，client/server 可使用不同本地命名。逗号列表显式开启多轨，新连接在健康轨间轮转；显式设备名会发给 peer，故两端必须存在同名且互通的 fabric。 |
 | `DFKV_REQUIRE_RDMA` | `0` | 生产 `1` | 无 RDMA 设备时启动失败，禁止静默 TCP fallback |
-| `DFKV_RDMA_DEPTH` | `1` | **两侧一致** | 单连接在途请求数。🔴 **契约：客户端 depth 必须 ≤ 服务端 depth（同名 env，各读各的）**——超出的在途请求撞 RNR 重试，表现为**静默 3-4 倍劣化而非报错**（2026-07-04 hd05 实测：两侧=32 时单连接 batch GET 1.39→4.42 GB/s、batch32 1.31→5.81）。⚠️ 历史"depth-flat（1≈8≈16≈32）"结论即此错配的假象（当时服务端恒为默认 1），作废。服务端每连接 pinned 内存 ≈ 2×control_cap×depth，抬 depth 前核内存；多连接 fan-out（`batch_concurrency`）仍是首选吞吐杠杆。服务端现值经 `dfkvctl ring` INFO `qd=` 可查 |
-| `DFKV_RDMA_MAX_BLOCK_BYTES` | 0(不声明) | **DCP1 容量声明**（v1.11.0+，issue #110）：本进程在此连接上会 PUT/GET 的最大块字节数。客户端把它藏进 bootstrap 设备名帧的确定性零尾部；新服务端按声明精确分配该连接的 per-slot 缓冲（不再按全局最坏 64MiB），GLM 4MiB 块连接 ≈ **6.7× 内存↓**。连接器可按块几何自动推导后 setenv。超声明的 op 客户端侧直接返回失败（不上 wire）。四配对兼容：不声明/老版本=旧行为。服务端日志 `rdma conn caps: declared=…` 是生效凭证。 |
-| `DFKV_RDMA_NUMA` | `0` | 多 NUMA 大机 `1` | 绑 buffer/线程到轨的 NUMA 节点 + 建连时按调用线程 NUMA 选本地轨（无本地轨→轮转全轨）。仅新建连接触发，热路径零开销。SGLang/vLLM 通吃 |
+| `DFKV_RDMA_DEPTH` | `1` | 两侧可不同，按容量选 | 握手协商 `min(client,server)` 作为安全窗口，不再因 client 深于 server 触发 RNR。v2 每连接只占 `2 × depth × 4 KiB` 量级控制 buffer，并从共享 receive segment 租 `depth` 个 slot；v1 fallback 仍分配 per-connection block buffer。 |
+| `DFKV_RDMA_MAX_BLOCK_BYTES` | 64 MiB 安全上限 | 按连接器块几何精确设置 | DCP2 声明本连接最大 PUT/GET block，决定共享 segment 的 slot 大小；超声明请求在客户端失败且不上 wire。声明越准，同一 segment 可容纳的 live/pooled v2 连接越多。 |
+| `DFKV_RDMA_PROTOCOL` | `auto-v2` | `auto-v2` | 客户端先探测 v2；老 server 或 v2 segment 暂时无 lease 时自动重连 v1。设 `1` 强制旧 SEND/RECV 路径；构造后不热切换，改值必须重启每个 client 进程。 |
+| `DFKV_RDMA_SERVER_PROTOCOL` | `auto-v2` | `auto-v2` | server 接受 v2 和 v1；设 `1` 禁用 v2。构造后不热切换，改值必须重启 server。 |
+| `DFKV_RDMA_RECV_SEGMENT_SIZE` | 2 GiB | 按下文 live/pooled 连接公式设置 | server 启动时申请，并在每个**显式选中** rail 的共享 PD 上注册一次；v2 连接只租 offset。segment 满时新 data QP 自动回退 v1。 |
+| `DFKV_RDMA_NUMA` | `0` | 显式多轨的大机可设 `1` | 建连时按调用线程 NUMA 选本地 rail（无本地 rail→轮转白名单），server serve 线程跟随 QP rail。单块共享 receive segment 不做 per-rail NUMA 分配；仅保证选轨/线程亲和。 |
 | `DFKV_RDMA_MAX_PAYLOAD_BYTES` | 64 MiB（67108864） | — | 客户端单 value payload 上限（不得超过 server 侧同名上限） |
+
+**v2 数据面**：PUT 把 `[request prefix | ValueHeader | payload]` 以
+`RDMA_WRITE_WITH_IMM` 直接写入 server 租出的 slot；GET 先用 SEND 提交
+`{addr,rkey,len}` 目标描述符，server 再以 RDMA WRITE 直接散射到调用方
+buffer，最后只 SEND 状态和小 header。两向 payload 都不经过 QP 的 4-KiB
+控制 buffer。新 client→老 server、老 client→新 server、v2 segment 临时满
+三种情况均回到 v1，不混读两种 frame。
+
+`kMembers` 遗留静态成员查询是例外：成员列表可能超过 4 KiB，client 使用独立
+v1 control QP；生产 MDS 发现不走该路径。
 
 #### 1.2.1 `DFKV_RDMA_MAX_BLOCK_BYTES` 怎么定（含 L2 / L2-bypass 两套公式）
 
-这个值决定**服务端**每连接 pin 多少内存：`qd × (ValueHeader + 声明值)`，握手时**预先分配**，
-不随实际流量增长。B200 实测（qd=32）：声明 16 MiB → **1.02 GB/连接**；声明 4 MiB → **0.34 GB/连接**；
-不声明（走 64 MiB 兜底）→ **约 2 GB/连接**。一个 8-rank 推理实例对单台服务端开约 **135 条连接**，
-所以这不是微调项，它决定环节点装不装得下。
+这个值在 **v2** 决定共享 receive segment 的 slot 大小：
+`align4K(4 KiB + ValueHeader + max(声明值, 4 KiB))`。每条数据连接租 `depth` 个 slot，
+但所有连接共享一块启动期注册的 `DFKV_RDMA_RECV_SEGMENT_SIZE`，不再各自
+注册 `depth × block` 的收发 buffer。强制 v1 或自动 fallback 时仍沿用旧的
+per-connection 分配，因此声明保持精确仍有价值。
+
+**共享 segment 容量必须按连接寿命算，不是按同时在飞请求算。** 数据 QP 的
+slot 为
+
+```
+S_data = align4K(4096 + sizeof(ValueHeader) + max(DFKV_RDMA_MAX_BLOCK_BYTES, 4096))
+B_required >= N_data × depth × S_data + N_control × depth × S_control
+```
+
+`N_data` / `N_control` 是该 server 上所有 rank、进程的**峰值 live + client
+pool 中空闲连接**；lease 一直保留到 QP 被销毁或 `DFKV_RDMA_IDLE_MS` 回收，
+线程峰值留下的 pooled QP 也要计入。4 MiB 声明、depth=4 时
+`S_data=4,202,496 B`，2 GiB segment 最多约 127 条 data QP（未扣 control
+lease）；depth=8 时约 63 条。上线同时观察
+`dfkv_rdma_recv_segment_free_bytes`、`dfkv_rdma_v2_ready` 与 v1 fallback
+连接计数，free 接近 0 即扩容或缩小声明/depth/pool。
 
 **块大小取决于走哪条路径**——两条路径的分块规则不同：
 
@@ -110,13 +145,14 @@ tp_rank=..,ver=<lib>`（无 `role`——HiCache 是前缀 L3 缓存，无生产/
 1. 按上表算出理论值（两条路径都算，取大者——同一集群可能两种都跑）
 2. 起一轮真实负载，读服务端/客户端日志里的 `rdma: max block observed <N>B` 高水位（v1.40+）
 3. 取实测值的 2~4 倍设定，注意**必须同时覆盖原版 L2 路径的整页对象**
-4. 复核服务端日志 `rdma conn caps: declared=…` 确认生效（这行只在客户端真声明时出现）
+4. 复核服务端日志 `rdma conn: protocol=v2 declared=… control=… shared-slot=… qd=…` 确认生效
 
-🔴 **设小了不会报错——这是最危险的部分。** 超声明的块被判 `kInvalid`，而 `kInvalid` 被客户端健康
-计数**刻意忽略**，上层看到的就是 `hits[i] != 1`，与"这页压根没缓存"**完全无法区分**：不崩、不报错、
-不熔断，只有命中率悄悄封顶。v1.40+ 起超限会打 `rdma: block …B exceeds the declared bound …B` 告警
-（首次 + 每 1024 次），在此之前**没有任何信号**。典型踩法：照 L2-bypass 实测的 1.02 MiB 调到 2 MiB，
-切回原版 L2 后 2.74 MiB 的整页对象全部静默失效。
+🔴 **设小后上层仍只看到 miss——这是最危险的部分。** 超声明的块被判 `kInvalid`，
+而 `kInvalid` 被客户端健康计数刻意忽略，上层 `hits[i] != 1` 与“这页压根没缓存”
+无法区分：不崩、不熔断。v1.40+ 会打 `rdma: block …B exceeds the declared bound
+…B` 告警（首次 + 每 1024 次），所以必须纳入日志告警。
+典型踩法：照 L2-bypass 实测的 1.02 MiB 调到 2 MiB，切回原版 L2 后
+2.74 MiB 的整页对象全部静默失效。
 
 > **服务端侧上限 `--max-msg`（v1.40+）**：默认 64 MiB，即"客户端不声明时给多少"。
 > 它同时是本服务端接受的**上限**：客户端声明**高于**它会被**明确拒绝连接**并打日志，
@@ -129,10 +165,13 @@ tp_rank=..,ver=<lib>`（无 `role`——HiCache 是前缀 L3 缓存，无生产/
 
 ### 1.3 wire 协议版本
 
-wire 协议为 **v1 单版本**（版本字节在帧首，未知版本 fail-fast 断连）。
-v1.7.0/v1.7.1 曾附带实验性 opt-in "wire v2"（`DFKV_WIRE_VERSION=2`，请求 seq 回显校验），
-**v1.7.2 起已移除**：生产数据面走 RDMA（RC 硬件已保证按序 + ICRC，v2 冗余且从未在 RDMA
-生效），TCP 侧也无部署使用。设置 `DFKV_WIRE_VERSION` 现在无任何效果，可从环境中清理。
+当前有两个不同概念，禁止混称：
+- **TCP / RDMA fallback v1**：42-byte request prefix、10-byte response prefix，RDMA payload 走 SEND/RECV。
+- **RDMA transport v2**：bootstrap 显式协商版本 2；GET request 在固定 prefix 后携带目标 MR，payload 走 one-sided WRITE。
+
+v1.7.0/v1.7.1 的 `DFKV_WIRE_VERSION=2` 是已删除的 **TCP seq 回显实验**，
+与当前 RDMA v2 无关；v1.7.2 起该变量无效，应从环境清理。详见
+[ARCHITECTURE.md](ARCHITECTURE.md) §4。
 
 ### 1.4 块身份（96-bit，无需配置，仅需知道）
 
@@ -208,7 +247,7 @@ export DFKV_REQUIRE_RDMA=1               # 可选：禁止悄悄 TCP fallback
 export DFKV_RDMA_DEV=ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7
 export DFKV_RDMA_NUMA=1                   # 可选：多 NUMA 大机 NUMA 选轨（§1.2）
 export DFKV_RDMA_MAX_PAYLOAD_BYTES=67108864  # 可选：单 chunk payload 上限，默认 64MiB
-# DFKV_RDMA_DEPTH 两侧一致（§1.2：客户端 > 服务端 = RNR 静默劣化）
+# DFKV_RDMA_DEPTH 可按容量分别设置；握手自动取两侧最小安全窗口
 ```
 
 > ⚠️ hd04 当前只有 `ib7s400p0,ib7s400p1` 两轨 up，但标准训练计算网节点是 8×400G，
@@ -269,11 +308,12 @@ env 同义项见 §1.6）、`rail_affinity`（已废弃 no-op）。
 
 - **`interface_v1:1` 必填**，插件 `__init__` 强校验：缺失即 `raise ValueError` 启动失败。
   原因——对 `dynamic` 后端，SGLang 仅在 `interface_v1` 为真时才走零拷贝
-  `batch_set_v1/get_v1`；否则退回 generic `set/get`，而 dfkv 的 generic `get/batch_get`
-  是未实现的桩 → **写成功、L3 读静默失败**（线上踩过：launch 脚本漏配，14GB 写入但
-  prefetch 全 miss）。`interface_v1:1` 下 GET payload 经 RDMA 散射**直落 HiCache 宿主页**
-  （client 零拷贝），server O_DIRECT 直读入已注册 direct buffer 并 scatter-send
-  （server 无 payload memcpy），两端零拷贝。
+  `batch_set_v1/get_v1`；否则退回 generic `set/get`，而 dfkv 的 generic
+  `get/batch_get` 是未实现的桩 → **写成功、L3 读静默失败**（线上踩过：
+  launch 脚本漏配，14GB 写入但 prefetch 全 miss）。`interface_v1:1` 下 GET
+  payload 经 RDMA 直落 HiCache 宿主页（client 零拷贝）；server O_DIRECT /
+  io_uring 直读入注册 buffer，RDMA v2 以 one-sided WRITE 直落 client 目标
+  MR（v1 fallback 用 scatter SEND），均无 payload memcpy。
 - MLA 下插件自动单对象、无 rank 后缀、`backup_skip`（仅 tp_rank0 写）。decode 共享前缀配同 members。
 - **多池模型**（Mamba/SWA/DeepSeek-V4）用 v2 PoolTransfer 接口（插件已实现）。
   DSA/DeepSeekV4 主 `kv` 池是无数据的 LogicalHostPool（`get_page_buffer_meta→None`），
@@ -301,20 +341,21 @@ env 同义项见 §1.6）、`rail_affinity`（已废弃 no-op）。
   （见 [DEPLOY.md](DEPLOY.md) §监控）。
 - 回滚：`--hicache-storage-backend` 改回原后端（mooncake 等）重启该副本，与 dfkv 解耦。
 
-### 2.6 特性边界（HiCache 侧不适用的 vLLM 特性）
+### 2.6 HiCache 特性边界
 
-后续给 vLLM 连接器加的几个特性**不适用于 HiCache 侧**——不是漏配，是数据形状不匹配，
-HiCache 维持常规路径即可：
+以下是 HiCache 的实际适用范围，不能照搬 vLLM 连接器的数据形状或旧 RDMA
+路径经验：
 
 - **scatter-gather（SG，合并 key）— HiCache 不用。** SG 把"一个 chunk 的多个层段"合成
   一个多-SGE RDMA key，是为 vLLM 连接器的变长 chunk × 多层段做的。HiCache MLA **每页就是
   一个打包 latent 对象（~2.74 MiB）**，本来一页一 key、无碎段可合，SG 无收益。
   （仅 MHA 的 `_k`/`_v` 对或未来多池 HiCache v2 才理论上有边际收益，且需改插件代码、非开关。）
-- **io_uring async GET（`DFKV_SERVER_URING`，server 侧）— 不要开。** 实测单盘对吞吐
-  **flat/无收益**（瓶颈是盘不是读提交），默认关。
-- **`DFKV_RDMA_DEPTH` — 两侧保持一致**（§1.2：客户端超过服务端 = RNR 静默劣化；历史 depth-flat 结论已作废）。
-- HiCache 真正需要的硬化与可观测性（RDMA 空闲回收、CLOCK 持久指针、MDS 硬化、
-  Prometheus 指标）**已在 v1.5.2+ 内**，无需额外动作。
+- **io_uring async GET（server 侧）— RDMA v1/v2 都支持。** 构建启用
+  `DFKV_WITH_URING` 时默认开，`DFKV_SERVER_URING=0` 才关闭；多连接场景实测
+  neutral，少连接深 pipeline 约 +6%，失败自动回同步并有指标。
+- **`DFKV_RDMA_DEPTH` — 两侧无需强制相等。** 握手取最小值，按共享 segment
+  容量和连接 fan-out 分别配置即可。
+- **HiCache 命中/吞吐/延迟与 client 注册指标**已在 v1.5.2+ 内，无需额外动作。
 
 ---
 
@@ -333,38 +374,37 @@ HiCache 维持常规路径即可：
 | `SGLANG_HICACHE_L2_BYPASS_DEDUP` | `1` | 同前缀并发 SG GET 去重：后到的请求 park 等待，不重复拉取 |
 | `SGLANG_HICACHE_L2_BYPASS_FUSE_DRAFT` | `0` | draft（EAGLE）是否与目标层融进同一次 RDMA op。**默认关**——收益未经重复取样确认，单次测量不足以认领 |
 | `DFKV_RDMA_MAX_BLOCK_BYTES` | 见 §1.2.1 | bypass 下块 = `29 × page_size × 每token每层字节`，比原版 L2 小约 2.7× |
-| `DFKV_RDMA_IO_MS` | `30000` | bootstrap 握手超时。**冷连接池场景必须放宽**，理由见下 |
+| `DFKV_RDMA_IO_MS` | 默认 `10000` | v2 只建小 control QP + 租共享 slot；通常保持默认。只有指标确认回到 v1 且旧 per-connection pin 握手超时，才临时放宽到 `30000` |
 
 SGLang 启动侧需配合：`--hicache-mem-layout page_first_direct --hicache-io-backend direct`。
 
-#### 🔴 冷连接池：为什么 `DFKV_RDMA_IO_MS` 默认的 10s 不够
+#### 冷连接池：v2 与 v1 fallback 的握手成本不同
 
-服务端每条**新**连接的 `ep.Open()` 要预分配并注册 `qd × (ValueHeader + 声明值)` 的 pin 内存，
-这一步占握手耗时的 **98%**（B200 实测六段计时：`devread=147ms open=9046ms qpx=0 connect=0 poolmr=0`）。
-新实例的**第一次** L3 读时连接池是空的，要一次性建大量连接，每条都付这个代价：
+RDMA v2 的 server 启动期已注册 process-wide receive segment；新 data QP
+只创建小 control buffers 并租 `depth × slot` 的 offset，不再为每连接注册
+`qd × block`。因此下面 9s `Open()` 数据只描述 **v1 SEND/RECV fallback**，
+不能用于估算 v2：
 
-| 配置 | `open` | 总握手 | 对 10s 超时余量 | 结果 |
-|---|---|---|---|---|
-| 未声明块大小（64 MiB 兜底） | 9046 ms | 9194 ms | 1.09× | **首读全盘 IO 错误 → L3 读命中 0%** |
-| 声明 16 MiB | 5180 ms | 5330 ms | 1.88× | 仍偏紧 |
-| 声明 4 MiB | 2837 ms | 2957 ms | 3.4× | — |
-| 声明 4 MiB + `IO_MS=30000` | 2837 ms | 2957 ms | **10×** | 稳定 |
+| v1 fallback 配置（历史实测） | `open` | 总握手 | 对 10s 超时余量 |
+|---|---:|---:|---:|
+| 未声明块大小（64 MiB） | 9046 ms | 9194 ms | 1.09× |
+| 声明 16 MiB | 5180 ms | 5330 ms | 1.88× |
+| 声明 4 MiB | 2837 ms | 2957 ms | 3.4× |
 
-失败形态很有欺骗性：握手在 QP 信息交换处超时（`errno=11 EAGAIN`）→ `Acquire` 返回 nullptr →
-`MarkBad` → 该轮全部 op 报 IO 错误 → 上层判为全 MISS。**只有首读崩，后续轮次复用池中连接不再走
-`Open`，恢复 100% 命中**——这个"只有第一次不行"的形态曾被误判成存储/键方案问题，实际在传输握手。
-
-修复前后（A 构型：新实例 → warmup → seed 写 → flush → 首读）：**8/8 全崩 → 6/6 全 100.0%**，
-32 轮长稳 32/32 无 FAIL、无泄漏。
+若首轮仍超时，先用 `dfkv_rdma_client_v2_conns_opened_total`、
+`dfkv_rdma_v2_ready` 和 server 连接日志确认是否实际 fallback 到 v1；不要
+直接把旧 30s 经验套到 v2。v1 冷池确实存在时可临时设
+`DFKV_RDMA_IO_MS=30000`，同时修复 v2 segment 容量/注册失败根因。
 
 #### 服务端
 
-L2-bypass 不需要服务端改配置，但两项与内存直接相关：
+L2-bypass 不需要独立 server 协议，但两项决定 v2 容量：
 
-- `--max-msg`（v1.40+）：见 §1.2.1。客户端不声明时的兜底 = 每连接 ~2 GB，大集群务必显式设定
-- `--rdma-depth`（qd）：每连接内存与它**线性**相关。B200 实测 32→8：内存 +137GB→+34GB（4.03×），
-  握手 `open` 4930→1314ms（3.75×），吞吐中位 −9%（n=4，两臂分布有重叠，只够看方向）。
-  内存不紧张时保持 32；紧张时 8 是机制清晰、收益线性的杠杆
+- `DFKV_RDMA_RECV_SEGMENT_SIZE`：按 §1.2.1 的 peak live/pooled QP 公式；
+  观察 `dfkv_rdma_recv_segment_free_bytes` 和 `dfkv_rdma_v2_ready`
+- `DFKV_RDMA_MAX_BLOCK_BYTES` + `DFKV_RDMA_DEPTH`：共同决定每 QP 的 lease；
+  声明要覆盖原版 L2 的较大整页对象。只有 v1 fallback 仍承担
+  per-connection `depth × block` pin 内存与旧握手成本
 
 #### 验证清单
 
@@ -372,7 +412,7 @@ L2-bypass 不需要服务端改配置，但两项与内存直接相关：
 # 1. bypass 真的开了（数自证日志，别只看 env）
 nerdctl logs <容器> 2>&1 | grep -c 'L2-bypass ENABLED'
 # 2. 声明真的到了服务端（这行只在客户端真声明时出现）
-journalctl -u dfkv-server | grep 'rdma conn caps: declared='
+journalctl -u dfkv-server | grep 'rdma conn: protocol=v2 declared=.*shared-slot='
 # 3. 块大小与余量（v1.40+）
 nerdctl logs <容器> 2>&1 | grep 'max block observed'
 nerdctl logs <容器> 2>&1 | grep -c 'exceeds the declared bound'   # 必须为 0
@@ -562,10 +602,10 @@ extra_config:
   remote_storage_plugin.dfkv.lib:         <LIBDFKV>
 ```
 
-**RDMA 版**：只改两点 —— URL 用 **RDMA 端口**（server `--rdma-port`），并给 vLLM 进程加
-`export DFKV_RDMA=1`。`DFKV_RDMA_DEV` **必须显式设为与缓存节点服务轨同 fabric 的本机
-设备**（同型号节点逗号列全 8 轨；异构/多 fabric 主机严禁留空——留空取枚举第一个设备，
-撞上另一张网就是跨轨 RC 黑洞，见 §1.2 🔴）。
+**RDMA 版**：URL 用 **RDMA 端口**（server `--rdma-port`），并给 vLLM
+进程加 `export DFKV_RDMA=1`。单 fabric 节点可直接使用自动 active-HCA 发现；
+生产多 fabric 节点必须用 `DFKV_RDMA_DEV` 过滤出与 cache server 同 fabric
+的本机设备（同型号节点可逗号列全轨，见 §1.2）。
 
 **生产推荐 MDS 动态发现**（节点增减自动生效）：`membership` 改 `mds`，URL endpoint 改成
 dfkv_mds 层 `ip:port` 列表，组名走 URL 末尾 `/<group>`：

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -14,9 +14,10 @@
 
 dfkv 把**控制面**与**数据面**解耦：
 
-- **控制面 = TCP**：客户端用一份静态成员表 `name=ip:port` 连到各节点的 **bootstrap TCP 端口**，只交换 ~32B 的 QP 信息（LID/GID/QPN/PSN）。这条 IP 走任意两端可达的网（如 200G 存储网或管理网 bond0）。
-- **数据面 = RDMA**：按**设备名**选 RDMA 口（`DFKV_RDMA_DEV=ib7s400p0`），数据走该 IB fabric，**无需该网有 IP**。因此 **400G 计算网（无 IP）与 200G 存储网（有 IP）即便是两张互不通的 IB 网也支持**：控制面走 200G、数据面走 400G。
-- TCP 回退：未设 `DFKV_RDMA` 或无 RDMA 设备时自动用 TCP 传输（控制面那条连接直接当数据通道）。
+- **控制面 = TCP + 两边 SEND/RECV**：bootstrap TCP 只交换设备/QP/receive-segment 描述；RDMA QP 上每个请求只发送 4-KiB 内的 descriptor、status 和小 header。
+- **payload = one-sided RDMA**：v2 PUT 用 `RDMA_WRITE_WITH_IMM` 直落 server 共享 receive-segment slot，GET 由 server `RDMA_WRITE` 到 client 提交的 `{addr,rkey,len}`。数据 fabric 无需 IP。
+- **设备发现**：留空时两端各选本地首个 port 1 `ACTIVE` HCA；显式逗号白名单才开启多轨轮转，多 fabric 节点须过滤到两端同名且互通的 fabric。
+- **回退**：未设 `DFKV_RDMA` 走 TCP；RDMA client 默认探测 v2，老 server、强制 v1 或共享 segment 暂无 slot 时按连接回退 v1 SEND/RECV。
 
 发现：默认走 **MDS 动态发现**（etcd + dfkv_mds，见 §2b）；静态成员表仍作为遗留/单节点备用路径（见 §4-legacy）。无副本（一致性哈希单属主，节点挂 = 该分片 miss → 重算）。
 
@@ -104,13 +105,19 @@ Description=dfkv KV cache node (SGLang HiCache L3)
 After=network-online.target
 [Service]
 Type=simple
+# v2 shared segment 示例：server 上限 4 MiB、depth=4、2 GiB segment。
+# 按所有 rank/process 的 peak live + pooled QP 公式复算，见 CONNECTORS §1.2.1。
+Environment=DFKV_RDMA_SERVER_PROTOCOL=auto-v2
+Environment=DFKV_RDMA_DEPTH=4
+Environment=DFKV_RDMA_RECV_SEGMENT_SIZE=2147483648
 # --port = TCP(bootstrap+TCP数据) 端口; --rdma-port = RDMA bootstrap 端口; --rdma-dev = 数据面 400G 口
 # --metrics-port = 可选 Prometheus /metrics（缺省=不开端口；--id/--group 成为指标标签）
 ExecStart=/usr/local/bin/dfkv_server \
   --dir /mnt/disk1/dfkv,/mnt/disk2/dfkv,/mnt/disk3/dfkv \
-  --port 28000 --rdma-port 28001 --rdma-dev ib7s400p0 --cap 6597069766656 \
-  --mds 10.0.0.1:9400,10.0.0.2:9400 --metrics-port 28010 \
-  --group default --id n57 --advertise 192.168.1.57:28001
+  --port 28000 --rdma-port 28001 --rdma-dev ib7s400p0 --max-msg 4194304 \
+  --cap 6597069766656 --mds 10.0.0.1:9400,10.0.0.2:9400 \
+  --metrics-port 28010 --group default --id n57 \
+  --advertise 192.168.1.57:28001
 Restart=on-failure
 RestartSec=2
 CPUQuota=1600%
@@ -121,6 +128,10 @@ LimitMEMLOCK=infinity        # RDMA 需要锁页内存
 [Install]
 WantedBy=multi-user.target
 ```
+
+> `DFKV_RDMA_MAX_BLOCK_BYTES=4194304` 是 **client-only DCP2 声明**，须注入每个
+> SGLang/vLLM/LMCache inference client 进程；server 用 `--max-msg 4194304`
+> 验证上限，不读取该 client env。
 
 > **可选存储/加速开关（见 [ARCHITECTURE.md](ARCHITECTURE.md) §5–7）。行为开关均为「门面 flag + `DFKV_*` env 双生」，flag 覆盖预设 env；运行时真值经 `dfkvctl ring` INFO 列审计（`engine=`/`wr=`/`ram=`）。**
 > - `--store-engine file|slab`（默认 `file`）：`slab` = extent 池 + slots.tbl 重启保温，消除"每块一文件"隐患。**切 slab 需清盘冷启**（旧 blocks/ 布局不复用），属独立迁移动作。
@@ -140,8 +151,14 @@ journalctl -u dfkv -n 10 --no-pager
 #      + "dfkv_server registered with MDS group=default id=n57 advertise=192.168.1.57:28001"
 ```
 > server 的 bootstrap 监听 `0.0.0.0`，靠防火墙限制在内网。优雅关闭已修（`systemctl stop` 约 1s 退出）。
-> **多轨**：让客户端在多张 400G 口间分散即可（客户端 `DFKV_RDMA_DEV` 逗号列表，见 [CONNECTORS.md](CONNECTORS.md) §1.2）；server 会按客户端请求的设备名在同轨开 QP，无需为多轨改 server 配置（保留 `--rdma-dev` 作默认）。
-> ⚠️ 同机 8×400G 多轨受 NUMA 限制（NIC 跨双 socket，单内存域）；单口已近线速，多轨叠加需 NUMA 感知，暂不必配。
+> **多轨**：server 启动时 anchor 白名单内全部 active rail；client 新 QP 轮转健康轨。留空时两端各选本地首个 ACTIVE HCA，适合 local device 名不同的单 fabric 主机；显式 `--rdma-dev` / `DFKV_RDMA_DEV` 会把设备选择发给 peer，故生产多 fabric 主机必须在两端过滤到**同名且互通**的一组设备。`DFKV_RDMA_NUMA=1` 只改变 QP 选轨与 serve 线程亲和；当前 receive segment 是单块 process-wide 分配，不是 per-NUMA/per-rail 分片。
+>
+> **v2 segment 预算**：`slot=align4K(4096 + sizeof(ValueHeader) + max(max_block,4096))`；
+> `segment >= Σ(live + client-pool-idle data/control QP × depth × slot)`。lease
+> 保留到 QP 销毁或 idle reclaim，不能只数在飞请求。4 MiB/depth=4/2 GiB
+> 约容纳 127 条 data QP（未扣 control lease）。上线先看
+> `dfkv_rdma_recv_segment_free_bytes`、`dfkv_rdma_v2_ready`、
+> `dfkv_rdma_{v1,v2}_conns_opened_total`；free 接近 0 会让新连接回退 v1。
 
 ## 4. 集群成员管理
 
@@ -173,17 +190,20 @@ n57=192.168.1.57:28001,n58=192.168.1.58:28001,...
 3. 冒烟（任一能访问内网的机器）：
    ```bash
    dfkv_smoke --members n57=192.168.1.57:28000 --size 2752512                          # TCP
-   DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 dfkv_smoke --members n57=192.168.1.57:28001 --size 2752512  # RDMA 400G
+   DFKV_RDMA=1 DFKV_RDMA_PROTOCOL=auto-v2 DFKV_RDMA_MAX_BLOCK_BYTES=4194304 \
+     DFKV_RDMA_DEV=ib7s400p0 dfkv_smoke --members n57=192.168.1.57:28001 --size 2752512
    ```
 4. 端到端零拷贝校验（插件 → libdfkv → RDMA → server，验证 payload 直落缓冲）：
    ```bash
    DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 DFKV_MEMBERS='n=192.168.1.57:28001' \
      python3 test/python/rdma_e2e_validate.py    # 期望 RESULT: ZERO-COPY RDMA E2E OK
+   # 随后在 server /metrics 确认 v2_ready=1、v2_conns_opened_total 增长且 free_bytes 有余量
    ```
 5. 压测（可选）：`DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 dfkv_bench --members ... --size 2752512 --count 8000 --threads 64`。
 6. 在**一个受控 SGLang 副本**上切 `dynamic` 后端，发共享长前缀请求看命中上涨，确认后推广。
 
 ## 6. 回滚（秒级）
+- 仅回滚 RDMA v2（保留 dfkv）：在**每个推理 client 进程**设置 `DFKV_RDMA_PROTOCOL=1` 并重启；需要 server 同时禁用时，在**每个 dfkv server 进程**设置 `DFKV_RDMA_SERVER_PROTOCOL=1` 并重启。变量只在 transport/server 构造时读取，已有连接池 QP 不会重新协商；恢复自动探测时也必须删除对应变量并再次重启所有受影响的 client/server。每次切换后用 v1/v2 connection counters 验证实际协议。
 - SGLang：`--hicache-storage-backend` 改回原后端（mooncake 等）重启该副本，与 dfkv 解耦。
 - dfkv 节点：`systemctl stop dfkv`；缓存可丢（KV 可重算），彻底清理删 `/mnt/diskX/dfkv`。
 - dfkv MDS：`systemctl stop dfkv_mds`；无状态，etcd 数据可保留也可清除（`etcdctl del /dfkv --prefix`）。
@@ -201,4 +221,4 @@ n57=192.168.1.57:28001,n58=192.168.1.58:28001,...
   - `dfkvctl stat <ip:port>` — 单节点原始 Prometheus 文本（旧用法不变）。
 - SGLang `--enable-cache-report` 的 HiCache storage hit/miss、TTFT。
 - 生产只读：不改现网组件；dfkv 端口（含 `/metrics`）仅内网开放、无鉴权勿暴露公网。
-- 线协议带 1B 版本号，混版本部署会被 server 拒（不静默错读）；升级时整集群同版本。**指标均为新增、不改 wire，v1.3.0 节点与 v1.4.0 客户端互通。**
+- RDMA v1/v2 frame 均带显式版本；新 client 先做能力 probe，滚动升级中的新旧 client/server 组合自动选择共同的 v1，不会把另一版本静默错读。`dfkv_rdma_{v1,v2}_conns_opened_total` 可审计实际路径。

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -55,8 +55,19 @@ dfkvctl stat <ip:port>                        # 单节点原始 /metrics 文本�
 RDMA 构建额外（折叠进同一 /metrics）：
 | `dfkv_rdma_completions_total` / `completion_errors_total` | counter | RDMA 请求完成 / 错误完成 |
 | `dfkv_rdma_active_conns` | gauge | 当前服务中的 RDMA 连接 |
+| `dfkv_rdma_v1_conns_opened_total` / `v2_conns_opened_total` | counter | server 累计打开的 v1 / v2 连接；滚动升级和回滚验收的路径真值 |
+| `dfkv_rdma_v2_put_writes_total` / `v2_get_writes_total` | counter | server 实际收到的 `WRITE_WITH_IMM` PUT / 实际发出的 RDMA WRITE GET payload |
+| `dfkv_rdma_recv_segment_bytes` / `dfkv_rdma_recv_segment_free_bytes` | gauge | v2 process-wide receive segment 总字节 / 当前未租 lease 字节；free 持续接近 0 = 新 data QP 将回退 v1 |
+| `dfkv_rdma_recv_segment_registered_rails` | gauge | 成功把共享 segment 注册到共享 PD 的 rail 数；应等于显式白名单内可用 rail 数 |
+| `dfkv_rdma_v2_ready` | gauge | 至少一个 rail 完成共享 segment 注册；0 = 本进程只能接 v1 |
 | `dfkv_uring_reads_total` / `dfkv_uring_init_fallbacks_total` | counter | io_uring 路径真实提交的读数（**>0 = 路径确实激活**，外部可证）/ 想用 uring 但 ring 初始化失败静默回退同步的连接数（>0 = 配了没生效，查内核/权限） |
 | `dfkv_rdma_idle_reclaims_total` | counter | 空闲超时回收的连接数 |
+
+> **v2 上线判据**：新 client + 新 server 车队应看到 client/server 两侧
+> `v2_conns_opened_total` 增长，PUT/GET write counter 随负载增长，
+> `v2_ready=1` 且 `recv_segment_free_bytes` 有容量余量。若 server 的
+> `v1_conns_opened_total` 在全新车队仍增长，先查 free bytes、segment 注册日志、
+> client/server 强制协议 env 和旧二进制；不要只凭 `DFKV_RDMA=1` 认定走了 v2。
 
 读侧 convoy 合并（v1.35+，`DFKV_READ_COALESCE=1` 时才有增量；恒零 = 开关没生效）：
 | `dfkv_read_coalesce_leaders_total` | counter | 经 coalescer 登记并执行的读（同步 leader + uring flight 完成各计一次;>0 = 合并路径确实在环内） |
@@ -134,7 +145,13 @@ RAM 热层（**仅 `DFKV_RAM_TIER=1` 时输出**；关时无此系列，向后�
 | `dfkv_client_get_calls/pages/hit_pages/bytes_total{tp_rank}` | get 量 |
 | `dfkv_client_set_seconds{tp_rank}` / `get_seconds{tp_rank}` | batch 调用耗时直方图 |
 
-C 客户端快照里还含传输级（RDMA 构建）：`dfkv_rdma_client_conns_opened_total`、`mr_regions`、`rail_conns_total{dev}`（NUMA 选轨分布）。
+C 客户端快照里还含传输级（RDMA 构建）：
+`dfkv_rdma_client_conns_opened_total`、
+`dfkv_rdma_client_v1_conns_opened_total` / `dfkv_rdma_client_v2_conns_opened_total`、
+`dfkv_rdma_client_v2_put_writes_total` / `dfkv_rdma_client_v2_get_writes_total`、
+`dfkv_rdma_client_mr_regions`、
+`dfkv_rdma_client_adhoc_user_mr_total`（生产注册池路径应稳定为 0）和
+`dfkv_rdma_client_rail_conns_total{dev}`（NUMA/轮转选轨分布）。
 
 ### 3.4 连接器车队指标（三连接器 OTLP **push**，opt-in）
 §3.3 是 SGLang 插件本地 `/metrics`（**pull**）。此外三个连接器（vLLM `dfkv-vllm` / LMCache `dfkv-connector` / SGLang HiCache `dfkv_hicache.py`）可把聚合后的运行指标经 **OTLP 主动推送**到中心 Collector→Prometheus→Grafana，用于"车队级"按实例/类型观测。

--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -44,8 +44,8 @@ int main(int argc, char** argv) {
       "  --dir <paths>        comma-separated NVMe paths; --cap is the TOTAL, split evenly\n"
       "  --cap <bytes>        total cache capacity (LRU self-limits)\n"
       "  --port <p>           TCP bootstrap/data port (0 = ephemeral)\n"
-      "  --rdma-port <p>      RDMA QP-bootstrap port (enables RDMA data path)\n"
-      "  --rdma-dev <name>    RDMA device by name (comma list = multi-rail)\n"
+      "  --rdma-port <p>      RDMA QP-bootstrap port (RDMA build only; enables data path)\n"
+      "  --rdma-dev <names>   HCA whitelist; default first ACTIVE local HCA (RDMA build only)\n"
       "  --mds <ip:port,...>  MDS endpoints to register into (with --group/--id/--advertise)\n"
       "  --group <g>          membership group name (default \"default\")\n"
       "  --id <id>            node id; --advertise <ip:port>  address peers reach (rdma-port)\n"
@@ -243,21 +243,22 @@ int main(int argc, char** argv) {
   DFKV_LOG_INFO("dfkv build: transport=RDMA (libibverbs) + TCP fallback");
 #else
   DFKV_LOG_INFO("dfkv build: transport=TCP-only (built WITHOUT -DDFKV_WITH_RDMA=ON)");
-  if (rdma_port >= 0 || !rdma_dev.empty())
-    DFKV_LOG_WARN("--rdma-port/--rdma-dev IGNORED: this binary has no RDMA support; "
-                  "rebuild with -DDFKV_WITH_RDMA=ON (needs libibverbs-dev)");
+  if (rdma_port >= 0) {
+    DFKV_LOG_ERROR("--rdma-port requires an RDMA-enabled binary; rebuild with "
+                   "-DDFKV_WITH_RDMA=ON (needs libibverbs-dev)");
+    srv.Stop();
+    return 1;
+  }
+  if (!rdma_dev.empty())
+    DFKV_LOG_WARN("--rdma-dev ignored: this binary has no RDMA support");
 #endif
 
 #ifdef DFKV_WITH_RDMA
-  // Per-connection RDMA buffers are pinned eagerly at handshake:
-  // qd x (ValueHeader + conn_max). conn_max is min(client declaration, this
-  // cap), and a client that declares nothing gets the cap outright -- so
-  // without a server-side ceiling the server's memory budget is decided
-  // entirely by its clients. Measured on a B200 node at qd=32: ~2 GB per
-  // connection at the 64 MiB default versus 0.34 GB when the client declares
-  // 4 MiB, and one 8-rank inference instance opens ~135 connections. A
-  // declaration ABOVE the cap is refused (see RdmaServer::Serve) rather than
-  // sized down, which would let that client send past our receives.
+  // --max-msg is the hard payload ceiling for both protocols. V2 leases slots
+  // from one process-wide receive segment, sized independently by
+  // DFKV_RDMA_RECV_SEGMENT_SIZE. Automatic v1 fallback retains the legacy
+  // per-connection depth * (ValueHeader + max_msg) registered-buffer geometry;
+  // clients with an explicit smaller declaration retain that smaller v1 cap.
   const unsigned long long max_msg = args.GetU64("--max-msg", 64ull << 20);
   std::unique_ptr<dfkv::RdmaServer> rsrv;
   if (rdma_port >= 0) {
@@ -322,12 +323,17 @@ int main(int argc, char** argv) {
       DFKV_LOG_INFO("dfkv_server RAM hot tier: RDMA zero-copy serve enabled (arena " +
                     std::to_string(srv.ram_arena_bytes()) + " bytes)");
     }
-    if (rsrv->Start(rdma_port) == Status::kOk)
-      DFKV_LOG_INFO("dfkv_server RDMA listening (TCP bootstrap) on port " +
-                    std::to_string(rsrv->port()) +
-                    (rdma_dev.empty() ? "" : ", dev=" + rdma_dev));
-    else
-      DFKV_LOG_WARN("dfkv_server RDMA listener failed to start (no device?)");
+    const Status rdma_status = rsrv->Start(rdma_port);
+    if (rdma_status != Status::kOk) {
+      DFKV_LOG_ERROR(
+          "dfkv_server RDMA listener failed to start; refusing readiness and "
+          "MDS registration");
+      srv.Stop();
+      return 1;
+    }
+    DFKV_LOG_INFO("dfkv_server RDMA listening (TCP bootstrap) on port " +
+                  std::to_string(rsrv->port()) +
+                  (rdma_dev.empty() ? "" : ", dev=" + rdma_dev));
     // Force-resolve the RDMA depth/uring knobs so their defaults land in the
     // config dump (they are otherwise read lazily on the serve path, after Emit).
     (void)rsrv->PipelineDepth();

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -23,6 +23,8 @@
 #include "utils/numa_util.h"    // pin serve thread to the device's NUMA node
 #include "utils/wire_limits.h"  // ResolveMaxPayload (shared with the TCP path)
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
+#include "transport/rdma_protocol.h"
+#include "transport/rdma_topology.h"
 #include "transport/transport.h"    // kReqPrefix, kRespPrefix
 #include "cache/uring_reader.h" // io_uring async-GET path (DFKV_WITH_URING only)
 #include "common/value_header.h"
@@ -52,6 +54,16 @@ size_t ControlCapFor(size_t max_payload) {
   size_t cap = std::min(kDefaultControlCap, max_payload);
   return cap < kMinControlCap ? kMinControlCap : cap;
 }
+
+size_t RecvSegmentBytes() {
+  constexpr size_t kDefault = 2ull << 30;
+  const size_t bytes = rdma::ResolveRecvSegmentBytes(
+      std::getenv("DFKV_RDMA_RECV_SEGMENT_SIZE"), kDefault,
+      rdma::kV2DataOffset);
+  config_dump::RecordResolved("DFKV_RDMA_RECV_SEGMENT_SIZE",
+                              std::to_string(bytes));
+  return bytes;
+}
 }  // namespace
 
 RdmaServer::RdmaServer(Handler handler, size_t max_msg, const std::string& dev_name)
@@ -63,7 +75,12 @@ RdmaServer::RdmaServer(Handler handler, size_t max_msg, const std::string& dev_n
     const char* e = std::getenv("DFKV_RDMA_DEV");
     if (e && *e) dev_name_ = e;
   }
+  auto_device_ = dev_name_.empty();
   config_dump::RecordResolved("DFKV_RDMA_DEV", dev_name_.empty() ? "(auto)" : dev_name_);
+  const char* protocol = std::getenv("DFKV_RDMA_SERVER_PROTOCOL");
+  v2_enabled_ = !(protocol && std::strcmp(protocol, "1") == 0);
+  config_dump::RecordResolved("DFKV_RDMA_SERVER_PROTOCOL",
+                              v2_enabled_ ? "auto-v2" : "v1");
   // --rdma-dev accepts a comma list (multi-rail): every listed device gets a
   // lifetime anchor in Start(); the FIRST entry stays the default for legacy
   // clients whose bootstrap dev frame is empty.
@@ -98,33 +115,86 @@ Status RdmaServer::Start(int port) {
   socklen_t sl = sizeof(sa);
   ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&sa), &sl);
   port_ = ntohs(sa.sin_port);
-  // Anchor the pool regions' MRs for the server's lifetime. The shared-device
-  // registry is refcounted by live endpoints: without an anchor, the moment
-  // the LAST client connection is torn down (disconnect or idle reclaim) the
-  // device closes and the pool MRs — arena-scale, seconds to pin — are
-  // deregistered, so the NEXT client's first op stalls ~5 s re-registering
-  // 128 GiB (observed on B200). The anchor endpoint holds one device ref and
-  // performs the registration once, HERE, where the cost is expected and
-  // reported. Only the configured device is anchored; a client requesting a
-  // different rail still pays that rail's first registration
-  // (SharedAddPoolMr logs slow ones).
-  if (!user_regions_.empty()) {
-    for (const auto& d : anchor_devs_) {
-      auto a = std::make_unique<rdma::RcEndpoint>();
-      if (a->Open(d.empty() ? nullptr : d.c_str(), 4096, 1)) {
-        a->EnsurePoolMrs(user_regions_);  // arena-scale pin: once, here, reported
-        anchors_.push_back(std::move(a));
-      }
-      // An unusable listed rail is skipped (clients requesting it fail the
-      // same way with or without an anchor); the default rail failing is the
-      // legacy no-anchor behavior.
-    }
-    if (anchor_devs_.size() > 1)
-      DFKV_LOG_INFO("rdma multi-rail anchors: " + std::to_string(anchors_.size()) +
-                    "/" + std::to_string(anchor_devs_.size()) + " devices pinned");
+  // Resolve an explicit comma list as an ACTIVE-device whitelist. With no
+  // override, preserve host-local device semantics by selecting only the first
+  // ACTIVE HCA; multi-rail is opt-in because names need not match on peers.
+  std::vector<std::string> requested_devices;
+  for (const auto& device : anchor_devs_) {
+    if (!device.empty()) requested_devices.push_back(device);
   }
+  auto active_devices = rdma::RdmaTopology::Discover(requested_devices);
+  if (auto_device_ && active_devices.size() > 1) active_devices.resize(1);
+  if (active_devices.empty()) {
+    DFKV_LOG_ERROR(
+        requested_devices.empty()
+            ? "rdma: no ACTIVE device found"
+            : "rdma: none of the configured devices is ACTIVE");
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return Status::kIOError;
+  }
+  anchor_devs_.clear();
+  std::string resolved_devices;
+  for (const auto& device : active_devices) {
+    anchor_devs_.push_back(device.name);
+    if (!resolved_devices.empty()) resolved_devices += ",";
+    resolved_devices += device.name;
+  }
+  dev_name_ = anchor_devs_.front();
+  config_dump::RecordResolved("DFKV_RDMA_DEV", resolved_devices);
+  // Allocate the process-wide v2 receive segment before opening device anchors.
+  // Allocation failure in auto-v2 mode preserves service by retaining the v1
+  // path; metrics expose that v2 has no registered segment.
+  if (v2_enabled_) {
+    recv_segment_bytes_ = RecvSegmentBytes();
+    if (recv_segment_bytes_ == 0 ||
+        !recv_segment_.Init(recv_segment_bytes_, rdma::kV2DataOffset)) {
+      DFKV_LOG_WARN("rdma: unable to allocate shared receive segment (" +
+                    std::to_string(recv_segment_bytes_) +
+                    " bytes); continuing v1-only");
+      recv_segment_bytes_ = 0;
+      v2_enabled_ = false;
+    }
+  }
+  recv_segment_registered_rails_ = 0;
+  for (const auto& d : anchor_devs_) {
+    auto anchor = std::make_unique<rdma::RcEndpoint>();
+    if (anchor->Open(d.empty() ? nullptr : d.c_str(),
+                     rdma::kV2ControlCap, 1)) {
+      anchor->EnsurePoolMrs(user_regions_);
+      if (v2_enabled_) {
+        if (!anchor->RegisterRemoteRegion(recv_segment_.data(),
+                                          recv_segment_.size())) {
+          DFKV_LOG_ERROR("rdma: failed to register shared receive segment on " +
+                         (d.empty() ? std::string("(auto)") : d) +
+                         "; v2 connections on this rail will be refused");
+        } else {
+          ++recv_segment_registered_rails_;
+        }
+      }
+      anchors_.push_back(std::move(anchor));
+    }
+  }
+  if (anchors_.empty()) {
+    DFKV_LOG_ERROR("rdma: failed to open every resolved ACTIVE device");
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return Status::kIOError;
+  }
+  if (v2_enabled_ && recv_segment_registered_rails_ == 0) {
+    DFKV_LOG_WARN(
+        "rdma: shared receive segment registration failed on every rail; "
+        "continuing v1-only");
+    v2_enabled_ = false;
+  }
+  if (anchor_devs_.size() > 1)
+    DFKV_LOG_INFO("rdma multi-rail anchors: " +
+                  std::to_string(anchors_.size()) + "/" +
+                  std::to_string(anchor_devs_.size()) +
+                  " devices pinned");
   running_ = true;
-  accept_thread_ = std::thread([this] { NameThisThread("rdma-accept"); AcceptLoop(); });
+  accept_thread_ =
+      std::thread([this] { NameThisThread("rdma-accept"); AcceptLoop(); });
   return Status::kOk;
 }
 
@@ -267,25 +337,28 @@ void RdmaServer::Serve(int boot_fd) {
   // Bootstrap: client first names the device it wants us to use (same rail for
   // multi-rail); fall back to our configured default if it sends an empty name.
   char devbuf[rdma::kDevNameBytes];
-  if (!net::ReadAll(boot_fd, devbuf, rdma::kDevNameBytes)) { ::close(boot_fd); return; }
-  // DCP1 (issue #110): the frame's zero tail may carry the client's declared
-  // max block size; size THIS connection's per-slot buffers to it instead of
-  // the global worst case. Undeclared (old client / no room) = max_msg_, the
-  // exact old behavior. Never below the control floor so metadata ops and
-  // small values always fit.
+  if (!net::ReadAll(boot_fd, devbuf, rdma::kDevNameBytes)) {
+    ::close(boot_fd);
+    return;
+  }
+  // A new client probes support before allocating a small v2 endpoint. Legacy
+  // servers try to open this deliberately nonexistent device and close quickly;
+  // a v2 server answers without creating a QP.
+  if (rdma::IsV2Probe(devbuf)) {
+    if (v2_enabled_) {
+      char reply[rdma::kV2ProbeReplyBytes];
+      rdma::EncodeV2ProbeReply(reply);
+      net::WriteAll(boot_fd, reply, sizeof(reply));
+    }
+    ::close(boot_fd);
+    return;
+  }
+
   const uint64_t declared = rdma::ParseDevFrameCaps(devbuf);
-  // A declaration ABOVE our cap is refused rather than quietly sized down.
-  // The client bounds its own ops by what it declared (RdmaTransport::OpBound),
-  // so sizing this connection smaller than the declaration would leave it
-  // sending past our posted receives -- an RNR/QP break far from the cause.
-  // Refusing here names both ends of the mismatch in one line instead.
-  //
-  // This is what makes --max-msg a usable memory guard: the per-connection
-  // pin is qd x (ValueHeader + conn_max), so an undeclaring client costs the
-  // full worst case (measured on a B200 node: ~2 GB/conn at 64 MiB and qd=32,
-  // against 0.34 GB when the client declares 4 MiB). Without a server-side
-  // ceiling the server's memory budget is decided entirely by its clients,
-  // which are often deployed by someone else and versioned independently.
+  const uint8_t requested_protocol = rdma::ParseDevFrameProtocol(devbuf);
+  const bool use_v2 =
+      v2_enabled_ && requested_protocol >= rdma::kDevProtoV2 &&
+      declared != 0;
   if (declared && declared > static_cast<uint64_t>(max_msg_)) {
     DFKV_LOG_ERROR("rdma: client declared max block " + std::to_string(declared) +
                    "B, above this server's cap " + std::to_string(max_msg_) +
@@ -301,53 +374,133 @@ void RdmaServer::Serve(int boot_fd) {
                : max_msg_;
   devbuf[rdma::kDevNameBytes - 1] = '\0';
   std::string dev = devbuf[0] ? std::string(devbuf) : dev_name_;
+  if (std::find(anchor_devs_.begin(), anchor_devs_.end(), dev) ==
+      anchor_devs_.end()) {
+    DFKV_LOG_ERROR("rdma: client requested device outside the ACTIVE filter: " +
+                   dev);
+    ::close(boot_fd);
+    return;
+  }
+
+  // The client writes QpInfo before waiting for ours, so read its negotiated
+  // depth before allocating any per-connection buffers. A default-depth=1
+  // client must lease one shared data slot, not ServerDepth() slots.
+  char peer[rdma::kQpInfoBytes];
+  if (!net::ReadAll(boot_fd, peer, sizeof(peer))) {
+    ::close(boot_fd);
+    return;
+  }
+  const rdma::QpInfo peer_info = rdma::ParseQpInfo(peer);
+  if (use_v2 &&
+      peer_info.protocol_version != rdma::kDevProtoV2) {
+    ::close(boot_fd);
+    return;
+  }
+  size_t K = ServerDepth();
+  if (peer_info.depth != 0)
+    K = std::min<size_t>(K, peer_info.depth);
+  if (K == 0) {
+    ::close(boot_fd);
+    return;
+  }
+  const size_t slot_size = use_v2 ? rdma::V2SlotSize(conn_max) : 0;
+  rdma::RecvSegment::Lease recv_lease;
+  if (use_v2) {
+    if (slot_size == 0 ||
+        K > std::numeric_limits<size_t>::max() / slot_size) {
+      ::close(boot_fd);
+      return;
+    }
+    recv_lease = recv_segment_.Allocate(K * slot_size,
+                                        rdma::kV2DataOffset);
+    if (!recv_lease) {
+      DFKV_LOG_ERROR(
+          "rdma v2: shared receive segment exhausted; refusing connection "
+          "(need=" +
+          std::to_string(K * slot_size) +
+          " free=" + std::to_string(recv_segment_.free_bytes()) + ")");
+      ::close(boot_fd);
+      return;
+    }
+  }
 
   rdma::RcEndpoint ep;
-  const size_t K = ServerDepth();
-  const size_t conn_control = ControlCapFor(conn_max);
+  const size_t conn_control =
+      use_v2 ? rdma::kV2ControlCap : ControlCapFor(conn_max);
   const size_t direct_cap = ValueHeader::kSize + conn_max;
   if (!ep.Open(dev.empty() ? nullptr : dev.c_str(), conn_control, K,
-               /*ib_port=*/1, /*direct_io_buffers=*/true, direct_cap)) {
-    ::close(boot_fd); return;
+               /*ib_port=*/1, /*direct_io_buffers=*/!use_v2, direct_cap,
+               /*v2_responder=*/use_v2)) {
+    ::close(boot_fd);
+    return;
   }
-  if (declared)
-    DFKV_LOG_INFO("rdma conn caps: declared=" + std::to_string(declared) +
-                  " -> per-slot dbuf=" + std::to_string(direct_cap) +
-                  " control=" + std::to_string(conn_control) +
-                  " (qd=" + std::to_string(K) + ")");
-  numa::PinThreadToNode(ep.numa_node());  // keep this conn's serve thread NUMA-local to its NIC
-  // QP bootstrap: read client's info, send ours (symmetric to the client).
-  char peer[rdma::kQpInfoBytes], mine[rdma::kQpInfoBytes];
+  ibv_mr* recv_segment_mr = nullptr;
+  if (use_v2) {
+    recv_segment_mr = ep.RegisterRemoteRegion(recv_segment_.data(),
+                                               recv_segment_.size());
+    if (!recv_segment_mr) {
+      DFKV_LOG_ERROR("rdma v2: receive-segment MR unavailable on device " +
+                     (dev.empty() ? std::string("(auto)") : dev));
+      ::close(boot_fd);
+      return;
+    }
+  }
+  DFKV_LOG_INFO(
+      "rdma conn: protocol=v" + std::to_string(use_v2 ? 2 : 1) +
+      " declared=" + std::to_string(declared) +
+      " control=" + std::to_string(conn_control) +
+      (use_v2 ? " shared-slot=" + std::to_string(slot_size)
+              : " per-slot-dbuf=" + std::to_string(direct_cap)) +
+      " qd=" + std::to_string(K));
+  numa::PinThreadToNode(ep.numa_node());
+
+  // QP bootstrap: the client's QpInfo was read before allocation above; send
+  // the now-right-sized server endpoint and connect.
+  char mine[rdma::kQpInfoBytes];
   rdma::QpInfo my = ep.Local();
-  my.depth = static_cast<uint16_t>(std::min<size_t>(K, 256));  // DPQ1: advertise our posted-recv depth
+  my.depth = static_cast<uint16_t>(std::min<size_t>(K, 256));
+  my.protocol_version = use_v2 ? rdma::kDevProtoV2 : rdma::kDevProtoV1;
   rdma::SerializeQpInfo(my, mine);
-  if (!net::ReadAll(boot_fd, peer, rdma::kQpInfoBytes) ||
-      !net::WriteAll(boot_fd, mine, rdma::kQpInfoBytes)) {
-    ::close(boot_fd); return;
+  if (!net::WriteAll(boot_fd, mine, rdma::kQpInfoBytes) ||
+      !ep.Connect(peer_info)) {
+    ::close(boot_fd);
+    return;
   }
-  if (!ep.Connect(rdma::ParseQpInfo(peer))) { ::close(boot_fd); return; }
-  // Register the RAM arena (and any other declared region) as a pool MR on this
-  // connection's PD so a RAM-hit payload resolves to an MR with no per-op reg_mr
-  // (B5-3). No-op when nothing was registered.
-  if (!user_regions_.empty()) ep.EnsurePoolMrs(user_regions_);
+  ep.EnsurePoolMrs(user_regions_);
   auto post_request_recv = [&](size_t slot) {
-    if (!ep.dbuf(slot) || !ep.dmr(slot) || ep.dbuf_cap() <= ValueHeader::kSize)
+    if (use_v2) return ep.PostRecv(slot);
+    if (!ep.dbuf(slot) || !ep.dmr(slot) ||
+        ep.dbuf_cap() <= ValueHeader::kSize)
       return ep.PostRecv(slot);
     return ep.PostRecvScatter(slot, ep.dbuf(slot) + ValueHeader::kSize,
                               ep.dbuf_cap() - ValueHeader::kSize, ep.dmr(slot),
                               kReqPrefix + ValueHeader::kSize);
   };
 
-  // Post all K receives so the client may keep up to K requests in flight
-  // (pipelining). recv buffers and send buffers are independent slot pools.
   bool armed = true;
   for (size_t i = 0; i < K; ++i) armed = armed && post_request_recv(i);
-  if (!armed) { ::close(boot_fd); return; }
-  // Tell the client we are ready (recvs posted) so its first SENDs won't hit RNR.
+  if (!armed) {
+    ::close(boot_fd);
+    return;
+  }
+  // Tell the client receives are posted, then publish its v2 receive-segment
+  // lease. The extension is read only when the QpInfo v2 bit was negotiated.
   char ready = 1;
   bool ok = net::WriteAll(boot_fd, &ready, 1);
-  ::close(boot_fd);  // bootstrap done
+  if (ok && use_v2) {
+    const rdma::RecvSegmentInfo info{
+        reinterpret_cast<uint64_t>(recv_lease.data()),
+        recv_segment_mr->rkey, slot_size};
+    char encoded[rdma::kRecvSegmentInfoBytes];
+    rdma::EncodeRecvSegmentInfo(info, encoded);
+    ok = net::WriteAll(boot_fd, encoded, sizeof(encoded));
+  }
+  ::close(boot_fd);
   if (!ok) return;
+  if (use_v2)
+    v2_conns_.fetch_add(1, std::memory_order_relaxed);
+  else
+    v1_conns_.fetch_add(1, std::memory_order_relaxed);
 
   // Register this endpoint so Stop() can Wake() us out of WaitComp and join. The
   // running_ check under conn_mu_ closes the race with a concurrent Stop(): either
@@ -363,134 +516,330 @@ void RdmaServer::Serve(int boot_fd) {
   free_send.reserve(K);
   for (size_t i = 0; i < K; ++i) free_send.push_back(i);
 
-  struct Reply {
-    bool scatter = false;
-    bool defer_recv_rearm = false;
-    size_t recv_slot = 0;
-    size_t first_len = 0;  // plain: full sbuf length; scatter: sbuf header length
-    const void* payload = nullptr;
-    size_t payload_len = 0;
-    ibv_mr* payload_mr = nullptr;
-    uint64_t release_token = 0;  // RAM-hit send-in-flight pin; 0 = none (B5-3)
+  auto direct_buffer = [&](size_t slot) -> char* {
+    if (use_v2)
+      return recv_lease.data() + slot * slot_size + rdma::kV2DataOffset;
+    return ep.dbuf(slot);
+  };
+  auto direct_mr = [&](size_t slot) -> ibv_mr* {
+    return use_v2 ? recv_segment_mr : ep.dmr(slot);
+  };
+  const size_t direct_buffer_cap =
+      use_v2 ? slot_size - rdma::kV2DataOffset : ep.dbuf_cap();
+  const size_t logical_data_cap = ValueHeader::kSize + conn_max;
+
+  struct Request {
+    ReqFields fields{};
+    uint32_t recv_bytes = 0;
+    size_t recv_slot = 0;  // RQ entry consumed by SEND or WRITE_WITH_IMM
+    size_t data_slot = 0;  // shared-segment slot (v2) / dbuf slot (v1)
+    const char* contiguous_payload = nullptr;
+    RdmaGetFields get;
   };
 
-  // Build the reply for one request. Generic ops are materialized in sbuf. For
-  // kRange with a direct range handler set, O_DIRECT reads into ep.dbuf[recv_slot]
-  // (4096-aligned + registered) and the wire reply is scatter-sent as
-  // [resp-prefix from sbuf | value bytes from dbuf], with no payload memcpy.
-  // For kCache with a direct cache handler set, the RDMA RECV has already placed
-  // the user payload into ep.dbuf[recv_slot]+ValueHeader::kSize; only the 48B
-  // value header is copied over so disk writes see one contiguous aligned blob.
-  auto copy_payload = [&](size_t recv_slot, const ReqFields& rq, uint32_t recv_bytes,
+  auto decode_request = [&](const ibv_wc& completion,
+                            Request* request) -> bool {
+    const size_t recv_slot = static_cast<size_t>(completion.wr_id);
+    const bool normal_recv = completion.opcode == IBV_WC_RECV;
+    const bool write_imm_recv =
+        completion.opcode == IBV_WC_RECV_RDMA_WITH_IMM;
+    const bool has_immediate =
+        (completion.wc_flags & IBV_WC_WITH_IMM) != 0;
+    if (recv_slot >= K ||
+        (!normal_recv && !(use_v2 && write_imm_recv)) ||
+        has_immediate != write_imm_recv) {
+      return false;
+    }
+    request->recv_slot = recv_slot;
+    request->data_slot = recv_slot;
+    request->recv_bytes = completion.byte_len;
+    if (use_v2 && write_imm_recv) {
+      const size_t data_slot = static_cast<size_t>(ntohl(completion.imm_data));
+      if (data_slot >= K || completion.byte_len < kReqPrefix) return false;
+      const char* frame = recv_lease.data() + data_slot * slot_size +
+                          rdma::kV2PutPrefixOffset;
+      if (!DecodeReqVersion(
+              frame, kProtoVersionV2, &request->fields,
+              static_cast<uint64_t>(logical_data_cap)) ||
+          request->fields.op != static_cast<uint8_t>(WireOp::kCache) ||
+          !rdma::V2PutCompletionIsValid(
+              write_imm_recv, has_immediate, completion.byte_len,
+              request->fields.payload_len, logical_data_cap, slot_size)) {
+        return false;
+      }
+      request->data_slot = data_slot;
+      request->contiguous_payload = frame + kReqPrefix;
+      v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+      return true;
+    }
+
+    const char* frame = ep.rbuf(recv_slot);
+    if (completion.byte_len < kReqPrefix ||
+        !DecodeReqVersion(
+            frame, use_v2 ? kProtoVersionV2 : kProtoVersionV1,
+            &request->fields,
+            static_cast<uint64_t>(ValueHeader::kSize + conn_max))) {
+      return false;
+    }
+    if (use_v2 &&
+        request->fields.op == static_cast<uint8_t>(WireOp::kRange)) {
+      if (!DecodeRdmaGetReq(
+              frame, completion.byte_len, &request->fields,
+              &request->get,
+              static_cast<uint64_t>(ValueHeader::kSize + conn_max))) {
+        return false;
+      }
+      return request->get.targets.size() <= rdma::kV2MaxGetTargets;
+    }
+    if (completion.byte_len <
+        kReqPrefix + request->fields.payload_len) {
+      return false;
+    }
+    if (use_v2 && request->fields.payload_len != 0)
+      request->contiguous_payload = frame + kReqPrefix;
+    return true;
+  };
+
+  struct Reply {
+    bool scatter = false;
+    bool remote_write = false;
+    bool defer_recv_rearm = false;
+    size_t recv_slot = 0;
+    size_t first_len = 0;
+    const char* payload = nullptr;
+    size_t payload_len = 0;
+    ibv_mr* payload_mr = nullptr;
+    std::vector<RdmaWriteTarget> targets;
+    uint64_t release_token = 0;
+  };
+
+  auto copy_payload = [&](const Request& request,
                           std::string* payload) -> bool {
     payload->clear();
-    if (rq.payload_len == 0) return true;
-    if (recv_bytes < kReqPrefix + rq.payload_len) return false;
-    if (rq.payload_len > static_cast<uint64_t>(ValueHeader::kSize + conn_max))
+    const ReqFields& fields = request.fields;
+    if (fields.payload_len == 0) return true;
+    if (fields.payload_len >
+        static_cast<uint64_t>(ValueHeader::kSize + conn_max))
       return false;
-    payload->resize(static_cast<size_t>(rq.payload_len));
+    if (request.contiguous_payload) {
+      payload->assign(request.contiguous_payload,
+                      static_cast<size_t>(fields.payload_len));
+      return true;
+    }
+    if (request.recv_bytes < kReqPrefix + fields.payload_len) return false;
+    payload->resize(static_cast<size_t>(fields.payload_len));
     const size_t head = static_cast<size_t>(
-        std::min<uint64_t>(rq.payload_len, ValueHeader::kSize));
-    if (head) std::memcpy(payload->data(), ep.rbuf(recv_slot) + kReqPrefix, head);
-    const size_t rest = static_cast<size_t>(rq.payload_len) - head;
+        std::min<uint64_t>(fields.payload_len, ValueHeader::kSize));
+    if (head)
+      std::memcpy(payload->data(),
+                  ep.rbuf(request.recv_slot) + kReqPrefix, head);
+    const size_t rest = static_cast<size_t>(fields.payload_len) - head;
     if (rest != 0) {
-      if (!ep.dbuf(recv_slot) || ep.dbuf_cap() < ValueHeader::kSize + rest) return false;
-      std::memcpy(payload->data() + head, ep.dbuf(recv_slot) + ValueHeader::kSize, rest);
+      if (!ep.dbuf(request.data_slot) ||
+          ep.dbuf_cap() < ValueHeader::kSize + rest)
+        return false;
+      std::memcpy(payload->data() + head,
+                  ep.dbuf(request.data_slot) + ValueHeader::kSize, rest);
     }
     return true;
   };
 
-  auto build_reply = [&](size_t send_slot, size_t recv_slot, const ReqFields& rq,
-                         uint32_t recv_bytes,
+  auto build_reply = [&](size_t send_slot, const Request& request,
                          Reply* reply) -> bool {
-    char* sb = ep.sbuf(send_slot);
+    const ReqFields& fields = request.fields;
+    char* send_buffer = ep.sbuf(send_slot);
+    auto encode_status = [&](Status status, uint64_t data_len) {
+      EncodeRespVersion(send_buffer,
+                        use_v2 ? kProtoVersionV2 : kProtoVersionV1,
+                        status, data_len);
+    };
     auto invalid_reply = [&] {
-      EncodeResp(sb, Status::kInvalid, 0);
+      encode_status(Status::kInvalid, 0);
       reply->first_len = kRespPrefix;
       return true;
     };
-    if (rq.op == static_cast<uint8_t>(WireOp::kRange) && range_handler_) {
-      if (!ep.dbuf(recv_slot) || !ep.dmr(recv_slot)) return false;
-      if (rq.length > static_cast<uint64_t>(ValueHeader::kSize + conn_max))
+    auto data_reply = [&](Status status, const char* data, size_t data_len,
+                          ibv_mr* data_mr, bool source_uses_slot,
+                          uint64_t release_token) -> bool {
+      const size_t successful_len =
+          status == Status::kOk ? data_len : 0;
+      if (!use_v2) {
+        encode_status(status, successful_len);
+        reply->first_len = kRespPrefix;
+        if (status == Status::kOk && successful_len != 0) {
+          if (!data || !data_mr) return false;
+          reply->scatter = true;
+          reply->defer_recv_rearm = source_uses_slot;
+          reply->recv_slot = request.recv_slot;
+          reply->payload = data;
+          reply->payload_len = successful_len;
+          reply->payload_mr = data_mr;
+          reply->release_token = release_token;
+        } else if (release_token && ram_release_handler_) {
+          ram_release_handler_(release_token);
+        }
+        return true;
+      }
+
+      if (status != Status::kOk) {
+        encode_status(status, 0);
+        reply->first_len = kRespPrefix;
+        if (release_token && ram_release_handler_)
+          ram_release_handler_(release_token);
+        return true;
+      }
+      const size_t header_len = request.get.header_len;
+      if (header_len > successful_len ||
+          kRespPrefix + header_len > ep.cap() ||
+          successful_len - header_len > request.get.Capacity() ||
+          (successful_len != 0 && !data)) {
+        if (release_token && ram_release_handler_)
+          ram_release_handler_(release_token);
         return invalid_reply();
-      // RAM hot tier (B5-3): if the block is resident in the arena, scatter-send
-      // it STRAIGHT from the arena MR -- no copy into dbuf, no disk. The slot is
-      // pinned until this send completes (release_token -> ram_release_handler_).
+      }
+      encode_status(Status::kOk, successful_len);
+      if (header_len)
+        std::memcpy(send_buffer + kRespPrefix, data, header_len);
+      reply->first_len = kRespPrefix + header_len;
+      const size_t remote_len = successful_len - header_len;
+      if (remote_len != 0) {
+        if (!data_mr) return false;
+        reply->remote_write = true;
+        reply->defer_recv_rearm = source_uses_slot;
+        reply->recv_slot = request.recv_slot;
+        reply->payload = data + header_len;
+        reply->payload_len = remote_len;
+        reply->payload_mr = data_mr;
+        reply->targets = request.get.targets;
+        reply->release_token = release_token;
+      } else if (release_token && ram_release_handler_) {
+        ram_release_handler_(release_token);
+      }
+      return true;
+    };
+
+    if (fields.op == static_cast<uint8_t>(WireOp::kRange) &&
+        range_handler_) {
+      if (!direct_buffer(request.data_slot) ||
+          !direct_mr(request.data_slot) ||
+          fields.length >
+              static_cast<uint64_t>(ValueHeader::kSize + conn_max))
+        return invalid_reply();
+
       if (ram_range_handler_) {
-        const char* rptr = nullptr; size_t rlen = 0; uint64_t tok = 0;
-        if (ram_range_handler_(rq.id, rq.index, rq.size, rq.offset, rq.length,
-                               &rptr, &rlen, &tok)) {
-          ibv_mr* amr = rlen ? ep.RegisterUser(const_cast<char*>(rptr), rlen) : nullptr;
-          if (rlen != 0 && amr == nullptr) {  // MR resolve failed -> release + fall back
-            if (ram_release_handler_) ram_release_handler_(tok);
-          } else {
-            EncodeResp(sb, Status::kOk, rlen);
-            reply->first_len = kRespPrefix;
-            if (rlen != 0) {
-              reply->scatter = true;
-              reply->defer_recv_rearm = true;
-              reply->recv_slot = recv_slot;
-              reply->payload = rptr;
-              reply->payload_len = rlen;
-              reply->payload_mr = amr;
-              reply->release_token = tok;
-            } else {
-              if (ram_release_handler_) ram_release_handler_(tok);  // 0-len: nothing to send
-            }
-            return true;
-          }
+        const char* ram_data = nullptr;
+        size_t ram_len = 0;
+        uint64_t token = 0;
+        if (ram_range_handler_(
+                fields.id, fields.index, fields.size, fields.offset,
+                fields.length, &ram_data, &ram_len, &token)) {
+          ibv_mr* ram_mr =
+              ram_len ? ep.RegisterUser(const_cast<char*>(ram_data), ram_len)
+                      : nullptr;
+          if (ram_len == 0 || ram_mr)
+            return data_reply(Status::kOk, ram_data, ram_len, ram_mr,
+                              /*source_uses_slot=*/false, token);
+          if (ram_release_handler_) ram_release_handler_(token);
         }
       }
-      const char* out_data = nullptr;
-      size_t out_len = 0;
-      Status st = range_handler_(rq.id, rq.index, rq.size, rq.offset, rq.length,
-                                 ep.dbuf(recv_slot), ep.dbuf_cap(), &out_data, &out_len);
-      uint64_t dlen = (st == Status::kOk) ? out_len : 0;
-      EncodeResp(sb, st, dlen);
-      reply->first_len = kRespPrefix;
-      if (st == Status::kOk && dlen != 0) {
-        if (!out_data) return false;
-        reply->scatter = true;
-        reply->defer_recv_rearm = true;
-        reply->recv_slot = recv_slot;
-        reply->payload = out_data;
-        reply->payload_len = out_len;
-        reply->payload_mr = ep.dmr(recv_slot);
-      }
-      return true;
+
+      const char* output = nullptr;
+      size_t output_len = 0;
+      const Status status = range_handler_(
+          fields.id, fields.index, fields.size, fields.offset, fields.length,
+          direct_buffer(request.data_slot), direct_buffer_cap, &output,
+          &output_len);
+      return data_reply(status, output, output_len,
+                        direct_mr(request.data_slot),
+                        /*source_uses_slot=*/true, 0);
     }
 
-    if (rq.op == static_cast<uint8_t>(WireOp::kCache) && cache_direct_handler_) {
-      if (!ep.dbuf(recv_slot) || !ep.dmr(recv_slot)) return false;
-      if (rq.payload_len < ValueHeader::kSize ||
-          rq.payload_len > static_cast<uint64_t>(ValueHeader::kSize + conn_max) ||
-          recv_bytes < kReqPrefix + rq.payload_len) {
+    if (fields.op == static_cast<uint8_t>(WireOp::kCache) &&
+        cache_direct_handler_) {
+      if (!direct_buffer(request.data_slot) ||
+          !direct_mr(request.data_slot) ||
+          fields.payload_len < ValueHeader::kSize ||
+          fields.payload_len >
+              static_cast<uint64_t>(logical_data_cap))
         return invalid_reply();
+
+      char* cache_data = direct_buffer(request.data_slot);
+      if (request.contiguous_payload != cache_data) {
+        if (use_v2) {
+          if (!request.contiguous_payload) return invalid_reply();
+          std::memcpy(cache_data, request.contiguous_payload,
+                      static_cast<size_t>(fields.payload_len));
+        } else {
+          if (request.recv_bytes < kReqPrefix + fields.payload_len)
+            return invalid_reply();
+          std::memcpy(cache_data,
+                      ep.rbuf(request.recv_slot) + kReqPrefix,
+                      ValueHeader::kSize);
+        }
       }
-      std::memcpy(ep.dbuf(recv_slot), ep.rbuf(recv_slot) + kReqPrefix,
-                  ValueHeader::kSize);
-      Status st = cache_direct_handler_(
-          rq.id, rq.index, rq.size, ep.dbuf(recv_slot),
-          static_cast<size_t>(rq.payload_len), ep.dbuf_cap());
-      EncodeResp(sb, st, 0);
+      const Status status = cache_direct_handler_(
+          fields.id, fields.index, fields.size, cache_data,
+          static_cast<size_t>(fields.payload_len), direct_buffer_cap);
+      encode_status(status, 0);
       reply->first_len = kRespPrefix;
       return true;
     }
 
-    std::string payload_buf;
+    std::string payload_storage;
     const char* payload = nullptr;
-    if (rq.payload_len != 0) {
-      if (!copy_payload(recv_slot, rq, recv_bytes, &payload_buf)) return invalid_reply();
-      payload = payload_buf.data();
+    if (fields.payload_len != 0) {
+      if (request.contiguous_payload) {
+        payload = request.contiguous_payload;
+      } else {
+        if (!copy_payload(request, &payload_storage))
+          return invalid_reply();
+        payload = payload_storage.data();
+      }
     }
     std::string data;
-    Status st = handler_(rq.op, rq.id, rq.index, rq.size, rq.offset, rq.length,
-                         payload, rq.payload_len, &data);
+    const Status status = handler_(
+        fields.op, fields.id, fields.index, fields.size, fields.offset,
+        fields.length, payload, fields.payload_len, &data);
+    if (use_v2 &&
+        fields.op == static_cast<uint8_t>(WireOp::kRange)) {
+      if (data.size() > direct_buffer_cap) return invalid_reply();
+      if (!data.empty())
+        std::memcpy(direct_buffer(request.data_slot), data.data(),
+                    data.size());
+      return data_reply(status, direct_buffer(request.data_slot), data.size(),
+                        direct_mr(request.data_slot),
+                        /*source_uses_slot=*/true, 0);
+    }
     if (kRespPrefix + data.size() > ep.cap()) return false;
-    EncodeResp(sb, st, data.size());
-    if (!data.empty()) std::memcpy(sb + kRespPrefix, data.data(), data.size());
+    encode_status(status, data.size());
+    if (!data.empty())
+      std::memcpy(send_buffer + kRespPrefix, data.data(), data.size());
     reply->first_len = kRespPrefix + data.size();
     return true;
+  };
+
+  auto post_reply = [&](size_t send_slot, const Reply& reply) -> bool {
+    if (!reply.remote_write)
+      return reply.scatter
+                 ? ep.PostSendScatter(send_slot, reply.first_len,
+                                      reply.payload, reply.payload_len,
+                                      reply.payload_mr)
+                 : ep.PostSend(send_slot, reply.first_len);
+
+    size_t written = 0;
+    for (const auto& target : reply.targets) {
+      if (written == reply.payload_len) break;
+      const size_t bytes =
+          std::min<size_t>(target.length, reply.payload_len - written);
+      if (bytes == 0) continue;
+      if (!ep.PostWrite(send_slot, reply.payload + written, bytes,
+                        reply.payload_mr, target.addr, target.rkey))
+        return false;
+      written += bytes;
+    }
+    if (written != reply.payload_len) return false;
+    v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
+    return ep.PostSend(send_slot, reply.first_len);
   };
 
   // Single-threaded serve loop: reap completions and process each RECV inline, in
@@ -524,14 +873,12 @@ void RdmaServer::Serve(int boot_fd) {
   // Batch-and-wait model (Mooncake's uring_file batch_read adapted to dfkv's
   // per-WaitComp completion batch). For each completion batch returned by
   // WaitComp: handle SEND completions and non-kRange RECVs inline exactly as the
-  // sync loop; for the kRange GET RECVs, do the cheap prep (open O_DIRECT fd +
-  // index lookup + alignment) into an ordered descriptor list, submit ALL their
-  // reads to io_uring at once (QD>1 in flight => saturates the SSD), WAIT for the
-  // whole batch, then PostSendScatter each reply IN ARRIVAL ORDER. Because every
-  // read is complete before any reply is sent, in-order replies are preserved
-  // trivially — no reorder buffer, no out-of-order completion handling. Anything
-  // that can't go async (miss, zero-len, oversize, prep error) falls back to the
-  // synchronous build_reply for THAT request, still emitted in arrival order.
+  // sync loop; for kRange GETs, prep an ordered descriptor list, submit all disk
+  // reads at once, then emit v1 scatter SENDs or v2 RDMA WRITEs in arrival order.
+  // The slot backing each read stays leased until the signaled status SEND
+  // completes, so neither a new PUT nor another GET can overwrite bytes still
+  // being consumed by the NIC. Anything that cannot go async falls back to
+  // build_reply for that request without reordering.
   if (UseUringPath()) {
     const size_t uring_depth = std::max(UringDepth(K), K);
     UringReader ring(static_cast<unsigned>(uring_depth));
@@ -557,6 +904,8 @@ void RdmaServer::Serve(int boot_fd) {
       struct Queued {
         size_t send_slot = 0;
         size_t recv_slot = 0;
+        size_t data_slot = 0;
+        RdmaGetFields get;       // v2 response header/remote destinations
         int read_idx = -1;   // >=0: index into descs (async read); -1: sync reply
         int fd = -1;         // owned (async only); closed after the batch read
         uint64_t prep_token = 0;  // slab slot hold; released where fd is closed
@@ -596,33 +945,36 @@ void RdmaServer::Serve(int boot_fd) {
             free_send.push_back(sid);
             continue;
           }
-          if (wc.opcode != IBV_WC_RECV || wc.byte_len < kReqPrefix) { fail = true; break; }
-          completions_.fetch_add(1, std::memory_order_relaxed);  // a request RECV
-          size_t r = static_cast<size_t>(wc.wr_id);
-          ReqFields rq;
-          if (!DecodeReq(ep.rbuf(r), &rq)) { fail = true; break; }
+          Request request;
+          if (!decode_request(wc, &request)) { fail = true; break; }
+          completions_.fetch_add(1, std::memory_order_relaxed);
+          const size_t r = request.recv_slot;
+          const ReqFields& rq = request.fields;
           if (free_send.empty()) { fail = true; break; }
           size_t s = free_send.back(); free_send.pop_back();
 
           Queued qd;
           qd.send_slot = s;
           qd.recv_slot = r;
+          qd.data_slot = request.data_slot;
+          qd.get = request.get;
 
           // Defer a kRange GET hit's disk read to the io_uring batch below; reply
           // after the whole batch completes (the emit pass preserves arrival order).
           bool deferred = false;
           if (rq.op == static_cast<uint8_t>(WireOp::kRange) &&
-              ep.dbuf(r) && ep.dmr(r) &&
+              direct_buffer(request.data_slot) &&
+              direct_mr(request.data_slot) &&
               rq.length <= static_cast<uint64_t>(ValueHeader::kSize + conn_max)) {
             RangePrepResult pr;
             Status pst = range_prep_handler_(rq.id, rq.index, rq.size, rq.offset,
-                                             rq.length, ep.dbuf_cap(), &pr);
+                                             rq.length, direct_buffer_cap, &pr);
             if (pst == Status::kOk && pr.fd >= 0 && pr.payload_len != 0 &&
-                pr.aligned_len <= ep.dbuf_cap() &&
+                pr.aligned_len <= direct_buffer_cap &&
                 pr.aligned_len <= std::numeric_limits<unsigned>::max()) {
               UringReader::ReadDesc d;
               d.fd = pr.fd;
-              d.buf = ep.dbuf(r);
+              d.buf = direct_buffer(request.data_slot);
               d.len = static_cast<unsigned>(pr.aligned_len);
               d.off = pr.aligned_off;
               qd.read_idx = static_cast<int>(descs.size());
@@ -646,7 +998,10 @@ void RdmaServer::Serve(int boot_fd) {
           if (!deferred) {
             // Synchronous build for this request (non-range, or range miss / zero /
             // oversize / prep miss). Consumes rbuf/dbuf[r]. Queued, not sent yet.
-            if (!build_reply(s, r, rq, wc.byte_len, &qd.reply)) { fail = true; break; }
+            if (!build_reply(s, request, &qd.reply)) {
+              fail = true;
+              break;
+            }
           }
           queue.push_back(qd);
         }
@@ -659,10 +1014,9 @@ void RdmaServer::Serve(int boot_fd) {
         if (!descs.empty()) {
           uring_reads_.fetch_add(descs.size(), std::memory_order_relaxed);
           batch_ok = ring.BatchRead(descs.data(), static_cast<int>(descs.size()));
-          // A failed batch may have left async reads in flight against the
-          // recv-slot dbufs. Drain (reap-and-discard) until the kernel is done
-          // with them BEFORE the emit pass touches those buffers: the sync
-          // pread fallback and the recv rearm would otherwise race the kernel's
+          // A failed batch may have left async reads in flight against leased
+          // v1 dbufs or v2 shared-segment slots. Drain before the sync fallback
+          // or receive rearm can reuse those buffers.
           // writes and put mixed-generation bytes on the wire — undetectable by
           // the client (ValueHeader carries no CRC; RDMA ICRC only covers the
           // network). If the drain itself times out the buffers still belong to
@@ -689,12 +1043,10 @@ void RdmaServer::Serve(int boot_fd) {
               fail = true; break;
             }
             release_on_send[qd.send_slot] = reply.release_token;  // RAM-hit pin (B5-3)
-            bool sent = reply.scatter
-                            ? ep.PostSendScatter(qd.send_slot, reply.first_len,
-                                                 reply.payload, reply.payload_len,
-                                                 reply.payload_mr)
-                            : ep.PostSend(qd.send_slot, reply.first_len);
-            if (!sent) { fail = true; break; }
+            if (!post_reply(qd.send_slot, reply)) {
+              fail = true;
+              break;
+            }
             continue;
           }
           // Deferred async read: validate result (or sync fallback), then SEND.
@@ -712,29 +1064,75 @@ void RdmaServer::Serve(int boot_fd) {
             if (range_release_handler_) range_release_handler_(qd.prep_token);
             qd.prep_token = 0;
           }
-          // Runs BEFORE the reply send on purpose: coalesced waiters and the
-          // RAM promotion copy from the dbuf payload, and the buffer is reused
-          // the moment the scatter SEND is posted.
+          // Runs BEFORE the reply send on purpose: coalesced waiters and RAM
+          // promotion copy from the completed read buffer.
+          const char* out_data =
+              static_cast<const char*>(d.buf) + qd.head;
           if (range_complete_handler_) {
             range_complete_handler_(ok, ok ? qd.payload_len : 0,
                                     NowSteadySec() - qd.submit_sec, qd.flight,
-                                    ok ? ep.dbuf(qd.recv_slot) + qd.head : nullptr);
+                                    ok ? out_data : nullptr);
             qd.flight = 0;  // completed: the teardown sweep must not abort it
           }
           char* sb = ep.sbuf(qd.send_slot);
-          if (ok) {
-            EncodeResp(sb, Status::kOk, qd.payload_len);
-            const char* out_data = ep.dbuf(qd.recv_slot) + qd.head;
+          if (ok && use_v2) {
+            const size_t header_len = qd.get.header_len;
+            const size_t remote_len =
+                header_len <= qd.payload_len ? qd.payload_len - header_len : 0;
+            if (header_len > qd.payload_len ||
+                kRespPrefix + header_len > ep.cap() ||
+                remote_len > qd.get.Capacity()) {
+              EncodeRespVersion(sb, kProtoVersionV2, Status::kInvalid, 0);
+              if (!post_request_recv(qd.recv_slot) ||
+                  !ep.PostSend(qd.send_slot, kRespPrefix)) {
+                fail = true;
+                break;
+              }
+              continue;
+            }
+            EncodeRespVersion(sb, kProtoVersionV2, Status::kOk,
+                              qd.payload_len);
+            if (header_len)
+              std::memcpy(sb + kRespPrefix, out_data, header_len);
+            Reply reply;
+            reply.first_len = kRespPrefix + header_len;
+            if (remote_len != 0) {
+              reply.remote_write = true;
+              reply.payload = out_data + header_len;
+              reply.payload_len = remote_len;
+              reply.payload_mr = direct_mr(qd.data_slot);
+              reply.targets = qd.get.targets;
+              reply.defer_recv_rearm = true;
+              reply.recv_slot = qd.recv_slot;
+              rearm_on_send[qd.send_slot] = qd.recv_slot;
+            } else if (!post_request_recv(qd.recv_slot)) {
+              fail = true;
+              break;
+            }
+            if (!post_reply(qd.send_slot, reply)) {
+              fail = true;
+              break;
+            }
+          } else if (ok) {
+            EncodeRespVersion(sb, kProtoVersionV1, Status::kOk,
+                              qd.payload_len);
             // Defer recv rearm until this scatter SEND completes (read target reuse).
             rearm_on_send[qd.send_slot] = qd.recv_slot;
             if (!ep.PostSendScatter(qd.send_slot, kRespPrefix, out_data,
-                                    qd.payload_len, ep.dmr(qd.recv_slot))) {
-              fail = true; break;
+                                    qd.payload_len,
+                                    direct_mr(qd.data_slot))) {
+              fail = true;
+              break;
             }
           } else {
-            EncodeResp(sb, Status::kIOError, 0);
-            if (!post_request_recv(qd.recv_slot)) { fail = true; break; }
-            if (!ep.PostSend(qd.send_slot, kRespPrefix)) { fail = true; break; }
+            EncodeRespVersion(sb,
+                              use_v2 ? kProtoVersionV2 : kProtoVersionV1,
+                              Status::kIOError, 0);
+            if (!post_request_recv(qd.recv_slot) ||
+                !ep.PostSend(qd.send_slot, kRespPrefix)) {
+              fail = true;
+              break;
+            }
           }
         }
       }
@@ -778,15 +1176,14 @@ sync_serve_loop:;
         free_send.push_back(sid);
         continue;
       }
-      if (wc.opcode != IBV_WC_RECV || wc.byte_len < kReqPrefix) { fail = true; break; }
-      completions_.fetch_add(1, std::memory_order_relaxed);  // a request RECV
-      size_t r = static_cast<size_t>(wc.wr_id);
-      ReqFields rq;
-      if (!DecodeReq(ep.rbuf(r), &rq)) { fail = true; break; }
+      Request request;
+      if (!decode_request(wc, &request)) { fail = true; break; }
+      completions_.fetch_add(1, std::memory_order_relaxed);
+      const size_t r = request.recv_slot;
       if (free_send.empty()) { fail = true; break; }
       size_t s = free_send.back(); free_send.pop_back();
       Reply reply;
-      bool built = build_reply(s, r, rq, wc.byte_len, &reply);  // consumes rbuf/dbuf[r]
+      bool built = build_reply(s, request, &reply);
       if (!built) { fail = true; break; }
       if (reply.defer_recv_rearm) {
         rearm_on_send[s] = reply.recv_slot;
@@ -794,10 +1191,7 @@ sync_serve_loop:;
         fail = true; break;  // re-arm (request consumed)
       }
       release_on_send[s] = reply.release_token;  // RAM-hit pin (B5-3)
-      bool sent = reply.scatter
-                      ? ep.PostSendScatter(s, reply.first_len, reply.payload,
-                                           reply.payload_len, reply.payload_mr)
-                      : ep.PostSend(s, reply.first_len);
+      bool sent = post_reply(s, reply);
       if (!sent) { fail = true; break; }
     }
   }
@@ -820,8 +1214,27 @@ std::string RdmaServer::MetricsText() const {
     Completions());
   m(s, "dfkv_rdma_completion_errors_total", "counter", "RDMA error completions",
     CompletionErrors());
-  m(s, "dfkv_rdma_active_conns", "gauge", "RDMA connections currently serving",
-    ActiveConns());
+  m(s, "dfkv_rdma_active_conns", "gauge",
+    "RDMA connections currently serving", ActiveConns());
+  m(s, "dfkv_rdma_v1_conns_opened_total", "counter",
+    "RDMA v1 connections opened", V1Conns());
+  m(s, "dfkv_rdma_v2_conns_opened_total", "counter",
+    "RDMA v2 connections opened", V2Conns());
+  m(s, "dfkv_rdma_v2_put_writes_total", "counter",
+    "PUT requests received by RDMA WRITE_WITH_IMM", V2PutWrites());
+  m(s, "dfkv_rdma_v2_get_writes_total", "counter",
+    "GET payloads sent by RDMA WRITE", V2GetWrites());
+  m(s, "dfkv_rdma_recv_segment_bytes", "gauge",
+    "Process-wide registered receive-segment bytes", recv_segment_.size());
+  m(s, "dfkv_rdma_recv_segment_free_bytes", "gauge",
+    "Unleased bytes remaining in the process-wide receive segment",
+    recv_segment_.free_bytes());
+  m(s, "dfkv_rdma_recv_segment_registered_rails", "gauge",
+    "RDMA rails with the process-wide receive segment registered",
+    recv_segment_registered_rails_);
+  m(s, "dfkv_rdma_v2_ready", "gauge",
+    "Whether RDMA v2 has a registered shared receive segment",
+    v2_enabled_ && recv_segment_registered_rails_ > 0 ? 1 : 0);
   m(s, "dfkv_rdma_idle_reclaims_total", "counter", "RDMA connections reclaimed on idle timeout",
     IdleReclaims());
   m(s, "dfkv_uring_reads_total", "counter",

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -1,12 +1,11 @@
-/* RDMA cache-node listener — native libibverbs RC. Built only when
- * DFKV_WITH_RDMA is defined. Reuses the wire frames + a request handler so the
- * cache logic (DiskCacheGroup + metrics) is shared with the TCP server.
+/* RDMA cache-node listener — native libibverbs RC. Mixed v2 uses small
+ * per-QP control buffers plus leases from one process-wide registered receive
+ * segment; legacy v1 remains available per connection.
  *
- * The "listener" is a plain TCP accept socket used only to bootstrap QPs
- * (exchange LID/GID/QPN over a few bytes). Each accepted connection opens an RC
- * QP on the named RDMA device (--rdma-dev / DFKV_RDMA_DEV) and serves requests
- * over RDMA. Using TCP accept (not rdma_get_request) makes Stop() interruptible:
- * shutdown(listen_fd) wakes accept() instantly — no shutdown hang. */
+ * The listener is a TCP socket used only for capability/QP bootstrap. Startup
+ * discovers ACTIVE HCAs (or applies the configured whitelist), anchors their
+ * shared PD/MRs, and each accepted connection opens an RC QP on its requested
+ * rail. shutdown(listen_fd) keeps Stop() interruptible. */
 #ifndef DFKV_RDMA_SERVER_H_
 #define DFKV_RDMA_SERVER_H_
 
@@ -24,6 +23,7 @@
 
 #include "common/status.h"
 #include "transport/rdma_verbs.h"  // rdma::RcEndpoint
+#include "transport/rdma_recv_segment.h"
 
 namespace dfkv {
 
@@ -98,7 +98,8 @@ class RdmaServer {
   // their own reads instead of hanging until timeout.
   using RangeFlightAbortHandler = std::function<void(uint64_t flight)>;
 
-  // dev_name empty => env DFKV_RDMA_DEV, else first device.
+  // dev_name empty => env DFKV_RDMA_DEV; both empty => first ACTIVE local HCA
+  // (legacy host-local semantics). An explicit comma list enables multi-rail.
   explicit RdmaServer(Handler handler, size_t max_msg = (64u << 20),
                       const std::string& dev_name = "");
   void set_range_handler(RangeHandler h) { range_handler_ = std::move(h); }
@@ -165,6 +166,14 @@ class RdmaServer {
   // otherwise silent by design, correctness-first).
   uint64_t UringReads() const { return uring_reads_.load(std::memory_order_relaxed); }
   uint64_t UringInitFallbacks() const { return uring_init_fallbacks_.load(std::memory_order_relaxed); }
+  uint64_t V1Conns() const { return v1_conns_.load(std::memory_order_relaxed); }
+  uint64_t V2Conns() const { return v2_conns_.load(std::memory_order_relaxed); }
+  uint64_t V2PutWrites() const {
+    return v2_put_writes_.load(std::memory_order_relaxed);
+  }
+  uint64_t V2GetWrites() const {
+    return v2_get_writes_.load(std::memory_order_relaxed);
+  }
   // The server-side pipeline depth (env DFKV_RDMA_DEPTH, default 1) -- surfaced
   // in ring INFO because the CLIENT's depth must not exceed it: excess in-flight
   // requests hit receiver-not-ready retries and degrade SILENTLY (measured 3-4x
@@ -204,6 +213,8 @@ class RdmaServer {
   size_t max_msg_;
   size_t control_cap_;
   std::string dev_name_;
+  bool v2_enabled_ = true;
+  bool auto_device_ = true;
   int listen_fd_ = -1;
   int port_ = 0;
   std::atomic<bool> running_{false};
@@ -214,13 +225,21 @@ class RdmaServer {
   std::mutex conn_mu_;
   std::vector<Conn> conns_;
   std::unordered_set<rdma::RcEndpoint*> live_eps_;
-  // Lifetime device ref + one-time pool-MR registration (see Start()).
-  // One anchor per configured rail (--rdma-dev comma list): each holds a
-  // lifetime device ref + the pool-region MRs, so neither first-touch nor
-  // idle-reclaim of the last data connection ever re-pins the arena.
+  // One process-wide receive segment replaces per-connection multi-MiB
+  // request/direct-I/O buffers for v2. Each connection leases depth*slot_size;
+  // the segment MR is shared per PD through RcEndpoint's device registry.
+  rdma::RecvSegment recv_segment_;
+  size_t recv_segment_bytes_ = 0;
+  size_t recv_segment_registered_rails_ = 0;
+  // One anchor per resolved ACTIVE rail holds a lifetime shared-device ref and
+  // registers the receive segment / caller pools once on that rail's shared PD.
+  // With no explicit device filter only the first ACTIVE local rail is anchored,
+  // preserving the legacy rule that HCA names are host-local, not peer IDs.
   std::vector<std::unique_ptr<rdma::RcEndpoint>> anchors_;
-  std::vector<std::string> anchor_devs_;  // parsed from dev_name_ (>=1 entries)
+  std::vector<std::string> anchor_devs_;  // configured filter, then active rails
   std::atomic<uint64_t> uring_reads_{0}, uring_init_fallbacks_{0};
+  std::atomic<uint64_t> v1_conns_{0}, v2_conns_{0}, v2_put_writes_{0},
+      v2_get_writes_{0};
   std::atomic<uint64_t> completions_{0}, completion_errors_{0}, active_conns_{0},
       idle_reclaims_{0};
 };

--- a/src/transport/dev_frame.h
+++ b/src/transport/dev_frame.h
@@ -1,16 +1,16 @@
-/* DCP1 ("Declared Caps") -- a capacity declaration hidden in the RDMA
- * bootstrap device-name frame, using the same deterministic-zero-pad trick as
- * DPQ1: the client has always memset the 32-byte frame before writing the
- * NUL-terminated device name, and the server has always stopped reading at
- * the first NUL. So the tail is a compatible extension area:
- *   [ name bytes | \0 | magic "DCP1" u32 | max_block_bytes u64 | zeros... ]
- * max_block_bytes is the largest value payload the client will ever PUT or
- * GET on this connection (connectors know their block geometry exactly); the
- * server sizes that connection's per-slot buffers to it instead of the global
- * worst case (issue #110). 0 / absent / no room after a long name =
- * undeclared = worst-case sizing (exactly the old behavior).
- * Header-only and verbs-free so the codec is unit-testable in non-RDMA
- * builds; rdma_verbs.h re-exports it for the transport/server. */
+/* RDMA bootstrap device-name frame with a backwards-compatible declaration
+ * hidden after the NUL-terminated device name.  Legacy readers stop at the
+ * first NUL and therefore ignore the extension:
+ *
+ *   DCP1: [name | \0 | "DCP1" u32 | max_block_bytes u64]
+ *   DCP2: [name | \0 | "DCP2" u32 | max_block_bytes u64 | protocol u8]
+ *
+ * DCP1 preserves the original SEND/RECV protocol.  DCP2 requests the mixed
+ * v2 data plane and declares the block bound needed to size its shared receive
+ * segment slots.  A missing/zero declaration is always treated as v1.
+ *
+ * Header-only and verbs-free so the codec is unit-testable in non-RDMA builds;
+ * rdma_verbs.h re-exports it for the transport/server. */
 #ifndef DFKV_TRANSPORT_DEV_FRAME_H_
 #define DFKV_TRANSPORT_DEV_FRAME_H_
 
@@ -22,15 +22,27 @@ namespace dfkv::rdma {
 
 constexpr size_t kDevNameBytes = 32;
 constexpr uint32_t kDevCapsMagic = 0x31504344u;  // ASCII "DCP1" (LE)
+constexpr uint32_t kDevCapsV2Magic = 0x32504344u;  // ASCII "DCP2" (LE)
+constexpr uint8_t kDevProtoV1 = 1;
+constexpr uint8_t kDevProtoV2 = 2;
 
-// Writes name + optional DCP1 tail. max_block_bytes==0 or a name too long to
-// leave 13 tail bytes -> plain legacy frame.
+// Writes name + an optional DCP1/DCP2 tail. max_block_bytes==0 or a name too
+// long to leave the selected tail bytes produces a plain legacy frame.
 inline void EncodeDevFrame(const std::string& dev, uint64_t max_block_bytes,
-                           char out[kDevNameBytes]) {
+                           char out[kDevNameBytes],
+                           uint8_t protocol_version = kDevProtoV1) {
   std::memset(out, 0, kDevNameBytes);
   const size_t n = dev.size() < kDevNameBytes - 1 ? dev.size() : kDevNameBytes - 1;
   std::memcpy(out, dev.data(), n);
-  if (max_block_bytes == 0 || n + 1 + 4 + 8 > kDevNameBytes) return;
+  if (max_block_bytes == 0) return;
+  if (protocol_version >= kDevProtoV2) {
+    if (n + 1 + 4 + 8 + 1 > kDevNameBytes) return;
+    std::memcpy(out + n + 1, &kDevCapsV2Magic, 4);
+    std::memcpy(out + n + 5, &max_block_bytes, 8);
+    out[n + 13] = static_cast<char>(kDevProtoV2);
+    return;
+  }
+  if (n + 1 + 4 + 8 > kDevNameBytes) return;
   std::memcpy(out + n + 1, &kDevCapsMagic, 4);
   std::memcpy(out + n + 5, &max_block_bytes, 8);
 }
@@ -42,10 +54,24 @@ inline uint64_t ParseDevFrameCaps(const char in[kDevNameBytes]) {
   if (nul + 1 + 4 + 8 > kDevNameBytes) return 0;
   uint32_t magic = 0;
   std::memcpy(&magic, in + nul + 1, 4);
-  if (magic != kDevCapsMagic) return 0;
+  if (magic != kDevCapsMagic && magic != kDevCapsV2Magic) return 0;
   uint64_t v = 0;
   std::memcpy(&v, in + nul + 5, 8);
   return v;
+}
+
+inline uint8_t ParseDevFrameProtocol(const char in[kDevNameBytes]) {
+  size_t nul = 0;
+  while (nul < kDevNameBytes && in[nul] != '\0') ++nul;
+  if (nul + 1 + 4 + 8 + 1 > kDevNameBytes) return kDevProtoV1;
+  uint32_t magic = 0;
+  std::memcpy(&magic, in + nul + 1, 4);
+  if (magic != kDevCapsV2Magic ||
+      static_cast<uint8_t>(in[nul + 13]) != kDevProtoV2 ||
+      ParseDevFrameCaps(in) == 0) {
+    return kDevProtoV1;
+  }
+  return kDevProtoV2;
 }
 
 }  // namespace dfkv::rdma

--- a/src/transport/rdma_protocol.h
+++ b/src/transport/rdma_protocol.h
@@ -1,0 +1,131 @@
+/* RDMA v2 bootstrap/data-plane constants and verbs-free codecs. */
+#ifndef DFKV_TRANSPORT_RDMA_PROTOCOL_H_
+#define DFKV_TRANSPORT_RDMA_PROTOCOL_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+
+#include "common/value_header.h"
+#include "transport/dev_frame.h"
+#include "transport/wire.h"
+#include "utils/net_util.h"
+
+namespace dfkv::rdma {
+
+// v2 endpoints keep only small two-sided control buffers. Large PUT payloads
+// land at the aligned data area of a shared server receive segment; GET payloads
+// are RDMA-WRITEd into client-owned memory.
+constexpr size_t kV2ControlCap = 4096;
+constexpr size_t kV2DataOffset = 4096;
+constexpr size_t kV2PutPrefixOffset = kV2DataOffset - kReqPrefix;
+// Fleet-wide protocol bound. A GET target is one server RDMA WRITE WR, not one
+// local QP SGE; tying this to either peer's max_sge breaks heterogeneous HCAs.
+// Keep it equal to the public SG layout's maximum payload width.
+constexpr size_t kV2MaxGetTargets = 29;
+
+constexpr const char* kV2ProbeDevice = "__dfkv_v2__";
+constexpr uint32_t kV2ProbeMagic = 0x32564644u;  // ASCII "DFV2" (LE)
+constexpr size_t kV2ProbeReplyBytes = 8;
+
+inline bool IsV2Probe(const char frame[kDevNameBytes]) {
+  size_t n = 0;
+  while (n < kDevNameBytes && frame[n] != '\0') ++n;
+  return std::string(frame, n) == kV2ProbeDevice &&
+         ParseDevFrameProtocol(frame) == kDevProtoV2;
+}
+
+inline void EncodeV2ProbeReply(char out[kV2ProbeReplyBytes]) {
+  std::memset(out, 0, kV2ProbeReplyBytes);
+  std::memcpy(out, &kV2ProbeMagic, sizeof(kV2ProbeMagic));
+  out[4] = static_cast<char>(kDevProtoV2);
+}
+
+inline bool ParseV2ProbeReply(const char in[kV2ProbeReplyBytes]) {
+  uint32_t magic = 0;
+  std::memcpy(&magic, in, sizeof(magic));
+  return magic == kV2ProbeMagic &&
+         static_cast<uint8_t>(in[4]) == kDevProtoV2;
+}
+
+inline size_t AlignUp(size_t value, size_t alignment) {
+  if (alignment == 0 || (alignment & (alignment - 1)) != 0 ||
+      value > std::numeric_limits<size_t>::max() - (alignment - 1)) {
+    return 0;
+  }
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+inline size_t V2SlotSize(uint64_t max_block_bytes) {
+  if (max_block_bytes == 0 ||
+      max_block_bytes > std::numeric_limits<size_t>::max() -
+                            kV2DataOffset - ValueHeader::kSize) {
+    return 0;
+  }
+  return AlignUp(kV2DataOffset + ValueHeader::kSize +
+                     static_cast<size_t>(max_block_bytes),
+                 kV2DataOffset);
+}
+
+// WRITE_WITH_IMM completion length is the only proof that the peer overwrote
+// the whole v2 PUT frame in its leased slot. Require an exact frame; accepting a
+// short write would expose stale bytes from the slot's previous generation.
+inline bool V2PutCompletionCoversFrame(uint32_t completion_bytes,
+                                       uint64_t payload_len,
+                                       size_t slot_size) {
+  if (slot_size < kV2PutPrefixOffset + kReqPrefix)
+    return false;
+  const size_t frame_cap = slot_size - kV2PutPrefixOffset;
+  if (payload_len > frame_cap - kReqPrefix)
+    return false;
+  return completion_bytes == kReqPrefix + payload_len;
+}
+
+// SEND_WITH_IMM also sets IBV_WC_WITH_IMM at the receiver, but its opcode is
+// ordinary RECV and its bytes live in the posted receive buffer, not the shared
+// segment. Accept only an RDMA_WRITE_WITH_IMM receive completion.
+inline bool V2PutCompletionIsValid(bool is_rdma_write_with_imm,
+                                   bool has_immediate,
+                                   uint32_t completion_bytes,
+                                   uint64_t payload_len,
+                                   uint64_t logical_payload_cap,
+                                   size_t slot_size) {
+  return is_rdma_write_with_imm && has_immediate &&
+         payload_len <= logical_payload_cap &&
+         V2PutCompletionCoversFrame(completion_bytes, payload_len, slot_size);
+}
+
+struct RecvSegmentInfo {
+  uint64_t base_addr = 0;  // this connection's K-slot lease, not global base
+  uint32_t rkey = 0;
+  uint64_t slot_size = 0;
+};
+
+constexpr uint32_t kRecvSegmentInfoMagic = 0x32475352u;  // "RSG2" (LE)
+constexpr size_t kRecvSegmentInfoBytes = 24;
+
+inline void EncodeRecvSegmentInfo(const RecvSegmentInfo& info,
+                                  char out[kRecvSegmentInfoBytes]) {
+  std::memset(out, 0, kRecvSegmentInfoBytes);
+  net::PutU32(out, kRecvSegmentInfoMagic);
+  net::PutU32(out + 4, info.rkey);
+  net::PutU64(out + 8, info.base_addr);
+  net::PutU64(out + 16, info.slot_size);
+}
+
+inline bool DecodeRecvSegmentInfo(const char in[kRecvSegmentInfoBytes],
+                                  RecvSegmentInfo* info) {
+  if (net::GetU32(in) != kRecvSegmentInfoMagic) return false;
+  info->rkey = net::GetU32(in + 4);
+  info->base_addr = net::GetU64(in + 8);
+  info->slot_size = net::GetU64(in + 16);
+  return info->rkey != 0 && info->base_addr != 0 &&
+         info->slot_size >= kV2DataOffset &&
+         info->slot_size % kV2DataOffset == 0;
+}
+
+}  // namespace dfkv::rdma
+
+#endif  // DFKV_TRANSPORT_RDMA_PROTOCOL_H_

--- a/src/transport/rdma_recv_segment.cc
+++ b/src/transport/rdma_recv_segment.cc
@@ -1,0 +1,149 @@
+#include "transport/rdma_recv_segment.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <utility>
+
+namespace dfkv::rdma {
+namespace {
+
+bool IsPowerOfTwo(size_t value) {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+size_t AlignUpChecked(size_t value, size_t alignment) {
+  if (!IsPowerOfTwo(alignment) ||
+      value > std::numeric_limits<size_t>::max() - (alignment - 1)) {
+    return std::numeric_limits<size_t>::max();
+  }
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+}  // namespace
+
+size_t ResolveRecvSegmentBytes(const char* value, size_t fallback,
+                               size_t alignment) {
+  if (!IsPowerOfTwo(alignment)) return 0;
+  size_t bytes = fallback;
+  if (value && *value) {
+    errno = 0;
+    char* end = nullptr;
+    const unsigned long long parsed = std::strtoull(value, &end, 10);
+    if (errno == 0 && end != value && *end == '\0' && parsed != 0 &&
+        parsed <= std::numeric_limits<size_t>::max()) {
+      bytes = static_cast<size_t>(parsed);
+    }
+  }
+  const size_t aligned = AlignUpChecked(bytes, alignment);
+  return aligned == std::numeric_limits<size_t>::max() ? 0 : aligned;
+}
+
+RecvSegment::Lease::Lease(Lease&& other) noexcept
+    : owner_(other.owner_), offset_(other.offset_), size_(other.size_) {
+  other.owner_ = nullptr;
+  other.offset_ = 0;
+  other.size_ = 0;
+}
+
+RecvSegment::Lease& RecvSegment::Lease::operator=(Lease&& other) noexcept {
+  if (this == &other) return *this;
+  Reset();
+  owner_ = other.owner_;
+  offset_ = other.offset_;
+  size_ = other.size_;
+  other.owner_ = nullptr;
+  other.offset_ = 0;
+  other.size_ = 0;
+  return *this;
+}
+
+RecvSegment::Lease::~Lease() { Reset(); }
+
+char* RecvSegment::Lease::data() const {
+  return owner_ ? owner_->data_ + offset_ : nullptr;
+}
+
+void RecvSegment::Lease::Reset() {
+  if (!owner_) return;
+  owner_->Release(offset_, size_);
+  owner_ = nullptr;
+  offset_ = 0;
+  size_ = 0;
+}
+
+RecvSegment::~RecvSegment() { std::free(data_); }
+
+bool RecvSegment::Init(size_t bytes, size_t alignment) {
+  if (data_) return size_ == bytes && alignment_ == alignment;
+  if (bytes == 0 || !IsPowerOfTwo(alignment) || bytes % alignment != 0 ||
+      alignment < sizeof(void*)) {
+    return false;
+  }
+  void* raw = nullptr;
+  if (::posix_memalign(&raw, alignment, bytes) != 0) return false;
+  data_ = static_cast<char*>(raw);
+  size_ = bytes;
+  alignment_ = alignment;
+  free_.emplace(0, bytes);
+  return true;
+}
+
+RecvSegment::Lease RecvSegment::Allocate(size_t bytes, size_t alignment) {
+  if (!data_ || bytes == 0 || !IsPowerOfTwo(alignment)) return {};
+  std::lock_guard<std::mutex> lock(mu_);
+  for (auto it = free_.begin(); it != free_.end(); ++it) {
+    const size_t range_begin = it->first;
+    const size_t range_size = it->second;
+    const uintptr_t base = reinterpret_cast<uintptr_t>(data_);
+    if (range_begin > std::numeric_limits<uintptr_t>::max() - base) continue;
+    const size_t absolute =
+        AlignUpChecked(static_cast<size_t>(base + range_begin), alignment);
+    if (absolute == std::numeric_limits<size_t>::max() || absolute < base)
+      continue;
+    const size_t begin = absolute - base;
+    if (begin < range_begin || begin - range_begin > range_size ||
+        bytes > range_size - (begin - range_begin)) {
+      continue;
+    }
+    const size_t range_end = range_begin + range_size;
+    const size_t end = begin + bytes;
+    free_.erase(it);
+    if (begin > range_begin) free_.emplace(range_begin, begin - range_begin);
+    if (end < range_end) free_.emplace(end, range_end - end);
+    return Lease(this, begin, bytes);
+  }
+  return {};
+}
+
+size_t RecvSegment::free_bytes() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  size_t total = 0;
+  for (const auto& range : free_) total += range.second;
+  return total;
+}
+
+void RecvSegment::Release(size_t offset, size_t bytes) {
+  if (bytes == 0) return;
+  std::lock_guard<std::mutex> lock(mu_);
+  size_t begin = offset;
+  size_t end = offset + bytes;
+
+  auto next = free_.lower_bound(begin);
+  if (next != free_.begin()) {
+    auto prev = std::prev(next);
+    if (prev->first + prev->second == begin) {
+      begin = prev->first;
+      free_.erase(prev);
+    }
+  }
+  next = free_.lower_bound(end);
+  if (next != free_.end() && next->first == end) {
+    end += next->second;
+    free_.erase(next);
+  }
+  free_.emplace(begin, end - begin);
+}
+
+}  // namespace dfkv::rdma

--- a/src/transport/rdma_recv_segment.h
+++ b/src/transport/rdma_recv_segment.h
@@ -1,0 +1,67 @@
+/* Shared, aligned receive segment allocator for RDMA v2 server connections. */
+#ifndef DFKV_TRANSPORT_RDMA_RECV_SEGMENT_H_
+#define DFKV_TRANSPORT_RDMA_RECV_SEGMENT_H_
+
+#include <cstddef>
+#include <map>
+#include <mutex>
+
+namespace dfkv::rdma {
+// Parse and align the process-wide receive-segment size without applying the
+// wire payload's uint32 ceiling. Invalid/zero/overflow values use fallback;
+// returns 0 only when the fallback geometry itself is invalid.
+size_t ResolveRecvSegmentBytes(const char* value, size_t fallback,
+                               size_t alignment = 4096);
+
+class RecvSegment {
+ public:
+  class Lease {
+   public:
+    Lease() = default;
+    Lease(const Lease&) = delete;
+    Lease& operator=(const Lease&) = delete;
+    Lease(Lease&& other) noexcept;
+    Lease& operator=(Lease&& other) noexcept;
+    ~Lease();
+
+    explicit operator bool() const { return owner_ != nullptr; }
+    char* data() const;
+    size_t offset() const { return offset_; }
+    size_t size() const { return size_; }
+    void Reset();
+
+   private:
+    friend class RecvSegment;
+    Lease(RecvSegment* owner, size_t offset, size_t size)
+        : owner_(owner), offset_(offset), size_(size) {}
+
+    RecvSegment* owner_ = nullptr;
+    size_t offset_ = 0;
+    size_t size_ = 0;
+  };
+
+  RecvSegment() = default;
+  RecvSegment(const RecvSegment&) = delete;
+  RecvSegment& operator=(const RecvSegment&) = delete;
+  ~RecvSegment();
+
+  bool Init(size_t bytes, size_t alignment = 4096);
+  Lease Allocate(size_t bytes, size_t alignment = 4096);
+
+  char* data() const { return data_; }
+  size_t size() const { return size_; }
+  size_t free_bytes() const;
+
+ private:
+  void Release(size_t offset, size_t bytes);
+
+  char* data_ = nullptr;
+  size_t size_ = 0;
+  size_t alignment_ = 0;
+  mutable std::mutex mu_;
+  std::map<size_t, size_t> free_;  // offset -> length, sorted and coalesced
+};
+
+}  // namespace dfkv::rdma
+
+#endif  // DFKV_TRANSPORT_RDMA_RECV_SEGMENT_H_

--- a/src/transport/rdma_topology.cc
+++ b/src/transport/rdma_topology.cc
@@ -1,0 +1,140 @@
+#include "transport/rdma_topology.h"
+
+#include <infiniband/verbs.h>
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+#include "utils/log.h"
+#include "utils/numa_util.h"
+
+namespace dfkv::rdma {
+namespace {
+
+bool Contains(const std::vector<std::string>& names, const std::string& name) {
+  return names.empty() ||
+         std::find(names.begin(), names.end(), name) != names.end();
+}
+
+}  // namespace
+
+RdmaTopology::RdmaTopology(std::vector<RdmaDevInfo> devices)
+    : devices_(std::move(devices)), enabled_(devices_.size(), 1) {}
+
+std::vector<RdmaDevInfo> RdmaTopology::FilterActive(
+    const std::vector<RdmaDevInfo>& candidates,
+    const std::vector<std::string>& filter) {
+  std::vector<RdmaDevInfo> out;
+  out.reserve(candidates.size());
+  for (const auto& candidate : candidates) {
+    if (!candidate.active || !Contains(filter, candidate.name)) continue;
+    const bool duplicate = std::any_of(
+        out.begin(), out.end(), [&](const RdmaDevInfo& selected) {
+          return selected.name == candidate.name;
+        });
+    if (!duplicate) out.push_back(candidate);
+  }
+  return out;
+}
+
+std::vector<RdmaDevInfo> RdmaTopology::Discover(
+    const std::vector<std::string>& filter) {
+  int count = 0;
+  ibv_device** list = ibv_get_device_list(&count);
+  if (!list || count == 0) {
+    if (list) ibv_free_device_list(list);
+    DFKV_LOG_WARN("rdma: no verbs devices found");
+    return {};
+  }
+
+  std::vector<RdmaDevInfo> candidates;
+  candidates.reserve(static_cast<size_t>(count));
+  for (int i = 0; i < count; ++i) {
+    const char* raw_name = ibv_get_device_name(list[i]);
+    if (!raw_name) continue;
+    const std::string name(raw_name);
+    if (!Contains(filter, name)) continue;
+
+    ibv_context* context = ibv_open_device(list[i]);
+    if (!context) {
+      DFKV_LOG_WARN("rdma: skipping device " + name +
+                    ": ibv_open_device failed");
+      continue;
+    }
+
+    ibv_port_attr port{};
+    if (ibv_query_port(context, 1, &port) != 0) {
+      DFKV_LOG_WARN("rdma: skipping device " + name +
+                    ": ibv_query_port(1) failed");
+      ibv_close_device(context);
+      continue;
+    }
+
+    RdmaDevInfo info;
+    info.name = name;
+    info.numa_node = numa::DeviceNode(name.c_str());
+    info.lid = port.lid;
+    info.active = port.state == IBV_PORT_ACTIVE;
+    union ibv_gid gid{};
+    if (ibv_query_gid(context, 1, 0, &gid) == 0)
+      std::memcpy(info.gid.data(), gid.raw, info.gid.size());
+    ibv_close_device(context);
+
+    if (!info.active) {
+      DFKV_LOG_WARN("rdma: skipping device " + name + ": port 1 state=" +
+                    std::to_string(static_cast<int>(port.state)) +
+                    " (ACTIVE=" +
+                    std::to_string(static_cast<int>(IBV_PORT_ACTIVE)) + ")");
+    }
+    candidates.push_back(std::move(info));
+  }
+  ibv_free_device_list(list);
+
+  std::vector<RdmaDevInfo> active = FilterActive(candidates, filter);
+  for (const auto& requested : filter) {
+    const bool found = std::any_of(
+        active.begin(), active.end(), [&](const RdmaDevInfo& device) {
+          return device.name == requested;
+        });
+    if (!found)
+      DFKV_LOG_WARN("rdma: configured device " + requested +
+                    " is absent or not ACTIVE");
+  }
+  return active;
+}
+
+int RdmaTopology::SelectDevice(int numa_node, bool numa_aware,
+                               size_t retry_count) const {
+  std::lock_guard<std::mutex> lock(mu_);
+  size_t local_count = 0;
+  size_t enabled_count = 0;
+  for (size_t i = 0; i < devices_.size(); ++i) {
+    if (!enabled_[i]) continue;
+    ++enabled_count;
+    if (numa_aware && numa_node >= 0 && devices_[i].numa_node == numa_node)
+      ++local_count;
+  }
+  if (enabled_count == 0) return -1;
+
+  const bool use_local = local_count != 0;
+  const size_t choice_count = use_local ? local_count : enabled_count;
+  const size_t choice =
+      (rr_.fetch_add(1, std::memory_order_relaxed) + retry_count) % choice_count;
+  size_t seen = 0;
+  for (size_t i = 0; i < devices_.size(); ++i) {
+    if (!enabled_[i]) continue;
+    if (use_local && devices_[i].numa_node != numa_node) continue;
+    if (seen++ == choice) return static_cast<int>(i);
+  }
+  return -1;
+}
+
+void RdmaTopology::DisableDevice(const std::string& name) {
+  std::lock_guard<std::mutex> lock(mu_);
+  for (size_t i = 0; i < devices_.size(); ++i) {
+    if (devices_[i].name == name) enabled_[i] = 0;
+  }
+}
+
+}  // namespace dfkv::rdma

--- a/src/transport/rdma_topology.h
+++ b/src/transport/rdma_topology.h
@@ -1,0 +1,64 @@
+/* RDMA device discovery and runtime rail selection.
+ *
+ * Device names supplied through DFKV_RDMA_DEV are a whitelist, never a bypass
+ * around link-state checks. Only port-1 devices in IBV_PORT_ACTIVE state are
+ * returned, so an unconfigured client automatically uses every healthy rail
+ * and an explicit list safely degrades when one member is down. */
+#ifndef DFKV_RDMA_TOPOLOGY_H_
+#define DFKV_RDMA_TOPOLOGY_H_
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace dfkv::rdma {
+
+struct RdmaDevInfo {
+  std::string name;
+  int numa_node = -1;
+  uint16_t lid = 0;
+  std::array<uint8_t, 16> gid{};
+  bool active = false;
+};
+
+class RdmaTopology {
+ public:
+  explicit RdmaTopology(std::vector<RdmaDevInfo> devices);
+
+  // Enumerate port 1 on every verbs device, apply the optional name whitelist,
+  // and return only ports whose state is IBV_PORT_ACTIVE.
+  static std::vector<RdmaDevInfo> Discover(
+      const std::vector<std::string>& filter = {});
+
+  // Pure filtering seam shared by Discover and the hardware-free unit tests.
+  // Preserves enumeration order and removes duplicate names.
+  static std::vector<RdmaDevInfo> FilterActive(
+      const std::vector<RdmaDevInfo>& candidates,
+      const std::vector<std::string>& filter = {});
+
+  const std::vector<RdmaDevInfo>& devices() const { return devices_; }
+
+  // Return the stable index into devices(). Prefer enabled rails local to
+  // numa_node when requested, otherwise round-robin all enabled rails.
+  // retry_count rotates the choice further for callers retrying a failed open.
+  int SelectDevice(int numa_node, bool numa_aware,
+                   size_t retry_count = 0) const;
+
+  // Exclude a rail after a runtime local-device failure. Existing connections
+  // remain valid; only subsequent selections are affected.
+  void DisableDevice(const std::string& name);
+
+ private:
+  std::vector<RdmaDevInfo> devices_;
+  mutable std::mutex mu_;
+  std::vector<uint8_t> enabled_;
+  mutable std::atomic<size_t> rr_{0};
+};
+
+}  // namespace dfkv::rdma
+
+#endif  // DFKV_RDMA_TOPOLOGY_H_

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -5,15 +5,18 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <stdexcept>
 
 #include "utils/log.h"
 #include "utils/net_util.h"     // Dial / WriteAll / ReadAll / Put*/Get*
+#include "transport/rdma_topology.h"
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
-#include "utils/numa_util.h"     // numa::DeviceNode / CurrentNode / Enabled
-#include "transport/rail_select.h"   // rdma::PickRail
+#include "transport/rdma_protocol.h"
+#include "utils/numa_util.h"     // CurrentNode / Enabled
 #include "common/value_header.h"
 
 namespace dfkv {
@@ -60,62 +63,129 @@ size_t ControlCapFor(size_t max_payload) {
   return cap < kMinControlCap ? kMinControlCap : cap;
 }
 
-// Post w requests (already built in ep.sbuf[j], send length slen[j]) with one
-// recv per slot, then reap all 2*w completions. recv wr_id = slot, so the reply
-// for request j lands in ep.rbuf[j] (RC in-order delivery). rbytes[j] = reply
-// length. Returns false (connection unusable) on any error completion.
-bool RunWindow(rdma::RcEndpoint& ep, const std::vector<size_t>& slen,
-               std::vector<uint32_t>* rbytes, int timeout_ms) {
-  const size_t w = slen.size();
-  rbytes->assign(w, 0);
-  for (size_t j = 0; j < w; ++j)
-    if (!ep.PostRecv(j) || !ep.PostSend(j, slen[j])) return false;
-  std::vector<ibv_wc> wcs(2 * w);
-  int need = static_cast<int>(2 * w);
+std::vector<std::string> ParseDeviceList(const std::string& list) {
+  std::vector<std::string> devices;
+  for (size_t i = 0; i <= list.size();) {
+    size_t comma = list.find(',', i);
+    if (comma == std::string::npos) comma = list.size();
+    size_t begin = i;
+    size_t end = comma;
+    while (begin < end &&
+           std::isspace(static_cast<unsigned char>(list[begin])))
+      ++begin;
+    while (end > begin &&
+           std::isspace(static_cast<unsigned char>(list[end - 1])))
+      --end;
+    if (end > begin) devices.push_back(list.substr(begin, end - begin));
+    i = comma + 1;
+  }
+  return devices;
+}
+
+std::string JoinDevices(const std::vector<std::string>& devices) {
+  std::string out;
+  for (const auto& device : devices) {
+    if (!out.empty()) out += ",";
+    out += device;
+  }
+  return out;
+}
+
+// Reap one signaled request completion and one status RECV per slot. Requests
+// may be SEND or WRITE_WITH_IMM; both surface as a send-side completion.
+bool ReapWindow(rdma::RcEndpoint& ep, size_t width,
+                std::vector<uint32_t>* rbytes, int timeout_ms) {
+  rbytes->assign(width, 0);
+  std::vector<ibv_wc> wcs(2 * width);
+  int need = static_cast<int>(2 * width);
   while (need > 0) {
-    int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), timeout_ms);
-    if (g <= 0) return false;  // <0 error, 0 timeout => conn unusable, caller retries
-    for (int i = 0; i < g; ++i) {
+    int got = ep.WaitComp(wcs.data(), static_cast<int>(2 * width), timeout_ms);
+    if (got <= 0) return false;
+    for (int i = 0; i < got; ++i) {
       if (wcs[i].status != IBV_WC_SUCCESS) return false;
-      if (wcs[i].opcode == IBV_WC_RECV)
-        (*rbytes)[static_cast<size_t>(wcs[i].wr_id)] = wcs[i].byte_len;
+      if (wcs[i].opcode == IBV_WC_RECV) {
+        const size_t slot = static_cast<size_t>(wcs[i].wr_id);
+        if (slot >= width) return false;
+        (*rbytes)[slot] = wcs[i].byte_len;
+      }
       --need;
     }
   }
   return true;
 }
+
+// Post w ordinary SEND requests with one status RECV per slot.
+bool RunWindow(rdma::RcEndpoint& ep, const std::vector<size_t>& slen,
+               std::vector<uint32_t>* rbytes, int timeout_ms) {
+  for (size_t j = 0; j < slen.size(); ++j)
+    if (!ep.PostRecv(j) || !ep.PostSend(j, slen[j])) return false;
+  return ReapWindow(ep, slen.size(), rbytes, timeout_ms);
+}
 }  // namespace
 
 struct RdmaTransport::Conn {
   rdma::RcEndpoint ep;
+  uint8_t protocol_version = kProtoVersionV1;
+  rdma::RecvSegmentInfo recv_segment;
+
+  bool v2() const { return protocol_version == kProtoVersionV2; }
+  void Encode(char* out, WireOp op, const BlockKey& key, uint64_t offset,
+              uint64_t length, uint64_t payload_len) const {
+    EncodeReqVersion(out, protocol_version, op, key, offset, length,
+                     payload_len);
+  }
+  bool Decode(const char* in, Status* status, uint64_t* data_len,
+              uint64_t max_data = kMaxFrameLen) const {
+    return DecodeRespVersion(in, protocol_version, status, data_len, max_data);
+  }
+  size_t data_capacity() const {
+    return recv_segment.slot_size >= rdma::kV2DataOffset
+               ? static_cast<size_t>(recv_segment.slot_size -
+                                     rdma::kV2DataOffset)
+               : 0;
+  }
+  uint64_t put_addr(size_t slot) const {
+    return recv_segment.base_addr +
+           slot * recv_segment.slot_size + rdma::kV2PutPrefixOffset;
+  }
 };
 
 bool RdmaTransport::Available() {
-  int n = 0;
-  ibv_device** devs = ibv_get_device_list(&n);
-  if (devs) ibv_free_device_list(devs);
-  return n > 0;
+  const char* configured = std::getenv("DFKV_RDMA_DEV");
+  const auto filter =
+      ParseDeviceList(configured ? std::string(configured) : std::string());
+  return !rdma::RdmaTopology::Discover(filter).empty();
 }
 
 RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
     : max_payload_(ResolveMaxPayload(max_msg)),
-      declared_(std::min<uint64_t>(EnvBytes("DFKV_RDMA_MAX_BLOCK_BYTES", 0),
-                                   ResolveMaxPayload(max_msg))),
-      control_cap_(ControlCapFor(declared_ ? static_cast<size_t>(declared_)
-                                           : ResolveMaxPayload(max_msg))),
+      declared_(std::min<uint64_t>(
+          EnvBytes("DFKV_RDMA_MAX_BLOCK_BYTES",
+                   ResolveMaxPayload(max_msg)),
+          ResolveMaxPayload(max_msg))),
+      legacy_declared_(std::min<uint64_t>(
+          EnvBytes("DFKV_RDMA_MAX_BLOCK_BYTES", 0),
+          ResolveMaxPayload(max_msg))),
+      control_cap_(ControlCapFor(declared_)),
       depth_(1) {
   std::string list = dev_name;
-  if (list.empty()) { const char* e = std::getenv("DFKV_RDMA_DEV"); if (e) list = e; }
-  for (size_t i = 0; i <= list.size();) {  // split on commas (multi-rail)
-    size_t c = list.find(',', i);
-    if (c == std::string::npos) c = list.size();
-    std::string d = list.substr(i, c - i);
-    if (!d.empty()) devs_.push_back(d);
-    i = c + 1;
+  if (list.empty()) {
+    const char* configured = std::getenv("DFKV_RDMA_DEV");
+    if (configured) list = configured;
   }
-  if (devs_.empty()) devs_.push_back("");  // first available device
-  for (const auto& d : devs_)
-    dev_node_.push_back(numa::DeviceNode(d.empty() ? nullptr : d.c_str()));
+  const auto filter = ParseDeviceList(list);
+  auto_device_ = filter.empty();
+  auto discovered = rdma::RdmaTopology::Discover(filter);
+  if (discovered.empty()) {
+    throw std::runtime_error(
+        filter.empty() ? "no ACTIVE RDMA device found"
+                       : "no configured RDMA device is ACTIVE");
+  }
+  if (auto_device_ && discovered.size() > 1) discovered.resize(1);
+  devs_.reserve(discovered.size());
+  for (const auto& device : discovered) devs_.push_back(device.name);
+  topology_ =
+      std::make_unique<rdma::RdmaTopology>(std::move(discovered));
   // Live SG width: the tightest rail decides (connections round-robin rails,
   // and a key must fit whichever rail carries it). Queried once — device caps
   // don't change under a running process.
@@ -127,8 +197,12 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
   }
   const char* d = std::getenv("DFKV_RDMA_DEPTH");  // pipeline depth (must be <= server's)
   if (d && *d) { long v = std::strtol(d, nullptr, 10); if (v >= 1 && v <= 256) depth_ = (size_t)v; }
-  config_dump::RecordResolved("DFKV_RDMA_DEV", list.empty() ? "(auto)" : list);
+  config_dump::RecordResolved("DFKV_RDMA_DEV", JoinDevices(devs_));
   config_dump::RecordResolved("DFKV_RDMA_DEPTH", std::to_string(depth_));
+  const char* protocol = std::getenv("DFKV_RDMA_PROTOCOL");
+  v2_enabled_ = !(protocol && std::strcmp(protocol, "1") == 0);
+  config_dump::RecordResolved("DFKV_RDMA_PROTOCOL",
+                              v2_enabled_ ? "auto-v2" : "v1");
   connect_ms_ = EnvInt("DFKV_RDMA_CONNECT_MS", 3000);
   io_ms_ = EnvInt("DFKV_RDMA_IO_MS", 10000);
   // Datapath completion timeout. EnvInt maps non-positive => default; treat an
@@ -161,9 +235,29 @@ RdmaTransport::~RdmaTransport() {
     for (Conn* c : cs) Destroy(c);
   for (auto& [node, cs] : control_pool_)
     for (Conn* c : cs) Destroy(c);
+  for (auto& [node, cs] : legacy_control_pool_)
+    for (Conn* c : cs) Destroy(c);
 }
 
 void RdmaTransport::Destroy(Conn* c) { delete c; }  // RcEndpoint dtor tears down QP/MRs
+
+bool RdmaTransport::ProbeV2(const std::string& node) const {
+  if (!v2_enabled_) return false;
+  int fd = net::Dial(node, connect_ms_, io_ms_);
+  if (fd < 0) return false;
+  char frame[rdma::kDevNameBytes];
+  const uint64_t declaration =
+      declared_ ? declared_ : static_cast<uint64_t>(rdma::kV2ControlCap);
+  rdma::EncodeDevFrame(rdma::kV2ProbeDevice, declaration, frame,
+                       rdma::kDevProtoV2);
+  char reply[rdma::kV2ProbeReplyBytes];
+  const bool ok =
+      net::WriteAll(fd, frame, sizeof(frame)) &&
+      net::ReadAll(fd, reply, sizeof(reply)) &&
+      rdma::ParseV2ProbeReply(reply);
+  ::close(fd);
+  return ok;
+}
 
 RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, Lane lane,
                                             bool* from_pool, bool force_new) {
@@ -171,70 +265,147 @@ RdmaTransport::Conn* RdmaTransport::Acquire(const std::string& node, Lane lane,
   Conn* pooled = nullptr;
   {
     std::lock_guard<std::mutex> lk(mu_);
-    pools = pools_;  // snapshot (a few regions); register on the conn outside the lock
-    // A retry (force_new) skips the pool: the conn we just tore down was reclaimed
-    // by the server, and the pool may hold more reclaimed conns — bootstrapping a
-    // fresh one guarantees the retry isn't handed another dead conn.
+    pools = pools_;
     if (!force_new) {
-      auto& p = (lane == Lane::kControl) ? control_pool_ : pool_;
-      auto it = p.find(node);
-      if (it != p.end() && !it->second.empty()) {
-        pooled = it->second.back(); it->second.pop_back();
+      auto& pool = lane == Lane::kData
+                       ? pool_
+                       : (lane == Lane::kControl ? control_pool_
+                                                 : legacy_control_pool_);
+      auto it = pool.find(node);
+      if (it != pool.end() && !it->second.empty()) {
+        pooled = it->second.back();
+        it->second.pop_back();
       }
     }
   }
-  if (pooled) { pooled->ep.EnsurePoolMrs(pools); *from_pool = true; return pooled; }
+  if (pooled) {
+    pooled->ep.EnsurePoolMrs(
+        pools, pooled->protocol_version == kProtoVersionV2);
+    *from_pool = true;
+    return pooled;
+  }
   *from_pool = false;
-  // Bootstrap the QP over a short-lived TCP connection to the node's member
-  // address (control plane). The data plane then rides the named RDMA device.
-  int fd = net::Dial(node, connect_ms_, io_ms_);
-  if (fd < 0) return nullptr;
 
-  // Pick a device for this connection: NUMA-aware when DFKV_RDMA_NUMA is on
-  // (prefer a rail on the calling thread's NUMA node), else round-robin all.
-  size_t tick = rr_.fetch_add(1, std::memory_order_relaxed);
-  size_t ridx = rdma::PickRail(dev_node_, numa::CurrentNode(), numa::Enabled(), tick);
+  const int selected =
+      topology_->SelectDevice(numa::CurrentNode(), numa::Enabled());
+  if (selected < 0) return nullptr;
+  const size_t ridx = static_cast<size_t>(selected);
   const std::string& dev = devs_[ridx];
 
-  auto* c = new Conn();
-  if (!c->ep.Open(dev.empty() ? nullptr : dev.c_str(), control_cap_, depth_)) {
-    ::close(fd); delete c; return nullptr;
+  bool local_open_failed = false;
+  auto connect_protocol = [&](bool protocol_v2) -> Conn* {
+    int fd = net::Dial(node, connect_ms_, io_ms_);
+    if (fd < 0) return nullptr;
+
+    auto* conn = new Conn();
+    const size_t endpoint_cap =
+        protocol_v2 ? rdma::kV2ControlCap : control_cap_;
+    if (!conn->ep.Open(dev.c_str(), endpoint_cap, depth_)) {
+      local_open_failed = true;
+      ::close(fd);
+      delete conn;
+      return nullptr;
+    }
+
+    // V2 control lanes declare a tiny bound so they lease only a small shared
+    // segment slot. V1 (including automatic fallback) must preserve legacy DCP1
+    // semantics: absent DFKV_RDMA_MAX_BLOCK_BYTES means an undeclared plain
+    // frame, not a synthetic max_payload_ declaration.
+    const uint64_t conn_declared =
+        protocol_v2
+            ? (lane == Lane::kControl
+                   ? static_cast<uint64_t>(rdma::kV2ControlCap)
+                   : declared_)
+            : legacy_declared_;
+    char devbuf[rdma::kDevNameBytes];
+    rdma::EncodeDevFrame(
+        auto_device_ ? std::string() : dev, conn_declared, devbuf,
+        protocol_v2 ? rdma::kDevProtoV2 : rdma::kDevProtoV1);
+    char mine[rdma::kQpInfoBytes], peer[rdma::kQpInfoBytes];
+    rdma::QpInfo my = conn->ep.Local();
+    my.depth = static_cast<uint16_t>(std::min<size_t>(depth_, 256));
+    my.protocol_version =
+        protocol_v2 ? rdma::kDevProtoV2 : rdma::kDevProtoV1;
+    rdma::SerializeQpInfo(my, mine);
+    if (!net::WriteAll(fd, devbuf, rdma::kDevNameBytes) ||
+        !net::WriteAll(fd, mine, rdma::kQpInfoBytes) ||
+        !net::ReadAll(fd, peer, rdma::kQpInfoBytes)) {
+      ::close(fd);
+      delete conn;
+      return nullptr;
+    }
+    const rdma::QpInfo remote = rdma::ParseQpInfo(peer);
+    const uint8_t expected =
+        protocol_v2 ? rdma::kDevProtoV2 : rdma::kDevProtoV1;
+    if (remote.protocol_version != expected || !conn->ep.Connect(remote)) {
+      ::close(fd);
+      delete conn;
+      return nullptr;
+    }
+    if (remote.depth > 0) {
+      conn->ep.set_remote_depth(remote.depth);
+      if (remote.depth < depth_)
+        DFKV_LOG_INFO("rdma: server depth " + std::to_string(remote.depth) +
+                      " < client depth " + std::to_string(depth_) +
+                      ": batching window clamped to " +
+                      std::to_string(remote.depth));
+    }
+    char ready = 0;
+    if (!net::ReadAll(fd, &ready, 1) || ready != 1) {
+      ::close(fd);
+      delete conn;
+      return nullptr;
+    }
+    if (protocol_v2) {
+      char encoded[rdma::kRecvSegmentInfoBytes];
+      if (!net::ReadAll(fd, encoded, sizeof(encoded)) ||
+          !rdma::DecodeRecvSegmentInfo(encoded, &conn->recv_segment)) {
+        ::close(fd);
+        delete conn;
+        return nullptr;
+      }
+      const size_t expected_slot = rdma::V2SlotSize(
+          static_cast<size_t>(std::max<uint64_t>(
+              conn_declared, rdma::kV2DataOffset)));
+      if (expected_slot == 0 ||
+          conn->recv_segment.slot_size != expected_slot) {
+        ::close(fd);
+        delete conn;
+        return nullptr;
+      }
+    }
+    ::close(fd);
+    conn->protocol_version = expected;
+    conn->ep.EnsurePoolMrs(pools, protocol_v2);
+    return conn;
+  };
+
+  const bool want_v2 =
+      v2_enabled_ && lane != Lane::kLegacyControl &&
+      (lane == Lane::kControl || declared_ != 0) &&
+      ProbeV2(node);
+  Conn* conn = connect_protocol(want_v2);
+  if (!conn && want_v2 && !local_open_failed) {
+    DFKV_LOG_WARN("rdma: v2 bootstrap failed; retrying v1 for " + node);
+    conn = connect_protocol(false);
   }
-  // Bootstrap: tell the server which device to open (same rail), then exchange QP.
-  char devbuf[rdma::kDevNameBytes];
-  // DCP1: declare this process's max block size in the frame's zero tail so
-  // the server sizes this connection's buffers to it (issue #110). declared_
-  // == 0 -> legacy frame -> server keeps worst-case sizing.
-  rdma::EncodeDevFrame(dev, declared_, devbuf);
-  char mine[rdma::kQpInfoBytes], peer[rdma::kQpInfoBytes];
-  rdma::QpInfo my = c->ep.Local();
-  my.depth = static_cast<uint16_t>(std::min<size_t>(depth_, 256));  // DPQ1 advertisement
-  rdma::SerializeQpInfo(my, mine);
-  if (!net::WriteAll(fd, devbuf, rdma::kDevNameBytes) ||
-      !net::WriteAll(fd, mine, rdma::kQpInfoBytes) ||
-      !net::ReadAll(fd, peer, rdma::kQpInfoBytes)) {
-    ::close(fd); delete c; return nullptr;
+  if (!conn) {
+    if (local_open_failed) {
+      topology_->DisableDevice(dev);
+      DFKV_LOG_WARN("rdma: disabling device " + dev +
+                    " after a local Open failure");
+    }
+    return nullptr;
   }
-  const rdma::QpInfo pq = rdma::ParseQpInfo(peer);
-  if (!c->ep.Connect(pq)) { ::close(fd); delete c; return nullptr; }
-  // Honor the server's advertised depth: clamp our batching window so we never
-  // pipeline past its posted receives (RNR-retry silent degradation otherwise).
-  if (pq.depth > 0) {
-    c->ep.set_remote_depth(pq.depth);
-    if (pq.depth < depth_)
-      DFKV_LOG_INFO("rdma: server depth " + std::to_string(pq.depth) +
-                    " < client depth " + std::to_string(depth_) +
-                    ": batching window clamped to " + std::to_string(pq.depth));
-  }
-  // Wait for the server's "ready" byte: it has posted its recvs, so our first
-  // SEND won't hit RNR.
-  char ready = 0;
-  if (!net::ReadAll(fd, &ready, 1) || ready != 1) { ::close(fd); delete c; return nullptr; }
-  ::close(fd);  // bootstrap done; QP is RTS
-  c->ep.EnsurePoolMrs(pools);  // register the declared host-pool regions on this PD
+
   conns_opened_.fetch_add(1, std::memory_order_relaxed);
-  if (ridx < devs_.size()) rail_conns_[ridx].fetch_add(1, std::memory_order_relaxed);
-  return c;
+  if (conn->protocol_version == kProtoVersionV2)
+    v2_conns_opened_.fetch_add(1, std::memory_order_relaxed);
+  else
+    v1_conns_opened_.fetch_add(1, std::memory_order_relaxed);
+  if (ridx < devs_.size())
+    rail_conns_[ridx].fetch_add(1, std::memory_order_relaxed);
+  return conn;
 }
 
 void RdmaTransport::RegisterMemory(void* base, size_t size) {
@@ -267,7 +438,7 @@ void RdmaTransport::RegisterMemory(void* base, size_t size) {
   // The actual (seconds-scale for huge pools) registration runs outside mu_;
   // anchors_ itself is only ever filled once under mu_, so the snapshot of raw
   // pointers stays valid for the transport's lifetime.
-  for (auto* ep : anchor_ptrs) ep->EnsurePoolMrs(pools);
+  for (auto* ep : anchor_ptrs) ep->EnsurePoolMrs(pools, true);
   // Connections still EnsurePoolMrs on Acquire (no-op once anchored here).
 }
 
@@ -277,6 +448,22 @@ std::string RdmaTransport::MetricsText() const {
   s += "# TYPE dfkv_rdma_client_conns_opened_total counter\n";
   s += "dfkv_rdma_client_conns_opened_total " +
        std::to_string(conns_opened_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_v1_conns_opened_total RDMA v1 connections opened\n";
+  s += "# TYPE dfkv_rdma_client_v1_conns_opened_total counter\n";
+  s += "dfkv_rdma_client_v1_conns_opened_total " +
+       std::to_string(v1_conns_opened_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_v2_conns_opened_total RDMA v2 connections opened\n";
+  s += "# TYPE dfkv_rdma_client_v2_conns_opened_total counter\n";
+  s += "dfkv_rdma_client_v2_conns_opened_total " +
+       std::to_string(v2_conns_opened_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_v2_put_writes_total PUT requests sent with RDMA WRITE_WITH_IMM\n";
+  s += "# TYPE dfkv_rdma_client_v2_put_writes_total counter\n";
+  s += "dfkv_rdma_client_v2_put_writes_total " +
+       std::to_string(v2_put_writes_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_v2_get_writes_total GET requests posted with RDMA WRITE destinations\n";
+  s += "# TYPE dfkv_rdma_client_v2_get_writes_total counter\n";
+  s += "dfkv_rdma_client_v2_get_writes_total " +
+       std::to_string(v2_get_writes_.load(std::memory_order_relaxed)) + "\n";
   s += "# HELP dfkv_rdma_client_mr_regions Declared host MR regions\n";
   s += "# TYPE dfkv_rdma_client_mr_regions gauge\n";
   s += "dfkv_rdma_client_mr_regions " +
@@ -305,68 +492,181 @@ std::string RdmaTransport::MetricsText() const {
 void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
   {
     std::lock_guard<std::mutex> lk(mu_);
-    auto& v = (lane == Lane::kControl ? control_pool_ : pool_)[node];
+    auto& pool = lane == Lane::kData
+                     ? pool_
+                     : (lane == Lane::kControl ? control_pool_
+                                               : legacy_control_pool_);
+    auto& v = pool[node];
     if (v.size() < pool_max_) { v.push_back(c); return; }
   }
   Destroy(c);  // pool full -> drop (and tear down the QP/MRs) instead of growing
 }
 
 Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
-                                const BlockKey& k, uint64_t offset,
+                                const BlockKey& key, uint64_t offset,
                                 uint64_t length, const void* payload,
                                 uint64_t payload_len, std::string* out) {
-  if (payload_len > control_cap_ - kReqPrefix) return Status::kInvalid;
-  if (op == WireOp::kRange && length > control_cap_ - kRespPrefix)
+  const uint64_t value_bound =
+      static_cast<uint64_t>(ValueHeader::kSize) + OpBound();
+  if (op == WireOp::kCache && payload_len > value_bound)
     return Status::kInvalid;
-  // Key-only ops (Exist/Remove/Members) ride the control lane so a lookup
-  // storm never queues behind payload transfers; Cache/Range carry payloads.
-  const Lane lane = (op == WireOp::kCache || op == WireOp::kRange)
-                        ? Lane::kData : Lane::kControl;
+  if (op == WireOp::kRange && length > value_bound)
+    return Status::kInvalid;
+
+  const Lane lane =
+      op == WireOp::kCache || op == WireOp::kRange
+          ? Lane::kData
+          : (op == WireOp::kMembers ? Lane::kLegacyControl : Lane::kControl);
   for (int attempt = 0; attempt < 2; ++attempt) {
+    if (out) out->clear();
     bool from_pool = false;
-    Conn* c = Acquire(node, lane, &from_pool, attempt > 0);
-    if (!c) return Status::kIOError;
-    rdma::RcEndpoint& ep = c->ep;
+    Conn* conn = Acquire(node, lane, &from_pool, attempt > 0);
+    if (!conn) return Status::kIOError;
+    rdma::RcEndpoint& ep = conn->ep;
 
-    EncodeReq(ep.sbuf(0), op, k, offset, length, payload_len);
-    if (payload_len) std::memcpy(ep.sbuf(0) + kReqPrefix, payload, payload_len);
+    bool ok = false;
+    ibv_mr* transient_output_mr = nullptr;
+    if (!conn->v2()) {
+      if (payload_len > ep.cap() - kReqPrefix ||
+          (op == WireOp::kRange && length > ep.cap() - kRespPrefix)) {
+        Release(node, lane, conn);
+        return Status::kInvalid;
+      }
+      conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
+      if (payload_len)
+        std::memcpy(ep.sbuf(0) + kReqPrefix, payload, payload_len);
+      ok = ep.PostRecv(0) &&
+           ep.PostSend(0, kReqPrefix + static_cast<size_t>(payload_len));
+    } else if (op == WireOp::kCache) {
+      if (payload_len > conn->data_capacity()) {
+        Release(node, lane, conn);
+        return Status::kInvalid;
+      }
+      ibv_mr* payload_mr =
+          payload_len
+              ? ep.RegisterTransient(const_cast<void*>(payload),
+                                     static_cast<size_t>(payload_len),
+                                     /*remote_write=*/false)
+              : nullptr;
+      transient_output_mr = payload_mr;
+      if (payload_len != 0 && !payload_mr) {
+        Release(node, lane, conn);
+        return Status::kIOError;
+      }
+      conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
+      ok = ep.PostRecv(0) &&
+           ep.PostWriteImmScatter(
+               0, kReqPrefix, payload, static_cast<size_t>(payload_len),
+               payload_mr, conn->put_addr(0), conn->recv_segment.rkey, 0);
+      if (ok)
+        v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+    } else if (op == WireOp::kRange) {
+      if (!out || length > conn->data_capacity() ||
+          length > std::numeric_limits<uint32_t>::max()) {
+        Release(node, lane, conn);
+        return Status::kInvalid;
+      }
+      out->resize(static_cast<size_t>(length));
+      std::vector<RdmaWriteTarget> targets;
+      if (length != 0) {
+        transient_output_mr = ep.RegisterTransient(out->data(), out->size());
+        if (!transient_output_mr) {
+          Release(node, lane, conn);
+          return Status::kIOError;
+        }
+        targets.push_back(
+            {reinterpret_cast<uint64_t>(out->data()),
+             transient_output_mr->rkey, static_cast<uint32_t>(length)});
+      }
+      size_t frame_len = 0;
+      ok = EncodeRdmaGetReq(ep.sbuf(0), ep.cap(), key, offset, length,
+                            /*header_len=*/0, targets, &frame_len) &&
+           ep.PostRecv(0) && ep.PostSend(0, frame_len);
+      if (ok)
+        v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
+      ok = ep.PostRecv(0) &&
+           ep.PostSend(0, kReqPrefix + static_cast<size_t>(payload_len));
+    }
 
-    bool ok = ep.PostRecv(0) && ep.PostSend(0, kReqPrefix + payload_len);
-    // Reap both the send and the recv completion (shared CQ; either order).
     uint32_t recv_bytes = 0;
-    bool need_send = ok, need_recv = ok;
-    while (ok && (need_send || need_recv)) {
-      ibv_wc wc{};
-      int g = ep.WaitComp(&wc, 1, op_timeout_ms_);
-      if (g <= 0 || wc.status != IBV_WC_SUCCESS) { ok = false; break; }
-      if (wc.opcode == IBV_WC_SEND) need_send = false;
-      else if (wc.opcode == IBV_WC_RECV) { need_recv = false; recv_bytes = wc.byte_len; }
+    bool need_request = ok;
+    bool need_recv = ok;
+    while (ok && (need_request || need_recv)) {
+      ibv_wc completion{};
+      int got = ep.WaitComp(&completion, 1, op_timeout_ms_);
+      if (got <= 0 || completion.status != IBV_WC_SUCCESS) {
+        ok = false;
+        break;
+      }
+      if (completion.opcode == IBV_WC_RECV) {
+        need_recv = false;
+        recv_bytes = completion.byte_len;
+      } else {
+        need_request = false;
+      }
+    }
+    if (ok && transient_output_mr) {
+      ep.ReleaseTransient(transient_output_mr);
+      transient_output_mr = nullptr;
     }
 
     if (!ok) {
-      Destroy(c);
+      Destroy(conn);
       if (!from_pool) return Status::kIOError;
-      continue;  // stale pooled conn -> retry fresh
+      continue;
     }
-    if (recv_bytes < kRespPrefix) { Destroy(c); return Status::kIOError; }
-    Status st; uint64_t dlen = 0;
-    if (!DecodeResp(ep.rbuf(0), &st, &dlen)) { Destroy(c); return Status::kIOError; }
+    if (recv_bytes < kRespPrefix) {
+      Destroy(conn);
+      return Status::kIOError;
+    }
+    Status status;
+    uint64_t data_len = 0;
+    if (!conn->Decode(ep.rbuf(0), &status, &data_len)) {
+      Destroy(conn);
+      return Status::kIOError;
+    }
     if (out) {
-      if (kRespPrefix + dlen > recv_bytes) { Destroy(c); return Status::kIOError; }
-      out->assign(ep.rbuf(0) + kRespPrefix, dlen);
+      if (conn->v2() && op == WireOp::kRange) {
+        if (status == Status::kOk && data_len <= out->size()) {
+          out->resize(static_cast<size_t>(data_len));
+        } else if (status != Status::kOk) {
+          out->clear();
+        } else {
+          Destroy(conn);
+          return Status::kIOError;
+        }
+      } else {
+        if (kRespPrefix + data_len > recv_bytes) {
+          Destroy(conn);
+          return Status::kIOError;
+        }
+        out->assign(ep.rbuf(0) + kRespPrefix,
+                    static_cast<size_t>(data_len));
+      }
     }
-    Release(node, lane, c);
-    return st;
+    Release(node, lane, conn);
+    return status;
   }
   return Status::kIOError;
 }
 
 Status RdmaTransport::Cache(const std::string& node, const BlockKey& key,
                             const void* data, size_t len) {
+  const size_t value_bytes =
+      len > ValueHeader::kSize ? len - ValueHeader::kSize : len;
+  if (NoteBlock(value_bytes)) return Status::kInvalid;
   return RoundTrip(node, WireOp::kCache, key, 0, 0, data, len, nullptr);
 }
 Status RdmaTransport::Range(const std::string& node, const BlockKey& key,
-                            uint64_t offset, uint64_t length, std::string* out) {
+                            uint64_t offset, uint64_t length,
+                            std::string* out) {
+  const uint64_t value_bytes =
+      length > ValueHeader::kSize ? length - ValueHeader::kSize : length;
+  if (value_bytes > std::numeric_limits<size_t>::max() ||
+      NoteBlock(static_cast<size_t>(value_bytes)))
+    return Status::kInvalid;
   return RoundTrip(node, WireOp::kRange, key, offset, length, nullptr, 0, out);
 }
 Status RdmaTransport::Exist(const std::string& node, const BlockKey& key, bool* exist) {
@@ -377,112 +677,223 @@ Status RdmaTransport::Exist(const std::string& node, const BlockKey& key, bool* 
 }
 
 Status RdmaTransport::Remove(const std::string& node, const BlockKey& key) {
-  // Key-only request, Status-only response (same framing as kExist).
   return RoundTrip(node, WireOp::kRemove, key, 0, 0, nullptr, 0, nullptr);
+}
+
+std::vector<Status> RdmaTransport::CacheMany(
+    const std::string& node, const std::vector<CacheItem>& items) {
+  const size_t count = items.size();
+  std::vector<Status> result(count, Status::kIOError);
+  if (count == 0) return result;
+  for (const auto& item : items) {
+    const size_t value_bytes =
+        item.len > ValueHeader::kSize ? item.len - ValueHeader::kSize
+                                     : item.len;
+    if (NoteBlock(value_bytes)) {
+      std::fill(result.begin(), result.end(), Status::kInvalid);
+      return result;
+    }
+  }
+
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    std::fill(result.begin(), result.end(), Status::kIOError);
+    bool from_pool = false;
+    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0);
+    if (!conn) return result;
+    rdma::RcEndpoint& ep = conn->ep;
+    const size_t window = ep.window();
+    bool conn_ok = true;
+    for (size_t base = 0; base < count && conn_ok; base += window) {
+      const size_t width = std::min(window, count - base);
+      std::vector<uint32_t> reply_bytes;
+      if (!conn->v2()) {
+        std::vector<size_t> send_lengths(width);
+        for (size_t slot = 0; slot < width; ++slot) {
+          const CacheItem& item = items[base + slot];
+          if (item.len > ep.cap() - kReqPrefix) {
+            conn_ok = false;
+            break;
+          }
+          conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0,
+                       item.len);
+          if (item.len)
+            std::memcpy(ep.sbuf(slot) + kReqPrefix, item.data, item.len);
+          send_lengths[slot] = kReqPrefix + item.len;
+        }
+        if (conn_ok &&
+            !RunWindow(ep, send_lengths, &reply_bytes, op_timeout_ms_))
+          conn_ok = false;
+      } else {
+        std::vector<ibv_mr*> payload_mrs(width, nullptr);
+        for (size_t slot = 0; slot < width; ++slot) {
+          const CacheItem& item = items[base + slot];
+          if (item.len > conn->data_capacity()) {
+            conn_ok = false;
+            break;
+          }
+          ibv_mr* mr =
+              item.len
+                  ? ep.RegisterTransient(const_cast<void*>(item.data), item.len,
+                                         /*remote_write=*/false)
+                  : nullptr;
+          payload_mrs[slot] = mr;
+          if ((item.len != 0 && !mr) ||
+              !ep.PostRecv(slot)) {
+            conn_ok = false;
+            break;
+          }
+          conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0,
+                       item.len);
+          if (!ep.PostWriteImmScatter(
+                  slot, kReqPrefix, item.data, item.len, mr,
+                  conn->put_addr(slot), conn->recv_segment.rkey,
+                  static_cast<uint32_t>(slot))) {
+            conn_ok = false;
+            break;
+          }
+          v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (conn_ok &&
+            !ReapWindow(ep, width, &reply_bytes, op_timeout_ms_))
+          conn_ok = false;
+        if (conn_ok) {
+          for (ibv_mr* mr : payload_mrs) ep.ReleaseTransient(mr);
+        }
+      }
+      if (!conn_ok) break;
+      for (size_t slot = 0; slot < width; ++slot) {
+        Status status;
+        uint64_t data_len = 0;
+        if (reply_bytes[slot] >= kRespPrefix &&
+            conn->Decode(ep.rbuf(slot), &status, &data_len))
+          result[base + slot] = status;
+      }
+    }
+    if (conn_ok) {
+      Release(node, Lane::kData, conn);
+      return result;
+    }
+    Destroy(conn);
+    if (from_pool) continue;
+    return result;
+  }
+  return result;
 }
 
 Status RdmaTransport::Members(const std::string& node, std::string* out) {
   return RoundTrip(node, WireOp::kMembers, BlockKey{}, 0, 0, nullptr, 0, out);
 }
 
-std::vector<Status> RdmaTransport::CacheMany(const std::string& node,
-                                             const std::vector<CacheItem>& items) {
-  const size_t n = items.size();
-  std::vector<Status> res(n, Status::kIOError);
-  if (n == 0) return res;
-  for (const auto& it : items) {
-    if (it.len > control_cap_ - kReqPrefix) {
-      std::fill(res.begin(), res.end(), Status::kInvalid);
-      return res;
-    }
+
+std::vector<Status> RdmaTransport::RangeMany(
+    const std::string& node, const std::vector<BlockKey>& keys,
+    uint64_t offset, uint64_t length, std::vector<std::string>* outputs) {
+  const size_t count = keys.size();
+  outputs->assign(count, std::string());
+  std::vector<Status> result(count, Status::kIOError);
+  if (count == 0) return result;
+  const uint64_t value_bytes =
+      length > ValueHeader::kSize ? length - ValueHeader::kSize : length;
+  if (length > std::numeric_limits<uint32_t>::max() ||
+      value_bytes > std::numeric_limits<size_t>::max() ||
+      NoteBlock(static_cast<size_t>(value_bytes))) {
+    std::fill(result.begin(), result.end(), Status::kInvalid);
+    return result;
   }
 
-  // 2-attempt loop: a stale pooled conn (peer reclaimed it after idle) fails fast
-  // on the first window; tear it down and retry once on a fresh conn. Cache is
-  // idempotent, so replaying the whole batch is harmless. Mirrors RoundTrip.
   for (int attempt = 0; attempt < 2; ++attempt) {
-    std::fill(res.begin(), res.end(), Status::kIOError);
+    std::fill(result.begin(), result.end(), Status::kIOError);
+    outputs->assign(count, std::string());
     bool from_pool = false;
-    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
-    if (!c) return res;
-    rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
+    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0);
+    if (!conn) return result;
+    rdma::RcEndpoint& ep = conn->ep;
+    const size_t window = ep.window();
     bool conn_ok = true;
-    for (size_t base = 0; base < n && conn_ok; base += W) {
-      const size_t w = std::min(W, n - base);
-      std::vector<size_t> slen(w);
-      for (size_t j = 0; j < w; ++j) {
-        const CacheItem& it = items[base + j];
-        EncodeReq(ep.sbuf(j), WireOp::kCache, it.key, 0, 0, it.len);
-        if (it.len) std::memcpy(ep.sbuf(j) + kReqPrefix, it.data, it.len);
-        slen[j] = kReqPrefix + it.len;
+    for (size_t base = 0; base < count && conn_ok; base += window) {
+      const size_t width = std::min(window, count - base);
+      std::vector<uint32_t> reply_bytes;
+      if (!conn->v2()) {
+        if (length > ep.cap() - kRespPrefix) {
+          std::fill(result.begin(), result.end(), Status::kInvalid);
+          Release(node, Lane::kData, conn);
+          return result;
+        }
+        std::vector<size_t> send_lengths(width, kReqPrefix);
+        for (size_t slot = 0; slot < width; ++slot)
+          conn->Encode(ep.sbuf(slot), WireOp::kRange, keys[base + slot],
+                       offset, length, 0);
+        if (!RunWindow(ep, send_lengths, &reply_bytes, op_timeout_ms_))
+          conn_ok = false;
+      } else {
+        std::vector<ibv_mr*> transient_output_mrs(width, nullptr);
+        for (size_t slot = 0; slot < width; ++slot) {
+          std::string& output = (*outputs)[base + slot];
+          output.resize(static_cast<size_t>(length));
+          std::vector<RdmaWriteTarget> targets;
+          if (length != 0) {
+            ibv_mr* mr = ep.RegisterTransient(output.data(), output.size());
+            if (!mr) {
+              conn_ok = false;
+              break;
+            }
+            transient_output_mrs[slot] = mr;
+            targets.push_back(
+                {reinterpret_cast<uint64_t>(output.data()), mr->rkey,
+                 static_cast<uint32_t>(length)});
+          }
+          size_t frame_len = 0;
+          if (!EncodeRdmaGetReq(ep.sbuf(slot), ep.cap(),
+                                keys[base + slot], offset, length, 0,
+                                targets, &frame_len) ||
+              !ep.PostRecv(slot) || !ep.PostSend(slot, frame_len)) {
+            conn_ok = false;
+            break;
+          }
+          v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (conn_ok &&
+            !ReapWindow(ep, width, &reply_bytes, op_timeout_ms_))
+          conn_ok = false;
+        if (conn_ok) {
+          for (ibv_mr* mr : transient_output_mrs)
+            ep.ReleaseTransient(mr);
+        }
       }
-      std::vector<uint32_t> rbytes;
-      if (!RunWindow(ep, slen, &rbytes, op_timeout_ms_)) { conn_ok = false; break; }
-      for (size_t j = 0; j < w; ++j) {
-        Status st; uint64_t dl = 0;
-        if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
-      }
-    }
-    if (conn_ok) { Release(node, Lane::kData, c); return res; }
-    Destroy(c);
-    if (from_pool) continue;  // stale pooled conn -> one fresh retry
-    return res;               // fresh conn failed -> terminal
-  }
-  return res;
-}
+      if (!conn_ok) break;
 
-std::vector<Status> RdmaTransport::RangeMany(const std::string& node,
-                                             const std::vector<BlockKey>& keys,
-                                             uint64_t offset, uint64_t length,
-                                             std::vector<std::string>* outs) {
-  const size_t n = keys.size();
-  outs->assign(n, std::string());
-  std::vector<Status> res(n, Status::kIOError);
-  if (n == 0) return res;
-  if (length > control_cap_ - kRespPrefix) {  // reply wouldn't fit the recv buffer
-    std::fill(res.begin(), res.end(), Status::kInvalid);
-    return res;
-  }
-
-  // 2-attempt loop: retry a stale pooled conn once on a fresh one. Range is a
-  // read (idempotent), so replaying the whole batch is harmless. Mirrors RoundTrip.
-  for (int attempt = 0; attempt < 2; ++attempt) {
-    std::fill(res.begin(), res.end(), Status::kIOError);
-    outs->assign(n, std::string());
-    bool from_pool = false;
-    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
-    if (!c) return res;
-    rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
-    bool conn_ok = true;
-    for (size_t base = 0; base < n && conn_ok; base += W) {
-      const size_t w = std::min(W, n - base);
-      std::vector<size_t> slen(w);
-      for (size_t j = 0; j < w; ++j) {
-        EncodeReq(ep.sbuf(j), WireOp::kRange, keys[base + j], offset, length, 0);
-        slen[j] = kReqPrefix;
-      }
-      std::vector<uint32_t> rbytes;
-      if (!RunWindow(ep, slen, &rbytes, op_timeout_ms_)) { conn_ok = false; break; }
-      for (size_t j = 0; j < w; ++j) {
-        uint32_t rb = rbytes[j];
-        if (rb < kRespPrefix) continue;
-        Status st; uint64_t dlen = 0;
-        if (!DecodeResp(ep.rbuf(j), &st, &dlen)) continue;
-        res[base + j] = st;
-        if (st == Status::kOk) {
-          if (kRespPrefix + dlen <= rb) (*outs)[base + j].assign(ep.rbuf(j) + kRespPrefix, dlen);
-          else res[base + j] = Status::kIOError;
+      for (size_t slot = 0; slot < width; ++slot) {
+        const uint32_t received = reply_bytes[slot];
+        if (received < kRespPrefix) continue;
+        Status status;
+        uint64_t data_len = 0;
+        if (!conn->Decode(ep.rbuf(slot), &status, &data_len)) continue;
+        result[base + slot] = status;
+        std::string& output = (*outputs)[base + slot];
+        if (status != Status::kOk) {
+          output.clear();
+        } else if (conn->v2()) {
+          if (data_len <= output.size())
+            output.resize(static_cast<size_t>(data_len));
+          else
+            result[base + slot] = Status::kIOError;
+        } else if (kRespPrefix + data_len <= received) {
+          output.assign(ep.rbuf(slot) + kRespPrefix,
+                        static_cast<size_t>(data_len));
+        } else {
+          result[base + slot] = Status::kIOError;
         }
       }
     }
-    if (conn_ok) { Release(node, Lane::kData, c); return res; }
-    Destroy(c);
-    if (from_pool) continue;  // stale pooled conn -> one fresh retry
-    return res;               // fresh conn failed -> terminal
+    if (conn_ok) {
+      Release(node, Lane::kData, conn);
+      return result;
+    }
+    Destroy(conn);
+    if (from_pool) continue;
+    return result;
   }
-  return res;
+  return result;
 }
 
 std::vector<Status> RdmaTransport::ExistMany(const std::string& node,
@@ -510,7 +921,7 @@ std::vector<Status> RdmaTransport::ExistMany(const std::string& node,
       const size_t w = std::min(W, n - base);
       std::vector<size_t> slen(w);
       for (size_t j = 0; j < w; ++j) {
-        EncodeReq(ep.sbuf(j), WireOp::kExist, keys[base + j], 0, 0, 0);
+        c->Encode(ep.sbuf(j), WireOp::kExist, keys[base + j], 0, 0, 0);
         slen[j] = kReqPrefix;
       }
       std::vector<uint32_t> rbytes;
@@ -518,7 +929,7 @@ std::vector<Status> RdmaTransport::ExistMany(const std::string& node,
       for (size_t j = 0; j < w; ++j) {
         if (rbytes[j] < kRespPrefix) continue;
         Status st; uint64_t dl = 0;
-        if (!DecodeResp(ep.rbuf(j), &st, &dl)) continue;
+        if (!c->Decode(ep.rbuf(j), &st, &dl)) continue;
         res[base + j] = st;                              // kOk=present, kNotFound=absent
         (*exists)[base + j] = (st == Status::kOk) ? 1 : 0;
       }
@@ -531,309 +942,442 @@ std::vector<Status> RdmaTransport::ExistMany(const std::string& node,
   return res;
 }
 
-std::vector<Status> RdmaTransport::RangeInto(const std::string& node,
-                                             const std::vector<BlockKey>& keys,
-                                             const std::vector<RangeDst>& dsts,
-                                             size_t header_size,
-                                             std::vector<std::string>* hdrs) {
-  const size_t n = keys.size();
-  hdrs->assign(n, std::string());
-  std::vector<Status> res(n, Status::kIOError);
-  if (n == 0) return res;
-  const size_t hdr_bytes = kRespPrefix + header_size;  // resp prefix + value header
-  if (hdr_bytes > control_cap_) {
-    std::fill(res.begin(), res.end(), Status::kInvalid);
-    return res;
+std::vector<Status> RdmaTransport::RangeInto(
+    const std::string& node, const std::vector<BlockKey>& keys,
+    const std::vector<RangeDst>& destinations, size_t header_size,
+    std::vector<std::string>* headers) {
+  const size_t count = keys.size();
+  headers->assign(count, std::string());
+  std::vector<Status> result(count, Status::kIOError);
+  if (count == 0) return result;
+  if (header_size > rdma::kV2ControlCap - kRespPrefix) {
+    std::fill(result.begin(), result.end(), Status::kInvalid);
+    return result;
   }
-  // Per-item bound check: an oversized dst fails ONLY itself (kInvalid, which
-  // the client's health accounting ignores) — the multi variants already
-  // fail-soft per item; poisoning the whole node batch made one oversized key
-  // cost every sibling its cache hit.
-  std::vector<char> bad(n, 0);
-  for (size_t i = 0; i < n; ++i)
-    if (NoteBlock(dsts[i].n)) bad[i] = 1;
+  const size_t status_bytes = kRespPrefix + header_size;
+  std::vector<char> bad(count, 0);
+  for (size_t i = 0; i < count; ++i) {
+    if (destinations[i].n > std::numeric_limits<uint32_t>::max() ||
+        destinations[i].n >
+            std::numeric_limits<size_t>::max() - header_size ||
+        NoteBlock(destinations[i].n))
+      bad[i] = 1;
+  }
 
-  // 2-attempt loop: retry a stale pooled conn once on a fresh one. Range is a read
-  // (idempotent) and the scatter lands in the caller's buffers, so replaying the
-  // whole batch is harmless. Mirrors RoundTrip. (MR-registration failure is a
-  // local resource issue, not staleness, so it stays terminal — no retry.)
   for (int attempt = 0; attempt < 2; ++attempt) {
-    std::fill(res.begin(), res.end(), Status::kIOError);
-    for (size_t i = 0; i < n; ++i) if (bad[i]) res[i] = Status::kInvalid;
-    hdrs->assign(n, std::string());
+    std::fill(result.begin(), result.end(), Status::kIOError);
+    for (size_t i = 0; i < count; ++i)
+      if (bad[i]) result[i] = Status::kInvalid;
+    headers->assign(count, std::string());
     bool from_pool = false;
-    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
-    if (!c) return res;
-    rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
+    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0);
+    if (!conn) return result;
+    rdma::RcEndpoint& ep = conn->ep;
+    const size_t window = ep.window();
     bool conn_ok = true;
-    for (size_t base = 0; base < n && conn_ok; base += W) {
-      const size_t w = std::min(W, n - base);
-      // Register the destination buffers (cached).
-      std::vector<ibv_mr*> mrs(w, nullptr);
-      bool regok = true;
-      for (size_t j = 0; j < w && regok; ++j) {
-        if (bad[base + j]) continue;          // oversized: slot never posted
-        if (dsts[base + j].n == 0) continue;  // empty: header-only reply into rbuf, no MR
-        mrs[j] = ep.RegisterUser(dsts[base + j].payload, dsts[base + j].n);
-        if (!mrs[j]) regok = false;
+    for (size_t base = 0; base < count && conn_ok; base += window) {
+      const size_t width = std::min(window, count - base);
+      std::vector<ibv_mr*> mrs(width, nullptr);
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot] || destinations[base + slot].n == 0)
+          continue;
+        mrs[slot] = ep.RegisterUser(destinations[base + slot].payload,
+                                    destinations[base + slot].n);
+        if (!mrs[slot]) {
+          for (size_t i = base; i < count; ++i)
+            if (!bad[i]) result[i] = Status::kInvalid;
+          Release(node, Lane::kData, conn);
+          return result;
+        }
       }
-      if (!regok) {
-        // LOCAL resource failure (ibv_reg_mr), not the peer's fault: report the
-        // unprocessed remainder as kInvalid so the caller's health accounting
-        // does not MarkBad (cooldown) a healthy node for our own MR pressure.
-        for (size_t i = base; i < n; ++i) if (!bad[i]) res[i] = Status::kInvalid;
-        Release(node, Lane::kData, c);
-        return res;
-      }
-      // Scatter recv [hdr -> rbuf | payload -> caller buffer], then send the Range req.
-      // Empty (n==0) dsts use a plain recv (the reply is just resp-prefix + header).
+
       size_t posted = 0;
-      for (size_t j = 0; j < w && conn_ok; ++j) {
-        if (bad[base + j]) continue;  // stays kInvalid; slot not posted
-        bool armed = dsts[base + j].n
-                         ? ep.PostRecvScatter(j, dsts[base + j].payload, dsts[base + j].n, mrs[j], hdr_bytes)
-                         : ep.PostRecv(j);
-        if (!armed) { conn_ok = false; break; }
-        EncodeReq(ep.sbuf(j), WireOp::kRange, keys[base + j], 0, header_size + dsts[base + j].n, 0);
-        if (!ep.PostSend(j, kReqPrefix)) { conn_ok = false; break; }
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot]) continue;
+        const RangeDst& destination = destinations[base + slot];
+        bool request_ok = false;
+        if (!conn->v2()) {
+          const bool armed =
+              destination.n
+                  ? ep.PostRecvScatter(slot, destination.payload,
+                                       destination.n, mrs[slot], status_bytes)
+                  : ep.PostRecv(slot);
+          conn->Encode(ep.sbuf(slot), WireOp::kRange, keys[base + slot],
+                       0, header_size + destination.n, 0);
+          request_ok = armed && ep.PostSend(slot, kReqPrefix);
+        } else {
+          std::vector<RdmaWriteTarget> targets;
+          if (destination.n != 0)
+            targets.push_back(
+                {reinterpret_cast<uint64_t>(destination.payload),
+                 mrs[slot]->rkey,
+                 static_cast<uint32_t>(destination.n)});
+          size_t frame_len = 0;
+          request_ok =
+              EncodeRdmaGetReq(
+                  ep.sbuf(slot), ep.cap(), keys[base + slot], 0,
+                  header_size + destination.n,
+                  static_cast<uint32_t>(header_size), targets, &frame_len) &&
+              ep.PostRecv(slot) && ep.PostSend(slot, frame_len);
+          if (request_ok)
+            v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (!request_ok) {
+          conn_ok = false;
+          break;
+        }
         ++posted;
       }
       if (!conn_ok) break;
-      if (posted == 0) continue;  // whole window oversized
-      std::vector<ibv_wc> wcs(2 * posted);
-      std::vector<uint32_t> rbytes(w, 0);
-      int need = static_cast<int>(2 * posted);
-      while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * posted), BatchTimeout());
-        if (g <= 0) { conn_ok = false; break; }
-        for (int i = 0; i < g; ++i) {
-          if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
-          if (wcs[i].opcode == IBV_WC_RECV) rbytes[static_cast<size_t>(wcs[i].wr_id)] = wcs[i].byte_len;
-          --need;
+      if (posted == 0) continue;
+
+      std::vector<ibv_wc> completions(2 * posted);
+      std::vector<uint32_t> reply_bytes(width, 0);
+      int needed = static_cast<int>(2 * posted);
+      while (needed > 0) {
+        int got = ep.WaitComp(completions.data(),
+                              static_cast<int>(2 * posted), BatchTimeout());
+        if (got <= 0) {
+          conn_ok = false;
+          break;
+        }
+        for (int i = 0; i < got; ++i) {
+          if (completions[i].status != IBV_WC_SUCCESS) {
+            conn_ok = false;
+            break;
+          }
+          if (completions[i].opcode == IBV_WC_RECV) {
+            const size_t slot =
+                static_cast<size_t>(completions[i].wr_id);
+            if (slot >= width) {
+              conn_ok = false;
+              break;
+            }
+            reply_bytes[slot] = completions[i].byte_len;
+          }
+          --needed;
         }
         if (!conn_ok) break;
       }
       if (!conn_ok) break;
-      for (size_t j = 0; j < w; ++j) {
-        if (bad[base + j]) continue;
-        uint32_t rb = rbytes[j];
-        if (rb < kRespPrefix) continue;
-        Status st; uint64_t dl = 0;
-        if (!DecodeResp(ep.rbuf(j), &st, &dl)) continue;
-        res[base + j] = st;            // payload (if any) already in dsts[].payload
-        if (st == Status::kOk) {
-          if (rb >= hdr_bytes) (*hdrs)[base + j].assign(ep.rbuf(j) + kRespPrefix, header_size);
-          else res[base + j] = Status::kIOError;
+
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot] || reply_bytes[slot] < kRespPrefix) continue;
+        Status status;
+        uint64_t data_len = 0;
+        if (!conn->Decode(ep.rbuf(slot), &status, &data_len)) continue;
+        result[base + slot] = status;
+        if (status == Status::kOk) {
+          if (reply_bytes[slot] >= status_bytes &&
+              data_len >= header_size &&
+              data_len - header_size <= destinations[base + slot].n) {
+            (*headers)[base + slot].assign(
+                ep.rbuf(slot) + kRespPrefix, header_size);
+          } else {
+            result[base + slot] = Status::kIOError;
+          }
         }
       }
     }
-    if (conn_ok) { Release(node, Lane::kData, c); return res; }
-    Destroy(c);
-    if (from_pool) continue;  // stale pooled conn -> one fresh retry
-    return res;               // fresh conn failed -> terminal
+    if (conn_ok) {
+      Release(node, Lane::kData, conn);
+      return result;
+    }
+    Destroy(conn);
+    if (from_pool) continue;
+    return result;
   }
-  return res;
+  return result;
 }
 
-std::vector<Status> RdmaTransport::CacheFrom(const std::string& node,
-                                             const std::vector<CacheSrc>& srcs) {
-  const size_t n = srcs.size();
-  std::vector<Status> res(n, Status::kIOError);
-  if (n == 0) return res;
-  // Do not silently fall back to the base copy path: RDMA CacheFrom is the
-  // connector's zero-copy PUT route, so oversize/reg failures are explicit.
-  // Per-item: an oversized item fails ONLY itself (kInvalid, ignored by the
-  // client's health accounting) — same fail-soft the multi variants ship.
-  std::vector<char> bad(n, 0);
-  for (size_t i = 0; i < n; ++i) {
-    const CacheSrc& s = srcs[i];
-    if (NoteBlock(s.payload_len) || s.header_len > control_cap_ - kReqPrefix) bad[i] = 1;
+std::vector<Status> RdmaTransport::CacheFrom(
+    const std::string& node, const std::vector<CacheSrc>& sources) {
+  const size_t count = sources.size();
+  std::vector<Status> result(count, Status::kIOError);
+  if (count == 0) return result;
+  std::vector<char> bad(count, 0);
+  for (size_t i = 0; i < count; ++i) {
+    const CacheSrc& source = sources[i];
+    if (source.header_len > rdma::kV2ControlCap - kReqPrefix ||
+        source.payload_len >
+            std::numeric_limits<size_t>::max() - source.header_len ||
+        NoteBlock(source.payload_len))
+      bad[i] = 1;
   }
 
-  // 2-attempt loop: retry a stale pooled conn once on a fresh one. Cache is
-  // idempotent, so replaying the whole batch (re-sending earlier windows) is
-  // harmless. Mirrors RoundTrip. (MR-registration failure stays terminal.)
   for (int attempt = 0; attempt < 2; ++attempt) {
-    std::fill(res.begin(), res.end(), Status::kIOError);
-    for (size_t i = 0; i < n; ++i) if (bad[i]) res[i] = Status::kInvalid;
+    std::fill(result.begin(), result.end(), Status::kIOError);
+    for (size_t i = 0; i < count; ++i)
+      if (bad[i]) result[i] = Status::kInvalid;
     bool from_pool = false;
-    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
-    if (!c) return res;
-    rdma::RcEndpoint& ep = c->ep;
-    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
+    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0);
+    if (!conn) return result;
+    rdma::RcEndpoint& ep = conn->ep;
+    const size_t window = ep.window();
     bool conn_ok = true;
-    for (size_t base = 0; base < n && conn_ok; base += W) {
-      const size_t w = std::min(W, n - base);
-      // Register the payload buffers (cached).
-      std::vector<ibv_mr*> mrs(w, nullptr);
-      bool regok = true;
-      for (size_t j = 0; j < w && regok; ++j) {
-        const CacheSrc& s = srcs[base + j];
-        if (bad[base + j]) continue;       // oversized: slot never posted
-        if (s.payload_len == 0) continue;  // empty value: header-only 1-SGE send, no MR
-        // const_cast: a SEND source is only read by the NIC; the LOCAL_WRITE-only
-        // MR is never written, and RegisterUser keys its cache by address.
-        mrs[j] = ep.RegisterUser(const_cast<void*>(s.payload), s.payload_len);
-        if (!mrs[j]) regok = false;
+    for (size_t base = 0; base < count && conn_ok; base += window) {
+      const size_t width = std::min(window, count - base);
+      std::vector<ibv_mr*> mrs(width, nullptr);
+      for (size_t slot = 0; slot < width; ++slot) {
+        const CacheSrc& source = sources[base + slot];
+        if (bad[base + slot] || source.payload_len == 0) continue;
+        mrs[slot] = ep.RegisterUser(
+            const_cast<void*>(source.payload), source.payload_len);
+        if (!mrs[slot]) {
+          for (size_t i = base; i < count; ++i)
+            if (!bad[i]) result[i] = Status::kInvalid;
+          Release(node, Lane::kData, conn);
+          return result;
+        }
       }
-      if (!regok) {
-        // LOCAL resource failure (ibv_reg_mr), not the peer's fault: kInvalid
-        // for the unprocessed remainder so health accounting does not MarkBad
-        // (cooldown) a healthy node for our own MR pressure.
-        for (size_t i = base; i < n; ++i) if (!bad[i]) res[i] = Status::kInvalid;
-        Release(node, Lane::kData, c);
-        return res;
-      }
-      // Build [req prefix | value header] into sbuf[j], scatter-send with the
-      // payload coming straight from the caller's registered buffer. The wire
-      // payload_len field is header_len + user payload_len (the full stored blob).
+
       size_t posted = 0;
-      for (size_t j = 0; j < w && conn_ok; ++j) {
-        const CacheSrc& s = srcs[base + j];
-        if (bad[base + j]) continue;  // stays kInvalid; slot not posted
-        EncodeReq(ep.sbuf(j), WireOp::kCache, s.key, 0, 0, s.header_len + s.payload_len);
-        if (s.header_len) std::memcpy(ep.sbuf(j) + kReqPrefix, s.header, s.header_len);
-        if (!ep.PostRecv(j)) { conn_ok = false; break; }
-        if (!ep.PostSendScatter(j, kReqPrefix + s.header_len, s.payload, s.payload_len, mrs[j])) {
-          conn_ok = false; break;
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot]) continue;
+        const CacheSrc& source = sources[base + slot];
+        const size_t stored_len = source.header_len + source.payload_len;
+        if (conn->v2() && stored_len > conn->data_capacity()) {
+          result[base + slot] = Status::kInvalid;
+          continue;
+        }
+        conn->Encode(ep.sbuf(slot), WireOp::kCache, source.key, 0, 0,
+                     stored_len);
+        if (source.header_len)
+          std::memcpy(ep.sbuf(slot) + kReqPrefix, source.header,
+                      source.header_len);
+        if (!ep.PostRecv(slot)) {
+          conn_ok = false;
+          break;
+        }
+        bool sent = false;
+        if (!conn->v2()) {
+          sent = ep.PostSendScatter(
+              slot, kReqPrefix + source.header_len, source.payload,
+              source.payload_len, mrs[slot]);
+        } else {
+          sent = ep.PostWriteImmScatter(
+              slot, kReqPrefix + source.header_len, source.payload,
+              source.payload_len, mrs[slot], conn->put_addr(slot),
+              conn->recv_segment.rkey, static_cast<uint32_t>(slot));
+          if (sent)
+            v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (!sent) {
+          conn_ok = false;
+          break;
         }
         ++posted;
       }
       if (!conn_ok) break;
-      if (posted == 0) continue;  // whole window oversized
-      // Reap 2*posted completions (send + recv per posted slot) before reusing
-      // any slot or returning — the NIC reads the payload until SEND completes.
-      std::vector<ibv_wc> wcs(2 * posted);
-      std::vector<uint32_t> rbytes(w, 0);
-      int need = static_cast<int>(2 * posted);
-      while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * posted), BatchTimeout());
-        if (g <= 0) { conn_ok = false; break; }
-        for (int i = 0; i < g; ++i) {
-          if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
-          if (wcs[i].opcode == IBV_WC_RECV) rbytes[static_cast<size_t>(wcs[i].wr_id)] = wcs[i].byte_len;
-          --need;
+      if (posted == 0) continue;
+
+      std::vector<ibv_wc> completions(2 * posted);
+      std::vector<uint32_t> reply_bytes(width, 0);
+      int needed = static_cast<int>(2 * posted);
+      while (needed > 0) {
+        int got = ep.WaitComp(completions.data(),
+                              static_cast<int>(2 * posted), BatchTimeout());
+        if (got <= 0) {
+          conn_ok = false;
+          break;
+        }
+        for (int i = 0; i < got; ++i) {
+          if (completions[i].status != IBV_WC_SUCCESS) {
+            conn_ok = false;
+            break;
+          }
+          if (completions[i].opcode == IBV_WC_RECV) {
+            const size_t slot =
+                static_cast<size_t>(completions[i].wr_id);
+            if (slot >= width) {
+              conn_ok = false;
+              break;
+            }
+            reply_bytes[slot] = completions[i].byte_len;
+          }
+          --needed;
         }
         if (!conn_ok) break;
       }
       if (!conn_ok) break;
-      for (size_t j = 0; j < w; ++j) {
-        if (bad[base + j]) continue;
-        Status st; uint64_t dl = 0;
-        if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot] ||
+            result[base + slot] == Status::kInvalid)
+          continue;
+        Status status;
+        uint64_t data_len = 0;
+        if (reply_bytes[slot] >= kRespPrefix &&
+            conn->Decode(ep.rbuf(slot), &status, &data_len))
+          result[base + slot] = status;
       }
     }
-    if (conn_ok) { Release(node, Lane::kData, c); return res; }
-    Destroy(c);
-    if (from_pool) continue;  // stale pooled conn -> one fresh retry
-    return res;               // fresh conn failed -> terminal
+    if (conn_ok) {
+      Release(node, Lane::kData, conn);
+      return result;
+    }
+    Destroy(conn);
+    if (from_pool) continue;
+    return result;
   }
-  return res;
+  return result;
 }
 
 std::vector<Status> RdmaTransport::CacheFromMulti(
-    const std::string& node, const std::vector<CacheSrcMulti>& srcs) {
-  const size_t n = srcs.size();
-  std::vector<Status> res(n, Status::kIOError);
-  if (n == 0) return res;
-  // Validate: header fits the control buffer, total payload fits one message, and
-  // the segment count fits one work request (1 header SGE + segs). Like CacheFrom,
-  // do not silently fall back — this is the zero-copy SG PUT route.
-  // 2-attempt loop: retry a stale pooled conn once on a fresh one. Cache is
-  // idempotent, so replaying the whole batch is harmless. Mirrors RoundTrip.
+    const std::string& node, const std::vector<CacheSrcMulti>& sources) {
+  const size_t count = sources.size();
+  std::vector<Status> result(count, Status::kIOError);
+  if (count == 0) return result;
+
   for (int attempt = 0; attempt < 2; ++attempt) {
-    std::fill(res.begin(), res.end(), Status::kIOError);
+    std::fill(result.begin(), result.end(), Status::kIOError);
     bool from_pool = false;
-    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
-    if (!c) return res;
-    rdma::RcEndpoint& ep = c->ep;
-    const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
-    // Per-item validation: an oversized key must fail ONLY itself (kInvalid), not
-    // poison its node batch. The connector treats per-key kInvalid as a save miss
-    // (fail-soft recompute), so we mark offenders and skip them in the window below.
-    std::vector<char> bad(n, 0);
-    for (size_t i = 0; i < n; ++i) {
-      const auto& s = srcs[i];
+    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0);
+    if (!conn) return result;
+    rdma::RcEndpoint& ep = conn->ep;
+    const size_t max_payload_segments = ep.max_sge() - 1;
+    std::vector<char> bad(count, 0);
+    std::vector<size_t> totals(count, 0);
+    for (size_t i = 0; i < count; ++i) {
+      const CacheSrcMulti& source = sources[i];
+      bool invalid =
+          source.header_len > rdma::kV2ControlCap - kReqPrefix ||
+          source.payloads.size() > max_payload_segments;
       size_t total = 0;
-      for (const auto& p : s.payloads) total += p.second;
-      if (NoteBlock(total) || s.header_len > control_cap_ - kReqPrefix ||
-          s.payloads.size() > max_payload_segs) {
+      for (const auto& payload : source.payloads) {
+        if (payload.second > std::numeric_limits<uint32_t>::max() ||
+            payload.second > std::numeric_limits<size_t>::max() - total) {
+          invalid = true;
+          break;
+        }
+        total += payload.second;
+      }
+      if (!invalid && (total >
+                           std::numeric_limits<size_t>::max() -
+                               source.header_len ||
+                       NoteBlock(total)))
+        invalid = true;
+      totals[i] = total;
+      if (invalid) {
         bad[i] = 1;
-        res[i] = Status::kInvalid;
+        result[i] = Status::kInvalid;
       }
     }
 
-    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
+    const size_t window = ep.window();
     bool conn_ok = true;
-    for (size_t base = 0; base < n && conn_ok; base += W) {
-      const size_t w = std::min(W, n - base);
-      // Register every payload segment of every key in this window (cached MR lookup).
-      // mrs_per[j] holds the per-segment MRs for slot j. Any failure => give the conn
-      // back; Cache is idempotent so re-sending earlier windows on retry is harmless.
-      // Oversized slots (bad[base+j]) are skipped: no MR, no recv/send, and they do
-      // not consume a completion (need is sized to the posted slots only).
-      std::vector<std::vector<ibv_mr*>> mrs_per(w);
-      bool regok = true;
-      for (size_t j = 0; j < w && regok; ++j) {
-        if (bad[base + j]) continue;
-        const CacheSrcMulti& s = srcs[base + j];
-        mrs_per[j].assign(s.payloads.size(), nullptr);
-        for (size_t e = 0; e < s.payloads.size() && regok; ++e) {
-          if (s.payloads[e].second == 0) continue;  // empty segment: lkey 0, no MR
-          mrs_per[j][e] = ep.RegisterUser(const_cast<void*>(s.payloads[e].first),
-                                          s.payloads[e].second);
-          if (!mrs_per[j][e]) regok = false;
+    for (size_t base = 0; base < count && conn_ok; base += window) {
+      const size_t width = std::min(window, count - base);
+      std::vector<std::vector<ibv_mr*>> mrs(width);
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot]) continue;
+        const CacheSrcMulti& source = sources[base + slot];
+        mrs[slot].assign(source.payloads.size(), nullptr);
+        for (size_t i = 0; i < source.payloads.size(); ++i) {
+          if (source.payloads[i].second == 0) continue;
+          mrs[slot][i] = ep.RegisterUser(
+              const_cast<void*>(source.payloads[i].first),
+              source.payloads[i].second);
+          if (!mrs[slot][i]) {
+            Release(node, Lane::kData, conn);
+            return result;
+          }
         }
       }
-      if (!regok) { Release(node, Lane::kData, c); return res; }
+
       size_t posted = 0;
-      for (size_t j = 0; j < w && conn_ok; ++j) {
-        if (bad[base + j]) continue;
-        const CacheSrcMulti& s = srcs[base + j];
-        size_t total = 0;
-        std::vector<std::pair<const void*, uint32_t>> segs;
-        segs.reserve(s.payloads.size());
-        for (const auto& p : s.payloads) {
-          segs.emplace_back(p.first, static_cast<uint32_t>(p.second));
-          total += p.second;
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot]) continue;
+        const CacheSrcMulti& source = sources[base + slot];
+        const size_t stored_len = source.header_len + totals[base + slot];
+        if (conn->v2() && stored_len > conn->data_capacity()) {
+          result[base + slot] = Status::kInvalid;
+          continue;
         }
-        // Wire payload_len = header_len + total user payload (the full stored blob).
-        EncodeReq(ep.sbuf(j), WireOp::kCache, s.key, 0, 0, s.header_len + total);
-        if (s.header_len) std::memcpy(ep.sbuf(j) + kReqPrefix, s.header, s.header_len);
-        if (!ep.PostRecv(j)) { conn_ok = false; break; }
-        if (!ep.PostSendScatterMulti(j, kReqPrefix + s.header_len, segs, mrs_per[j])) {
-          conn_ok = false; break;
+        std::vector<std::pair<const void*, uint32_t>> segments;
+        segments.reserve(source.payloads.size());
+        for (const auto& payload : source.payloads)
+          segments.emplace_back(payload.first,
+                                static_cast<uint32_t>(payload.second));
+
+        conn->Encode(ep.sbuf(slot), WireOp::kCache, source.key, 0, 0,
+                     stored_len);
+        if (source.header_len)
+          std::memcpy(ep.sbuf(slot) + kReqPrefix, source.header,
+                      source.header_len);
+        if (!ep.PostRecv(slot)) {
+          conn_ok = false;
+          break;
+        }
+        bool sent = false;
+        if (!conn->v2()) {
+          sent = ep.PostSendScatterMulti(
+              slot, kReqPrefix + source.header_len, segments, mrs[slot]);
+        } else {
+          sent = ep.PostWriteImmScatterMulti(
+              slot, kReqPrefix + source.header_len, segments, mrs[slot],
+              conn->put_addr(slot), conn->recv_segment.rkey,
+              static_cast<uint32_t>(slot));
+          if (sent)
+            v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (!sent) {
+          conn_ok = false;
+          break;
         }
         ++posted;
       }
       if (!conn_ok) break;
-      if (posted == 0) continue;  // whole window was oversized: nothing to reap
-      std::vector<ibv_wc> wcs(2 * w);
-      std::vector<uint32_t> rbytes(w, 0);
-      int need = static_cast<int>(2 * posted);
-      while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
-        if (g <= 0) { conn_ok = false; break; }
-        for (int i = 0; i < g; ++i) {
-          if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
-          if (wcs[i].opcode == IBV_WC_RECV) rbytes[static_cast<size_t>(wcs[i].wr_id)] = wcs[i].byte_len;
-          --need;
+      if (posted == 0) continue;
+
+      std::vector<ibv_wc> completions(2 * posted);
+      std::vector<uint32_t> reply_bytes(width, 0);
+      int needed = static_cast<int>(2 * posted);
+      while (needed > 0) {
+        int got = ep.WaitComp(completions.data(),
+                              static_cast<int>(2 * posted), BatchTimeout());
+        if (got <= 0) {
+          conn_ok = false;
+          break;
+        }
+        for (int i = 0; i < got; ++i) {
+          if (completions[i].status != IBV_WC_SUCCESS) {
+            conn_ok = false;
+            break;
+          }
+          if (completions[i].opcode == IBV_WC_RECV) {
+            const size_t slot =
+                static_cast<size_t>(completions[i].wr_id);
+            if (slot >= width) {
+              conn_ok = false;
+              break;
+            }
+            reply_bytes[slot] = completions[i].byte_len;
+          }
+          --needed;
         }
         if (!conn_ok) break;
       }
       if (!conn_ok) break;
-      for (size_t j = 0; j < w; ++j) {
-        Status st; uint64_t dl = 0;
-        if (rbytes[j] >= kRespPrefix && DecodeResp(ep.rbuf(j), &st, &dl)) res[base + j] = st;
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot] ||
+            result[base + slot] == Status::kInvalid)
+          continue;
+        Status status;
+        uint64_t data_len = 0;
+        if (reply_bytes[slot] >= kRespPrefix &&
+            conn->Decode(ep.rbuf(slot), &status, &data_len))
+          result[base + slot] = status;
       }
     }
-    if (conn_ok) { Release(node, Lane::kData, c); return res; }
-    Destroy(c);
-    if (from_pool) continue;  // stale pooled conn -> one fresh retry
-    return res;               // fresh conn failed -> terminal
+    if (conn_ok) {
+      Release(node, Lane::kData, conn);
+      return result;
+    }
+    Destroy(conn);
+    if (from_pool) continue;
+    return result;
   }
-  return res;
+  return result;
 }
 
 // Records n as a high-water candidate and reports whether it exceeds the
@@ -874,121 +1418,191 @@ bool RdmaTransport::NoteBlock(size_t n) const {
 
 std::vector<Status> RdmaTransport::RangeIntoMulti(
     const std::string& node, const std::vector<BlockKey>& keys,
-    const std::vector<RangeDstMulti>& dsts, size_t header_size,
-    std::vector<std::string>* hdrs, std::vector<size_t>* out_lens) {
-  const size_t n = keys.size();
-  hdrs->assign(n, std::string());
-  if (out_lens) out_lens->assign(n, 0);
-  std::vector<Status> res(n, Status::kIOError);
-  if (n == 0) return res;
-  const size_t hdr_bytes = kRespPrefix + header_size;  // resp prefix + value header
-  if (hdr_bytes > control_cap_) {
-    std::fill(res.begin(), res.end(), Status::kInvalid);
-    return res;
+    const std::vector<RangeDstMulti>& destinations, size_t header_size,
+    std::vector<std::string>* headers, std::vector<size_t>* out_lengths) {
+  const size_t count = keys.size();
+  headers->assign(count, std::string());
+  if (out_lengths) out_lengths->assign(count, 0);
+  std::vector<Status> result(count, Status::kIOError);
+  if (count == 0) return result;
+  if (header_size > rdma::kV2ControlCap - kRespPrefix) {
+    std::fill(result.begin(), result.end(), Status::kInvalid);
+    return result;
   }
-  // 2-attempt loop: retry a stale pooled conn once on a fresh one. Range is a read
-  // (idempotent) and the scatter lands in the caller's buffers, so replaying the
-  // whole batch is harmless. Mirrors RoundTrip.
+  const size_t status_bytes = kRespPrefix + header_size;
+
   for (int attempt = 0; attempt < 2; ++attempt) {
-    std::fill(res.begin(), res.end(), Status::kIOError);
-    hdrs->assign(n, std::string());
-    if (out_lens) out_lens->assign(n, 0);
+    std::fill(result.begin(), result.end(), Status::kIOError);
+    headers->assign(count, std::string());
+    if (out_lengths) out_lengths->assign(count, 0);
     bool from_pool = false;
-    Conn* c = Acquire(node, Lane::kData, &from_pool, attempt > 0);
-    if (!c) return res;
-    rdma::RcEndpoint& ep = c->ep;
-    const size_t max_payload_segs = ep.max_sge() - 1;  // SGE0 = header
-    // Per-item validation: an oversized destination must fail ONLY itself (kInvalid),
-    // not poison its node batch. Offenders are marked and skipped in the window below.
-    std::vector<char> bad(n, 0);
-    for (size_t i = 0; i < n; ++i) {
-      size_t cap = 0;
-      for (const auto& p : dsts[i].payloads) cap += p.second;
-      if (NoteBlock(cap) || dsts[i].payloads.size() > max_payload_segs) {
+    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0);
+    if (!conn) return result;
+    rdma::RcEndpoint& ep = conn->ep;
+    const size_t max_payload_segments =
+        conn->v2() ? rdma::kV2MaxGetTargets : ep.max_sge() - 1;
+    std::vector<char> bad(count, 0);
+    std::vector<size_t> capacities(count, 0);
+    for (size_t i = 0; i < count; ++i) {
+      bool invalid =
+          destinations[i].payloads.size() > max_payload_segments;
+      size_t capacity = 0;
+      for (const auto& destination : destinations[i].payloads) {
+        if (destination.second > std::numeric_limits<uint32_t>::max() ||
+            destination.second >
+                std::numeric_limits<size_t>::max() - capacity) {
+          invalid = true;
+          break;
+        }
+        capacity += destination.second;
+      }
+      if (!invalid &&
+          (capacity > std::numeric_limits<size_t>::max() - header_size ||
+           NoteBlock(capacity)))
+        invalid = true;
+      capacities[i] = capacity;
+      if (invalid) {
         bad[i] = 1;
-        res[i] = Status::kInvalid;
+        result[i] = Status::kInvalid;
       }
     }
 
-    const size_t W = ep.window();  // negotiated: never exceed the server's posted recvs
+    const size_t window = ep.window();
     bool conn_ok = true;
-    for (size_t base = 0; base < n && conn_ok; base += W) {
-      const size_t w = std::min(W, n - base);
-      // Register every destination segment of every key in this window. Oversized
-      // slots (bad[base+j]) are skipped: no MR, no recv/send, no completion consumed.
-      std::vector<std::vector<ibv_mr*>> mrs_per(w);
-      std::vector<size_t> caps(w, 0);
-      bool regok = true;
-      for (size_t j = 0; j < w && regok; ++j) {
-        if (bad[base + j]) continue;
-        const RangeDstMulti& d = dsts[base + j];
-        mrs_per[j].assign(d.payloads.size(), nullptr);
-        for (size_t e = 0; e < d.payloads.size() && regok; ++e) {
-          caps[j] += d.payloads[e].second;
-          if (d.payloads[e].second == 0) continue;
-          mrs_per[j][e] = ep.RegisterUser(d.payloads[e].first, d.payloads[e].second);
-          if (!mrs_per[j][e]) regok = false;
+    for (size_t base = 0; base < count && conn_ok; base += window) {
+      const size_t width = std::min(window, count - base);
+      std::vector<std::vector<ibv_mr*>> mrs(width);
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot]) continue;
+        const RangeDstMulti& destination = destinations[base + slot];
+        mrs[slot].assign(destination.payloads.size(), nullptr);
+        for (size_t i = 0; i < destination.payloads.size(); ++i) {
+          if (destination.payloads[i].second == 0) continue;
+          mrs[slot][i] = ep.RegisterUser(
+              destination.payloads[i].first,
+              destination.payloads[i].second);
+          if (!mrs[slot][i]) {
+            Release(node, Lane::kData, conn);
+            return result;
+          }
         }
       }
-      if (!regok) { Release(node, Lane::kData, c); return res; }
+
       size_t posted = 0;
-      for (size_t j = 0; j < w && conn_ok; ++j) {
-        if (bad[base + j]) continue;
-        const RangeDstMulti& d = dsts[base + j];
-        bool armed;
-        if (caps[j]) {
-          std::vector<std::pair<void*, uint32_t>> segs;
-          segs.reserve(d.payloads.size());
-          for (const auto& p : d.payloads)
-            segs.emplace_back(p.first, static_cast<uint32_t>(p.second));
-          armed = ep.PostRecvScatterMulti(j, segs, mrs_per[j], hdr_bytes);
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot]) continue;
+        const RangeDstMulti& destination = destinations[base + slot];
+        bool request_ok = false;
+        if (!conn->v2()) {
+          bool armed = false;
+          if (capacities[base + slot] != 0) {
+            std::vector<std::pair<void*, uint32_t>> segments;
+            segments.reserve(destination.payloads.size());
+            for (const auto& payload : destination.payloads)
+              segments.emplace_back(
+                  payload.first, static_cast<uint32_t>(payload.second));
+            armed = ep.PostRecvScatterMulti(
+                slot, segments, mrs[slot], status_bytes);
+          } else {
+            armed = ep.PostRecv(slot);
+          }
+          conn->Encode(
+              ep.sbuf(slot), WireOp::kRange, keys[base + slot], 0,
+              header_size + capacities[base + slot], 0);
+          request_ok = armed && ep.PostSend(slot, kReqPrefix);
         } else {
-          armed = ep.PostRecv(j);  // header-only reply
+          std::vector<RdmaWriteTarget> targets;
+          targets.reserve(destination.payloads.size());
+          for (size_t i = 0; i < destination.payloads.size(); ++i) {
+            const auto& payload = destination.payloads[i];
+            if (payload.second == 0) continue;
+            targets.push_back(
+                {reinterpret_cast<uint64_t>(payload.first),
+                 mrs[slot][i]->rkey,
+                 static_cast<uint32_t>(payload.second)});
+          }
+          size_t frame_len = 0;
+          request_ok =
+              EncodeRdmaGetReq(
+                  ep.sbuf(slot), ep.cap(), keys[base + slot], 0,
+                  header_size + capacities[base + slot],
+                  static_cast<uint32_t>(header_size), targets, &frame_len) &&
+              ep.PostRecv(slot) && ep.PostSend(slot, frame_len);
+          if (request_ok)
+            v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
         }
-        if (!armed) { conn_ok = false; break; }
-        EncodeReq(ep.sbuf(j), WireOp::kRange, keys[base + j], 0, header_size + caps[j], 0);
-        if (!ep.PostSend(j, kReqPrefix)) { conn_ok = false; break; }
+        if (!request_ok) {
+          conn_ok = false;
+          break;
+        }
         ++posted;
       }
       if (!conn_ok) break;
-      if (posted == 0) continue;  // whole window was oversized: nothing to reap
-      std::vector<ibv_wc> wcs(2 * w);
-      std::vector<uint32_t> rbytes(w, 0);
-      int need = static_cast<int>(2 * posted);
-      while (need > 0) {
-        int g = ep.WaitComp(wcs.data(), static_cast<int>(2 * w), BatchTimeout());
-        if (g <= 0) { conn_ok = false; break; }
-        for (int i = 0; i < g; ++i) {
-          if (wcs[i].status != IBV_WC_SUCCESS) { conn_ok = false; break; }
-          if (wcs[i].opcode == IBV_WC_RECV) rbytes[static_cast<size_t>(wcs[i].wr_id)] = wcs[i].byte_len;
-          --need;
+      if (posted == 0) continue;
+
+      std::vector<ibv_wc> completions(2 * posted);
+      std::vector<uint32_t> reply_bytes(width, 0);
+      int needed = static_cast<int>(2 * posted);
+      while (needed > 0) {
+        int got = ep.WaitComp(completions.data(),
+                              static_cast<int>(2 * posted), BatchTimeout());
+        if (got <= 0) {
+          conn_ok = false;
+          break;
+        }
+        for (int i = 0; i < got; ++i) {
+          if (completions[i].status != IBV_WC_SUCCESS) {
+            conn_ok = false;
+            break;
+          }
+          if (completions[i].opcode == IBV_WC_RECV) {
+            const size_t slot =
+                static_cast<size_t>(completions[i].wr_id);
+            if (slot >= width) {
+              conn_ok = false;
+              break;
+            }
+            reply_bytes[slot] = completions[i].byte_len;
+          }
+          --needed;
         }
         if (!conn_ok) break;
       }
       if (!conn_ok) break;
-      for (size_t j = 0; j < w; ++j) {
-        uint32_t rb = rbytes[j];
-        if (rb < kRespPrefix) continue;
-        Status st; uint64_t dl = 0;
-        if (!DecodeResp(ep.rbuf(j), &st, &dl)) continue;
-        res[base + j] = st;  // payload (if any) already scattered into dsts[].payloads
-        if (st == Status::kOk) {
-          if (rb >= hdr_bytes) {
-            (*hdrs)[base + j].assign(ep.rbuf(j) + kRespPrefix, header_size);
-            // True stored payload bytes received = rb - resp-prefix - value header.
-            if (out_lens) (*out_lens)[base + j] = rb - hdr_bytes;
+
+      for (size_t slot = 0; slot < width; ++slot) {
+        if (bad[base + slot] || reply_bytes[slot] < kRespPrefix)
+          continue;
+        Status status;
+        uint64_t data_len = 0;
+        if (!conn->Decode(ep.rbuf(slot), &status, &data_len)) continue;
+        result[base + slot] = status;
+        if (status == Status::kOk) {
+          const uint64_t payload_len =
+              data_len >= header_size ? data_len - header_size
+                                      : std::numeric_limits<uint64_t>::max();
+          if (reply_bytes[slot] >= status_bytes &&
+              payload_len <= capacities[base + slot]) {
+            (*headers)[base + slot].assign(
+                ep.rbuf(slot) + kRespPrefix, header_size);
+            if (out_lengths)
+              (*out_lengths)[base + slot] =
+                  static_cast<size_t>(payload_len);
           } else {
-            res[base + j] = Status::kIOError;
+            result[base + slot] = Status::kIOError;
           }
         }
       }
     }
-    if (conn_ok) { Release(node, Lane::kData, c); return res; }
-    Destroy(c);
-    if (from_pool) continue;  // stale pooled conn -> one fresh retry
-    return res;               // fresh conn failed -> terminal
+    if (conn_ok) {
+      Release(node, Lane::kData, conn);
+      return result;
+    }
+    Destroy(conn);
+    if (from_pool) continue;
+    return result;
   }
-  return res;
+  return result;
 }
 
 }  // namespace dfkv

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -1,12 +1,11 @@
-/* RDMA client transport — native libibverbs RC, two-sided SEND/RECV.
- * Built only when DFKV_WITH_RDMA is defined. Mirrors the TCP wire frames so the
- * server request logic is shared. Connection-pooled per node.
+/* RDMA client transport — native libibverbs RC. Mixed v2 keeps request/status
+ * on small SEND/RECV control buffers while PUT/GET payloads move with one-sided
+ * RDMA WRITEs; connection-level probing falls back to legacy v1 SEND/RECV.
  *
- * Device is selected BY NAME (env DFKV_RDMA_DEV, e.g. "ib7s400p0"), not by IP,
- * so the data plane can ride a 400G IB fabric that has no IP and is separate
- * from the IP network. The QP is bootstrapped over a small TCP channel to the
- * node's member address (an IP on the shared 200G/bond0 network). See
- * rdma_verbs.h for the control-plane/data-plane split rationale. */
+ * An empty DFKV_RDMA_DEV discovers every ACTIVE HCA; an explicit comma list is
+ * a whitelist. Device names, not IPs, select the data fabric. QPs bootstrap over
+ * a small TCP channel to the node's member address, so the RDMA fabric itself
+ * needs no IP. */
 #ifndef DFKV_RDMA_TRANSPORT_H_
 #define DFKV_RDMA_TRANSPORT_H_
 
@@ -22,15 +21,20 @@
 #include "transport/transport.h"
 
 namespace dfkv {
-namespace rdma { class RcEndpoint; }
+namespace rdma {
+class RcEndpoint;
+class RdmaTopology;
+}
 
 class RdmaTransport : public Transport {
  public:
-  static bool Available();  // true if at least one RDMA device is present
+  static bool Available();  // true if at least one ACTIVE RDMA port is present
 
-  // dev_name empty => env DFKV_RDMA_DEV (comma-separated list = multi-rail; each
-  // new connection round-robins across the devices), else first device.
-  explicit RdmaTransport(size_t max_msg = (64u << 20), const std::string& dev_name = "");
+  // dev_name empty => env DFKV_RDMA_DEV. A comma-separated explicit value is a
+  // whitelist and opts into multi-rail. With neither, use the first ACTIVE local
+  // HCA and send no device name to the peer, preserving host-local selection.
+  explicit RdmaTransport(size_t max_msg = (64u << 20),
+                         const std::string& dev_name = "");
   ~RdmaTransport() override;
 
   Status Cache(const std::string& node, const BlockKey& key, const void* data,
@@ -85,7 +89,7 @@ class RdmaTransport : public Transport {
   // share a connection, so a lookup storm can't queue behind in-flight 1 MB
   // GETs on the same QP — the hot-round exist p99 of ~800 s the phase-8
   // hit-rate probe measured was exactly that head-of-line blocking.
-  enum class Lane { kData, kControl };
+  enum class Lane { kData, kControl, kLegacyControl };
   Conn* Acquire(const std::string& node, Lane lane, bool* from_pool,
                 bool force_new = false);
   void Release(const std::string& node, Lane lane, Conn* c);
@@ -93,12 +97,16 @@ class RdmaTransport : public Transport {
   Status RoundTrip(const std::string& node, WireOp op, const BlockKey& key,
                    uint64_t offset, uint64_t length, const void* payload,
                    uint64_t payload_len, std::string* out);
+  bool ProbeV2(const std::string& node) const;
 
   std::mutex mu_;
   std::unordered_map<std::string, std::vector<Conn*>> pool_;
   // Separate idle-conn pool for control-lane ops (Exist/Remove/Members), so
   // small key-only round trips never share a QP with payload transfers.
   std::unordered_map<std::string, std::vector<Conn*>> control_pool_;
+  // Members replies can exceed the 4-KiB v2 control frame. Keep a dedicated
+  // legacy pool so discovery does not mix with v2 Exist/Remove connections.
+  std::unordered_map<std::string, std::vector<Conn*>> legacy_control_pool_;
   // Caller memory regions to register on every connection (the host KV pool).
   // Guarded by mu_; snapshotted in Acquire and registered on the connection.
   std::vector<std::pair<void*, size_t>> pools_;
@@ -108,23 +116,22 @@ class RdmaTransport : public Transport {
   // min over rails of (negotiated max_sge) - 1; set once in the ctor.
   size_t sg_payload_segs_ = 29;
   size_t max_payload_;
-  // DCP1 declared max block bytes (DFKV_RDMA_MAX_BLOCK_BYTES, clamped to
-  // max_payload_). 0 = undeclared: worst-case buffers both sides, old wire
-  // behavior. When set it also shrinks OUR control buffers and bounds ops
-  // client-side (oversize -> kInvalid before touching the wire, because the
-  // server sized this conn's recv buffers to the declaration and a bigger
-  // send would hard-break the QP).
+  // DCP2 max block bytes. An explicit DFKV_RDMA_MAX_BLOCK_BYTES is honored;
+  // otherwise v2 declares max_payload_ because its shared-slot geometry requires
+  // an exact nonzero bound. legacy_declared_ deliberately stays 0 when the env is
+  // absent: automatic v1 fallback must preserve the old plain-frame behavior,
+  // or an older server with a smaller --max-msg would reject a synthetic 64-MiB
+  // DCP1 declaration before seeing the actual (small) request.
   uint64_t declared_ = 0;
+  uint64_t legacy_declared_ = 0;
+  bool v2_enabled_ = true;
   size_t OpBound() const {  // per-op payload bound honoring the declaration
     return declared_ ? static_cast<size_t>(declared_) : max_payload_;
   }
-  // Largest block this client has actually handed to the transport. Sizing
-  // DFKV_RDMA_MAX_BLOCK_BYTES is otherwise guesswork: the declaration decides
-  // how much the SERVER pins per connection (qd x (ValueHeader + declared)),
-  // which at qd=32 is ~1 GiB per connection measured on a B200 node -- yet the
-  // only figure available to an operator was the average transfer size. This
-  // reports the actual high-water mark so the declaration can be set from
-  // evidence with a deliberate margin.
+  // Largest block this client has actually handed to the transport. Operators
+  // use the high-water mark to choose a tight DCP2 declaration: smaller slots
+  // admit more concurrent v2 connections into the fixed shared segment, while
+  // oversize operations must remain a deterministic client-side rejection.
   mutable std::atomic<uint64_t> max_block_seen_{0};
   mutable std::atomic<uint64_t> oversize_rejects_{0};
   // Records n as a candidate high-water mark and reports whether it exceeds the
@@ -152,12 +159,14 @@ class RdmaTransport : public Transport {
   int batch_op_timeout_ms_ = 0;
   int BatchTimeout() const { return batch_op_timeout_ms_ > 0 ? batch_op_timeout_ms_ : op_timeout_ms_; }
   size_t pool_max_ = 256;             // idle conns kept per node (DFKV_RDMA_POOL_MAX)
-  std::vector<std::string> devs_;     // RDMA devices (multi-rail); "" = first
-  std::vector<int> dev_node_;         // NUMA node per devs_ entry (-1 unknown)
-  std::atomic<size_t> rr_{0};         // round-robin selector across devs_
+  std::unique_ptr<rdma::RdmaTopology> topology_;
+  std::vector<std::string> devs_;  // stable discovered ACTIVE rail order
+  bool auto_device_ = true;
   // observability (relaxed): connections opened total + per-rail breakdown +
   // declared MR regions. Connection opens are infrequent (pooled), off the op path.
   std::atomic<uint64_t> conns_opened_{0};
+  std::atomic<uint64_t> v1_conns_opened_{0}, v2_conns_opened_{0};
+  std::atomic<uint64_t> v2_put_writes_{0}, v2_get_writes_{0};
   std::atomic<uint64_t> mr_regions_{0};
   std::unique_ptr<std::atomic<uint64_t>[]> rail_conns_;  // sized to devs_.size()
 };

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -1,4 +1,6 @@
 #include "transport/rdma_verbs.h"
+#include "transport/rdma_protocol.h"
+#include <arpa/inet.h>
 
 #include <fcntl.h>
 #include <poll.h>
@@ -9,6 +11,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <mutex>
 #include <random>
 #include <string>
@@ -35,7 +38,12 @@ namespace {
 // to any one connection, so it is registered ONCE per device and shared by all
 // endpoints — previously each new connection re-ran ibv_reg_mr over the whole
 // (tens-to-hundreds-of-GB) region, a registration storm at reconnect time.
-struct SharedPoolMr { uintptr_t base; size_t size; ibv_mr* mr; };
+struct SharedPoolMr {
+  uintptr_t base;
+  size_t size;
+  int access;
+  ibv_mr* mr;
+};
 struct SharedDevice {
   ibv_context* ctx;
   ibv_pd* pd;
@@ -77,7 +85,7 @@ std::pair<ibv_context*, ibv_pd*> AcquireSharedDevice(const char* dev_name) {
   if (!ctx) return {nullptr, nullptr};
   ibv_pd* pd = ibv_alloc_pd(ctx);
   if (!pd) { ibv_close_device(ctx); return {nullptr, nullptr}; }
-  g_devs.emplace(key, SharedDevice{ctx, pd, 1});
+  g_devs.emplace(key, SharedDevice{ctx, pd, 1, {}});
   return {ctx, pd};
 }
 
@@ -104,15 +112,19 @@ void ReleaseSharedDevice(ibv_context* ctx) {
 // lkey is valid for any QP on this PD, so callers may cache the pointer locally
 // for lock-free lookup. Only called at connection setup (not the datapath), so
 // taking g_dev_mu here is fine.
-ibv_mr* SharedAddPoolMr(ibv_context* ctx, ibv_pd* pd, void* base, size_t size) {
+ibv_mr* SharedAddPoolMr(ibv_context* ctx, ibv_pd* pd, void* base, size_t size,
+                        int access) {
   auto b = reinterpret_cast<uintptr_t>(base);
   std::lock_guard<std::mutex> lk(g_dev_mu);
   for (auto& d : g_devs) {
     if (d.second.ctx != ctx) continue;
-    for (const auto& p : d.second.pool_mrs)
-      if (p.base == b && p.size >= size) return p.mr;  // already registered on this PD
+    for (const auto& p : d.second.pool_mrs) {
+      if (p.base == b && p.size >= size && (p.access & access) == access) {
+        return p.mr;
+      }
+    }
     const auto t0 = std::chrono::steady_clock::now();
-    ibv_mr* mr = ibv_reg_mr(pd, base, size, IBV_ACCESS_LOCAL_WRITE);
+    ibv_mr* mr = ibv_reg_mr(pd, base, size, access);
     if (!mr) return nullptr;
     const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                         std::chrono::steady_clock::now() - t0).count();
@@ -123,11 +135,11 @@ ibv_mr* SharedAddPoolMr(ibv_context* ctx, ibv_pd* pd, void* base, size_t size) {
     if (ms > 100)
       DFKV_LOG_INFO("pool MR registered: " + std::to_string(size >> 20) +
                     " MiB in " + std::to_string(ms) + " ms");
-    g_pool_mr_regs.fetch_add(1, std::memory_order_relaxed);  // one actual registration
-    d.second.pool_mrs.push_back(SharedPoolMr{b, size, mr});
+    g_pool_mr_regs.fetch_add(1, std::memory_order_relaxed);
+    d.second.pool_mrs.push_back(SharedPoolMr{b, size, access, mr});
     return mr;
   }
-  return nullptr;  // device not found (shouldn't happen for a live endpoint)
+  return nullptr;
 }
 }  // namespace
 
@@ -158,9 +170,10 @@ void SerializeQpInfo(const QpInfo& in, char out[kQpInfoBytes]) {
   net::PutU32(out + 4, in.psn);
   std::memcpy(out + 8, &in.lid, 2);   // host LE; both ends x86_64
   std::memcpy(out + 10, in.gid, 16);
-  if (in.depth > 0) {                 // depth advertisement rides the pad (DPQ1)
+  if (in.depth > 0 || in.protocol_version >= 2) {
     net::PutU32(out + 26, kQpDepthMagic);
-    const uint16_t d = in.depth;
+    uint16_t d = in.depth;
+    if (in.protocol_version >= 2) d |= 0x8000u;
     std::memcpy(out + 30, &d, 2);
   }
 }
@@ -175,7 +188,11 @@ QpInfo ParseQpInfo(const char in[kQpInfoBytes]) {
   if (net::GetU32(in + 26) == kQpDepthMagic) {
     uint16_t d = 0;
     std::memcpy(&d, in + 30, 2);
-    if (d >= 1 && d <= 256) q.depth = d;  // out-of-range = treat as absent
+    if ((d & 0x8000u) != 0) {
+      q.protocol_version = 2;
+      d &= 0x7FFFu;
+    }
+    if (d >= 1 && d <= 256) q.depth = d;
   }
   return q;
 }
@@ -190,6 +207,8 @@ void RcEndpoint::Close() {
   for (auto& [addr, e] : user_mr_) if (e.first) ibv_dereg_mr(e.first);
   user_mr_.clear();
   user_lru_.clear();
+  for (auto* mr : transient_mr_) if (mr) ibv_dereg_mr(mr);
+  transient_mr_.clear();
   // pool_mr_ holds SHARED, PD-owned MRs (SharedAddPoolMr); the SharedDevice
   // frees them on the last device ref (ReleaseSharedDevice). Just drop the local
   // lookup cache — do NOT dereg here (that would free an MR other live endpoints
@@ -210,8 +229,9 @@ void RcEndpoint::Close() {
   if (wake_wfd_ >= 0) { ::close(wake_wfd_); wake_wfd_ = -1; }
 }
 
-bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib_port,
-                      bool direct_io_buffers, size_t direct_io_cap) {
+bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth,
+                      uint8_t ib_port, bool direct_io_buffers,
+                      size_t direct_io_cap, bool v2_responder) {
   cap_ = cap; depth_ = depth; ib_port_ = ib_port;
 
   int wp[2];
@@ -239,14 +259,16 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib
   // header; the rest carry payload segments for the scatter-gather datapath. The
   // legacy [hdr | payload] path only ever uses 2, so raising the cap is additive.
   max_sge_ = 2;
+  uint32_t max_qp_wr = 0;
   {
     ibv_device_attr dev_attr{};
     if (ibv_query_device(ctx_, &dev_attr) == 0 && dev_attr.max_sge > 0) {
-      size_t cap_sge = static_cast<size_t>(dev_attr.max_sge);
+      const size_t cap_sge = static_cast<size_t>(dev_attr.max_sge);
       max_sge_ = std::min(kMaxSge, cap_sge);
       if (max_sge_ < 2) max_sge_ = 2;
+      max_qp_wr = dev_attr.max_qp_wr;
     } else {
-      max_sge_ = kMaxSge;  // query failed: trust the documented device cap
+      max_sge_ = kMaxSge;  // query failed: let ibv_create_qp validate the caps
     }
   }
   // The ad-hoc MR cache must never evict an MR another slot of the SAME window
@@ -258,14 +280,35 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib
   // and on the RECV side a completion scattering into freed memory.
   user_mr_cap_ = std::max(kMinUserMr, depth_ * max_sge_);
 
+  // A v2 server GET may chain one unsignaled RDMA WRITE per protocol target
+  // plus one signaled status SEND. Target count is fleet-wide and independent
+  // of either HCA's max_sge because every WRITE itself has one SGE.
+  static_assert(kV2MaxGetTargets == kMaxSge - 1);
+  const size_t wr_per_slot =
+      v2_responder ? kV2MaxGetTargets + 1 : 1;
+  if (depth_ > (std::numeric_limits<uint32_t>::max() - 1) / wr_per_slot) {
+    DFKV_LOG_ERROR("rdma: requested send queue depth overflows uint32");
+    Close();
+    return false;
+  }
+  const uint32_t send_wr =
+      static_cast<uint32_t>(depth_ * wr_per_slot + 1);
+  if (max_qp_wr != 0 && send_wr > max_qp_wr) {
+    DFKV_LOG_ERROR("rdma: required send WRs " + std::to_string(send_wr) +
+                   " exceed device max_qp_wr " +
+                   std::to_string(max_qp_wr));
+    Close();
+    return false;
+  }
   ibv_qp_init_attr qa{};
-  qa.send_cq = cq_; qa.recv_cq = cq_;
-  qa.cap.max_send_wr = static_cast<uint32_t>(depth_ + 1);
+  qa.send_cq = cq_;
+  qa.recv_cq = cq_;
+  qa.cap.max_send_wr = send_wr;
   qa.cap.max_recv_wr = static_cast<uint32_t>(depth_ + 1);
   qa.cap.max_send_sge = static_cast<uint32_t>(max_sge_);  // SGE0=hdr, rest=payload segs
   qa.cap.max_recv_sge = static_cast<uint32_t>(max_sge_);
   qa.qp_type = IBV_QPT_RC;
-  qa.sq_sig_all = 1;
+  qa.sq_sig_all = 0;
   qp_ = ibv_create_qp(pd_, &qa);
   if (!qp_) { Close(); return false; }
 
@@ -308,7 +351,7 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib
   at.qp_state = IBV_QPS_INIT;
   at.pkey_index = 0;
   at.port_num = ib_port_;
-  at.qp_access_flags = IBV_ACCESS_LOCAL_WRITE;
+  at.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
   if (ibv_modify_qp(qp_, &at,
         IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS) != 0) {
     Close(); return false;
@@ -447,29 +490,48 @@ bool RcEndpoint::PostSend(size_t slot, size_t len) {
   return ibv_post_send(qp_, &wr, &bad) == 0;
 }
 
-bool RcEndpoint::AddPoolMr(void* base, size_t size) {
-  auto b = reinterpret_cast<uintptr_t>(base);
-  for (const auto& p : pool_mr_) if (p.base == b) return true;  // local cache hit
+bool RcEndpoint::AddPoolMr(void* base, size_t size, bool remote_write) {
+  const auto b = reinterpret_cast<uintptr_t>(base);
+  const int access = IBV_ACCESS_LOCAL_WRITE |
+                     (remote_write ? IBV_ACCESS_REMOTE_WRITE : 0);
+  for (const auto& p : pool_mr_) {
+    if (p.base == b && p.size >= size && (p.access & access) == access)
+      return true;
+  }
   // Register on the shared PD (deduped across all endpoints on this device), then
   // cache the (shared) MR locally so the datapath RegisterUser lookup stays
-  // lock-free. The MR is owned by the SharedDevice and freed on the last ref, so
-  // this endpoint must NOT dereg it in Close().
-  ibv_mr* mr = SharedAddPoolMr(ctx_, pd_, base, size);
+  // lock-free. New entries go first: an access upgrade for an already-covered
+  // range must win over the older LOCAL_WRITE-only entry.
+  ibv_mr* mr = SharedAddPoolMr(ctx_, pd_, base, size, access);
   if (!mr) return false;
-  pool_mr_.push_back(PoolMr{b, size, mr});
+  pool_mr_.insert(pool_mr_.begin(), PoolMr{b, size, access, mr});
   return true;
 }
 
-void RcEndpoint::EnsurePoolMrs(const std::vector<std::pair<void*, size_t>>& regions) {
-  for (const auto& [base, size] : regions) AddPoolMr(base, size);
+void RcEndpoint::EnsurePoolMrs(
+    const std::vector<std::pair<void*, size_t>>& regions, bool remote_write) {
+  for (const auto& [base, size] : regions) AddPoolMr(base, size, remote_write);
+}
+
+ibv_mr* RcEndpoint::RegisterRemoteRegion(void* base, size_t size) {
+  const int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
+  if (!AddPoolMr(base, size, /*remote_write=*/true)) return nullptr;
+  const auto b = reinterpret_cast<uintptr_t>(base);
+  for (const auto& p : pool_mr_) {
+    if (p.base == b && p.size >= size && (p.access & access) == access)
+      return p.mr;
+  }
+  return nullptr;
 }
 
 ibv_mr* RcEndpoint::RegisterUser(void* addr, size_t len) {
   // Fast path: addr fully inside a pre-registered pool region -> reuse its MR
   // (the SGE uses `addr` with this MR's lkey; valid anywhere in the MR's range).
-  auto a = reinterpret_cast<uintptr_t>(addr);
-  for (const auto& p : pool_mr_)
-    if (a >= p.base && a + len <= p.base + p.size) return p.mr;
+  const auto a = reinterpret_cast<uintptr_t>(addr);
+  for (const auto& p : pool_mr_) {
+    if (a >= p.base && len <= p.size && a - p.base <= p.size - len)
+      return p.mr;
+  }
 
   auto key = reinterpret_cast<uintptr_t>(addr);
   auto it = user_mr_.find(key);
@@ -490,13 +552,43 @@ ibv_mr* RcEndpoint::RegisterUser(void* addr, size_t len) {
     if (vit != user_mr_.end()) { ibv_dereg_mr(vit->second.first); user_mr_.erase(vit); }
     user_lru_.pop_back();
   }
-  ibv_mr* mr = ibv_reg_mr(pd_, addr, len, IBV_ACCESS_LOCAL_WRITE);
+  ibv_mr* mr = ibv_reg_mr(
+      pd_, addr, len, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
   if (mr) {
     g_adhoc_user_mr.fetch_add(1, std::memory_order_relaxed);  // out-of-pool: should be 0 in prod
     user_lru_.push_front(key);
     user_mr_[key] = {mr, user_lru_.begin()};
   }
   return mr;
+}
+
+ibv_mr* RcEndpoint::RegisterTransient(void* addr, size_t len,
+                                      bool remote_write) {
+  if (!addr || len == 0) return nullptr;
+  const auto a = reinterpret_cast<uintptr_t>(addr);
+  const int access = remote_write
+                         ? IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE
+                         : 0;
+  for (const auto& p : pool_mr_) {
+    if (a >= p.base && len <= p.size && a - p.base <= p.size - len &&
+        (p.access & access) == access) {
+      return p.mr;
+    }
+  }
+  ibv_mr* mr = ibv_reg_mr(pd_, addr, len, access);
+  if (mr) {
+    transient_mr_.push_back(mr);
+    g_adhoc_user_mr.fetch_add(1, std::memory_order_relaxed);
+  }
+  return mr;
+}
+
+void RcEndpoint::ReleaseTransient(ibv_mr* mr) {
+  if (!mr) return;
+  const auto it = std::find(transient_mr_.begin(), transient_mr_.end(), mr);
+  if (it == transient_mr_.end()) return;
+  ibv_dereg_mr(mr);
+  transient_mr_.erase(it);
 }
 
 bool RcEndpoint::PostSendScatter(size_t slot, size_t hdr_len, const void* payload,
@@ -576,6 +668,113 @@ bool RcEndpoint::PostRecvScatterMulti(
   wr.wr_id = slot; wr.sg_list = sge.data();
   wr.num_sge = static_cast<int>(sge.size());
   return ibv_post_recv(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostWrite(size_t slot, const void* source, size_t length,
+                           ibv_mr* source_mr, uint64_t remote_addr,
+                           uint32_t remote_rkey) {
+  if (slot >= depth_ || length > std::numeric_limits<uint32_t>::max() ||
+      (length != 0 && (!source || !source_mr)) ||
+      remote_addr == 0 || remote_rkey == 0) {
+    return false;
+  }
+  ibv_sge sge{};
+  sge.addr = reinterpret_cast<uintptr_t>(source);
+  sge.length = static_cast<uint32_t>(length);
+  sge.lkey = length ? source_mr->lkey : 0;
+  ibv_send_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot;
+  wr.sg_list = &sge;
+  wr.num_sge = length ? 1 : 0;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = 0;
+  wr.wr.rdma.remote_addr = remote_addr;
+  wr.wr.rdma.rkey = remote_rkey;
+  return ibv_post_send(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostWriteImm(size_t slot, size_t length,
+                              uint64_t remote_addr, uint32_t remote_rkey,
+                              uint32_t immediate) {
+  if (slot >= depth_ || length > cap_ ||
+      length > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  ibv_sge sge{};
+  sge.addr = reinterpret_cast<uintptr_t>(sbuf_[slot]);
+  sge.length = static_cast<uint32_t>(length);
+  sge.lkey = smr_[slot]->lkey;
+  ibv_send_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot;
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.imm_data = htonl(immediate);
+  wr.wr.rdma.remote_addr = remote_addr;
+  wr.wr.rdma.rkey = remote_rkey;
+  return ibv_post_send(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostWriteImmScatter(
+    size_t slot, size_t header_len, const void* payload, size_t payload_len,
+    ibv_mr* payload_mr, uint64_t remote_addr, uint32_t remote_rkey,
+    uint32_t immediate) {
+  if (slot >= depth_ || header_len > cap_ ||
+      header_len > std::numeric_limits<uint32_t>::max() ||
+      payload_len > std::numeric_limits<uint32_t>::max() ||
+      (payload_len != 0 && (!payload || !payload_mr))) {
+    return false;
+  }
+  ibv_sge sge[2]{};
+  sge[0].addr = reinterpret_cast<uintptr_t>(sbuf_[slot]);
+  sge[0].length = static_cast<uint32_t>(header_len);
+  sge[0].lkey = smr_[slot]->lkey;
+  sge[1].addr = reinterpret_cast<uintptr_t>(payload);
+  sge[1].length = static_cast<uint32_t>(payload_len);
+  sge[1].lkey = payload_len ? payload_mr->lkey : 0;
+  ibv_send_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot;
+  wr.sg_list = sge;
+  wr.num_sge = payload_len ? 2 : 1;
+  wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.imm_data = htonl(immediate);
+  wr.wr.rdma.remote_addr = remote_addr;
+  wr.wr.rdma.rkey = remote_rkey;
+  return ibv_post_send(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostWriteImmScatterMulti(
+    size_t slot, size_t header_len,
+    const std::vector<std::pair<const void*, uint32_t>>& segs,
+    const std::vector<ibv_mr*>& mrs, uint64_t remote_addr,
+    uint32_t remote_rkey, uint32_t immediate) {
+  if (slot >= depth_ || segs.size() != mrs.size() ||
+      1 + segs.size() > max_sge_ || header_len > cap_ ||
+      header_len > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  std::vector<ibv_sge> sge(1 + segs.size());
+  sge[0].addr = reinterpret_cast<uintptr_t>(sbuf_[slot]);
+  sge[0].length = static_cast<uint32_t>(header_len);
+  sge[0].lkey = smr_[slot]->lkey;
+  for (size_t i = 0; i < segs.size(); ++i) {
+    if (segs[i].second != 0 && (!segs[i].first || !mrs[i])) return false;
+    sge[i + 1].addr = reinterpret_cast<uintptr_t>(segs[i].first);
+    sge[i + 1].length = segs[i].second;
+    sge[i + 1].lkey = segs[i].second ? mrs[i]->lkey : 0;
+  }
+  ibv_send_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot;
+  wr.sg_list = sge.data();
+  wr.num_sge = static_cast<int>(sge.size());
+  wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.imm_data = htonl(immediate);
+  wr.wr.rdma.remote_addr = remote_addr;
+  wr.wr.rdma.rkey = remote_rkey;
+  return ibv_post_send(qp_, &wr, &bad) == 0;
 }
 
 int RcEndpoint::WaitComp(ibv_wc* out, int max, int timeout_ms) {

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -55,6 +55,7 @@ struct QpInfo {
   uint8_t gid[16] = {0};
   uint8_t pad[6] = {0};
   uint16_t depth = 0;  // not a standalone wire field: rides the pad (see above)
+  uint8_t protocol_version = 1;  // v2 is encoded in the depth field's high bit
 };
 constexpr size_t kQpInfoBytes = 32;
 constexpr uint32_t kQpDepthMagic = 0x31515044u;  // ASCII DPQ1 (LE)
@@ -91,13 +92,16 @@ class RcEndpoint {
   RcEndpoint& operator=(const RcEndpoint&) = delete;
 
   // Open device `dev_name` (nullptr/"" = first device), create RC QP in INIT,
-  // allocate+register `depth` send & recv buffers of `cap` bytes. When
+  // allocate+register `depth` send and receive buffers of `cap` bytes. When
   // direct_io_buffers is true, also allocate one 4096-aligned registered buffer
   // per slot for O_DIRECT reads/writes that are scatter-transferred without a
   // payload copy. direct_io_cap lets that buffer be larger than the ordinary
-  // control send/recv buffers.
+  // control buffers. v2_responder reserves enough SQ WRs for a server to chain
+  // several one-sided GET writes before its signaled status SEND; client and v1
+  // endpoints retain the legacy depth+1 SQ geometry.
   bool Open(const char* dev_name, size_t cap, size_t depth, uint8_t ib_port = 1,
-            bool direct_io_buffers = false, size_t direct_io_cap = 0);
+            bool direct_io_buffers = false, size_t direct_io_cap = 0,
+            bool v2_responder = false);
 
   QpInfo Local() const { return local_; }              // my QP info (after Open)
   bool Connect(const QpInfo& remote);                  // INIT -> RTR -> RTS
@@ -128,11 +132,16 @@ class RcEndpoint {
   // Register a large caller memory region (e.g. the WHOLE SGLang host KV pool)
   // once on this PD. After this, RegisterUser() for any buffer inside the region
   // returns this MR by range lookup with NO per-op ibv_reg_mr — registration is a
-  // one-time connection-setup cost, not a per-transfer cost. Idempotent per base.
-  bool AddPoolMr(void* base, size_t size);
+  // one-time connection-setup cost, not a per-transfer cost. Client destination
+  // pools set remote_write=true so a v2 server can RDMA-WRITE GET data into them.
+  bool AddPoolMr(void* base, size_t size, bool remote_write = false);
   // Register every region not yet present as a pool MR. Called when a connection
   // is acquired so regions declared at any time land on every connection's PD.
-  void EnsurePoolMrs(const std::vector<std::pair<void*, size_t>>& regions);
+  void EnsurePoolMrs(const std::vector<std::pair<void*, size_t>>& regions,
+                     bool remote_write = false);
+  // Register a shared server receive segment for remote PUT writes and return
+  // the MR carrying both the local lkey and peer-visible rkey.
+  ibv_mr* RegisterRemoteRegion(void* base, size_t size);
 
   // Process-wide count of ad-hoc user MRs registered OUTSIDE any pool region
   // (RegisterUser slow path). Should stay 0 in correct deployments where every
@@ -150,6 +159,14 @@ class RcEndpoint {
   // buffers stay cached). Valid as a recv target AND a send source (LOCAL_WRITE is
   // a superset of the no-flag local read a SEND does). nullptr on failure.
   ibv_mr* RegisterUser(void* addr, size_t len);
+  // One-shot MR for API-owned buffers whose lifetime ends or may move after the
+  // current operation. `remote_write=true` is for receive targets; false keeps
+  // const/read-only send sources valid. Registered pool MRs with sufficient
+  // access are reused. The endpoint owns ad-hoc MRs until ReleaseTransient() or
+  // Close(), so a failed/timed-out QP tears down before deregistration.
+  ibv_mr* RegisterTransient(void* addr, size_t len,
+                            bool remote_write = true);
+  void ReleaseTransient(ibv_mr* mr);
   // Scatter recv: first `hdr_bytes` of the message land in rbuf_[slot] (resp
   // prefix + value header), the remaining payload lands directly in `payload`
   // (must belong to `payload_mr` from RegisterUser) — zero copy into the caller.
@@ -179,6 +196,25 @@ class RcEndpoint {
   bool PostRecvScatterMulti(
       size_t slot, const std::vector<std::pair<void*, uint32_t>>& segs,
       const std::vector<ibv_mr*>& mrs, size_t hdr_bytes);
+
+  // RDMA v2 one-sided primitives. PostWrite is intentionally UNSIGNALED: a
+  // following signaled status SEND on the same RC QP fences its source buffer
+  // lifetime and produces the sole server-side completion. WRITE_WITH_IMM is
+  // signaled because it is the client's request operation.
+  bool PostWrite(size_t slot, const void* source, size_t length,
+                 ibv_mr* source_mr, uint64_t remote_addr,
+                 uint32_t remote_rkey);
+  bool PostWriteImm(size_t slot, size_t length, uint64_t remote_addr,
+                    uint32_t remote_rkey, uint32_t immediate);
+  bool PostWriteImmScatter(
+      size_t slot, size_t header_len, const void* payload,
+      size_t payload_len, ibv_mr* payload_mr, uint64_t remote_addr,
+      uint32_t remote_rkey, uint32_t immediate);
+  bool PostWriteImmScatterMulti(
+      size_t slot, size_t header_len,
+      const std::vector<std::pair<const void*, uint32_t>>& segs,
+      const std::vector<ibv_mr*>& mrs, uint64_t remote_addr,
+      uint32_t remote_rkey, uint32_t immediate);
 
   // QP scatter-gather capability negotiated in Open() = min(kMaxSge, device cap).
   // The SG datapath caps payload segments at max_sge()-1 (SGE0 is the header).
@@ -217,7 +253,12 @@ class RcEndpoint {
   std::vector<ibv_mr*> smr_, rmr_, dmr_;
   // Big pre-registered caller regions (the host KV pool). Registered once at
   // connection setup, never evicted; RegisterUser range-looks-up into these.
-  struct PoolMr { uintptr_t base; size_t size; ibv_mr* mr; };
+  struct PoolMr {
+    uintptr_t base;
+    size_t size;
+    int access;
+    ibv_mr* mr;
+  };
   std::vector<PoolMr> pool_mr_;
   // LRU-capped cache of caller-buffer MRs (addr -> {mr, lru-iterator}); front of
   // user_lru_ is MRU. Bounded so a workload with many distinct buffers can't leak
@@ -232,6 +273,7 @@ class RcEndpoint {
   size_t user_mr_cap_ = kMinUserMr;
   std::list<uintptr_t> user_lru_;
   std::unordered_map<uintptr_t, std::pair<ibv_mr*, std::list<uintptr_t>::iterator>> user_mr_;
+  std::vector<ibv_mr*> transient_mr_;
   QpInfo local_;
 };
 

--- a/src/transport/transport_factory.cc
+++ b/src/transport/transport_factory.cc
@@ -1,6 +1,7 @@
 #include "transport/transport_factory.h"
 
 #include <cstdlib>
+#include <exception>
 #include <cstring>
 #include <string>
 
@@ -20,17 +21,33 @@ bool EnvTruthy(const char* name) {
 }
 
 bool RequireRdma() { return EnvTruthy("DFKV_REQUIRE_RDMA"); }
+bool DeviceFilterConfigured() {
+  const char* devices = std::getenv("DFKV_RDMA_DEV");
+  return devices && *devices;
+}
 }  // namespace
 
 std::unique_ptr<Transport> MakeClientTransport(std::string* reason) {
 #ifdef DFKV_WITH_RDMA
   if (EnvTruthy("DFKV_RDMA")) {
     if (RdmaTransport::Available()) {  // native verbs (device-by-name, 400G)
-      if (reason) *reason = "rdma";
-      return std::make_unique<RdmaTransport>();
+      // Availability and construction both discover live HCAs. A link can drop
+      // between those probes, so construction failure must follow the same
+      // fail-closed/fallback policy instead of escaping through dfkv_open.
+      try {
+        auto transport = std::make_unique<RdmaTransport>();
+        if (reason) *reason = "rdma";
+        return transport;
+      } catch (const std::exception&) {
+        // Fall through to the common policy below.
+      }
     }
-    if (RequireRdma()) {
-      if (reason) *reason = "rdma-required-but-no-device";
+    if (RequireRdma() || DeviceFilterConfigured()) {
+      if (reason) {
+        *reason = DeviceFilterConfigured()
+                      ? "rdma-configured-devices-not-active"
+                      : "rdma-required-but-no-active-device";
+      }
       return nullptr;
     }
     if (reason) *reason = "tcp(rdma-requested-but-no-device)";
@@ -42,6 +59,10 @@ std::unique_ptr<Transport> MakeClientTransport(std::string* reason) {
   }
   if (reason) *reason = "tcp(rdma-not-requested)";
 #else
+  if (EnvTruthy("DFKV_RDMA") && DeviceFilterConfigured()) {
+    if (reason) *reason = "rdma-configured-devices-but-rdma-not-built";
+    return nullptr;
+  }
   if (RequireRdma()) {
     if (reason) {
       *reason = EnvTruthy("DFKV_RDMA") ? "rdma-required-but-not-built"

--- a/src/transport/wire.h
+++ b/src/transport/wire.h
@@ -8,6 +8,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <vector>
 
 #include "common/status.h"
 #include "common/kv_types.h"   // BlockKey
@@ -31,7 +33,11 @@ enum class WireOp : uint8_t {
   kClientRegister = 11, kClientHeartbeat = 12, kListClients = 13
 };
 
-constexpr uint8_t kProtoVersion = 1;
+constexpr uint8_t kProtoVersionV1 = 1;
+constexpr uint8_t kProtoVersionV2 = 2;
+// The TCP/MDS protocol remains v1.  RDMA peers negotiate v2 explicitly during
+// bootstrap; the legacy helpers below intentionally continue to emit v1.
+constexpr uint8_t kProtoVersion = kProtoVersionV1;
 
 // Hard ceiling on a single wire frame's variable payload. Decode rejects any
 // frame whose declared length exceeds this, so a garbage/hostile 64-bit length
@@ -46,9 +52,10 @@ constexpr size_t kReqPrefix = 1 + 1 + 8 + 4 + 4 + 8 + 8 + 8;  // = 42
 // Response prefix: ver(1) status(1) data_len(8)
 constexpr size_t kRespPrefix = 1 + 1 + 8;  // = 10
 
-inline void EncodeReq(char* p, WireOp op, const BlockKey& k, uint64_t offset,
-                      uint64_t length, uint64_t payload_len) {
-  p[0] = static_cast<char>(kProtoVersion);
+inline void EncodeReqVersion(char* p, uint8_t version, WireOp op,
+                             const BlockKey& k, uint64_t offset,
+                             uint64_t length, uint64_t payload_len) {
+  p[0] = static_cast<char>(version);
   p[1] = static_cast<char>(op);
   net::PutU64(p + 2, k.id);
   net::PutU32(p + 10, k.index);
@@ -56,6 +63,11 @@ inline void EncodeReq(char* p, WireOp op, const BlockKey& k, uint64_t offset,
   net::PutU64(p + 18, offset);
   net::PutU64(p + 26, length);
   net::PutU64(p + 34, payload_len);
+}
+
+inline void EncodeReq(char* p, WireOp op, const BlockKey& k, uint64_t offset,
+                      uint64_t length, uint64_t payload_len) {
+  EncodeReqVersion(p, kProtoVersionV1, op, k, offset, length, payload_len);
 }
 
 struct ReqFields {
@@ -70,9 +82,10 @@ struct ReqFields {
 
 // False on a version mismatch or an oversized declared payload (> max_payload)
 // — the caller drops the connection.
-inline bool DecodeReq(const char* p, ReqFields* o,
-                      uint64_t max_payload = kMaxFrameLen) {
-  if (static_cast<uint8_t>(p[0]) != kProtoVersion) return false;
+inline bool DecodeReqVersion(const char* p, uint8_t expected_version,
+                             ReqFields* o,
+                             uint64_t max_payload = kMaxFrameLen) {
+  if (static_cast<uint8_t>(p[0]) != expected_version) return false;
   o->op = static_cast<uint8_t>(p[1]);
   o->id = net::GetU64(p + 2);
   o->index = net::GetU32(p + 10);
@@ -80,22 +93,133 @@ inline bool DecodeReq(const char* p, ReqFields* o,
   o->offset = net::GetU64(p + 18);
   o->length = net::GetU64(p + 26);
   o->payload_len = net::GetU64(p + 34);
-  return o->payload_len <= max_payload;  // reject oversized frame
+  return o->payload_len <= max_payload;
 }
 
-inline void EncodeResp(char* p, Status st, uint64_t data_len) {
-  p[0] = static_cast<char>(kProtoVersion);
+inline bool DecodeReq(const char* p, ReqFields* o,
+                      uint64_t max_payload = kMaxFrameLen) {
+  return DecodeReqVersion(p, kProtoVersionV1, o, max_payload);
+}
+
+inline void EncodeRespVersion(char* p, uint8_t version, Status st,
+                              uint64_t data_len) {
+  p[0] = static_cast<char>(version);
   p[1] = static_cast<char>(st);
   net::PutU64(p + 2, data_len);
 }
 
+inline void EncodeResp(char* p, Status st, uint64_t data_len) {
+  EncodeRespVersion(p, kProtoVersionV1, st, data_len);
+}
+
 // False on version mismatch or an oversized declared data_len (> max_data).
-inline bool DecodeResp(const char* p, Status* st, uint64_t* data_len,
-                       uint64_t max_data = kMaxFrameLen) {
-  if (static_cast<uint8_t>(p[0]) != kProtoVersion) return false;
+inline bool DecodeRespVersion(const char* p, uint8_t expected_version,
+                              Status* st, uint64_t* data_len,
+                              uint64_t max_data = kMaxFrameLen) {
+  if (static_cast<uint8_t>(p[0]) != expected_version) return false;
   *st = static_cast<Status>(static_cast<uint8_t>(p[1]));
   *data_len = net::GetU64(p + 2);
-  return *data_len <= max_data;  // reject oversized frame
+  return *data_len <= max_data;
+}
+
+inline bool DecodeResp(const char* p, Status* st, uint64_t* data_len,
+                       uint64_t max_data = kMaxFrameLen) {
+  return DecodeRespVersion(p, kProtoVersionV1, st, data_len, max_data);
+}
+
+// RDMA v2 GET carries one or more client destinations after the unchanged
+// request prefix.  The server sends the first header_len result bytes in the
+// status SEND and RDMA-WRITEs the remainder into these regions in order.
+struct RdmaWriteTarget {
+  uint64_t addr = 0;
+  uint32_t rkey = 0;
+  uint32_t length = 0;
+};
+
+struct RdmaGetFields {
+  uint32_t header_len = 0;
+  std::vector<RdmaWriteTarget> targets;
+
+  uint64_t Capacity() const {
+    uint64_t out = 0;
+    for (const auto& target : targets) out += target.length;
+    return out;
+  }
+};
+
+constexpr size_t kRdmaGetFixed = 8;   // header_len(4), target_count(4)
+constexpr size_t kRdmaGetTarget = 16; // addr(8), rkey(4), length(4)
+
+inline size_t RdmaGetFrameSize(size_t target_count) {
+  if (target_count >
+      (std::numeric_limits<size_t>::max() - kReqPrefix - kRdmaGetFixed) /
+          kRdmaGetTarget) {
+    return 0;
+  }
+  return kReqPrefix + kRdmaGetFixed + target_count * kRdmaGetTarget;
+}
+
+inline bool EncodeRdmaGetReq(char* p, size_t cap, const BlockKey& key,
+                             uint64_t offset, uint64_t length,
+                             uint32_t header_len,
+                             const std::vector<RdmaWriteTarget>& targets,
+                             size_t* encoded_len) {
+  const size_t frame_len = RdmaGetFrameSize(targets.size());
+  if (frame_len == 0 || frame_len > cap ||
+      targets.size() > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  EncodeReqVersion(p, kProtoVersionV2, WireOp::kRange, key, offset, length, 0);
+  net::PutU32(p + kReqPrefix, header_len);
+  net::PutU32(p + kReqPrefix + 4, static_cast<uint32_t>(targets.size()));
+  char* out = p + kReqPrefix + kRdmaGetFixed;
+  for (const auto& target : targets) {
+    net::PutU64(out, target.addr);
+    net::PutU32(out + 8, target.rkey);
+    net::PutU32(out + 12, target.length);
+    out += kRdmaGetTarget;
+  }
+  *encoded_len = frame_len;
+  return true;
+}
+
+inline bool DecodeRdmaGetReq(const char* p, size_t frame_len, ReqFields* req,
+                             RdmaGetFields* get,
+                             uint64_t max_payload = kMaxFrameLen) {
+  if (frame_len < kReqPrefix + kRdmaGetFixed ||
+      !DecodeReqVersion(p, kProtoVersionV2, req, max_payload) ||
+      req->op != static_cast<uint8_t>(WireOp::kRange) ||
+      req->payload_len != 0) {
+    return false;
+  }
+  const uint32_t count = net::GetU32(p + kReqPrefix + 4);
+  const size_t expected = RdmaGetFrameSize(count);
+  if (expected == 0 || expected != frame_len) return false;
+  get->header_len = net::GetU32(p + kReqPrefix);
+  get->targets.clear();
+  get->targets.reserve(count);
+  const char* in = p + kReqPrefix + kRdmaGetFixed;
+  uint64_t capacity = 0;
+  for (uint32_t i = 0; i < count; ++i) {
+    RdmaWriteTarget target;
+    target.addr = net::GetU64(in);
+    target.rkey = net::GetU32(in + 8);
+    target.length = net::GetU32(in + 12);
+    if (target.length != 0 && (target.addr == 0 || target.rkey == 0)) {
+      return false;
+    }
+    if (capacity > std::numeric_limits<uint64_t>::max() - target.length) {
+      return false;
+    }
+    capacity += target.length;
+    get->targets.push_back(target);
+    in += kRdmaGetTarget;
+  }
+  if (get->header_len > req->length ||
+      capacity < req->length - get->header_len) {
+    return false;
+  }
+  return true;
 }
 
 }  // namespace dfkv

--- a/test/transport/dev_frame_caps_test.cc
+++ b/test/transport/dev_frame_caps_test.cc
@@ -1,4 +1,4 @@
-// DCP1 device-frame caps declaration: codec round-trip + every legacy /
+// DCP1/DCP2 device-frame capability declarations and every legacy /
 // degenerate shape an old peer can produce. Hermetic (no RDMA device).
 #include <gtest/gtest.h>
 
@@ -13,6 +13,30 @@ TEST(DevFrameCaps, RoundTrip) {
   EncodeDevFrame("ib7s400p0", 4u << 20, f);
   EXPECT_STREQ(f, "ib7s400p0");            // name intact for old servers
   EXPECT_EQ(ParseDevFrameCaps(f), 4u << 20);
+}
+
+TEST(DevFrameCaps, V2RoundTripAndLegacyName) {
+  char f[kDevNameBytes];
+  EncodeDevFrame("ib7s400p0", 4u << 20, f, kDevProtoV2);
+  EXPECT_STREQ(f, "ib7s400p0");
+  EXPECT_EQ(ParseDevFrameCaps(f), 4u << 20);
+  EXPECT_EQ(ParseDevFrameProtocol(f), kDevProtoV2);
+}
+
+TEST(DevFrameCaps, V2RequiresDeclarationAndTailRoom) {
+  char f[kDevNameBytes];
+  EncodeDevFrame("ib7s400p0", 0, f, kDevProtoV2);
+  EXPECT_EQ(ParseDevFrameProtocol(f), kDevProtoV1);
+
+  std::string too_long(19, 'x');
+  EncodeDevFrame(too_long, 4u << 20, f, kDevProtoV2);
+  EXPECT_EQ(ParseDevFrameCaps(f), 0u);
+  EXPECT_EQ(ParseDevFrameProtocol(f), kDevProtoV1);
+
+  std::string edge(18, 'y');
+  EncodeDevFrame(edge, 4u << 20, f, kDevProtoV2);
+  EXPECT_EQ(ParseDevFrameCaps(f), 4u << 20);
+  EXPECT_EQ(ParseDevFrameProtocol(f), kDevProtoV2);
 }
 
 TEST(DevFrameCaps, LegacyZeroTailParsesAsUndeclared) {

--- a/test/transport/factory_test.cc
+++ b/test/transport/factory_test.cc
@@ -60,3 +60,18 @@ TEST(Factory, RequireRdmaRejectsImplicitTcpFallback) {
   EXPECT_EQ(t, nullptr);
   EXPECT_NE(reason.find("rdma-required"), std::string::npos) << reason;
 }
+
+TEST(Factory, ExplicitDeviceFilterNeverFallsBackToTcp) {
+  EnvSave save_require("DFKV_REQUIRE_RDMA");
+  EnvSave save_rdma("DFKV_RDMA");
+  EnvSave save_dev("DFKV_RDMA_DEV");
+  ::unsetenv("DFKV_REQUIRE_RDMA");
+  ::setenv("DFKV_RDMA", "1", 1);
+  ::setenv("DFKV_RDMA_DEV", "dfkv-no-such-rdma-device", 1);
+
+  std::string reason;
+  auto t = MakeClientTransport(&reason);
+  EXPECT_EQ(t, nullptr);
+  EXPECT_NE(reason.find("rdma-configured-devices"), std::string::npos)
+      << reason;
+}

--- a/test/transport/qp_depth_negotiation_test.cc
+++ b/test/transport/qp_depth_negotiation_test.cc
@@ -42,6 +42,24 @@ TEST(QpDepthNegotiation, DepthRoundTrips) {
   EXPECT_EQ(out.depth, 32);
 }
 
+TEST(QpDepthNegotiation, V2FlagSharesDepthFieldWithoutTouchingLegacyFields) {
+  QpInfo v2 = Sample(32);
+  v2.protocol_version = 2;
+  char encoded[kQpInfoBytes], legacy[kQpInfoBytes];
+  SerializeQpInfo(v2, encoded);
+  SerializeQpInfo(Sample(32), legacy);
+  EXPECT_EQ(std::memcmp(encoded, legacy, 30), 0);
+
+  QpInfo parsed = ParseQpInfo(encoded);
+  ExpectLegacyFieldsEqual(parsed, v2);
+  EXPECT_EQ(parsed.depth, 32);
+  EXPECT_EQ(parsed.protocol_version, 2);
+
+  uint16_t raw_depth = 0;
+  std::memcpy(&raw_depth, encoded + 30, 2);
+  EXPECT_GT(raw_depth, 256u);  // an old parser safely treats it as absent
+}
+
 TEST(QpDepthNegotiation, LegacyZeroPadMeansNoAdvertisement) {
   // A legacy peer's serializer memsets the blob and writes only the fields:
   // emulate it by serializing WITHOUT depth (writer skips the magic).

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -39,6 +39,11 @@ ValueHeader SelfHdr() {
   return ValueHeader::Make(0x51ULL, 64, 0x46384534u, ValueHeader::kFlagIsMla,
                            8, 0, 78, 1, 576);
 }
+void ConfigureTestRecvSegment() {
+  // Keep Soft-RoCE CI below modest RLIMIT_MEMLOCK. Production defaults to
+  // 2 GiB, but these fixtures use 256-KiB blocks and need only a small segment.
+  ::setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", "33554432", 0);
+}
 
 // A cache node serving RDMA: KvNodeServer owns the DiskCacheGroup; RdmaServer
 // bootstraps QPs and routes requests to it (generic handler + zero-copy range).
@@ -49,6 +54,7 @@ struct RdmaNode {
   std::string addr;  // bootstrap "ip:port" for the client member list
 
   explicit RdmaNode(const std::string& tag, size_t max_msg = kMaxMsg) {
+    ConfigureTestRecvSegment();
     dir = fs::temp_directory_path() / ("dfkv_rdma_" + tag);
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -272,17 +278,146 @@ TEST(RdmaLoopback, MetricsCountersTrackOps) {
   EXPECT_GE(node.rsrv->Completions(), 2u);
   std::string srv_text = node.rsrv->MetricsText();
   EXPECT_NE(srv_text.find("dfkv_rdma_completions_total"), std::string::npos) << srv_text;
+  EXPECT_GE(CounterVal(srv_text, "dfkv_rdma_v2_conns_opened_total"), 1);
+  EXPECT_GE(CounterVal(srv_text, "dfkv_rdma_v2_put_writes_total"), 1);
+  EXPECT_GE(CounterVal(srv_text, "dfkv_rdma_v2_get_writes_total"), 1);
+  EXPECT_GT(CounterVal(srv_text, "dfkv_rdma_recv_segment_bytes"), 0);
 
   // client transport: a connection was opened and the MR region declared
   std::string cli_text = rt.MetricsText();
   EXPECT_NE(cli_text.find("dfkv_rdma_client_conns_opened_total"), std::string::npos) << cli_text;
   EXPECT_NE(cli_text.find("dfkv_rdma_client_rail_conns_total{dev="), std::string::npos) << cli_text;
   EXPECT_NE(cli_text.find("dfkv_rdma_client_mr_regions 1"), std::string::npos) << cli_text;
+  EXPECT_GE(CounterVal(cli_text, "dfkv_rdma_client_v2_conns_opened_total"), 1);
+  EXPECT_GE(CounterVal(cli_text, "dfkv_rdma_client_v2_put_writes_total"), 1);
+  EXPECT_GE(CounterVal(cli_text, "dfkv_rdma_client_v2_get_writes_total"), 1);
 
   // and the client snapshot folds transport metrics in after the health metrics
   std::string snap = c.MetricsSnapshot();
   EXPECT_NE(snap.find("dfkv_client_ops_served_total"), std::string::npos) << snap;
   EXPECT_NE(snap.find("dfkv_rdma_client_conns_opened_total"), std::string::npos) << snap;
+}
+TEST(RdmaLoopback, AutoFallsBackWhenServerForcesV1) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ::setenv("DFKV_RDMA_SERVER_PROTOCOL", "1", 1);
+  RdmaNode node("v1-fallback");
+  ::unsetenv("DFKV_RDMA_SERVER_PROTOCOL");
+
+  RdmaTransport transport(kMaxMsg);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  std::string value(4096, 'f');
+  ASSERT_TRUE(client.Put("fallback", value.data(), value.size()));
+  std::string output(value.size(), '\0');
+  ASSERT_TRUE(client.Get("fallback", output.data(), output.size()));
+  EXPECT_EQ(output, value);
+
+  EXPECT_GE(node.rsrv->V1Conns(), 1u);
+  EXPECT_EQ(node.rsrv->V2Conns(), 0u);
+  EXPECT_GE(CounterVal(transport.MetricsText(),
+                       "dfkv_rdma_client_v1_conns_opened_total"),
+            1);
+}
+
+TEST(RdmaLoopback, AutoFallbackPreservesLegacyUndeclaredFrame) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  // Before v2, an unset block declaration produced a plain legacy frame. The
+  // fallback must not invent the client's larger max as DCP1: an older server
+  // with a smaller --max-msg would reject it even when the real value fits.
+  ::unsetenv("DFKV_RDMA_MAX_BLOCK_BYTES");
+  ::setenv("DFKV_RDMA_SERVER_PROTOCOL", "1", 1);
+  constexpr size_t kSmallerOldServerCap = 64 * 1024;
+  RdmaNode node("v1-undeclared-fallback", kSmallerOldServerCap);
+  ::unsetenv("DFKV_RDMA_SERVER_PROTOCOL");
+
+  RdmaTransport transport(kMaxMsg);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  std::string value(4096, 'u');
+  ASSERT_TRUE(client.Put("undeclared-fallback", value.data(), value.size()));
+  std::string output(value.size(), '\0');
+  ASSERT_TRUE(
+      client.Get("undeclared-fallback", output.data(), output.size()));
+  EXPECT_EQ(output, value);
+  EXPECT_GE(node.rsrv->V1Conns(), 1u);
+  EXPECT_EQ(node.rsrv->V2Conns(), 0u);
+}
+
+TEST(RdmaLoopback, LargeMembersReplyUsesDedicatedV1ControlLane) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  RdmaNode node("large-members");
+  const std::string members(32u << 10, 'm');
+  node.srv->set_members(members);
+
+  RdmaTransport transport(kMaxMsg);
+  std::string output;
+  ASSERT_EQ(transport.Members(node.addr, &output), Status::kOk);
+  EXPECT_EQ(output, members);
+  EXPECT_GE(node.rsrv->V1Conns(), 1u);
+  EXPECT_EQ(node.rsrv->V2Conns(), 0u);
+}
+
+TEST(RdmaLoopback, AutoFallsBackWhenSharedSegmentHasNoLease) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ::setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", "4096", 1);
+  RdmaNode node("segment-fallback");
+  ::unsetenv("DFKV_RDMA_RECV_SEGMENT_SIZE");
+
+  RdmaTransport transport(kMaxMsg);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  std::string value(4096, 's');
+  ASSERT_TRUE(client.Put("segment-fallback", value.data(), value.size()));
+  std::string output(value.size(), '\0');
+  ASSERT_TRUE(
+      client.Get("segment-fallback", output.data(), output.size()));
+  EXPECT_EQ(output, value);
+  EXPECT_GE(node.rsrv->V1Conns(), 1u);
+  EXPECT_EQ(node.rsrv->V2Conns(), 0u);
+}
+
+
+TEST(RdmaLoopback, V2CacheAcceptsReadOnlySourceMemory) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  RdmaNode node("readonly-v2");
+  RdmaTransport transport(kMaxMsg);
+  const BlockKey key = ToBlockKey("readonly-v2", SelfHdr().model_hash);
+  constexpr size_t kPayload = 512;
+  const size_t stored_len = ValueHeader::kSize + kPayload;
+  void* mapping =
+      ::mmap(nullptr, 4096, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(mapping, MAP_FAILED);
+  const ValueHeader header = SelfHdr();
+  std::memcpy(mapping, &header, ValueHeader::kSize);
+  std::memset(static_cast<char*>(mapping) + ValueHeader::kSize, 'r', kPayload);
+  ASSERT_EQ(::mprotect(mapping, 4096, PROT_READ), 0);
+
+  ASSERT_EQ(transport.Cache(node.addr, key, mapping, stored_len), Status::kOk);
+  std::string output;
+  ASSERT_EQ(transport.Range(node.addr, key, 0, stored_len, &output),
+            Status::kOk);
+  ASSERT_EQ(output.size(), stored_len);
+  EXPECT_EQ(std::memcmp(output.data(), mapping, stored_len), 0);
+  EXPECT_EQ(::munmap(mapping, 4096), 0);
+}
+
+TEST(RdmaLoopback, DirectSingleCacheRangeUsesV2Writes) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  RdmaNode node("direct-v2");
+  RdmaTransport transport(kMaxMsg);
+  const BlockKey key = ToBlockKey("direct-v2", SelfHdr().model_hash);
+  std::string stored(ValueHeader::kSize + 4096, '\0');
+  const ValueHeader header = SelfHdr();
+  std::memcpy(stored.data(), &header, ValueHeader::kSize);
+  for (size_t i = ValueHeader::kSize; i < stored.size(); ++i)
+    stored[i] = static_cast<char>((i * 29 + 3) & 0xff);
+
+  ASSERT_EQ(transport.Cache(node.addr, key, stored.data(), stored.size()),
+            Status::kOk);
+  std::string output;
+  ASSERT_EQ(transport.Range(node.addr, key, 0, stored.size(), &output),
+            Status::kOk);
+  EXPECT_EQ(output, stored);
+  EXPECT_GE(node.rsrv->V2PutWrites(), 1u);
+  EXPECT_GE(node.rsrv->V2GetWrites(), 1u);
 }
 
 TEST(RdmaLoopback, BatchZeroCopyRoundtrip) {
@@ -379,11 +514,14 @@ TEST(RdmaLoopback, UserMrCapTracksDepth) {
   EXPECT_GE(shallow.user_mr_cap(), 64u);            // floor
   EXPECT_GE(shallow.user_mr_cap(), shallow.depth());
   rdma::RcEndpoint deep;
-  ASSERT_TRUE(deep.Open(nullptr, 16 * 1024, 100));  // depth > default cap of 64
+  // v2 reserves up to max_sge+1 SQ WRs per request. Keep this above the
+  // historical 64-MR floor without asking the NIC for a pathological QP.
+  constexpr size_t kDeepDepth = 65;
+  ASSERT_TRUE(deep.Open(nullptr, 16 * 1024, kDeepDepth));
   // The SG multi paths register up to max_sge-1 out-of-pool segments per slot
   // and post only after the whole window is registered: the cap must cover
   // depth * max_sge or a same-window LRU eviction hands a freed MR to a WR.
-  EXPECT_GE(deep.user_mr_cap(), 100u * deep.max_sge())
+  EXPECT_GE(deep.user_mr_cap(), kDeepDepth * deep.max_sge())
       << "cap below depth*max_sge -> in-window MR eviction risk on SG batches";
 }
 
@@ -415,6 +553,22 @@ TEST(RdmaLoopback, PoolMrSharedAcrossBuffers) {
   ibv_mr* c = ep.RegisterUser(outside.data(), outside.size());
   ASSERT_NE(c, nullptr);
   EXPECT_NE(c, a);  // outside the pool -> ad-hoc registration
+}
+
+TEST(RdmaLoopback, PoolMrAccessUpgradeWinsRangeLookup) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  rdma::RcEndpoint ep;
+  ASSERT_TRUE(ep.Open(nullptr, 64 * 1024, 1));
+  std::vector<char> region(256 * 1024);
+  ASSERT_TRUE(ep.AddPoolMr(region.data(), region.size()));
+  ibv_mr* local_only = ep.RegisterUser(region.data() + 4096, 4096);
+  ASSERT_NE(local_only, nullptr);
+  ibv_mr* remote_write =
+      ep.RegisterRemoteRegion(region.data(), region.size());
+  ASSERT_NE(remote_write, nullptr);
+  EXPECT_NE(remote_write, local_only);
+  EXPECT_EQ(ep.RegisterUser(region.data() + 4096, 4096), remote_write)
+      << "range lookup must prefer the remote-write access upgrade";
 }
 
 // The host KV pool belongs to the PD, not to a connection: many endpoints on
@@ -930,6 +1084,7 @@ TEST(RdmaLoopback, UringAsyncGetManyConcurrentInOrder) {
   ::setenv("DFKV_SERVER_URING", "1", 0);
   ::setenv("DFKV_SERVER_URING_DEPTH", "32", 1);
   ::setenv("DFKV_RDMA_DEPTH", "8", 1);      // K=8 in-flight => multi-read batches
+  ::setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", "4194304", 1);
   // Small per-buffer cap so K=8 slots (rbuf+sbuf+dbuf each) stay under an 8 MiB
   // RLIMIT_MEMLOCK (CI default). Values below are <= 12 KiB, well within 64 KiB.
   constexpr size_t kUringMsg = 64 * 1024;
@@ -1014,10 +1169,20 @@ TEST(RdmaLoopback, UringAsyncGetManyConcurrentInOrder) {
   long gcnt = std::stol(mtext.substr(
       gp + std::string("dfkv_op_latency_seconds_count{op=\"get\"}").size()));
   EXPECT_GT(gcnt, 0) << "uring GET path recorded no op=\"get\" latency sample";
+#ifdef DFKV_WITH_URING
+  const char* uring_enabled = std::getenv("DFKV_SERVER_URING");
+  if (!uring_enabled || std::strcmp(uring_enabled, "0") != 0) {
+    EXPECT_GT(node.rsrv->UringReads(), 0u)
+        << "auto-v2 silently bypassed the io_uring read path";
+    EXPECT_GT(node.rsrv->V2Conns(), 0u)
+        << "test did not exercise the v2 async-GET response path";
+  }
+#endif
 
   ::unsetenv("DFKV_SERVER_URING");
   ::unsetenv("DFKV_SERVER_URING_DEPTH");
   ::unsetenv("DFKV_RDMA_DEPTH");
+  ::unsetenv("DFKV_RDMA_RECV_SEGMENT_SIZE");
 }
 
 // --- P3 B5-3: RAM hot-tier zero-copy RDMA serve --------------------------------
@@ -1033,6 +1198,7 @@ struct RamRdmaNode {
   std::string addr;
 
   explicit RamRdmaNode(const std::string& tag, size_t max_msg = kMaxMsg) {
+    ConfigureTestRecvSegment();
     ::setenv("DFKV_RAM_TIER", "1", 1);
     ::setenv("DFKV_RAM_TIER_BYTES", "8388608", 1);  // 8 MiB arena
     dir = fs::temp_directory_path() / ("dfkv_ramrdma_" + tag);
@@ -1110,10 +1276,9 @@ TEST(RdmaLoopback, RamTierZeroCopyServe) {
   EXPECT_EQ(out2, vals[0]);
 }
 
-// DCP1 declared caps (issue #110): a client that declares its max block size
-// gets right-sized server buffers and must still complete every op within the
-// declaration; oversized ops must fail CLIENT-side with kInvalid (never
-// reaching the wire, where the under-sized recv would hard-break the QP).
+// DCP2 declared caps: a client that tightens its max block size gets smaller
+// shared slots and must still complete every op within the declaration;
+// oversized ops fail client-side with kInvalid without touching the wire.
 TEST(RdmaLoopback, DeclaredCapsRoundTripAndClientSideBound) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   RdmaNode node("caps");
@@ -1137,9 +1302,9 @@ TEST(RdmaLoopback, DeclaredCapsRoundTripAndClientSideBound) {
   EXPECT_EQ(got, v);
 }
 
-// Undeclared client (legacy frame) against the same server keeps worst-case
-// sizing: blocks right up to the transport max still round-trip.
-TEST(RdmaLoopback, UndeclaredClientKeepsWorstCase) {
+// With no explicit override, DCP2 declares the transport's safe global cap;
+// blocks right up to that bound still round-trip.
+TEST(RdmaLoopback, DefaultDeclarationKeepsGlobalCap) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   RdmaNode node("nocaps");
   RdmaTransport rt(kMaxMsg);

--- a/test/transport/rdma_protocol_test.cc
+++ b/test/transport/rdma_protocol_test.cc
@@ -1,0 +1,68 @@
+#include "transport/rdma_protocol.h"
+
+#include <gtest/gtest.h>
+
+namespace dfkv::rdma {
+
+TEST(RdmaProtocol, ProbeRoundTrip) {
+  char frame[kDevNameBytes];
+  EncodeDevFrame(kV2ProbeDevice, 4u << 20, frame, kDevProtoV2);
+  EXPECT_TRUE(IsV2Probe(frame));
+
+  char reply[kV2ProbeReplyBytes];
+  EncodeV2ProbeReply(reply);
+  EXPECT_TRUE(ParseV2ProbeReply(reply));
+  reply[4] = 1;
+  EXPECT_FALSE(ParseV2ProbeReply(reply));
+}
+
+TEST(RdmaProtocol, SlotGeometryKeepsPayloadAligned) {
+  const size_t slot = V2SlotSize(4u << 20);
+  ASSERT_NE(slot, 0u);
+  EXPECT_EQ(slot % kV2DataOffset, 0u);
+  EXPECT_GE(slot - kV2DataOffset, (4u << 20) + ValueHeader::kSize);
+  EXPECT_EQ(kV2PutPrefixOffset + kReqPrefix, kV2DataOffset);
+  EXPECT_EQ(kV2MaxGetTargets, 29u);
+}
+
+TEST(RdmaProtocol, PutCompletionMustCoverExactFrame) {
+  const size_t slot = V2SlotSize(4u << 20);
+  ASSERT_NE(slot, 0u);
+  constexpr uint64_t payload = 64u << 10;
+  const uint32_t frame = static_cast<uint32_t>(kReqPrefix + payload);
+  EXPECT_TRUE(V2PutCompletionCoversFrame(frame, payload, slot));
+  EXPECT_FALSE(V2PutCompletionCoversFrame(frame - 1, payload, slot));
+  EXPECT_FALSE(V2PutCompletionCoversFrame(frame + 1, payload, slot));
+  EXPECT_FALSE(V2PutCompletionCoversFrame(
+      static_cast<uint32_t>(kReqPrefix - 1), payload, slot));
+  EXPECT_FALSE(V2PutCompletionCoversFrame(
+      frame, static_cast<uint64_t>(slot), slot));
+  EXPECT_TRUE(V2PutCompletionIsValid(
+      /*is_rdma_write_with_imm=*/true, /*has_immediate=*/true, frame,
+      payload, payload, slot));
+  EXPECT_FALSE(V2PutCompletionIsValid(
+      /*is_rdma_write_with_imm=*/false, /*has_immediate=*/true, frame,
+      payload, payload, slot));  // SEND_WITH_IMM is not a shared-slot write
+  EXPECT_FALSE(V2PutCompletionIsValid(
+      /*is_rdma_write_with_imm=*/true, /*has_immediate=*/false, frame,
+      payload, payload, slot));
+  EXPECT_FALSE(V2PutCompletionIsValid(
+      /*is_rdma_write_with_imm=*/true, /*has_immediate=*/true, frame,
+      payload, payload - 1, slot));  // alignment padding is not logical capacity
+}
+
+TEST(RdmaProtocol, SegmentInfoRoundTripAndValidation) {
+  const RecvSegmentInfo expected{0x12345000, 0xAABBCCDD, 4u << 20};
+  char frame[kRecvSegmentInfoBytes];
+  EncodeRecvSegmentInfo(expected, frame);
+  RecvSegmentInfo actual;
+  ASSERT_TRUE(DecodeRecvSegmentInfo(frame, &actual));
+  EXPECT_EQ(actual.base_addr, expected.base_addr);
+  EXPECT_EQ(actual.rkey, expected.rkey);
+  EXPECT_EQ(actual.slot_size, expected.slot_size);
+
+  frame[0] = 0;
+  EXPECT_FALSE(DecodeRecvSegmentInfo(frame, &actual));
+}
+
+}  // namespace dfkv::rdma

--- a/test/transport/rdma_recv_segment_test.cc
+++ b/test/transport/rdma_recv_segment_test.cc
@@ -1,0 +1,77 @@
+#include "transport/rdma_recv_segment.h"
+
+#include <cstdint>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace dfkv::rdma {
+
+TEST(RecvSegment, AllocatesAlignedNonOverlappingLeasesAndCoalesces) {
+  RecvSegment segment;
+  ASSERT_TRUE(segment.Init(64u << 10));
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(segment.data()) % 4096, 0u);
+
+  auto first = segment.Allocate(8192);
+  auto second = segment.Allocate(4096);
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+  EXPECT_EQ(first.offset() % 4096, 0u);
+  EXPECT_EQ(second.offset() % 4096, 0u);
+  EXPECT_GE(second.offset(), first.offset() + first.size());
+  EXPECT_EQ(segment.free_bytes(), (64u << 10) - 12288);
+
+  first.Reset();
+  second.Reset();
+  EXPECT_EQ(segment.free_bytes(), 64u << 10);
+  auto whole = segment.Allocate(64u << 10);
+  EXPECT_TRUE(whole);
+}
+
+TEST(RecvSegment, MoveTransfersOwnershipAndExhaustionFailsCleanly) {
+  RecvSegment segment;
+  ASSERT_TRUE(segment.Init(8192));
+  auto lease = segment.Allocate(8192);
+  ASSERT_TRUE(lease);
+  EXPECT_FALSE(segment.Allocate(4096));
+
+  RecvSegment::Lease moved = std::move(lease);
+  EXPECT_FALSE(lease);
+  EXPECT_TRUE(moved);
+  moved.Reset();
+  EXPECT_EQ(segment.free_bytes(), 8192u);
+}
+
+TEST(RecvSegment, RejectsInvalidGeometry) {
+  RecvSegment segment;
+  EXPECT_FALSE(segment.Init(0));
+  EXPECT_FALSE(segment.Init(4097));
+  EXPECT_FALSE(segment.Init(8192, 3000));
+}
+
+TEST(RecvSegment, LargerLeaseAlignmentUsesAbsoluteAddress) {
+  RecvSegment segment;
+  ASSERT_TRUE(segment.Init(64u << 10, 4096));
+  auto lease = segment.Allocate(8192, 8192);
+  ASSERT_TRUE(lease);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(lease.data()) % 8192, 0u);
+}
+
+TEST(RecvSegment, SizeParserIs64BitAlignedAndNotWireCapped) {
+  constexpr size_t fallback = 2ull << 30;
+  EXPECT_EQ(ResolveRecvSegmentBytes(nullptr, fallback), fallback);
+  EXPECT_EQ(ResolveRecvSegmentBytes("", fallback), fallback);
+  EXPECT_EQ(ResolveRecvSegmentBytes("0", fallback), fallback);
+  EXPECT_EQ(ResolveRecvSegmentBytes("garbage", fallback), fallback);
+  EXPECT_EQ(ResolveRecvSegmentBytes("8193", fallback), 12288u);
+  EXPECT_EQ(ResolveRecvSegmentBytes("8192junk", fallback), fallback);
+  if constexpr (sizeof(size_t) >= 8) {
+    EXPECT_EQ(ResolveRecvSegmentBytes("8589934592", fallback),
+              static_cast<size_t>(8ull << 30));
+    EXPECT_EQ(ResolveRecvSegmentBytes("8589934593", fallback),
+              static_cast<size_t>((8ull << 30) + 4096));
+  }
+  EXPECT_EQ(ResolveRecvSegmentBytes("8192", fallback, 3000), 0u);
+}
+
+}  // namespace dfkv::rdma

--- a/test/transport/rdma_topology_test.cc
+++ b/test/transport/rdma_topology_test.cc
@@ -1,0 +1,86 @@
+#include "transport/rdma_topology.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+using dfkv::rdma::RdmaDevInfo;
+using dfkv::rdma::RdmaTopology;
+
+RdmaDevInfo Device(std::string name, bool active, int numa_node = -1) {
+  RdmaDevInfo info;
+  info.name = std::move(name);
+  info.active = active;
+  info.numa_node = numa_node;
+  return info;
+}
+
+TEST(RdmaTopology, DiscoveryDropsDownPortsWithoutAFilter) {
+  const std::vector<RdmaDevInfo> candidates{
+      Device("ib7s400p0", true, 0), Device("ib9s400p0", false, 1),
+      Device("ib7s400p1", true, 1)};
+
+  const auto selected = RdmaTopology::FilterActive(candidates);
+
+  ASSERT_EQ(selected.size(), 2u);
+  EXPECT_EQ(selected[0].name, "ib7s400p0");
+  EXPECT_EQ(selected[1].name, "ib7s400p1");
+}
+
+TEST(RdmaTopology, WhitelistAndActiveChecksAreBothApplied) {
+  const std::vector<RdmaDevInfo> candidates{
+      Device("ib7s400p0", true), Device("ib7s400p1", false),
+      Device("ib6s200p0", true)};
+  const std::vector<std::string> filter{"ib7s400p0", "ib7s400p1"};
+
+  const auto selected = RdmaTopology::FilterActive(candidates, filter);
+
+  ASSERT_EQ(selected.size(), 1u);
+  EXPECT_EQ(selected[0].name, "ib7s400p0");
+}
+
+TEST(RdmaTopology, AllFilteredPortsDownReturnsEmpty) {
+  const std::vector<RdmaDevInfo> candidates{
+      Device("ib9s400p0", false), Device("ib9s400p1", false)};
+  const std::vector<std::string> filter{"ib9s400p0", "ib9s400p1"};
+
+  EXPECT_TRUE(RdmaTopology::FilterActive(candidates, filter).empty());
+}
+
+TEST(RdmaTopology, DuplicateCandidatesRemainOneRail) {
+  const std::vector<RdmaDevInfo> candidates{
+      Device("ib7s400p0", true), Device("ib7s400p0", true)};
+
+  const auto selected = RdmaTopology::FilterActive(candidates);
+
+  ASSERT_EQ(selected.size(), 1u);
+  EXPECT_EQ(selected[0].name, "ib7s400p0");
+}
+
+TEST(RdmaTopology, SelectsLocalRailsRoundRobin) {
+  RdmaTopology topology({Device("ib0", true, 0), Device("ib1", true, 1),
+                         Device("ib2", true, 1)});
+
+  const int first = topology.SelectDevice(1, true);
+  const int second = topology.SelectDevice(1, true);
+  const int third = topology.SelectDevice(1, true);
+
+  EXPECT_EQ(first, 1);
+  EXPECT_EQ(second, 2);
+  EXPECT_EQ(third, 1);
+}
+
+TEST(RdmaTopology, DisabledRailIsNotSelectedAgain) {
+  RdmaTopology topology(
+      {Device("ib0", true, 0), Device("ib1", true, 0)});
+  topology.DisableDevice("ib0");
+
+  for (int i = 0; i < 4; ++i) EXPECT_EQ(topology.SelectDevice(0, true), 1);
+  topology.DisableDevice("ib1");
+  EXPECT_EQ(topology.SelectDevice(0, true), -1);
+}
+
+}  // namespace

--- a/test/transport/wire_test.cc
+++ b/test/transport/wire_test.cc
@@ -86,3 +86,52 @@ TEST(Wire, RespRejectsOversizedData) {
   EXPECT_EQ(dlen, kMaxFrameLen + 1);
 }
 
+TEST(Wire, V2GetScatterRoundTrip) {
+  char buf[512];
+  const BlockKey key{0x1122, 7, 4096};
+  const std::vector<RdmaWriteTarget> targets{
+      {0x100000, 0xA1, 1024}, {0x200000, 0xB2, 3024}};
+  size_t encoded = 0;
+  ASSERT_TRUE(EncodeRdmaGetReq(buf, sizeof(buf), key, 0, 4096, 48, targets,
+                               &encoded));
+  EXPECT_EQ(encoded, RdmaGetFrameSize(2));
+
+  ReqFields req{};
+  RdmaGetFields get;
+  ASSERT_TRUE(DecodeRdmaGetReq(buf, encoded, &req, &get));
+  EXPECT_EQ(req.op, static_cast<uint8_t>(WireOp::kRange));
+  EXPECT_EQ(req.id, key.id);
+  EXPECT_EQ(req.length, 4096u);
+  EXPECT_EQ(get.header_len, 48u);
+  ASSERT_EQ(get.targets.size(), 2u);
+  EXPECT_EQ(get.targets[0].addr, targets[0].addr);
+  EXPECT_EQ(get.targets[1].rkey, targets[1].rkey);
+  EXPECT_EQ(get.Capacity(), 4048u);
+}
+
+TEST(Wire, V2GetRejectsShortCapacityAndMalformedTarget) {
+  char buf[256];
+  size_t encoded = 0;
+  ASSERT_TRUE(EncodeRdmaGetReq(
+      buf, sizeof(buf), BlockKey{1, 2, 3}, 0, 4096, 48,
+      std::vector<RdmaWriteTarget>{{0x1000, 7, 1024}}, &encoded));
+  ReqFields req{};
+  RdmaGetFields get;
+  EXPECT_FALSE(DecodeRdmaGetReq(buf, encoded, &req, &get));
+
+  ASSERT_TRUE(EncodeRdmaGetReq(
+      buf, sizeof(buf), BlockKey{1, 2, 3}, 0, 48, 0,
+      std::vector<RdmaWriteTarget>{{0, 0, 48}}, &encoded));
+  EXPECT_FALSE(DecodeRdmaGetReq(buf, encoded, &req, &get));
+}
+
+TEST(Wire, VersionedResponseRequiresNegotiatedVersion) {
+  char buf[kRespPrefix];
+  EncodeRespVersion(buf, kProtoVersionV2, Status::kOk, 99);
+  Status status = Status::kInvalid;
+  uint64_t data_len = 0;
+  EXPECT_FALSE(DecodeResp(buf, &status, &data_len));
+  ASSERT_TRUE(DecodeRespVersion(buf, kProtoVersionV2, &status, &data_len));
+  EXPECT_EQ(status, Status::kOk);
+  EXPECT_EQ(data_len, 99u);
+}


### PR DESCRIPTION
## Summary

Add an opt-in, per-connection negotiated RDMA v2 data plane while preserving TCP and the existing RDMA v1 protocol.

- v2 PUT uses `IBV_WR_RDMA_WRITE_WITH_IMM` into a process-wide registered receive segment.
- v2 GET advertises client `{addr,rkey,len}` targets; the server RDMA-WRITEs payload bytes and completes with a small ordered SEND.
- v1/v2 negotiation is connection-local. New clients probe and fall back to v1 against old/forced-v1 servers.
- HCA context/PD and large pool MRs are shared per device; QP/CQ remain per connection.
- Add active-HCA discovery, explicit local whitelists, NUMA-aware selection, bounded connection pools, idle reclaim, and an interruptible shutdown path.
- Add true windowed scalar/SG/batch PUT, GET, Range and Exist paths with strict in-order replies.
- Keep the default build portable: `DFKV_WITH_RDMA=OFF` has no verbs dependency and retains TCP behavior.

The design borrows the proven memory-registration, single-sided payload, topology, and submit/wait principles from Mooncake Transfer Engine without importing Mooncake Store's master/replica/object semantics into dfkv's existing MDS + consistent-hash architecture.

## Protocol and compatibility

The existing device bootstrap frame gains an optional versioned DCP tail:

- legacy/plain and DCP1 connections use RDMA v1 SEND/RECV;
- DCP2 requests v2 and carries the declared max block geometry;
- wire prefix, QP metadata, slot geometry, target count/capacity, opcode, immediate flag, and completion byte length are validated fail-closed;
- `DFKV_RDMA_PROTOCOL=1` forces client v1;
- `DFKV_RDMA_SERVER_PROTOCOL=1` forces server v1;
- `auto-v2` falls back by creating a fresh v1 connection, never by changing protocol on a live QP.

An explicit `DFKV_RDMA_DEV` is treated as a hard local fabric selection in both RDMA and TCP-only builds: an unsatisfied whitelist returns no transport instead of silently using TCP. Without a whitelist, each peer independently selects its first ACTIVE local HCA; host-local HCA names are not assumed to be peer identities.

## Memory and lifetime model

- `RecvSegment` allocates aligned `depth * slot_size` leases from one process-wide region.
- Startup anchor endpoints register that region once on every selected shared PD.
- Pool MRs are PD-owned and survive individual connection reclaim.
- API-owned buffers use transient MRs, released after the corresponding completion; endpoint teardown owns failed/timed-out cleanup.
- Read-only Cache sources are registered without remote/local-write requirements.
- RAM-hit pins are released only on the signaled SEND completion, after all prior unsignaled WRITEs on that QP.
- Server `Stop()` wakes CQ waiters and joins all Serve threads before owner destruction.

## Capacity and observability

The v2 slot geometry is:

```
slot_size = align4K(4096 + sizeof(ValueHeader) + max(declared_block, 4096))
```

The shared-segment budget is approximately:

```
slot_size * negotiated_depth * (active + pooled data connections)
```

New metrics expose v1/v2 connections, v2 PUT/GET writes, per-rail connections, pool/ad-hoc MR usage, registered receive-segment rails/free bytes, completion errors, active connections, and idle reclaims. Documentation includes rollout, rollback, memlock, NUMA and sizing guidance.

## Validation

Final branch was rebased onto `upstream/main@eadb3fd` and verified as follows:

- `DFKV_WITH_RDMA=ON` Debug build on a real ConnectX host: **464/464 CTest passed**.
- `DFKV_WITH_RDMA=OFF` Debug build: **406/406 CTest passed**.
- ThreadSanitizer RDMA protocol/segment/loopback matrix: **40/40 passed**.
- Two independent final reviews found no remaining blocking protocol or integration findings.
- Python syntax check passed for the rebased vLLM connector files.

TSan note: the unchanged baseline `RamTier` destructor emits a GNU 11 TSan `double lock` diagnostic for its condition-variable stop/join sequence. `RdmaLoopback.RamTierZeroCopyServe` is therefore covered by the normal 464-test ConnectX run and excluded from the 40-test race matrix; this patch does not modify `ram_tier.{h,cc}`.

## Rollout

1. Upgrade servers while forcing `DFKV_RDMA_SERVER_PROTOCOL=1`; restart all changed server processes.
2. Remove the force-v1 setting, restart servers, and verify segment/connection metrics.
3. Enable `auto-v2` on one client process, restart it, and verify v2 write/connection counters plus zero completion errors.
4. Expand by rank/node.
5. Roll back by forcing v1 and restarting every affected client/server. Removing the force variables also requires restarts because existing pooled QPs never renegotiate.
