### PR TITLE
feat(mds): optional legacy v1 control-plane framing for mixed-generation rollout

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -110,6 +110,14 @@ journalctl -u dfkv_mds -n 5 --no-pager   # 应见 "dfkv_mds listening on 9400, e
 > 立即返回 503，使 scheduler 摘除该 MDS；etcd 恢复后同一进程自动回到 200。
 > `dfkv_mds` 不因运行期 etcd 短暂故障退出。
 
+> **混合代际滚动（v1.x ↔ v2）**：`DFKV_MDS_ACCEPT_LEGACY=1` 把 MDS 控制面版本闸
+> 按已知 epoch 放宽一档——v1.x 节点/客户端以旧 42/10 字节帧直接被服务（操作码、
+> MemberInfo 载荷、etcd schema、租约语义跨代一致，status 字节按 v1 枚举顺序回声）。
+> 默认关闭 = 历史严格行为（旧 epoch 帧立即拒连）。这**只打通 MDS 控制面**：数据面
+> 仍严格 epoch 6/7，v1/v2 节点与客户端必须各属一个 group（环级隔离），客户端版本
+> 跟随自己的环。迁移期配好后用 `dfkv_mds_legacy_frames_total` 观察旧流量，归零后
+> 撤掉该 env 恢复严格模式。
+
 
 ## 3. 每节点：systemd unit
 如启用示例 quota 文件，先创建（已存在时绝不覆盖）：

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -172,6 +172,7 @@ RAM 热层（**仅 `DFKV_RAM_TIER=1` 时输出**；关时无此系列，向后�
 | `dfkv_mds_members` | gauge | 上次 List 返回的成员数 |
 | `dfkv_mds_local_member_leases` / `dfkv_mds_local_client_leases` | gauge | 本 MDS 进程当前缓存的 member/client lease shortcut 数；只是 etcd 权威状态的有界优化 |
 | `dfkv_mds_local_member_leases_pruned_total` / `dfkv_mds_local_client_leases_pruned_total` | counter | 因多个 TTL 未在本 MDS 使用而丢弃的本地 shortcut；churn 下增长正常，下次心跳会 fresh grant+Put |
+| `dfkv_mds_legacy_frames_total` | counter | 以 v1.x 旧控制面帧（42/10 字节帧）服务的请求数；仅在 `DFKV_MDS_ACCEPT_LEGACY=1` 的混合代际迁移期出现，**归零后应撤掉该 env** |
 
 ### 3.3 客户端（SGLang 插件 /metrics，经 prometheus_client）
 插件后台轮询线程读 C 客户端快照（`client_stats_poll_s`，默认 10s，0=关）并镜像为带 `{tp_rank}` 的 Counter：

--- a/src/mds/mds_metrics.h
+++ b/src/mds/mds_metrics.h
@@ -30,6 +30,11 @@ struct MdsMetrics {
   std::atomic<uint64_t> local_client_leases{0};
   std::atomic<uint64_t> local_member_leases_pruned{0};
   std::atomic<uint64_t> local_client_leases_pruned{0};
+  // Mixed-generation rollout visibility: control frames accepted in the
+  // legacy v1.x control-plane encoding (wire_legacy.h). Operators watch this
+  // drain to zero as the last v1 ring retires, then drop
+  // DFKV_MDS_ACCEPT_LEGACY.
+  std::atomic<uint64_t> legacy_frames{0};
 
   std::string Render() const {
     std::string s;
@@ -60,6 +65,7 @@ struct MdsMetrics {
     m("dfkv_mds_local_client_leases", "gauge", "Client lease shortcuts currently cached in this MDS process", ld(local_client_leases));
     m("dfkv_mds_local_member_leases_pruned_total", "counter", "Idle member lease shortcuts discarded locally", ld(local_member_leases_pruned));
     m("dfkv_mds_local_client_leases_pruned_total", "counter", "Idle client lease shortcuts discarded locally", ld(local_client_leases_pruned));
+    m("dfkv_mds_legacy_frames_total", "counter", "Control frames served in the legacy v1.x control-plane encoding", ld(legacy_frames));
     return s;
   }
 };

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -16,6 +16,7 @@
 #include "utils/thread_name.h"
 #include "utils/wire_limits.h"
 #include "transport/wire.h"
+#include "transport/wire_legacy.h"
 
 namespace dfkv {
 
@@ -429,12 +430,33 @@ std::string MdsServer::GroupMetricsText() {
 
 void MdsServer::Handle(int fd) {
   while (running_) {
+    // Control-plane epoch discrimination for mixed-generation rollouts. The
+    // leading byte is the deterministic discriminator: native v2 peers write
+    // a 50-byte prefix, legacy v1.x peers a 42-byte one. Unknown epochs still
+    // fail closed — the deliberate fast-reject version gate is widened by one
+    // known epoch (via DFKV_MDS_ACCEPT_LEGACY), not removed. Data-plane
+    // listeners stay strictly epoch-6/7; this shim exists only in the MDS.
     char prefix[kReqPrefix];
-    if (!net::ReadAll(fd, prefix, kReqPrefix)) return;
+    if (!net::ReadAll(fd, prefix, 1)) return;
+    const uint8_t epoch = static_cast<uint8_t>(prefix[0]);
+    bool legacy = false;
     ReqFields rq;
     // MDS frames carry a group name + one MemberInfo (<1 KiB); cap the
     // declared length so a forged prefix can't trigger a giant allocation.
-    if (!DecodeReq(prefix, &rq, wire_limits::kMdsMaxReqPayload)) return;
+    if (epoch == kNativeProtoTcp) {
+      if (!net::ReadAll(fd, prefix + 1, kReqPrefix - 1) ||
+          !DecodeReq(prefix, &rq, wire_limits::kMdsMaxReqPayload)) {
+        return;
+      }
+    } else {
+      if (!accept_legacy_ || epoch != kNativeProtoLegacyTcp) return;
+      if (!net::ReadAll(fd, prefix + 1, kLegacyReqPrefix - 1) ||
+          !DecodeLegacyReq(prefix, &rq, wire_limits::kMdsMaxReqPayload)) {
+        return;
+      }
+      legacy = true;
+      metrics_.legacy_frames.fetch_add(1, std::memory_order_relaxed);
+    }
     std::vector<char> payload(rq.payload_len);
     if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
 
@@ -473,8 +495,16 @@ void MdsServer::Handle(int fd) {
     }
 
     char rp[kRespPrefix];
-    EncodeResp(rp, st, data.size());
-    if (!net::WriteAll(fd, rp, kRespPrefix)) return;
+    size_t rp_len = kRespPrefix;
+    if (legacy) {
+      // v1.x peers expect a 10-byte prefix and the v1 status byte order
+      // (kIOError=3); the response data itself is generation-neutral.
+      EncodeLegacyResp(rp, st, data.size());
+      rp_len = kLegacyRespPrefix;
+    } else {
+      EncodeResp(rp, st, data.size());
+    }
+    if (!net::WriteAll(fd, rp, rp_len)) return;
     if (!data.empty() && !net::WriteAll(fd, data.data(), data.size())) return;
   }
 }

--- a/src/mds/mds_server.h
+++ b/src/mds/mds_server.h
@@ -14,6 +14,7 @@
 #include "mds/etcd_client.h"
 #include "utils/http_client.h"
 #include "common/status.h"
+#include "common/config_dump.h"
 #include "mds/mds_metrics.h"
 #include "common/membership.h"
 
@@ -53,8 +54,13 @@ class LocalLeaseMap {
 // the MDS keeps no durable state. Liveness = the lease (TTL kTtlSeconds).
 class MdsServer {
  public:
+  // DFKV_MDS_ACCEPT_LEGACY (default off) widens the control-plane version
+  // gate by exactly one epoch: v1.x peers are served with the legacy
+  // 42/10-byte framing via wire_legacy.h. Off = historic strict behavior.
   explicit MdsServer(const std::string& etcd_addr, int etcd_timeout_ms = 2000)
-      : http_(etcd_addr, etcd_timeout_ms), etcd_(&http_) {}
+      : http_(etcd_addr, etcd_timeout_ms),
+        etcd_(&http_),
+        accept_legacy_(config_dump::EnvBool("DFKV_MDS_ACCEPT_LEGACY", false)) {}
   ~MdsServer();
 
   Status Start(int port);
@@ -106,6 +112,9 @@ class MdsServer {
 
   TcpHttpTransport http_;
   EtcdClient etcd_;
+  // Resolved once at ctor; widens Handle()'s control-plane version gate by
+  // the single legacy epoch (v1.x peers, wire_legacy.h framing).
+  const bool accept_legacy_;
   std::atomic<bool> running_{false};
   int listen_fd_ = -1;
   int port_ = 0;

--- a/src/transport/wire_legacy.h
+++ b/src/transport/wire_legacy.h
@@ -1,0 +1,94 @@
+/* Legacy (v1.x) control-plane wire — mixed-generation rollout shim.
+ *
+ * Every v1.x release (v1.37.0..v1.40.x) speaks protocol epoch 1 on the TCP
+ * control plane (v1 wire.h, kProtoVersion = 1): a 42-byte request prefix
+ * (ver, op, id:u64, index:u32, size:u32, offset:u64, length:u64,
+ * payload_len:u64) and a 10-byte response prefix (ver, status, data_len).
+ * The v2 data plane stays strictly epoch-6/7; these helpers exist so the
+ * MDS can serve BOTH control-plane generations during a ring-level
+ * migration (one group per generation — the shim never lets a v1 peer
+ * route data to a v2 node or vice versa).
+ *
+ * Only the FRAMING differs; op codes, the group+MemberInfo payloads, the
+ * etcd key/value encoding and the lease contract are identical across
+ * generations (see src/common/membership.h, unchanged).
+ *
+ * Status byte caveat: v2 inserted kQuotaExceeded at 3, shifting kIOError to
+ * 4. All legacy peers (v1.37..v1.40.x, incl. v1.40.x clients) decode
+ * {0=kOk, 1=kNotFound, 2=kCacheFull, 3=kIOError, 4=kInvalid}. Legacy
+ * responses therefore map v2 statuses back onto the v1 enum; kQuotaExceeded
+ * never occurs on MDS op paths and folds to kIOError for byte sanity.
+ */
+#ifndef DFKV_WIRE_LEGACY_H_
+#define DFKV_WIRE_LEGACY_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "common/status.h"
+#include "transport/wire.h"    // ReqFields, kMaxFrameLen
+#include "utils/net_util.h"    // net::PutU64/PutU32/GetU64
+
+namespace dfkv {
+
+// Control-plane epoch of every v1.x release.
+constexpr uint8_t kNativeProtoLegacyTcp = 1;
+
+// Legacy request prefix: ver(1) op(1) id(8) index(4) size(4) offset(8)
+//                        length(8) payload_len(8)
+constexpr size_t kLegacyReqPrefix = 1 + 1 + 8 + 4 + 4 + 8 + 8 + 8;  // = 42
+// Legacy response prefix: ver(1) status(1) data_len(8)
+constexpr size_t kLegacyRespPrefix = 1 + 1 + 8;  // = 10
+
+// Encoder used by tests/benchmarks to synthesize legacy peers; production
+// code only ever *decodes* legacy frames.
+inline void EncodeLegacyReq(char* p, WireOp op, uint64_t payload_len) {
+  p[0] = static_cast<char>(kNativeProtoLegacyTcp);
+  p[1] = static_cast<char>(op);
+  net::PutU64(p + 2, 0);   // v1 BlockKey.id
+  net::PutU32(p + 10, 0);  // v1 BlockKey.index
+  net::PutU32(p + 14, 0);  // v1 BlockKey.size
+  net::PutU64(p + 18, 0);  // offset
+  net::PutU64(p + 26, 0);  // length
+  net::PutU64(p + 34, payload_len);
+}
+
+// Fills the shared ReqFields shape; false on epoch mismatch or an oversized
+// declared payload (caller drops the connection). The v1 id/index/size key
+// fields are deliberately NOT decoded: MDS control ops are key-free, and the
+// data plane — the only consumer of keys — rejects legacy epochs outright.
+inline bool DecodeLegacyReq(const char* p, ReqFields* o,
+                            uint64_t max_payload = kMaxFrameLen) {
+  if (static_cast<uint8_t>(p[0]) != kNativeProtoLegacyTcp) return false;
+  o->op = static_cast<uint8_t>(p[1]);
+  o->tenant_hash = 0;
+  o->digest_hi = 0;
+  o->digest_lo = 0;
+  o->offset = 0;
+  o->length = 0;
+  o->payload_len = net::GetU64(p + 34);
+  return o->payload_len <= max_payload;
+}
+
+// v2 status -> v1 enum byte (see the header comment for the enum shift).
+inline uint8_t LegacyStatusByte(Status st) {
+  switch (st) {
+    case Status::kOk: return 0;
+    case Status::kNotFound: return 1;
+    case Status::kCacheFull: return 2;
+    case Status::kQuotaExceeded: return 3;  // v2-only; folds into legacy kIOError
+    case Status::kIOError: return 3;
+    case Status::kInvalid: return 4;
+  }
+  return 4;
+}
+
+inline void EncodeLegacyResp(char* p, Status st, uint64_t data_len) {
+  p[0] = static_cast<char>(kNativeProtoLegacyTcp);
+  p[1] = static_cast<char>(LegacyStatusByte(st));
+  net::PutU64(p + 2, data_len);
+}
+
+}  // namespace dfkv
+
+#endif  // DFKV_WIRE_LEGACY_H_

--- a/test/mds/mds_dual_proto_test.cc
+++ b/test/mds/mds_dual_proto_test.cc
@@ -1,0 +1,199 @@
+// Dual-protocol MDS acceptance: with DFKV_MDS_ACCEPT_LEGACY=1 the MDS serves
+// v1.x control-plane peers using the legacy 42/10-byte framing, while native
+// v2 framing and the fail-closed epoch gate are unchanged.
+//
+// Wire-level expectations run against a dead etcd address (List ops surface
+// kIOError fast on ECONNREFUSED), so only the framing is exercised. The one
+// functional cross-protocol round-trip is gated on DFKV_TEST_ETCD like the
+// rest of the MDS suite.
+#include "mds/mds_server.h"
+#include "mds/mds_proto.h"
+#include "common/membership.h"
+#include "transport/wire.h"
+#include "transport/wire_legacy.h"
+#include "utils/net_util.h"
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <string>
+#include <vector>
+using namespace dfkv;  // NOLINT
+
+namespace {
+const char* EtcdEp() { return std::getenv("DFKV_TEST_ETCD"); }
+constexpr const char* kDeadEtcd = "127.0.0.1:59999";  // nothing listens: instant ECONNREFUSED
+constexpr uint64_t kTestMaxResp = 64ull << 20;
+
+// Legacy v1.x status byte order (v1.37..v1.40.x status.h — no kQuotaExceeded).
+constexpr uint8_t kLegacyOk = 0;
+constexpr uint8_t kLegacyIOError = 3;
+
+void EnableLegacy() { ::setenv("DFKV_MDS_ACCEPT_LEGACY", "1", 1); }
+void DisableLegacy() { ::unsetenv("DFKV_MDS_ACCEPT_LEGACY"); }
+
+bool DoLegacyReq(int port, WireOp op, const std::string& payload, uint8_t* ver,
+                 uint8_t* status, std::string* data) {
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 2000, 5000);
+  if (fd < 0) return false;
+  char pre[kLegacyReqPrefix];
+  EncodeLegacyReq(pre, op, payload.size());
+  bool ok = net::WriteAll(fd, pre, kLegacyReqPrefix) &&
+            (payload.empty() || net::WriteAll(fd, payload.data(), payload.size()));
+  if (ok) {
+    char rp[kLegacyRespPrefix];
+    if (!net::ReadAll(fd, rp, kLegacyRespPrefix)) {
+      ok = false;
+    } else {
+      *ver = static_cast<uint8_t>(rp[0]);
+      *status = static_cast<uint8_t>(rp[1]);
+      const uint64_t dlen = net::GetU64(rp + 2);
+      if (dlen > kTestMaxResp) {
+        ok = false;
+      } else {
+        data->resize(dlen);
+        ok = dlen == 0 || net::ReadAll(fd, &(*data)[0], dlen);
+      }
+    }
+  }
+  ::close(fd);
+  return ok;
+}
+
+bool DoNativeReq(int port, WireOp op, const std::string& payload, Status* st,
+                 std::string* data) {
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 2000, 5000);
+  if (fd < 0) return false;
+  char pre[kReqPrefix];
+  EncodeReq(pre, op, BlockKey{}, 0, 0, payload.size());
+  bool ok = net::WriteAll(fd, pre, kReqPrefix) &&
+            (payload.empty() || net::WriteAll(fd, payload.data(), payload.size()));
+  if (ok) {
+    char rp[kRespPrefix];
+    if (!net::ReadAll(fd, rp, kRespPrefix)) {
+      ok = false;
+    } else {
+      uint64_t dlen = 0;
+      if (!DecodeResp(rp, st, &dlen, kTestMaxResp)) {
+        ok = false;
+      } else {
+        data->resize(dlen);
+        ok = dlen == 0 || net::ReadAll(fd, &(*data)[0], dlen);
+      }
+    }
+  }
+  ::close(fd);
+  return ok;
+}
+}  // namespace
+
+TEST(MdsDualProto, LegacyFrameGetsLegacyResponseWhenEnabled) {
+  EnableLegacy();
+  MdsServer mds(kDeadEtcd);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+
+  uint8_t ver = 0, status = 0;
+  std::string data;
+  // ListGroups hits etcd, fails, and answers with a legacy-encoded kIOError.
+  ASSERT_TRUE(DoLegacyReq(mds.port(), WireOp::kListGroups, "", &ver, &status, &data));
+  EXPECT_EQ(ver, kNativeProtoLegacyTcp);
+  EXPECT_EQ(status, kLegacyIOError);
+  EXPECT_TRUE(data.empty());
+  // The legacy frame counter is the migration-drain observable.
+  EXPECT_NE(mds.MetricsText().find("dfkv_mds_legacy_frames_total 1"),
+            std::string::npos);
+  mds.Stop();
+}
+
+TEST(MdsDualProto, NativeFrameStillGetsNativeResponse) {
+  EnableLegacy();
+  MdsServer mds(kDeadEtcd);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+
+  Status st = Status::kOk;
+  std::string data;
+  ASSERT_TRUE(DoNativeReq(mds.port(), WireOp::kListGroups, "", &st, &data));
+  EXPECT_EQ(st, Status::kIOError);
+  mds.Stop();
+}
+
+TEST(MdsDualProto, LegacyFrameRejectedWhenDisabled) {
+  DisableLegacy();
+  MdsServer mds(kDeadEtcd);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+
+  uint8_t ver = 0, status = 0;
+  std::string data;
+  // Historic strict behavior: no reply, connection dropped.
+  EXPECT_FALSE(DoLegacyReq(mds.port(), WireOp::kListGroups, "", &ver, &status, &data));
+  mds.Stop();
+}
+
+TEST(MdsDualProto, UnknownEpochClosesConnection) {
+  EnableLegacy();
+  MdsServer mds(kDeadEtcd);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+
+  int fd = net::Dial("127.0.0.1:" + std::to_string(mds.port()), 2000, 5000);
+  ASSERT_GE(fd, 0);
+  char garbage = static_cast<char>(0x09);
+  ASSERT_TRUE(net::WriteAll(fd, &garbage, 1));
+  char x = 0;
+  EXPECT_FALSE(net::ReadAll(fd, &x, 1));
+  ::close(fd);
+  mds.Stop();
+}
+
+// The money test: a member registered over the legacy protocol must be
+// visible to a native-protocol client, and vice versa — op dispatch, payload
+// codec, etcd schema and lease contract are generation-shared.
+TEST(MdsDualProto, LegacyRegisterListCrossProtocolRoundTrip) {
+  const char* ep = EtcdEp();
+  if (!ep) GTEST_SKIP() << "set DFKV_TEST_ETCD=host:port";
+  EnableLegacy();
+  MdsServer mds(ep);
+  ASSERT_EQ(mds.Start(0), Status::kOk);
+  const int port = mds.port();
+  const std::string group = "itest-dual-" + std::to_string(port);
+
+  const MemberInfo legacy_node{"legacy-n1", "10.1.1.1", 28000, 1};
+  const MemberInfo native_node{"native-n2", "10.1.1.2", 28000, 3};
+
+  uint8_t ver = 0, status = 0;
+  std::string data;
+  ASSERT_TRUE(DoLegacyReq(port, WireOp::kRegister,
+                          EncodeMemberReq(group, legacy_node), &ver, &status, &data));
+  EXPECT_EQ(ver, kNativeProtoLegacyTcp);
+  EXPECT_EQ(status, kLegacyOk);
+  ASSERT_TRUE(DoLegacyReq(port, WireOp::kHeartbeat,
+                          EncodeMemberReq(group, legacy_node), &ver, &status, &data));
+  EXPECT_EQ(status, kLegacyOk);
+
+  Status st = Status::kOk;
+  ASSERT_TRUE(DoNativeReq(port, WireOp::kRegister,
+                          EncodeMemberReq(group, native_node), &st, &data));
+  EXPECT_EQ(st, Status::kOk);
+
+  // Native list sees both generations with placement intact.
+  ASSERT_TRUE(DoNativeReq(port, WireOp::kListMembers, group, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  std::vector<MemberInfo> got;
+  uint64_t epoch = 0;
+  ASSERT_TRUE(DecodeMembers(data.data(), data.size(), &got, &epoch));
+  EXPECT_GT(epoch, 0u);
+  ASSERT_EQ(got.size(), 2u);
+  bool saw_legacy = false, saw_native = false;
+  for (const auto& m : got) {
+    if (m == legacy_node) saw_legacy = true;
+    if (m == native_node) saw_native = true;
+  }
+  EXPECT_TRUE(saw_legacy);
+  EXPECT_TRUE(saw_native);
+
+  // Legacy list sees the same ring in the legacy framing.
+  ASSERT_TRUE(DoLegacyReq(port, WireOp::kListMembers, group, &ver, &status, &data));
+  ASSERT_EQ(ver, kNativeProtoLegacyTcp);
+  ASSERT_EQ(status, kLegacyOk);
+  ASSERT_TRUE(DecodeMembers(data.data(), data.size(), &got, &epoch));
+  EXPECT_EQ(got.size(), 2u);
+  mds.Stop();
+}


### PR DESCRIPTION
## Problem

v2 wire epochs hard-reject v1.x peers: the TCP data plane only accepts epoch 6 frames and RDMA only epoch 7 (`src/transport/wire.h`), and the MDS shares the data-plane framing, so its `DecodeReq` drops v1.x control-plane frames the same way. In a mixed-generation fleet that means an in-place MDS upgrade silently severs the v1.x control plane: heartbeats from v1.x nodes are rejected, etcd leases expire (~30 s), and every v1.x client's `ListMembers` fails — the MDS still reports `readyz=200` while each ring freezes into its stale membership view. Rings migrate node-by-node and client-by-client over days, so the control plane needs to serve **both** generations during the transition window.

## What this does

`DFKV_MDS_ACCEPT_LEGACY=1` (default **off**) widens the MDS control-plane version gate by exactly one known epoch. When enabled, the MDS accepts v1.x-framed control requests (legacy 42-byte request prefix, epoch byte 1) and answers them with legacy 10-byte responses; native epoch-6 peers are unaffected, and unknown epochs still fail closed.

This is deliberately a *framing-only* shim. The two generations already share everything else:

- identical `WireOp` numbering (`kRegister`/`kHeartbeat`/`kListMembers`/`kClientRegister`/…, ops 1–13 in both);
- byte-identical `src/common/membership.h` (MemberInfo, `Encode/DecodeMembers`, leased etcd value encoding, epoch computation) — unchanged since v1.37.0;
- identical etcd key schema (`/dfkv/v1/groups/<g>/{members,clients}/<id>`) and the 30 s lease + keepalive/re-Put contract.

One real incompatibility exists and is handled: the `Status` wire order shifted (v2 inserted `kQuotaExceeded` at 3). Legacy peers decode `kIOError` as byte 3, so legacy responses map v2 statuses back onto the v1 enum (`LegacyStatusByte`).

Implementation: leading-byte discrimination in `MdsServer::Handle` (read 1 byte → read the matching 41/49-byte rest-of-prefix → shared payload decode and dispatch), response echoed in the negotiated version, plus a `dfkv_mds_legacy_frames_total` counter and a config-dump record. The counter is the retirement trigger: when it reads zero after the last v1 ring is retired, the env can be dropped and the MDS returns to strict single-epoch behavior.

## Boundaries (unchanged)

- The **data plane stays strictly epoch 6/7** — a v1.x client can never be routed to a v2 cache node or vice versa; v1 and v2 nodes MUST live in separate groups, exactly as before.
- This shim does not bridge key formats, on-disk layouts, or client libraries; client-side generation still follows its own ring.
- Off (default) preserves historic strict behavior byte-for-byte.

## Testing

New `test/mds/mds_dual_proto_test.cc` (5 tests):

- legacy frame accepted and answered in legacy framing when enabled;
- legacy frame rejected without reply when the env is unset;
- unknown epoch byte closes the connection;
- native framing/response unchanged with the shim enabled;
- cross-protocol functional round trip on real etcd v3.5.17: member registered + heartbeated via the **legacy** protocol is visible via **native** `ListMembers`, and vice versa (mixed register, placement intact, epoch>0).

Full suite: **536/536 CTest pass** (hardware-gated suites skipped as on any dev host); the pre-existing `mds_server_test` passes 14/14 against real etcd with no regressions.

End-to-end with real v1.37.0 binaries: a v1.37.0 `dfkv_server` registers and heartbeats into this MDS (INFO `ver=1.37.0` passes through); `dfkvctl ring` built from v1.37.0 and from this tree list the same ring with identical placement; `dfkv_mds_legacy_frames_total` counts legacy traffic; and an MDS started without the env rejects the v1.37.0 `dfkvctl` (exit 1).

## Notes for reviewers

- The shim is one branch in `Handle()` plus the new `wire_legacy.h`; no payload, op-dispatch, etcd, or lease changes.
- Flag semantics are opt-in on purpose: the epoch gate is a deliberate fail-fast property, so widening it must be a declared migration posture, recorded in the startup config dump and collapsible once `dfkv_mds_legacy_frames_total` drains to zero.
