### PR TITLE
fix: resolve 17 post-merge review findings (correctness + hardening)

### DIFF
--- a/deploy/dfkv_node_replace.py
+++ b/deploy/dfkv_node_replace.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import re
 import shlex
+import subprocess
 import sys
 import time
 from dataclasses import asdict
@@ -83,7 +84,9 @@ class Replacer:
                 if value:
                     return value
                 last_error = "condition was false"
-            except (RuntimeError, ValueError) as error:
+            # Command timeouts and transient SSH/OS failures retry like any
+            # other pollable error; the deadline above still bounds total wait.
+            except (OSError, RuntimeError, ValueError, subprocess.TimeoutExpired) as error:
                 last_error = str(error)
             time.sleep(self.args.poll_interval)
         raise WorkflowError(f"timeout after {self.args.timeout}s waiting for {description}: {last_error}")

--- a/deploy/dfkv_node_replace.py
+++ b/deploy/dfkv_node_replace.py
@@ -124,7 +124,26 @@ class Replacer:
 
     def rollback(self, reason: BaseException) -> None:
         if not self.old_stopped:
-            self.record("abort", f"old node was never stopped; safe abort: {reason}")
+            if not self.started_new:
+                self.record("abort", f"old node was never stopped; safe abort: {reason}")
+                return
+            # The replacement may be running and registered in the ring even
+            # when its start command timed out locally; silently aborting
+            # would leave an unplanned member. Stop it best-effort, mirroring
+            # the old-node restart below.
+            self.record(
+                "rollback",
+                f"failure after replacement start; stopping {self.args.new_id} on {self.args.new_host}: {reason}",
+            )
+            try:
+                self.remote(self.args.new_host, "stop")
+                self.record("rollback", "replacement stopped; ring back to old-only membership")
+            except BaseException as rollback_error:
+                raise WorkflowError(
+                    f"replacement failed ({reason}); CRITICAL stopping the just-started replacement also failed "
+                    f"({rollback_error}); replacement may still be registered in the ring; "
+                    f"stop {self.args.service} on {self.args.new_host} manually"
+                ) from rollback_error
             return
         self.record("rollback", f"failure after old-node stop; restarting {self.args.old_id}: {reason}")
         try:
@@ -166,8 +185,11 @@ class Replacer:
 
         if not new_present:
             self.record("join", f"starting replacement {self.args.new_id} on {self.args.new_host}")
-            self.remote(self.args.new_host, "start")
+            # Mark replacement-started before SSH: a remote systemctl may
+            # succeed even when the local SSH command times out or is
+            # interrupted, mirroring the old-node stop marking below.
             self.started_new = True
+            self.remote(self.args.new_host, "start")
             if self.args.dry_run:
                 self.record("dry-run", f"would wait up to {self.args.timeout}s for replacement membership/readiness")
                 self.record("dry-run", f"would stop {self.args.old_id}, observe lease expiry, and verify clients")

--- a/integration/lmcache/src/dfkv_connector/native_client.py
+++ b/integration/lmcache/src/dfkv_connector/native_client.py
@@ -121,17 +121,44 @@ def _native_version(lib: ctypes.CDLL) -> str:
 
 
 def _mv_ptr(mv: memoryview) -> Tuple[int, Any]:
-    """Return ``(address, keepalive)`` for a memoryview buffer.
+    """Return ``(address, keepalive)`` for a PUT source buffer.
 
     Zero-copy for a writable, C-contiguous buffer (the common case — every
     MemoryObj byte_array is a slice of LMCache's pinned arena). A read-only
     buffer can't be aliased by ctypes, so we copy into a ctypes array (rare;
     correctness over zero-copy). The keepalive must outlive the C call.
+
+    Source buffers only: the copy fallback is safe here because the copy
+    *carries* the bytes towards dfkv. GET destinations must go through
+    :func:`_mv_dst_ptr` instead, where the same fallback would silently
+    drop the fetched payload.
     """
     try:
         arr = (ctypes.c_char * mv.nbytes).from_buffer(mv)
     except (TypeError, ValueError):
         arr = (ctypes.c_char * mv.nbytes).from_buffer_copy(mv)
+    return ctypes.addressof(arr), arr
+
+
+def _mv_dst_ptr(mv: memoryview) -> Tuple[int, Any]:
+    """Return ``(address, keepalive)`` for a GET destination buffer.
+
+    No copy fallback here, by design: the native call writes the fetched
+    bytes into the buffer we hand over, so a ``from_buffer_copy`` staging
+    array would leave the payload in a discarded temporary while
+    ``out_hit`` still reports a hit — the caller would then return stale
+    arena bytes as a hit. Destinations must be writable, C-contiguous
+    buffers (LMCache arena slices always are); anything else fails loudly
+    so the caller treats the op as a miss rather than a hit.
+    """
+    try:
+        arr = (ctypes.c_char * mv.nbytes).from_buffer(mv)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "dfkv GET destination must be a writable, C-contiguous buffer "
+            f"(readonly={mv.readonly}, c_contiguous={mv.c_contiguous}, "
+            f"nbytes={mv.nbytes})"
+        ) from exc
     return ctypes.addressof(arr), arr
 
 
@@ -290,7 +317,9 @@ class DfkvNativeClient:
         ptrs: List[int] = []
         keepalive: List[Any] = []
         for mv in bufs:
-            p, ka = _mv_ptr(mv)
+            # Destination buffers: never the copy fallback of _mv_ptr —
+            # fetched bytes must land in the caller's own buffer.
+            p, ka = _mv_dst_ptr(mv)
             ptrs.append(p)
             keepalive.append(ka)
         parr = (c_void_p * n)(*[c_void_p(p) for p in ptrs])

--- a/integration/lmcache/tests/test_native_client.py
+++ b/integration/lmcache/tests/test_native_client.py
@@ -189,3 +189,73 @@ def test_register_memory_surfaces_native_mr_failure():
         assert "dfkv_register_memory(base=0x1000, size=4096) rc=-1" == str(exc)
     else:
         raise AssertionError("MR registration failure was not surfaced")
+
+
+def test_batch_get_rejects_readonly_destination_before_native_call():
+    keys = [b"k"]
+    called = []
+
+    class FakeLib:
+        def dfkv_batch_get_auto(self, *args):
+            called.append(args)
+            return 0
+
+    client = object.__new__(DfkvNativeClient)
+    client._lib = FakeLib()
+    client._h = 0xBEEF
+    try:
+        client._batch_get_blocking(keys, [memoryview(b"abc")])
+    except ValueError as exc:
+        assert "writable, C-contiguous" in str(exc)
+    else:
+        raise AssertionError("read-only GET destination was not rejected")
+    # Fail before the native call: a hit can never be manufactured for a
+    # destination the payload cannot land in.
+    assert called == []
+
+
+def test_batch_get_rejects_strided_destination_before_native_call():
+    keys = [b"k"]
+    called = []
+
+    class FakeLib:
+        def dfkv_batch_get_auto(self, *args):
+            called.append(args)
+            return 0
+
+    client = object.__new__(DfkvNativeClient)
+    client._lib = FakeLib()
+    client._h = 0xBEEF
+    # Writable but not C-contiguous: the old copy fallback would alias it
+    # into a discarded temporary and still report out_hit=1.
+    strided = memoryview(bytearray(8))[::2]
+    assert not strided.c_contiguous and not strided.readonly
+    try:
+        client._batch_get_blocking(keys, [strided])
+    except ValueError as exc:
+        assert "writable, C-contiguous" in str(exc)
+    else:
+        raise AssertionError("strided GET destination was not rejected")
+    assert called == []
+
+
+def test_batch_set_still_ships_readonly_source_via_copy_fallback():
+    keys = [b"k"]
+    payload = b"ab\x00c"
+
+    class FakeLib:
+        def dfkv_batch_put(
+            self, _h, key_ptrs, key_lens, ptrs, sizes, n, out,
+        ):
+            assert n == 1
+            assert ctypes.string_at(key_ptrs[0], key_lens[0]) == keys[0]
+            # The copy fallback must carry the source bytes to dfkv.
+            assert ctypes.string_at(ptrs[0], sizes[0]) == payload
+            out[0] = 1
+            return 0
+
+    client = object.__new__(DfkvNativeClient)
+    client._lib = FakeLib()
+    client._h = 0xBEEF
+    assert client._batch_set_blocking(keys, [memoryview(payload)]) == (
+        True, [True])

--- a/integration/vllm/src/dfkv_vllm/_cabi.py
+++ b/integration/vllm/src/dfkv_vllm/_cabi.py
@@ -92,6 +92,17 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
     ]
 
 
+    # Remove support remains capability-detected for deployments that omit the
+    # optional eviction RPC; partial-SG cleanup degrades to a no-op then.
+    if hasattr(lib, "dfkv_remove"):
+        lib.dfkv_remove.restype = c_int
+        lib.dfkv_remove.argtypes = [c_void_p, c_void_p, c_uint64]
+    if hasattr(lib, "dfkv_batch_remove"):
+        lib.dfkv_batch_remove.restype = c_int
+        lib.dfkv_batch_remove.argtypes = [
+            c_void_p, POINTER(c_void_p), POINTER(c_uint64),
+            c_int, POINTER(c_int)]
+
     lib.dfkv_transport_mode.restype = c_char_p
     lib.dfkv_transport_mode.argtypes = [c_void_p]
 

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -335,6 +335,38 @@ class DfkvDeviceClient:
             del key_owners
             return res
 
+    def supports_remove(self) -> bool:
+        """True iff the loaded libdfkv.so exposes the remove RPC (additive)."""
+        return hasattr(self._lib, "dfkv_batch_remove")
+
+    def batch_remove(self, keys: Sequence[bytes]) -> list:
+        """Drop ``keys`` from the ring. Returns ``[1|0]`` per key: 1 iff the
+        owning node confirmed the op (removed or already absent). Used for
+        best-effort cleanup of partially-stored scatter groups. Raises if the
+        lib has no remove RPC."""
+        n = len(keys)
+        if not self.supports_remove():
+            raise RuntimeError(
+                "libdfkv.so has no dfkv_batch_remove (rebuild dfkv with the "
+                "remove RPC to enable partial-SG cleanup)"
+            )
+        with _push_metrics.op("remove", num_keys=n), \
+                _push_tracing.span("batch_remove", n) as _sp, \
+                access_log("batch_remove", lambda: f"{n} keys") as r:
+            karr, klens, key_owners = make_key_array(keys)
+            out = (c_int * n)()
+            rc = self._lib.dfkv_batch_remove(
+                self._h, karr, klens, n, out)
+            if rc != 0:
+                raise RuntimeError(f"dfkv_batch_remove rc={rc}")
+            res = list(out)
+            ok = res.count(1)
+            r.result = f"ok={ok}/{n}"
+            if _sp:
+                _sp.hits = ok
+            del key_owners
+            return res
+
     def close(self) -> None:
         try:
             if getattr(self, "_stats_poller", None):

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -454,30 +454,47 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 return
 
             # Stored values use explicit scatter-group coordinates (see
-            # _group_segments_sg), so probe group 0 as the block-present proxy.
-            # Lookup uses the same proxy. Probing the bare pool key would miss
-            # every stored group and defeat deduplication.
+            # _group_segments_sg). A chunk is "stored" only when EVERY group
+            # of it is present: group 0 alone is a partial write (a sibling
+            # group failed or was evicted) whose load would fail wholesale,
+            # so it must be rewritten, not skipped in place. Lookup probes
+            # the same full set so both paths agree on "present". Probing
+            # the bare pool key would miss every stored group and defeat
+            # deduplication.
+            max_sg_segs = _sg_segs_of(self.client)
+            probe_keys: list[bytes] = []
+            probe_owner: list[int] = []
+            for i, (k, s, e) in enumerate(zip(keys, starts, ends, strict=True)):
+                for grp in range(
+                    _num_sg_groups(
+                        self.token_databases[group_indices[i]], e - s, max_sg_segs
+                    )
+                ):
+                    probe_keys.append(_sg_group_key(k, grp, max_sg_segs))
+                    probe_owner.append(i)
             save_exists_start = time.perf_counter()
             try:
-                exists_states = self.client.batch_exist(
-                    [_sg_group_key(k, 0, _sg_segs_of(self.client)) for k in keys]
-                )
+                exists_states = self.client.batch_exist(probe_keys)
             except Exception:
                 self._record_operation(
                     "save_exists",
                     save_exists_start,
-                    len(keys),
+                    len(probe_keys),
                     status="error",
-                    num_failed_keys=len(keys),
+                    num_failed_keys=len(probe_keys),
                 )
                 raise
             self._record_operation(
                 "save_exists",
                 save_exists_start,
-                len(keys),
+                len(probe_keys),
             )
+            chunk_missing = [False] * len(keys)
+            for owner, exists in zip(probe_owner, exists_states, strict=True):
+                if exists != 1:
+                    chunk_missing[owner] = True
             missing_indices = [
-                i for i, exists in enumerate(exists_states) if exists != 1
+                i for i, missing in enumerate(chunk_missing) if missing
             ]
 
             if not missing_indices:
@@ -537,7 +554,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             # per explicit scatter group. This cuts the key count ~20x
             # (25392 -> ~1242), making loads bandwidth-bound rather than
             # per-key-bound.
-            sg_keys, sg_ptrs, sg_sizes, _ = _group_segments_sg(
+            sg_keys, sg_ptrs, sg_sizes, sg_owner = _group_segments_sg(
                 keys, addrs, sizes, _sg_segs_of(self.client)
             )
             batch_bytes = sum(sum(s) for s in sg_sizes)
@@ -572,6 +589,45 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         batch_bytes,
                         _key_label(sg_keys[0]) if sg_keys else "N/A",
                     )
+                    # Scrub every sibling group key of each failed chunk so no
+                    # half-stored chunk (group 0 in, siblings out) burns ring
+                    # capacity until eviction; the dedup probe above already
+                    # refuses to call such a chunk stored. Best-effort: never
+                    # raises, skipped entirely without a remove RPC.
+                    rm_start = time.perf_counter()
+                    rm_supported, rm_attempted, rm_confirmed = (
+                        _remove_partial_sg_groups(
+                            self.client, sg_keys, sg_owner, failed
+                        )
+                    )
+                    if rm_attempted:
+                        self._record_operation(
+                            "save_remove_partial",
+                            rm_start,
+                            rm_attempted,
+                            status="ok" if rm_confirmed == rm_attempted
+                            else "partial_failure",
+                            num_failed_keys=rm_attempted - rm_confirmed,
+                        )
+                        logger.debug(
+                            "dfkv save partial-group cleanup: removed %d/%d "
+                            "sibling keys of %d failed chunk(s)",
+                            rm_confirmed,
+                            rm_attempted,
+                            len({sg_owner[i] for i in failed}),
+                        )
+                    elif not rm_supported:
+                        self._record_operation(
+                            "save_remove_partial",
+                            rm_start,
+                            0,
+                            status="unsupported",
+                        )
+                        logger.debug(
+                            "dfkv client has no remove RPC; %d failed chunk(s) "
+                            "keep partial-group residue until eviction",
+                            len({sg_owner[i] for i in failed}),
+                        )
             except Exception as e:
                 self._record_operation(
                     "save_put",
@@ -849,6 +905,62 @@ def _group_segments_sg(
             sg_owner.append(key_idx)
             grp += 1
     return sg_keys, sg_ptrs, sg_sizes, sg_owner
+
+
+# How many explicit scatter-group values _group_segments_sg emits for one
+# chunk. Probing only group 0 would treat a partially-written chunk (group 0
+# present, a sibling group lost to a failed put or eviction) as stored, so
+# dedup/lookup must enumerate this exact set to agree with SAVE/LOAD on what
+# "present" means. Layout selection mirrors data.py prepare_value: the exact
+# per-run seg layout when installed, else the legacy flat base/len tables
+# (one segment per layer per block). An unknown layout (unit-test doubles)
+# degrades to a single group -- the pre-fix probe geometry.
+def _num_sg_groups(db: Any, token_span: int, max_segs: int) -> int:
+    layout = getattr(db, "_seg_layout", None)
+    if layout is not None:
+        segs_per_block = len(layout)
+    else:
+        segs_per_block = max(
+            len(getattr(db, "kv_caches_base_addr", None) or ()),
+            len(getattr(db, "block_len", None) or ()),
+        )
+    num_segments = segs_per_block * (token_span // db.block_size)
+    return max(1, (num_segments + max_segs - 1) // max_segs)
+
+
+# Best-effort remove of every group key of each failed chunk after a partial
+# batch_put_sg: a chunk whose group 0 landed while a sibling failed is
+# half-stored -- probing alone now refuses to call it present, but the
+# orphan still burns ring capacity until eviction. Removing the whole chunk
+# makes the next save a clean full rewrite. Returns (supported, attempted,
+# confirmed); never raises and never blocks the save path. Clients without a
+# remove RPC (older libdfkv) report supported=False and are skipped.
+def _remove_partial_sg_groups(
+    client: Any,
+    sg_keys: list[bytes],
+    sg_owner: list[int],
+    failed: list[int],
+) -> tuple[bool, int, int]:
+    if not failed:
+        return False, 0, 0
+    remove = getattr(client, "batch_remove", None)
+    if remove is None:
+        return False, 0, 0
+    try:
+        supports = getattr(client, "supports_remove", None)
+        if callable(supports) and not supports():
+            return False, 0, 0
+    except Exception:
+        return False, 0, 0
+    bad_chunks = {sg_owner[i] for i in failed}
+    siblings = [k for j, k in enumerate(sg_keys) if sg_owner[j] in bad_chunks]
+    if not siblings:
+        return False, 0, 0
+    try:
+        per_key = remove(siblings)
+    except Exception:
+        return True, len(siblings), 0
+    return True, len(siblings), sum(1 for ok in per_key if ok)
 
 
 # ============================================================
@@ -1579,6 +1691,9 @@ class DfkvStoreWorker:
         # candidate_meta[i] is the (group_id, hash_bytes) for candidate_keys[i].
         candidate_keys: list[bytes] = []
         candidate_meta: list[tuple[int, bytes]] = []
+        # Per-(group_id, hash) hit count required to call the chunk present:
+        # TP*PP rank replicas x the chunk's number of scatter groups.
+        expected_per_chunk: dict[tuple[int, bytes], int] = {}
         tp_count = min(self.tp_size, self.num_kv_head)
         # dfkv: gate candidates by store_mask -- the SAME per-(group,chunk) set
         # the SAVE path stores (worker.py save gate) and the LOAD path reads
@@ -1591,6 +1706,8 @@ class DfkvStoreWorker:
             token_len // self.coord.lcm_block_size * self.coord.lcm_block_size
         )
         store_masks = self.coord.store_mask(aligned_token_len)
+        # SG width is fixed per client/transport; resolve once (cached).
+        max_sg_segs = _sg_segs_of(self.client)
         for g_idx, db in enumerate(self.token_dbs):
             spec_block_size = db.block_size
             mask = store_masks[g_idx]
@@ -1605,23 +1722,30 @@ class DfkvStoreWorker:
             tp_candidates = (
                 [db.metadata.tp_rank] if db.metadata.tp_rank < 0 else range(tp_count)
             )
-            expected_per_key = max(1, len(list(tp_candidates)) * self.pp_size)
+            rank_probes = max(1, len(list(tp_candidates)) * self.pp_size)
             for chunk_id, h in enumerate(group_hashes):
                 start_idx = chunk_id * spec_block_size
                 if start_idx >= token_len:
                     break
                 if chunk_id >= len(mask) or not mask[chunk_id]:
                     continue
+                # Probe EVERY explicit scatter group of the chunk, not just
+                # group 0: a partial write (group 0 present, a sibling group
+                # missing) must count as uncached -- the save dedup gate
+                # rewrites it and the load path needs every group to succeed.
+                n_groups = _num_sg_groups(
+                    db, min(spec_block_size, token_len - start_idx), max_sg_segs
+                )
+                expected_per_chunk[(g_idx, bytes(h))] = rank_probes * n_groups
                 for tp in tp_candidates:
                     for pp in range(self.pp_size):
                         md = dataclasses.replace(db.metadata, tp_rank=tp, pp_rank=pp)
-                        # Probe scatter group 0 so lookup agrees with the exact
-                        # SAVE/LOAD object key.
-                        candidate_keys.append(
-                            _sg_group_key(PoolKey(md, h.hex()).to_bytes(), 0,
-                                          _sg_segs_of(self.client))
-                        )
-                        candidate_meta.append((g_idx, bytes(h)))
+                        base_key = PoolKey(md, h.hex()).to_bytes()
+                        for grp in range(n_groups):
+                            candidate_keys.append(
+                                _sg_group_key(base_key, grp, max_sg_segs)
+                            )
+                            candidate_meta.append((g_idx, bytes(h)))
 
         if not candidate_keys:
             return 0
@@ -1645,12 +1769,15 @@ class DfkvStoreWorker:
             logger.error("Remote connection failed in lookup: %s", e)
             return 0
 
-        # A (group, hash) is "present" only when every TP*PP rank has it.
+        # A (group, hash) is "present" only when every TP*PP rank has every
+        # scatter group of it.
         present_count: dict[tuple[int, bytes], int] = {}
         for gh, exists in zip(candidate_meta, res, strict=True):
             if exists == 1:
                 present_count[gh] = present_count.get(gh, 0) + 1
-        exists_set = {gh for gh, c in present_count.items() if c >= expected_per_key}
+        exists_set = {
+            gh for gh, c in present_count.items() if c >= expected_per_chunk[gh]
+        }
 
         _masks, hit_length = self.coord.find_longest_cache_hit(
             block_hashes, token_len, ExternalCachedBlockPool(exists_set)

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -1597,13 +1597,22 @@ class DfkvStoreWorker:
             group_hashes = self.coord.block_hashes_for_spec(
                 block_hashes, self._kv_cache_groups[g_idx].kv_cache_spec
             )
+            # Replicated MLA stores every SAVE under the single canonical
+            # tp_rank=-1 coordinate (see metadata init): expanding to
+            # tp_rank=0..tp_count-1 would never match it. Probe the stored
+            # coordinate as-is when negative; else expand across the per-TP
+            # head coordinates used by GQA/DCP saves.
+            tp_candidates = (
+                [db.metadata.tp_rank] if db.metadata.tp_rank < 0 else range(tp_count)
+            )
+            expected_per_key = max(1, len(list(tp_candidates)) * self.pp_size)
             for chunk_id, h in enumerate(group_hashes):
                 start_idx = chunk_id * spec_block_size
                 if start_idx >= token_len:
                     break
                 if chunk_id >= len(mask) or not mask[chunk_id]:
                     continue
-                for tp in range(tp_count):
+                for tp in tp_candidates:
                     for pp in range(self.pp_size):
                         md = dataclasses.replace(db.metadata, tp_rank=tp, pp_rank=pp)
                         # Probe scatter group 0 so lookup agrees with the exact
@@ -1637,7 +1646,6 @@ class DfkvStoreWorker:
             return 0
 
         # A (group, hash) is "present" only when every TP*PP rank has it.
-        expected_per_key = max(1, tp_count * self.pp_size)
         present_count: dict[tuple[int, bytes], int] = {}
         for gh, exists in zip(candidate_meta, res, strict=True):
             if exists == 1:

--- a/integration/vllm/tests/test_dcp_lookup_geometry.py
+++ b/integration/vllm/tests/test_dcp_lookup_geometry.py
@@ -33,6 +33,7 @@ is faked, only the pure-python key/lookup math is exercised.
 
 import hashlib
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -44,8 +45,13 @@ from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
 
 from dfkv_vllm.coordinator import DfkvStoreCoordinator
-from dfkv_vllm.data import KeyMetadata, PoolKey
-from dfkv_vllm.worker import DfkvStoreWorker, SG_MAX_SEGS, _sg_group_key
+from dfkv_vllm.data import ChunkedTokenDatabase, KeyMetadata, PoolKey, ReqMeta
+from dfkv_vllm.worker import (
+    DfkvStoreWorker,
+    KVCacheStoreSendingThread,
+    SG_MAX_SEGS,
+    _sg_group_key,
+)
 
 BLOCK = 64
 NCHUNK = 64
@@ -193,3 +199,311 @@ def test_replicated_mla_lookup_misses_legacy_tp0_coordinate():
     assert hit == 0, (
         f"lookup must not probe the legacy tp_rank=0 coordinate, got {hit}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Partial scatter-group probe/heal (v2 review #14)
+#
+# A chunk is stored as G = ceil(per-layer segments / SG_MAX_SEGS) explicit
+# SG objects (_group_segments_sg): a 40-layer model with 29-wide RDMA spans
+# 2 groups (29 + 11). The pre-fix dedup/lookup probed group 0 only, so a
+# partial write (group 0 in, a sibling group lost to a failed put or
+# eviction) probed "stored": dedup skipped the rewrite, lookup counted it
+# cached, and every load of that chunk then failed wholesale -- recomputed
+# for the chunk's whole LRU lifetime while pinning ring capacity. The tests
+# below drive the REAL lookup and the REAL save thread against the fixed
+# all-group geometry.
+# ---------------------------------------------------------------------------
+
+_SG_LAYERS = SG_MAX_SEGS + 11  # segments/chunk -> exactly 2 SG groups
+_SAVE_CHUNKS = 4
+
+
+def _sg_onewire_key(md: KeyMetadata, h: BlockHash, grp: int) -> bytes:
+    return _sg_group_key(PoolKey(md, h.hex()).to_bytes(), grp, SG_MAX_SEGS)
+
+
+def _spec() -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=BLOCK,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+    )
+
+
+def _lookup_hit_tokens_sg(
+    store: set[bytes],
+    hashes: list[BlockHash],
+    md: KeyMetadata,
+    segs_per_block: int,
+) -> int:
+    # Same as _lookup_hit_tokens but the fake db carries a seg layout, so
+    # _num_sg_groups resolves multi-group chunks exactly like the real
+    # ChunkedTokenDatabase does after register_kv_caches.
+    class _FakeClient:
+        _sg_segs_cache = SG_MAX_SEGS
+
+        def __init__(self, present: set[bytes]):
+            self._present = present
+
+        def batch_exist(self, keys):
+            return [1 if k in self._present else 0 for k in keys]
+
+    groups = [
+        KVCacheGroupSpec([f"layer{i}" for i in range(segs_per_block)], _spec())
+    ]
+    coord = DfkvStoreCoordinator(
+        groups, scheduler_block_size=BLOCK, hash_block_size=BLOCK
+    )
+    self_ = SimpleNamespace(
+        coord=coord,
+        token_dbs=[
+            SimpleNamespace(
+                metadata=md,
+                block_size=BLOCK,
+                _seg_layout=[(0, 4096, 4096)] * segs_per_block,
+            )
+        ],
+        client=_FakeClient(store),
+        tp_size=8,
+        num_kv_head=1,
+        pp_size=1,
+        _kv_cache_groups=groups,
+        _record_kv_connector_operation=lambda *a, **k: None,
+    )
+    return DfkvStoreWorker.lookup(self_, NCHUNK * BLOCK, hashes)
+
+
+def test_multigroup_lookup_hits_when_all_groups_present():
+    """Both SG groups of every chunk stored -> full prefix hit. Guard: the
+    all-group probe must not LOSE coverage the group-0 probe used to see."""
+    hashes = _hashes()
+    md = _mla_md()
+    store = {_sg_onewire_key(md, h, grp) for h in hashes for grp in (0, 1)}
+    assert len(store) == 2 * NCHUNK
+    hit = _lookup_hit_tokens_sg(store, hashes, md, _SG_LAYERS)
+    assert hit == NCHUNK * BLOCK, (
+        f"all-group store must yield a full prefix, got {hit}/{NCHUNK * BLOCK}"
+    )
+
+
+def test_multigroup_lookup_misses_when_either_group_missing():
+    """Root regression (lookup side): with only ONE of the two SG groups
+    stored the chunk must NOT count as cached. The pre-fix group-0 probe
+    reported the group-0-only case as a full hit while every load of the
+    chunk failed."""
+    hashes = _hashes()
+    md = _mla_md()
+    for present_grp in (0, 1):
+        store = {_sg_onewire_key(md, h, present_grp) for h in hashes}
+        assert len(store) == NCHUNK
+        hit = _lookup_hit_tokens_sg(store, hashes, md, _SG_LAYERS)
+        assert hit == 0, (
+            f"group{present_grp}-only partial store must probe as uncached, "
+            f"got {hit}/{NCHUNK * BLOCK} tokens"
+        )
+
+
+class _FakeSaveClient:
+    """In-memory dfkv stand-in for the save thread: scripted per-key put
+    failures and a recording remove RPC."""
+
+    _sg_segs_cache = SG_MAX_SEGS
+
+    def __init__(
+        self,
+        present: set[bytes] | None = None,
+        fail_keys: set[bytes] | None = None,
+    ):
+        self._present = set(present or ())
+        self._fail_keys = set(fail_keys or ())
+        self.exist_calls: list[list[bytes]] = []
+        self.put_calls: list[list[bytes]] = []
+        self.removed: list[bytes] = []
+
+    def batch_exist(self, keys):
+        keys = list(keys)
+        self.exist_calls.append(keys)
+        return [1 if k in self._present else 0 for k in keys]
+
+    def batch_put_sg(self, keys, seg_ptrs, seg_sizes):
+        keys = list(keys)
+        self.put_calls.append(keys)
+        res = []
+        for k in keys:
+            if k in self._fail_keys:
+                res.append(1)
+            else:
+                res.append(0)
+                self._present.add(k)
+        return res
+
+    def supports_remove(self):
+        return True
+
+    def batch_remove(self, keys):
+        keys = list(keys)
+        self.removed.extend(keys)
+        for k in keys:
+            self._present.discard(k)
+        return [1] * len(keys)
+
+
+def _run_save_request(
+    client,
+    md: KeyMetadata,
+    hashes: list[BlockHash],
+    segs_per_block: int = _SG_LAYERS,
+    record_ops: list | None = None,
+) -> None:
+    """Drive the REAL KVCacheStoreSendingThread._handle_request over a real
+    1-group coordinator + a real ChunkedTokenDatabase whose legacy layout
+    tables emulate a ``segs_per_block``-layer model (prepare_value emits one
+    segment per entry per block, so _num_sg_groups sees the legacy branch)."""
+    groups = [
+        KVCacheGroupSpec([f"layer{i}" for i in range(segs_per_block)], _spec())
+    ]
+    coord = DfkvStoreCoordinator(
+        groups, scheduler_block_size=BLOCK, hash_block_size=BLOCK
+    )
+    db = ChunkedTokenDatabase(md, block_size=BLOCK, hash_block_size=BLOCK)
+    db.set_kv_caches_base_addr([0x1000 + i * 4096 * 1024 for i in range(segs_per_block)])
+    db.set_block_len([4096] * segs_per_block)
+    thread = KVCacheStoreSendingThread(
+        client=client,
+        coord=coord,
+        token_databases=[db],
+        block_size=BLOCK,
+        tp_rank=0,
+        put_step=1,
+        kv_role="kv_both",
+        ready_event=threading.Event(),
+        enable_kv_event=False,
+        record_operation=(
+            (lambda **kw: record_ops.append(kw))
+            if record_ops is not None
+            else None
+        ),
+    )
+    nblocks = len(hashes)
+    meta = ReqMeta(
+        req_id="req-sg",
+        token_len_chunk=nblocks * BLOCK,
+        block_ids=(list(range(nblocks)),),
+        block_hashes=list(hashes),
+    )
+    thread.add_stored_request("req-sg")
+    thread._handle_request(meta)
+    assert thread.stored_requests.get("req-sg", 0) == 0
+
+
+def test_save_dedup_rewrites_when_sibling_group_missing():
+    """Root regression (dedup side): group 0 of every chunk is stored but
+    its sibling group is gone. The pre-fix gate probed group 0 only and
+    skipped the save entirely, so the partial chunk was never rewritten.
+    The gate must now probe both groups and re-store the chunks."""
+    hashes = _hashes()[:_SAVE_CHUNKS]
+    md = _mla_md()
+    present = {_sg_onewire_key(md, h, 0) for h in hashes}
+    client = _FakeSaveClient(present=present)
+    _run_save_request(client, md, hashes)
+    assert client.exist_calls, "dedup gate must probe first"
+    assert len(client.exist_calls[0]) == 2 * len(hashes), (
+        f"probe must cover both SG groups per chunk: "
+        f"{len(client.exist_calls[0])} keys for {len(hashes)} chunks"
+    )
+    assert client.put_calls, (
+        "group-0-only partial chunks must be rewritten, not skipped"
+    )
+    expected_keys = {
+        _sg_onewire_key(md, h, grp) for h in hashes for grp in (0, 1)
+    }
+    assert set(client.put_calls[0]) == expected_keys
+    assert expected_keys <= client._present
+
+
+def test_save_dedup_skips_when_all_groups_present():
+    """Guard: with BOTH SG groups of every chunk stored the dedup gate keeps
+    its skip-fast behavior (no put at all)."""
+    hashes = _hashes()[:_SAVE_CHUNKS]
+    md = _mla_md()
+    present = {_sg_onewire_key(md, h, grp) for h in hashes for grp in (0, 1)}
+    client = _FakeSaveClient(present=present)
+    _run_save_request(client, md, hashes)
+    assert client.put_calls == [], (
+        f"fully-stored chunks must stay dedup-skipped, got puts {client.put_calls}"
+    )
+
+
+def test_save_partial_put_failure_removes_sibling_groups():
+    """Cleanup: when one group put fails, the chunk's sibling group keys
+    (including the successfully written one) must receive a best-effort
+    remove so no half-stored ghost lingers in the ring."""
+    hashes = _hashes()[:_SAVE_CHUNKS]
+    md = _mla_md()
+    victim_g1 = _sg_onewire_key(md, hashes[1], 1)
+    ops: list[dict] = []
+    client = _FakeSaveClient(fail_keys={victim_g1})
+    _run_save_request(client, md, hashes, record_ops=ops)
+    assert set(client.removed) == {
+        _sg_onewire_key(md, hashes[1], 0),
+        victim_g1,
+    }, (
+        "both group keys of the failed chunk must be removed, got "
+        f"{[k.hex()[-8:] for k in client.removed]}"
+    )
+    assert not {_sg_onewire_key(md, hashes[1], grp) for grp in (0, 1)} & client._present
+    rm_ops = [op for op in ops if op.get("operation") == "save_remove_partial"]
+    assert rm_ops and rm_ops[0].get("status") == "ok", (
+        f"cleanup metric missing or wrong: {ops}"
+    )
+
+
+def test_save_partial_put_failure_without_remove_rpc_is_inert():
+    """Degradation: a client/lib without the remove RPC (older libdfkv)
+    must skip cleanup silently -- never raise into the save path -- and the
+    metric records the unsupported skip."""
+
+    class _OldLibClient(_FakeSaveClient):
+        def supports_remove(self):
+            return False
+
+        def batch_remove(self, keys):  # pragma: no cover - must never run
+            raise AssertionError("old lib without remove RPC must be skipped")
+
+    hashes = _hashes()[:_SAVE_CHUNKS]
+    md = _mla_md()
+    ops: list[dict] = []
+    client = _OldLibClient(fail_keys={_sg_onewire_key(md, hashes[0], 1)})
+    _run_save_request(client, md, hashes, record_ops=ops)  # must not raise
+    assert client.put_calls, "put was attempted before the scripted failure"
+    rm_ops = [op for op in ops if op.get("operation") == "save_remove_partial"]
+    assert rm_ops and rm_ops[0].get("status") == "unsupported", (
+        f"unsupported-cleanup metric missing or wrong: {ops}"
+    )
+
+
+def test_single_group_chunk_probe_geometry_unchanged():
+    """G=1 guard: a chunk that fits ONE SG group keeps the byte-identical
+    pre-fix geometry -- exactly one group-0 key per chunk in the dedup probe
+    and in the rewrite, and unchanged skip behavior."""
+    hashes = _hashes()[:_SAVE_CHUNKS]
+    md = _mla_md()
+    single_layers = SG_MAX_SEGS - 9  # 20 segments -> exactly 1 SG group
+    # Fully present -> still skipped, probe list identical to the pre-fix
+    # group-0-only form.
+    present = {_sg_onewire_key(md, h, 0) for h in hashes}
+    client = _FakeSaveClient(present=present)
+    _run_save_request(client, md, hashes, segs_per_block=single_layers)
+    assert client.put_calls == []
+    old_probe_form = [_sg_onewire_key(md, h, 0) for h in hashes]
+    assert client.exist_calls[0] == old_probe_form, (
+        "single-group chunk probe list must be byte-identical to the "
+        "pre-fix group-0-only form"
+    )
+    # Absent -> rewrite puts exactly the old group-0 keys.
+    client2 = _FakeSaveClient()
+    _run_save_request(client2, md, hashes, segs_per_block=single_layers)
+    assert len(client2.put_calls) == 1
+    assert client2.put_calls[0] == old_probe_form

--- a/integration/vllm/tests/test_dcp_lookup_geometry.py
+++ b/integration/vllm/tests/test_dcp_lookup_geometry.py
@@ -84,7 +84,9 @@ def _make_store(geometry: str, hashes: list[BlockHash]) -> set[bytes]:
     return store
 
 
-def _lookup_hit_tokens(store: set[bytes], hashes: list[BlockHash]) -> int:
+def _lookup_hit_tokens(
+    store: set[bytes], hashes: list[BlockHash], md: KeyMetadata | None = None
+) -> int:
     class _FakeClient:
         _sg_segs_cache = SG_MAX_SEGS
 
@@ -106,7 +108,10 @@ def _lookup_hit_tokens(store: set[bytes], hashes: list[BlockHash]) -> int:
     )
     self_ = SimpleNamespace(
         coord=coord,
-        token_dbs=[SimpleNamespace(metadata=_md(0), block_size=BLOCK)],
+        token_dbs=[
+            SimpleNamespace(metadata=md if md is not None else _md(0),
+                            block_size=BLOCK)
+        ],
         client=_FakeClient(store),
         tp_size=8,
         num_kv_head=1,
@@ -140,4 +145,51 @@ def test_pre_70_geometry_lookup_collapses():
     hit = _lookup_hit_tokens(store, hashes)
     assert 0 < hit < NCHUNK * BLOCK // 2, (
         f"documented-negative geometry should truncate badly, got {hit}"
+    )
+
+
+# Replicated MLA (plain-TP MLA -- put_step==tp_size, no DCP/PCP, e.g.
+# GLM-5.2 TP16 / V4-Flash TP8): the SAVE/dedup/LOAD paths encode the single
+# canonical tp_rank=-1 (worker.py metadata init), NOT a per-TP coordinate.
+# The pre-fix lookup probed tp_rank=0 unconditionally
+# (tp_count = min(tp_size, num_kv_head) = 1), so external L3 hit detection
+# was constantly 0 for exactly this topology.
+_MLA_METADATA = {**_METADATA, "dcp_size": 1, "tp_rank": -1}
+
+
+def _mla_md() -> KeyMetadata:
+    return KeyMetadata(**{**_MLA_METADATA, "dcp_rank": 0})
+
+
+def _legacy_tp0_md() -> KeyMetadata:
+    # The coordinate the pre-fix lookup probed for ANY metadata: tp_rank=0.
+    return KeyMetadata(**{**_METADATA, "dcp_size": 1, "dcp_rank": 0})
+
+
+def test_replicated_mla_lookup_full_prefix():
+    """Every chunk stored under the canonical tp_rank=-1 (group 0): lookup
+    with replicated-MLA metadata must probe that same coordinate and report
+    the complete prefix, i.e. plain-TP MLA has full external L3 coverage."""
+    hashes = _hashes()
+    md = _mla_md()
+    store = {_onewire_key(md, h) for h in hashes}
+    assert len(store) == NCHUNK
+    hit = _lookup_hit_tokens(store, hashes, md=md)
+    assert hit == NCHUNK * BLOCK, (
+        f"replicated-MLA lookup must hit the tp_rank=-1 store, "
+        f"got {hit}/{NCHUNK * BLOCK}"
+    )
+
+
+def test_replicated_mla_lookup_misses_legacy_tp0_coordinate():
+    """Negative control: keys under the OLD probe coordinate (tp_rank=0)
+    must NOT match a replicated-MLA lookup -- nothing in this geometry ever
+    saves there. Locks the regression: probing coordinates the SAVE side
+    never writes."""
+    hashes = _hashes()
+    store = {_onewire_key(_legacy_tp0_md(), h) for h in hashes}
+    assert len(store) == NCHUNK
+    hit = _lookup_hit_tokens(store, hashes, md=_mla_md())
+    assert hit == 0, (
+        f"lookup must not probe the legacy tp_rank=0 coordinate, got {hit}"
     )

--- a/src/cache/disk_slab_store.cc
+++ b/src/cache/disk_slab_store.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <limits>
@@ -34,6 +35,13 @@ constexpr uint32_t kFormatVersion = 3;
 constexpr uint32_t kStateMagic = 0x53424C53u;  // "SLBS"
 constexpr uint32_t kStateClean = 1;
 constexpr uint32_t kStateDirty = 2;
+
+// Bound on a re-PUT waiting out a deferred-remove window. The window lasts
+// one in-flight read/write of the slot -- I/O time, even for MiB-scale direct
+// reads -- so this is generous; but a request-serving thread must never park
+// behind a stuck holder, so on expiry the PUT falls back to the pre-wait
+// behavior (kIOError) instead of blocking forever.
+constexpr auto kDeferredRemoveWaitMax = std::chrono::seconds(5);
 
 // Small CRC32 (IEEE, reflected) over a byte range; enough to catch a torn record.
 uint32_t Crc32(const uint8_t* p, size_t n) {
@@ -84,6 +92,40 @@ struct ThreadUring {
   io_uring* ring = nullptr;
 };
 thread_local ThreadUring tls_uring_w;
+
+// Best-effort drain of `outstanding` batch writes the kernel has already
+// accepted, after a reap hard failure and BEFORE the ring is retired:
+// io_uring_queue_exit does NOT cancel in-flight requests (the contract
+// UringReader's Drain documents), so an undrained zombie write keeps
+// referencing its caller buffer (RAM arena slot / client recv segment) and
+// can land AFTER the flush returned -- by then the failed item's slot may be
+// rolled back and reused by a DIFFERENT key (slot payloads carry no CRC;
+// write order is the only correctness argument). Each completion is reaped
+// with the NON-BLOCKING peek and immediately seen; results are discarded --
+// every item of the failed batch is rewritten by the sequential path anyway.
+// The test hook, when installed, replaces the peek so a dropped-CQE kernel
+// can be simulated. Bounded to ~1 s of 1 ms polls (in-flight NVMe writes
+// complete in I/O time; beyond that the kernel has lost the CQEs and grinding
+// longer only parks the flush worker). Returns false with CQEs still missing:
+// the caller must then fail closed, because a zombie write may still land.
+bool DrainBatchWrites(io_uring* ring, size_t outstanding,
+                      const std::function<int(void*, void*)>& hook) {
+  int polls = 0;
+  while (outstanding > 0 && polls < 1000) {
+    io_uring_cqe* cqe = nullptr;
+    const int prc =
+        hook ? hook(ring, &cqe) : io_uring_peek_cqe(ring, &cqe);
+    if (prc == 0 && cqe != nullptr) {
+      io_uring_cqe_seen(ring, cqe);
+      --outstanding;
+      continue;
+    }
+    if (prc != -EAGAIN && prc != -EINTR) break;  // ring itself is dead: stop
+    ++polls;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return outstanding == 0;
+}
 #endif
 }  // namespace
 
@@ -850,13 +892,30 @@ Status DiskSlabStore::CacheImpl(const BlockKey& key, size_t len,
   std::shared_ptr<PutFlight> flight;
   bool leader = false;
   {
-    std::lock_guard<std::mutex> lk(mu_);
-    if (!Healthy()) return Status::kIOError;
-    if (payload_len_.count(fn) != 0) return Status::kOk;
-    auto existing = put_flights_.find(fn);
-    if (existing != put_flights_.end()) {
-      flight = existing->second;
-    } else {
+    std::unique_lock<std::mutex> lk(mu_);
+    for (;;) {
+      if (!Healthy()) return Status::kIOError;
+      if (payload_len_.count(fn) != 0) return Status::kOk;  // keep-first
+      auto existing = put_flights_.find(fn);
+      if (existing != put_flights_.end()) {
+        flight = existing->second;  // follower of the in-flight PUT
+        break;
+      }
+      if (deferred_remove_.count(fn) != 0) {
+        // Deferred-remove window, NOT a duplicate write: a Remove already
+        // erased this key's commit state, but an in-flight read/write still
+        // pins its slot, so the allocator would still report Contains(key)
+        // and the leader path below would hard-fail. Wait (bounded -- a
+        // serving thread must never park behind a stuck holder) for the last
+        // releaser to perform the real Remove, which it signals on
+        // remove_cv_, then re-judge from scratch. A genuine duplicate (no
+        // deferred remove in play) keeps the existing semantics below.
+        if (remove_cv_.wait_for(lk, kDeferredRemoveWaitMax, [&] {
+              return deferred_remove_.count(fn) == 0 || !Healthy();
+            }))
+          continue;  // window closed: the slot is gone; fresh judgment
+        return Status::kIOError;  // pin outlived the bound: fail as before
+      }
       flight = std::make_shared<PutFlight>();
       put_flights_.emplace(fn, flight);
       leader = true;
@@ -870,6 +929,7 @@ Status DiskSlabStore::CacheImpl(const BlockKey& key, size_t len,
       inflight_[fn]++;
       for (const BlockKey& ev : evicted)
         evicted_bytes_ += ErasePayloadLocked(ev.Filename());
+      break;
     }
   }
   if (!leader) return WaitPut(flight);
@@ -948,7 +1008,7 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
   std::vector<Slot> st(N);
   // -- L1: allocate leaders and attach followers under one lock --
   {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::unique_lock<std::mutex> lk(mu_);
     for (size_t i = 0; i < N; ++i) {
       const auto& it = items[i];
       if (it.len == 0 || it.data == nullptr) {
@@ -956,34 +1016,55 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
         continue;
       }
       st[i].fn = it.key.Filename();
-      if (payload_len_.count(st[i].fn) != 0) {
-        out[i] = Status::kOk;
-        continue;
+      // Per-item judgment, re-run (once per closed window) when the item sat
+      // out a deferred-remove window.
+      for (;;) {
+        if (!Healthy()) {
+          out[i] = Status::kIOError;
+          break;
+        }
+        if (payload_len_.count(st[i].fn) != 0) {
+          out[i] = Status::kOk;
+          break;
+        }
+        auto existing = put_flights_.find(st[i].fn);
+        if (existing != put_flights_.end()) {
+          st[i].flight = existing->second;  // follower: wait after leader L2
+          break;
+        }
+        if (deferred_remove_.count(st[i].fn) != 0) {
+          // Same deferred-remove window as CacheImpl: the Remove already raced
+          // (commit state erased, slot still pinned by in-flight I/O), so this
+          // re-PUT must wait the window out -- bounded, see remove_cv_ --
+          // instead of hard-failing on the allocator's still-resident slot.
+          if (remove_cv_.wait_for(lk, kDeferredRemoveWaitMax, [&] {
+                return deferred_remove_.count(st[i].fn) == 0 || !Healthy();
+              }))
+            continue;  // window closed: re-judge this item from scratch
+          out[i] = Status::kIOError;  // pin outlived the bound: fail as before
+          break;
+        }
+        st[i].flight = std::make_shared<PutFlight>();
+        put_flights_.emplace(st[i].fn, st[i].flight);
+        std::vector<BlockKey> evicted;
+        if (alloc_->Contains(it.key) ||
+            !alloc_->Put(it.key, it.len, &st[i].ref, &evicted)) {
+          put_flights_.erase(st[i].fn);
+          CompletePut(st[i].flight, Status::kIOError);
+          break;
+        }
+        alloc_->Pin(it.key);
+        inflight_[st[i].fn]++;
+        for (const BlockKey& ev : evicted)
+          evicted_bytes_ += ErasePayloadLocked(ev.Filename());
+        st[i].active = true;
+        // Same alignment and padded-capacity eligibility as CacheDirect.
+        const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
+        st[i].direct = !extent_dio_fds_.empty() && it.len != 0 &&
+                       (reinterpret_cast<uintptr_t>(it.data) & 4095) == 0 &&
+                       alen <= it.cap && alen <= st[i].ref.slot_size;
+        break;
       }
-      auto existing = put_flights_.find(st[i].fn);
-      if (existing != put_flights_.end()) {
-        st[i].flight = existing->second;  // follower: wait after leader L2
-        continue;
-      }
-      st[i].flight = std::make_shared<PutFlight>();
-      put_flights_.emplace(st[i].fn, st[i].flight);
-      std::vector<BlockKey> evicted;
-      if (alloc_->Contains(it.key) ||
-          !alloc_->Put(it.key, it.len, &st[i].ref, &evicted)) {
-        put_flights_.erase(st[i].fn);
-        CompletePut(st[i].flight, Status::kIOError);
-        continue;
-      }
-      alloc_->Pin(it.key);
-      inflight_[st[i].fn]++;
-      for (const BlockKey& ev : evicted)
-        evicted_bytes_ += ErasePayloadLocked(ev.Filename());
-      st[i].active = true;
-      // Use the same alignment and padded-capacity eligibility as CacheDirect.
-      const size_t alen = (it.len + 4095) & ~static_cast<size_t>(4095);
-      st[i].direct = !extent_dio_fds_.empty() && it.len != 0 &&
-                     (reinterpret_cast<uintptr_t>(it.data) & 4095) == 0 &&
-                     alen <= it.cap && alen <= st[i].ref.slot_size;
     }
   }
   // -- IO: payloads (uring one-submit when possible), then records --
@@ -1039,7 +1120,10 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
         bool reap_ok = true;
         while (done < expect) {
           io_uring_cqe* cqe = nullptr;
-          const int wrc = io_uring_wait_cqe(ring, &cqe);
+          const int wrc =
+              uring_reap_hook_for_test_
+                  ? uring_reap_hook_for_test_(ring, &cqe)
+                  : io_uring_wait_cqe(ring, &cqe);
           if (wrc == -EINTR) continue;         // signal: just retry the wait
           if (wrc != 0) { reap_ok = false; break; }
           // Bounds-check the completion's index BEFORE touching items[i]: a
@@ -1054,12 +1138,27 @@ std::vector<Status> DiskSlabStore::CacheDirectBatch(
           io_uring_cqe_seen(ring, cqe);
           ++done;
         }
-        if (!reap_ok || expect != submitted) {
-          // Unreaped CQEs or unsubmitted SQEs remain: retire the ring so they
-          // die with it; this thread's next batch re-inits a fresh one. The
-          // affected items keep io_ok=false and are rewritten by the
-          // sequential path below (their slots are exclusively owned by this
-          // flush, so the rewrite is idempotent).
+        if (!reap_ok) {
+          // Reap HARD FAILURE: `expect - done` writes the kernel already
+          // accepted are still un-reaped and reference this batch's caller
+          // buffers (see DrainBatchWrites for the zombie-write model). Drain
+          // them first; only retire the ring afterwards. If the drain comes
+          // up short the kernel has dropped CQEs -- a zombie write may still
+          // be in flight against a slot this flush is about to roll back and
+          // hand to another key -- so fail closed rather than risk serving
+          // bytes a late landing wrote over a committed payload.
+          if (!DrainBatchWrites(ring, expect - done,
+                                uring_reap_hook_for_test_))
+            FailMetadata();
+          tls_uring_w.Reset();
+        } else if (expect != submitted) {
+          // Short submit is the SAFE half: `expect` counts exactly the SQEs
+          // the kernel consumed, so the unsubmitted tail never owned a write
+          // -- no in-flight request references this batch's buffers and
+          // retiring the ring just drops the dormant SQEs (this thread's next
+          // batch re-inits a fresh one). The affected items keep io_ok=false
+          // and are rewritten by the sequential path below (their slots are
+          // exclusively owned by this flush, so the rewrite is idempotent).
           tls_uring_w.Reset();
         }
         did_uring = true;
@@ -1278,16 +1377,20 @@ bool DiskSlabStore::ReleaseInflightLocked(const BlockKey& key,
   if (--it->second > 0) return true;
   inflight_.erase(it);
   if (!deferred_remove_.erase(fn)) return true;
+  // The deferred Remove executes NOW (record invalidation, then physical
+  // removal). Wake any re-PUT waiting out the window on BOTH exits so it
+  // re-judges promptly instead of burning its full wait bound.
   SlabAllocator::SlotRef ref;
+  bool release_ok = true;
   if (alloc_->Get(key, &ref)) {
-    if (!WriteRecord(ref, key, 0, /*valid=*/false)) {
-      ErasePayloadLocked(fn);
-      return false;
-    }
-    alloc_->Remove(key);
+    if (!WriteRecord(ref, key, 0, /*valid=*/false))
+      release_ok = false;
+    else
+      alloc_->Remove(key);
   }
   ErasePayloadLocked(fn);
-  return true;
+  remove_cv_.notify_all();
+  return release_ok;
 }
 
 Status DiskSlabStore::Range(const BlockKey& key, uint64_t offset,

--- a/src/cache/disk_slab_store.h
+++ b/src/cache/disk_slab_store.h
@@ -246,6 +246,10 @@ class DiskSlabStore : public StoreEngine {
   // whose Remove arrived during that window (executed by the last releaser).
   std::unordered_map<std::string, uint32_t> inflight_;
   std::unordered_set<std::string> deferred_remove_;
+  // Signaled by the last in-flight releaser right after it executes a deferred
+  // Remove (mu_ held): a re-PUT of that key waits out the window (bounded)
+  // thereon instead of failing hard against the still-resident slot.
+  std::condition_variable remove_cv_;
   // A reserved-but-uncommitted key has exactly one leader. Scalar and batch
   // duplicates join this flight and observe its real commit result.
   std::unordered_map<std::string, std::shared_ptr<PutFlight>> put_flights_;
@@ -268,6 +272,12 @@ class DiskSlabStore : public StoreEngine {
   std::atomic<uint64_t> metadata_io_errors_{0};
   std::function<bool()> payload_write_hook_for_test_;
   std::function<bool()> record_write_hook_for_test_;
+  // Test-only seam (never set in production; same discipline as the hooks
+  // above): when set, replaces EVERY CQE reap of the batched io_uring write
+  // path -- the blocking wait AND the post-failure non-blocking drain -- so
+  // tests can inject a hard reap failure. The void* signature keeps liburing
+  // types out of the header (build-flag-independent class layout).
+  std::function<int(void* ring, void* cqe)> uring_reap_hook_for_test_;
   std::atomic<uint64_t> unclean_resets_{0};
   std::atomic<uint64_t> eviction_record_clears_{0};
   // slots.tbl sync thread (see Options::table_sync_ms): fdatasync only when

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -33,8 +33,10 @@ inline double NowSec() {
 }  // namespace
 
 void KvNodeServer::InitTcpListenerConfig() {
-  auto bounded = [](const char* name, uint64_t fallback,
-                    uint64_t hard_max) -> uint64_t {
+  // allow_zero: knobs where 0 is a documented "feature off" setting (the
+  // first-frame deadline) keep 0 instead of falling back with a warning.
+  auto bounded = [](const char* name, uint64_t fallback, uint64_t hard_max,
+                    bool allow_zero = false) -> uint64_t {
     const char* value = std::getenv(name);
     if (value == nullptr || *value == '\0') return fallback;
     if (*value < '0' || *value > '9') {
@@ -45,7 +47,8 @@ void KvNodeServer::InitTcpListenerConfig() {
     errno = 0;
     char* end = nullptr;
     const unsigned long long parsed = std::strtoull(value, &end, 10);
-    if (errno != 0 || end == value || *end != '\0' || parsed == 0) {
+    if (errno != 0 || end == value || *end != '\0' ||
+        (parsed == 0 && !allow_zero)) {
       DFKV_LOG_WARN(std::string("invalid ") + name + "='" + value +
                     "'; using " + std::to_string(fallback));
       return fallback;
@@ -63,10 +66,15 @@ void KvNodeServer::InitTcpListenerConfig() {
   tcp_io_timeout_seconds_ = static_cast<int>(
       bounded("DFKV_TCP_IO_TIMEOUT_S", kDefaultTcpIoTimeoutSeconds,
               kHardTcpIoTimeoutSeconds));
+  tcp_first_req_ms_ =
+      bounded("DFKV_TCP_FIRST_REQ_MS", kDefaultTcpFirstReqMs,
+              kHardTcpFirstReqMs, /*allow_zero=*/true);
   config_dump::RecordResolved("DFKV_TCP_MAX_CONNS",
                               std::to_string(tcp_max_connections_));
   config_dump::RecordResolved("DFKV_TCP_IO_TIMEOUT_S",
                               std::to_string(tcp_io_timeout_seconds_));
+  config_dump::RecordResolved("DFKV_TCP_FIRST_REQ_MS",
+                              std::to_string(tcp_first_req_ms_));
 }
 
 KvNodeServer::KvNodeServer(const std::string& cache_dir,
@@ -349,6 +357,10 @@ std::string KvNodeServer::MetricsText() const {
   metric("dfkv_tcp_io_timeout_seconds", "gauge",
          "Configured cache TCP per-socket receive/send timeout",
          tcp_io_timeout_seconds_);
+  metric("dfkv_tcp_first_req_ms", "gauge",
+         "Absolute deadline for the first complete request frame after accept "
+         "(0 = disabled; anti slow-drip bound, not per-syscall)",
+         tcp_first_req_ms_);
   metric("dfkv_tcp_rejected_connections_total", "counter",
          "Cache TCP connections rejected at the handler admission limit",
          rd(tcp_rejected_connections_));
@@ -575,6 +587,9 @@ void KvNodeServer::AcceptLoop() {
   while (running_) {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
     if (fd < 0) { if (!running_) break; continue; }
+    // The first-frame deadline is anchored at ACCEPT time: queuing delay
+    // (handler-thread spawn) counts against the peer's budget, not ours.
+    const auto accepted_at = std::chrono::steady_clock::now();
     int one = 1;
     ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     timeval timeout{tcp_io_timeout_seconds_, 0};
@@ -592,9 +607,9 @@ void KvNodeServer::AcceptLoop() {
     open_connections_.fetch_add(1, std::memory_order_relaxed);
     conn_fds_.insert(fd);
     auto done = std::make_shared<std::atomic<bool>>(false);
-    conns_.push_back({std::thread([this, fd, done] {
+    conns_.push_back({std::thread([this, fd, done, accepted_at] {
                         NameThisThread("kv-serve");
-                        Handle(fd);
+                        Handle(fd, accepted_at);
                         open_connections_.fetch_sub(1, std::memory_order_relaxed);
                         { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
                         ::close(fd);
@@ -1072,16 +1087,33 @@ void KvNodeServer::FinishRamRead(
 }
 
 // Keep-alive: serve requests on this connection until the peer closes it.
-void KvNodeServer::Handle(int fd) {
+void KvNodeServer::Handle(int fd,
+                          std::chrono::steady_clock::time_point accepted_at) {
   // Bound the declared payload_len BEFORE the allocation below: without this
   // a forged 42-byte prefix is a 16 GiB allocation. Same bound as the RDMA
   // path (utils/wire_limits.h).
   const uint64_t max_payload = max_request_payload_
                                    ? max_request_payload_
                                    : wire_limits::MaxRequestPayload();
+  // Absolute deadline for the FIRST complete frame on the connection
+  // (DFKV_TCP_FIRST_REQ_MS). SO_RCVTIMEO is a per-syscall budget, so a drip
+  // feeder (1 byte/interval) otherwise pins a connection slot forever; until
+  // the first prefix+payload are fully in, each read's per-syscall budget is
+  // recomputed as min(base timeout, deadline remaining) and an already-spent
+  // budget closes the connection. 0 disables (legacy per-syscall behavior).
+  bool first_frame_pending = tcp_first_req_ms_ > 0;
+  const auto first_deadline =
+      accepted_at + std::chrono::milliseconds(tcp_first_req_ms_);
+  const timeval base_timeout{tcp_io_timeout_seconds_, 0};
   while (running_) {
     char prefix[kReqPrefix];
-    if (!net::ReadAll(fd, prefix, kReqPrefix)) return;  // peer closed / error
+    if (first_frame_pending) {
+      if (!net::ReadAllWithin(fd, prefix, kReqPrefix, base_timeout,
+                              first_deadline))
+        return;
+    } else if (!net::ReadAll(fd, prefix, kReqPrefix)) {
+      return;  // peer closed / error
+    }
     ReqFields rq;
     if (!DecodeReq(prefix, &rq, max_payload)) return;  // bad version / oversize => drop
     // Same-source bound for a kRange's declared range length: a value can
@@ -1093,7 +1125,22 @@ void KvNodeServer::Handle(int fd) {
         rq.length > max_payload)
       return;
     std::vector<char> payload(rq.payload_len);
-    if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
+    if (rq.payload_len) {
+      if (first_frame_pending) {
+        if (!net::ReadAllWithin(fd, payload.data(), rq.payload_len,
+                                base_timeout, first_deadline))
+          return;
+      } else if (!net::ReadAll(fd, payload.data(), rq.payload_len)) {
+        return;
+      }
+    }
+    if (first_frame_pending) {
+      // First frame complete: restore the plain base per-syscall budget the
+      // deadline reads shrank, so keep-alive reads behave exactly as before.
+      first_frame_pending = false;
+      ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &base_timeout,
+                   sizeof(base_timeout));
+    }
 
     std::string data;
     size_t value_len = 0;

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -916,8 +916,12 @@ Status KvNodeServer::RangeDirectForKey(
           const char* p = nullptr;
           Status s = group_.RangeDirect(key, offset, length, buf, cap, &p, n,
                                         stored_len);
+          // A DIO superset read returns p = buf + head with head in (0, 4095]:
+          // src points INSIDE dst, so this in-place compaction overlaps
+          // (forward) and must be a memmove -- memcpy on an overlap is UB and
+          // can hand shifted bytes to the leader AND every follower.
           if (s == Status::kOk && p && p != buf && *n > 0)
-            std::memcpy(buf, p, *n < cap ? *n : cap);
+            std::memmove(buf, p, *n < cap ? *n : cap);
           return s;
         });
     if (st == Status::kOk && out_data) *out_data = io_buf;

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -693,25 +693,48 @@ Status KvNodeServer::ProcessRequestForKey(
         if (coalesce_enabled_ && length > 0) {
           // TCP convoy collapse: leader reads via group_.Range into a scratch
           // string sized by the store; followers copy the shared bytes.
-          const size_t cap = length;
-          out_data->resize(cap);
-          size_t n = 0;
-          st = read_coalescer_.Read(
-              key, offset, length,
-              out_data->empty() ? nullptr : &(*out_data)[0], cap, &n,
-              out_value_len,
-              [&](char* buf, size_t bcap, size_t* on, size_t* value_len) {
-                std::string tmp;
-                Status s =
-                    group_.Range(key, offset, length, &tmp, value_len);
-                if (s == Status::kOk) {
-                  size_t m = tmp.size() < bcap ? tmp.size() : bcap;
-                  std::memcpy(buf, tmp.data(), m);
-                  *on = m;
-                }
-                return s;
-              });
-          out_data->resize(st == Status::kOk ? n : 0);
+          //
+          // The client-declared length is UNTRUSTED: sizing the scratch
+          // straight from it lets one forged kRange frame drive an unbounded
+          // allocation (length_error/bad_alloc -> std::terminate, or OOM).
+          // Look up the authoritative stored length first -- an unknown key
+          // must fail here exactly like the plain path, before ANY sized
+          // allocation happens.
+          ValueMetadata metadata;
+          st = LookupForKey(key, &metadata);
+          if (st == Status::kOk) {
+            const uint64_t max_payload = max_request_payload_
+                                             ? max_request_payload_
+                                             : wire_limits::MaxRequestPayload();
+            const uint64_t avail = offset < metadata.value_len
+                                       ? metadata.value_len - offset
+                                       : 0;
+            // cap is an ALLOCATION bound only: the fill still issues
+            // group_.Range with the original (offset, length), so store-side
+            // Range semantics (offset >= value_len, data clamped to the
+            // remainder) are unchanged; a concurrent same-key rewrite stays
+            // the store-level race it already was.
+            const size_t cap =
+                static_cast<size_t>(std::min({length, avail, max_payload}));
+            out_data->resize(cap);
+            size_t n = 0;
+            st = read_coalescer_.Read(
+                key, offset, length,
+                out_data->empty() ? nullptr : &(*out_data)[0], cap, &n,
+                out_value_len,
+                [&](char* buf, size_t bcap, size_t* on, size_t* value_len) {
+                  std::string tmp;
+                  Status s =
+                      group_.Range(key, offset, length, &tmp, value_len);
+                  if (s == Status::kOk) {
+                    size_t m = tmp.size() < bcap ? tmp.size() : bcap;
+                    std::memcpy(buf, tmp.data(), m);
+                    *on = m;
+                  }
+                  return s;
+                });
+            out_data->resize(st == Status::kOk ? n : 0);
+          }
         } else {
           st = group_.Range(key, offset, length, out_data, out_value_len);
         }
@@ -1061,6 +1084,14 @@ void KvNodeServer::Handle(int fd) {
     if (!net::ReadAll(fd, prefix, kReqPrefix)) return;  // peer closed / error
     ReqFields rq;
     if (!DecodeReq(prefix, &rq, max_payload)) return;  // bad version / oversize => drop
+    // Same-source bound for a kRange's declared range length: a value can
+    // never exceed max_payload, so a longer range is always garbage or a
+    // hostile pre-allocation attempt. The RDMA frontend rejects this shape at
+    // its own decode/serve gates (rdma_server.cc); the TCP frontend drops the
+    // connection here so no request handler ever sees it.
+    if (rq.op == static_cast<uint8_t>(WireOp::kRange) &&
+        rq.length > max_payload)
+      return;
     std::vector<char> payload(rq.payload_len);
     if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
 

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -75,6 +75,7 @@ class KvNodeServer {
   }
   size_t TcpMaxConnections() const { return tcp_max_connections_; }
   int TcpIoTimeoutSeconds() const { return tcp_io_timeout_seconds_; }
+  uint64_t TcpFirstReqMs() const { return tcp_first_req_ms_; }
 
   // metrics (relaxed atomics)
   size_t m_cache_put() const { return cache_put_.load(std::memory_order_relaxed); }
@@ -143,7 +144,9 @@ class KvNodeServer {
                             Status result, size_t bytes_read,
                             double elapsed_sec, const char* data) noexcept;
   void AcceptLoop();
-  void Handle(int fd);
+  // accepted_at stamps the accept() return so the first complete request frame
+  // is due within DFKV_TCP_FIRST_REQ_MS of ACCEPT, not of handler scheduling.
+  void Handle(int fd, std::chrono::steady_clock::time_point accepted_at);
   void InitRamTier();     // construct ram_ if DFKV_RAM_TIER is enabled (env)
   void InitAdmission();   // read DFKV_PUT_INFLIGHT_LIMIT (0 = gate off)
   void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
@@ -170,8 +173,13 @@ class KvNodeServer {
   static constexpr size_t kHardTcpMaxConnections = 4096;
   static constexpr int kDefaultTcpIoTimeoutSeconds = 60;
   static constexpr int kHardTcpIoTimeoutSeconds = 3600;
+  // Absolute deadline for the FIRST complete request frame after accept
+  // (SO_RCVTIMEO alone is per-syscall, so a drip feeder never timed out).
+  static constexpr uint64_t kDefaultTcpFirstReqMs = 30000;
+  static constexpr uint64_t kHardTcpFirstReqMs = 3600000;
   size_t tcp_max_connections_ = kDefaultTcpMaxConnections;
   int tcp_io_timeout_seconds_ = kDefaultTcpIoTimeoutSeconds;
+  uint64_t tcp_first_req_ms_ = kDefaultTcpFirstReqMs;  // 0 = deadline disabled
   std::atomic<size_t> tcp_rejected_connections_{0};
   Sampler lat_sampler_{64};        // 1-in-64 latency sampling (near-zero hot-path cost)
   LatencyHist get_lat_, put_lat_;  // server-side op latency (sampled)

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -501,13 +501,19 @@ RamTier::Admission RamTier::Admit(
   char* dst = large ? dedicated.get() : arena_ + offset;
   if (len != 0) std::memcpy(dst, data, len);
 
+  // The canceled check, the writing-set erase and the index install must be
+  // ONE s.mu section: Remove() sets canceled while holding s.mu, so reading
+  // the flag anywhere else lets the cancel land between the read and the
+  // install and resurrects an explicitly Removed key. Nested lock order here
+  // is s.mu -> completion->mu, matching Remove() and every CompletePut call
+  // site under s.mu -- no path ever takes s.mu while holding completion->mu.
   bool canceled = false;
   {
-    std::lock_guard<std::mutex> lk(completion->mu);
-    canceled = completion->canceled;
-  }
-  {
     std::lock_guard<std::mutex> lk(s.mu);
+    {
+      std::lock_guard<std::mutex> state_lk(completion->mu);
+      canceled = completion->canceled;
+    }
     s.writing.erase(fn);
     if (!canceled) {
       Entry e;
@@ -626,20 +632,41 @@ bool RamTier::PutDurable(const BlockKey& key, const void* data, size_t len) {
   char* dst = large ? dedicated.get() : arena_ + offset;
   if (len != 0) std::memcpy(dst, data, len);
 
+  // Same cancel/install atomicity as Admit(): a Remove() that flagged the
+  // shared completion while the copy ran must suppress the install -- before
+  // this the promotion installed unconditionally and revived a Removed key.
+  bool canceled = false;
   {
     std::lock_guard<std::mutex> lk(s.mu);
-    Entry e;
-    e.key = key;
-    e.offset = offset;
-    e.len = len;
-    e.cap = cap;
-    e.large = std::move(dedicated);
-    e.durable = true;
-    e.completion = completion;
-    CompletePut(completion, true);
-    s.index.emplace(fn, std::move(e));
+    {
+      std::lock_guard<std::mutex> state_lk(completion->mu);
+      canceled = completion->canceled;
+    }
     s.writing.erase(fn);
-    if (!large) s.alloc->Unpin(key);
+    if (!canceled) {
+      Entry e;
+      e.key = key;
+      e.offset = offset;
+      e.len = len;
+      e.cap = cap;
+      e.large = std::move(dedicated);
+      e.durable = true;
+      e.completion = completion;
+      CompletePut(completion, true);
+      s.index.emplace(fn, std::move(e));
+      if (!large) s.alloc->Unpin(key);
+    } else if (!large) {
+      s.alloc->Unpin(key);   // release the copy-window pin
+      s.alloc->Remove(key);  // free the slot
+    }
+  }
+  if (canceled) {
+    if (large)
+      ReleaseLargeBudget(cap);
+    else
+      ReleaseBudget(cap);
+    CompletePut(completion, false);  // release Remove's WaitPut
+    return false;
   }
   promotes_.fetch_add(1, std::memory_order_relaxed);
   return true;
@@ -762,11 +789,32 @@ bool RamTier::Remove(const BlockKey& key) {
   }
   if (completion) (void)WaitPut(completion);
   {
+    // Fallback tombstone: no install path may outlive Remove(). If the key
+    // nevertheless sits in the index untombstoned, mark it now (purging its
+    // queued flush, mirroring phase one) and run the normal drop path, so
+    // Remove never returns while the key is still visible.
     std::lock_guard<std::mutex> lk(s.mu);
     auto it = s.index.find(fn);
-    if (it != s.index.end() && it->second.remove_pending &&
-        !it->second.flushing && it->second.send_pins == 0)
-      DropLocked(s, fn);
+    if (it != s.index.end()) {
+      Entry& e = it->second;
+      if (!e.remove_pending) {
+        e.remove_pending = true;
+        for (auto q = s.flushq.begin(); q != s.flushq.end();) {
+          if (q->fn == fn)
+            q = s.flushq.erase(q);
+          else
+            ++q;
+        }
+        if (!e.flushing) {
+          if (e.flush_pin) {
+            if (e.in_arena()) s.alloc->Unpin(e.key);
+            e.flush_pin = false;
+          }
+          if (!e.durable) CompletePut(e.completion, false);
+        }
+      }
+      if (!e.flushing && e.send_pins == 0) DropLocked(s, fn);
+    }
   }
   return had;
 }

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -87,6 +87,18 @@ RdmaServer::RdmaServer(Handler handler, size_t max_msg,
 RdmaServer::~RdmaServer() { Stop(); }
 
 Status RdmaServer::Start(int port) {
+  // An explicitly configured anchor whose name overruns the v2 bootstrap
+  // frame stays fully usable here — this server only EVER parses peer frames
+  // and default-anchor (empty-name) clients fall back to it — but it can
+  // never be selected BY NAME: an announceable client name must fit the frame
+  // (client-side startup rejects longer ones). Name it at startup with the
+  // real limit instead of leaving ops to decode per-connection rejections.
+  for (const auto& device : anchor_devs_) {
+    if (!device.empty() && !rdma::DeviceNameFitsFrame(device)) {
+      DFKV_LOG_WARN(rdma::OversizedDeviceNameError(device) +
+                    "; serving anyway, reachable as the default anchor only");
+    }
+  }
   listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
   if (listen_fd_ < 0) return Status::kIOError;
   int one = 1;

--- a/src/mds/dfkv_mds_main.cc
+++ b/src/mds/dfkv_mds_main.cc
@@ -99,11 +99,17 @@ int main(int argc, char** argv) {
   std::unique_ptr<dfkv::MetricsHttpServer> mhttp;
   if (metrics_port >= 0) {
     mhttp = std::make_unique<dfkv::MetricsHttpServer>([&srv] { return srv.MetricsText(); });
-    // Both liveness dependency reporting and scheduler readiness are live etcd
-    // probes. A running MDS cannot serve membership correctly without etcd, so
-    // it must be removed from routing during an outage and recover in place.
-    mhttp->set_health_check([&srv] { return srv.ProbeEtcd(); });
-    mhttp->set_ready_check([&srv] { return srv.ProbeEtcd(); });
+    // Liveness and readiness are deliberately DIFFERENT predicates:
+    // - /healthz is left unset (always 200): it reflects only this process
+    //   being alive. A live etcd probe here turns any second-long etcd blip
+    //   into kubelet restarting ALL MDS replicas at once — a CrashLoop that
+    //   outlasts the blip and further buries etcd under re-registrations.
+    // - /readyz keeps the etcd dependency check (a running MDS cannot serve
+    //   membership without etcd and must be pulled from routing), but through
+    //   a TTL-debounced probe (DFKV_MDS_PROBE_CACHE_MS, default 2500 ms) so
+    //   the kubelet scrape cadence can't amplify into etcd read load during
+    //   an ongoing incident; a not-ready replica re-probes at most once per TTL.
+    mhttp->set_ready_check([&srv] { return srv.ProbeEtcdCached(); });
     if (mhttp->Start(metrics_port, metrics_bind) == dfkv::Status::kOk)
       std::printf("dfkv_mds /metrics on port %d\n", mhttp->port());
     std::fflush(stdout);

--- a/src/mds/mds_member_poller.cc
+++ b/src/mds/mds_member_poller.cc
@@ -16,10 +16,16 @@
 namespace dfkv {
 
 namespace {
-// Mass-shrink suspicion threshold, percent of the adopted baseline that must
-// disappear IN ONE POLL to trigger hysteresis. 50 clears any realistic
-// same-poll failure burst (a 64-node ring trips only below 32 survivors) while
-// catching the etcd NOSPACE / lease-mass-expiry signature. 0 disables.
+// Suspicion threshold, percent of the guard's trusted REFERENCE (not the last
+// adopted hop) a view must deviate by — shrink or growth — to trigger
+// hysteresis. Anchoring on a reference frozen while under suspicion is what
+// stops diffuse mass expiry (heartbeat phases spread over polls) from
+// ratcheting the ring down hop by hop, and the symmetric growth arm stops a
+// re-registration ramp from rebuilding the ring once per epoch. 50 clears
+// any realistic same-poll failure burst (a 64-node ring trips only below 32
+// survivors or above 96 members) while catching the etcd NOSPACE /
+// lease-mass-expiry signature and its recovery mirror. 0 disables both
+// deviation arms; the empty arm always stays on.
 int ShrinkGuardPct() {
   // NOTE: this is a CLIENT-side MDS-discovery knob, read when the poller is
   // built during StartMdsDiscovery — after the client's startup config dump has
@@ -81,11 +87,13 @@ bool MdsMemberPoller::PollOnce() {
   uint64_t epoch = 0;
   if (!Query(&ms, &epoch)) return false;  // failed RPC never clears the ring
 
-  // Adoption guard (MemberViewGuard): a *successful* response that is empty OR
-  // sheds most of the adopted baseline at once is almost always etcd-outage
-  // recovery (mass lease expiry), not a genuine teardown; adopting it remaps
-  // the whole cluster into a miss storm and remaps AGAIN when the members
-  // re-register. Suspicious views must persist for kViewsToAccept polls.
+  // Adoption guard (MemberViewGuard): a *successful* response that is empty
+  // OR deviates from the trusted reference past the suspicion bar is almost
+  // always etcd-outage recovery (mass lease expiry / staggered
+  // re-registration), not a genuine membership swing; adopting it remaps the
+  // whole cluster into a miss storm and remaps AGAIN when the members
+  // stabilize. Suspicious views must reappear as the SAME value for
+  // kViewsToAccept polls.
   // Rejecting must not advance the placement-content epoch — eventual adoption
   // of that same content would otherwise be suppressed by epoch dedup below.
   if (!guard_.Admit(ms.size()))

--- a/src/mds/mds_member_poller.h
+++ b/src/mds/mds_member_poller.h
@@ -15,16 +15,23 @@
 
 namespace dfkv {
 
-// Guards ring adoption against transient view collapses. Two cases, same
-// hysteresis: a *successful* ListMembers that is (a) empty, or (b) a shrink
-// dropping more than shrink_pct% of the adopted baseline at once — both are
-// almost always etcd-outage recovery (mass lease expiry, e.g. NOSPACE) rather
-// than a genuine teardown. The old guard only covered (a); a partially-expired
-// table ("non-empty but shrunken") sailed through and remapped the whole
-// cluster twice (once on the collapse, once on recovery). Suspicious views
-// must persist for views_to_accept consecutive polls to be believed. Growth
-// and small shrinks (single-node failures) pass through immediately. Pure
-// logic; unit-tested without etcd.
+// Guards ring adoption against transient view swings. All suspicion verdicts
+// are taken against a trusted REFERENCE size, not the last adopted hop: the
+// reference only follows a view size that has repeated views_to_accept_
+// consecutive polls (or a persisted suspicious view, below), never a one-off
+// hop. Three suspicious cases share one hysteresis: a successful ListMembers
+// that is (a) empty, or (b) a shrink dropping more than shrink_pct% of the
+// reference, or (c) growth ballooning past +shrink_pct% of it. (a)/(b) are
+// almost always etcd-outage recovery (mass lease expiry, e.g. NOSPACE)
+// rather than a genuine teardown, and (c) is that same outage unwinding as
+// members re-register on their own schedule. Suspicious views must reappear
+// as the SAME value for views_to_accept consecutive polls to be believed;
+// the reference stays frozen meanwhile. That closes two ratchets an
+// adjacent-hop guard has: diffuse mass expiry (heartbeat phases spread over
+// polls, each hop below the bar) can no longer walk the anchor down hop by
+// hop, and a recovery ramp of ever-changing views can no longer rebuild the
+// ring once per epoch. Small deviations still pass through immediately —
+// single-node failures propagate fast. Pure logic; unit-tested without etcd.
 class MemberViewGuard {
  public:
   MemberViewGuard(int views_to_accept, int shrink_pct)
@@ -32,49 +39,94 @@ class MemberViewGuard {
 
   // May this successful view be adopted now? false = keep the last ring.
   bool Admit(size_t incoming) {
+    // Consecutive sightings of one value: the trusted reference follows only
+    // a size that repeats views_to_accept_ polls in a row.
+    if (have_baseline_ && incoming == last_seen_) {
+      ++same_streak_;
+    } else {
+      last_seen_ = incoming;
+      same_streak_ = 1;
+    }
+
     if (!have_baseline_) {  // first successful view: adopt as-is
       have_baseline_ = true;
       baseline_ = incoming;
+      stable_ref_ = incoming;
       return true;
     }
+
     if (incoming == 0 && baseline_ > 0) {
+      suspect_streak_ = 0;  // an empty sighting breaks any suspect streak
       if (++empty_streak_ >= views_to_accept_) {
-        baseline_ = 0; empty_streak_ = 0; shrink_streak_ = 0;
+        baseline_ = 0;
+        stable_ref_ = 0;
+        empty_streak_ = 0;
         return true;  // persisted: believe the teardown
       }
       ++rejected_empty_;
       return false;
     }
     empty_streak_ = 0;
+
     using Wide = unsigned __int128;
-    if (shrink_pct_ > 0 && baseline_ > 0 &&
-        static_cast<Wide>(incoming) * 100 <
-            static_cast<Wide>(baseline_) *
-                static_cast<unsigned>(100 - shrink_pct_)) {
-      if (++shrink_streak_ >= views_to_accept_) {
-        baseline_ = incoming; shrink_streak_ = 0;
-        return true;  // persisted: real mass drain
+    if (shrink_pct_ > 0 && stable_ref_ > 0) {
+      // Deviation arms vs the FROZEN reference: a shrink below (100-pct)% of
+      // it, or symmetric growth past (100+pct)% — wide math, no overflow.
+      // Either must persist as ONE value; a still-draining or still-growing
+      // view changes every poll and restarts the streak.
+      const Wide scaled = static_cast<Wide>(incoming) * 100;
+      const Wide ref = static_cast<Wide>(stable_ref_);
+      const bool shrink_suspect =
+          scaled < ref * static_cast<unsigned>(100 - shrink_pct_);
+      const bool growth_suspect =
+          scaled > ref * static_cast<unsigned>(100 + shrink_pct_);
+      if (shrink_suspect || growth_suspect) {
+        if (incoming == suspect_value_) {
+          ++suspect_streak_;
+        } else {
+          suspect_value_ = incoming;
+          suspect_streak_ = 1;
+        }
+        if (suspect_streak_ >= views_to_accept_) {
+          baseline_ = incoming;
+          stable_ref_ = incoming;  // persisted: real mass drain / rebuild
+          suspect_streak_ = 0;
+          return true;
+        }
+        ++(shrink_suspect ? rejected_shrink_ : rejected_growth_);
+        return false;
       }
-      ++rejected_shrink_;
-      return false;
+      suspect_streak_ = 0;
     }
-    shrink_streak_ = 0;
+
     baseline_ = incoming;
+    if (stable_ref_ == 0 || same_streak_ >= views_to_accept_) {
+      // stable_ref_ == 0: re-registration after a believed teardown reanchors
+      // immediately (mirrors the first view). Otherwise the reference only
+      // advances to a value that proved stable across consecutive polls.
+      stable_ref_ = incoming;
+    }
     return true;
   }
 
   uint64_t rejected_empty() const { return rejected_empty_; }
   uint64_t rejected_shrink() const { return rejected_shrink_; }
+  uint64_t rejected_growth() const { return rejected_growth_; }
 
  private:
   const int views_to_accept_;
-  const int shrink_pct_;  // 0 disables the shrink arm (empty arm always on)
+  const int shrink_pct_;  // 0 disables both deviation arms (empty arm stays on)
   bool have_baseline_ = false;
-  size_t baseline_ = 0;  // last admitted view's member count
+  size_t baseline_ = 0;       // last admitted view's member count
+  size_t stable_ref_ = 0;     // trusted reference; frozen while under suspicion
+  size_t last_seen_ = 0;      // last polled view size, adopted or not
+  int same_streak_ = 0;       // consecutive polls reporting last_seen_
+  size_t suspect_value_ = 0;  // view size currently held in hysteresis
+  int suspect_streak_ = 0;    // consecutive polls of suspect_value_
   int empty_streak_ = 0;
-  int shrink_streak_ = 0;
   uint64_t rejected_empty_ = 0;
   uint64_t rejected_shrink_ = 0;
+  uint64_t rejected_growth_ = 0;
 };
 
 // Client-side discovery: periodically polls the MDS for a group's member view
@@ -90,9 +142,11 @@ class MdsMemberPoller {
   void Start();
   void Stop();
   bool PollOnce();
-  // Views suppressed by the adoption guard (diagnostic).
+  // Views suppressed by the adoption guard (diagnostic): empty, mass-shrink,
+  // and the symmetric mass-growth arm (recovery ramp) respectively.
   uint64_t empty_view_rejected() const { return guard_.rejected_empty(); }
   uint64_t shrink_view_rejected() const { return guard_.rejected_shrink(); }
+  uint64_t growth_view_rejected() const { return guard_.rejected_growth(); }
 
   // MDS reachability, surfaced to metrics/logs. The poll thread is otherwise
   // silent, so a mistyped/unreachable mds endpoint leaves the ring empty forever

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -1,6 +1,8 @@
 #include "common/config_dump.h"
 #include "mds/mds_server.h"
 
+#include <algorithm>
+#include <cerrno>
 #include <cstdlib>
 #include <chrono>
 #include <map>
@@ -77,6 +79,44 @@ size_t LocalLeaseMap::Size() const {
   std::lock_guard<std::mutex> lk(mu_);
   return entries_.size();
 }
+
+bool EtcdProbeCache::Get() {
+  if (ttl_ms_ == 0) return prober_();  // caching off: live probe, old behavior
+  std::unique_lock<std::mutex> lk(mu_);
+  const uint64_t now = clock_();
+  if (have_value_ && now >= fetched_at_ms_ && now - fetched_at_ms_ < ttl_ms_)
+    return value_;  // fresh: replay the last result (failures included)
+  if (refreshing_) {
+    // Single-flight: wait for the in-flight probe instead of stacking a
+    // concurrent etcd read; the result it caches is fresh by construction.
+    cv_.wait(lk, [this] { return !refreshing_; });
+    return value_;
+  }
+  refreshing_ = true;
+  lk.unlock();
+  const bool v = prober_();  // the one real probe for this TTL window
+  lk.lock();
+  value_ = v;
+  have_value_ = true;
+  fetched_at_ms_ = clock_();
+  refreshing_ = false;
+  cv_.notify_all();
+  return value_;
+}
+
+MdsServer::MdsServer(const std::string& etcd_addr, int etcd_timeout_ms)
+    : http_(etcd_addr, etcd_timeout_ms),
+      etcd_(&http_),
+      accept_legacy_(config_dump::EnvBool("DFKV_MDS_ACCEPT_LEGACY", false)),
+      // DFKV_MDS_PROBE_CACHE_MS: /readyz probe debounce, default 2500 ms,
+      // 0 disables caching (ProbeEtcdCached then behaves like ProbeEtcd).
+      // Clamped at 10 min: a negative env value wraps strtoull into ~2^64 and
+      // would pin /readyz on its first result for the process lifetime.
+      probe_cache_(std::min<uint64_t>(
+                       config_dump::EnvU64("DFKV_MDS_PROBE_CACHE_MS", 2500),
+                       600000),
+                   SteadyNowMs,
+                   [this] { return ProbeEtcd(); }) {}
 
 MdsServer::~MdsServer() { Stop(); }
 
@@ -163,10 +203,28 @@ void MdsServer::AcceptLoop() {
     const long m = std::atol(v);
     if (m > 0) max_conns = static_cast<size_t>(m);
   }
+  // First-frame ABSOLUTE deadline (DFKV_MDS_FIRST_REQ_MS, default 30000,
+  // 0=disabled): the per-syscall SO_RCVTIMEO above only bounds ONE recv, so a
+  // peer dribbling one byte per sub-timeout interval would pin a handler
+  // thread forever. With the knob on, the first COMPLETE frame must arrive
+  // within this budget counted from accept(); steady-state traffic is
+  // untouched (plain per-syscall timeout, same as before).
+  long first_req_ms = 30000;
+  if (const char* v = std::getenv("DFKV_MDS_FIRST_REQ_MS")) {
+    errno = 0;
+    char* end = nullptr;
+    const long t = std::strtol(v, &end, 10);
+    // Strict full-string parse: garbage or a negative value falls back to the
+    // default (it must never silently DISABLE the safeguard); an explicit 0
+    // disables it. Hard-clamped at 1 h so the accept+ms deadline can't wrap.
+    if (errno == 0 && end != v && *end == '\0' && t >= 0)
+      first_req_ms = t > 3600000 ? 3600000 : t;
+  }
   // Recorded from the accept thread's prologue (runs at Start, before main
   // reaches Emit after its network etcd probe) so the dump shows these defaults.
   config_dump::RecordResolved("DFKV_MDS_IO_TIMEOUT_S", std::to_string(tmo_s));
   config_dump::RecordResolved("DFKV_MDS_MAX_CONNS", std::to_string(max_conns));
+  config_dump::RecordResolved("DFKV_MDS_FIRST_REQ_MS", std::to_string(first_req_ms));
   while (running_) {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
     if (fd < 0) { if (!running_) break; continue; }
@@ -180,10 +238,17 @@ void MdsServer::AcceptLoop() {
     ReapDoneLocked();  // join handlers that finished since the last accept
     if (conns_.size() >= max_conns) { ::close(fd); continue; }
     conn_fds_.push_back(fd);
+    // The deadline is stamped at ACCEPT time (before the handler thread even
+    // starts), so a thread-start delay can never extend it.
+    const auto first_req_deadline =
+        first_req_ms > 0
+            ? std::chrono::steady_clock::now() +
+                  std::chrono::milliseconds(first_req_ms)
+            : std::chrono::steady_clock::time_point::max();
     auto done = std::make_shared<std::atomic<bool>>(false);
-    conns_.push_back({std::thread([this, fd, done] {
+    conns_.push_back({std::thread([this, fd, done, tmo_s, first_req_deadline] {
                         NameThisThread("mds-conn");
-                        Handle(fd);
+                        Handle(fd, tmo_s, first_req_deadline);
                         {
                           std::lock_guard<std::mutex> lk(conn_mu_);
                           for (auto it = conn_fds_.begin(); it != conn_fds_.end(); ++it)
@@ -428,7 +493,15 @@ std::string MdsServer::GroupMetricsText() {
   return s;
 }
 
-void MdsServer::Handle(int fd) {
+void MdsServer::Handle(int fd, long io_timeout_s,
+                       std::chrono::steady_clock::time_point first_frame_deadline) {
+  const timeval base_rcvtmo{io_timeout_s, 0};
+  // While armed, both reads of the FIRST frame (prefix + payload) run through
+  // net::ReadAllWithin, which re-arms SO_RCVTIMEO to min(base, remaining)
+  // before every recv — so the deadline is absolute and a byte-at-a-time
+  // dribble dies on it instead of surviving under a fresh per-syscall budget.
+  bool arm_deadline =
+      first_frame_deadline != std::chrono::steady_clock::time_point::max();
   while (running_) {
     // Control-plane epoch discrimination for mixed-generation rollouts. The
     // leading byte is the deterministic discriminator: native v2 peers write
@@ -437,20 +510,38 @@ void MdsServer::Handle(int fd) {
     // known epoch (via DFKV_MDS_ACCEPT_LEGACY), not removed. Data-plane
     // listeners stay strictly epoch-6/7; this shim exists only in the MDS.
     char prefix[kReqPrefix];
-    if (!net::ReadAll(fd, prefix, 1)) return;
+    // Epoch discriminator: read the leading byte first (v2 = 50-byte prefix,
+    // legacy = 42-byte one). While armed it runs under the same absolute
+    // first-frame deadline as every other read of the first frame.
+    const bool got_discriminator =
+        arm_deadline
+            ? net::ReadAllWithin(fd, prefix, 1, base_rcvtmo,
+                                 first_frame_deadline)
+            : net::ReadAll(fd, prefix, 1);
+    if (!got_discriminator) return;
     const uint8_t epoch = static_cast<uint8_t>(prefix[0]);
     bool legacy = false;
     ReqFields rq;
     // MDS frames carry a group name + one MemberInfo (<1 KiB); cap the
     // declared length so a forged prefix can't trigger a giant allocation.
     if (epoch == kNativeProtoTcp) {
-      if (!net::ReadAll(fd, prefix + 1, kReqPrefix - 1) ||
+      const bool got_prefix =
+          arm_deadline
+              ? net::ReadAllWithin(fd, prefix + 1, kReqPrefix - 1, base_rcvtmo,
+                                   first_frame_deadline)
+              : net::ReadAll(fd, prefix + 1, kReqPrefix - 1);
+      if (!got_prefix ||
           !DecodeReq(prefix, &rq, wire_limits::kMdsMaxReqPayload)) {
         return;
       }
     } else {
       if (!accept_legacy_ || epoch != kNativeProtoLegacyTcp) return;
-      if (!net::ReadAll(fd, prefix + 1, kLegacyReqPrefix - 1) ||
+      const bool got_prefix =
+          arm_deadline
+              ? net::ReadAllWithin(fd, prefix + 1, kLegacyReqPrefix - 1,
+                                   base_rcvtmo, first_frame_deadline)
+              : net::ReadAll(fd, prefix + 1, kLegacyReqPrefix - 1);
+      if (!got_prefix ||
           !DecodeLegacyReq(prefix, &rq, wire_limits::kMdsMaxReqPayload)) {
         return;
       }
@@ -458,7 +549,22 @@ void MdsServer::Handle(int fd) {
       metrics_.legacy_frames.fetch_add(1, std::memory_order_relaxed);
     }
     std::vector<char> payload(rq.payload_len);
-    if (rq.payload_len && !net::ReadAll(fd, payload.data(), rq.payload_len)) return;
+    if (rq.payload_len) {
+      const bool got_payload =
+          arm_deadline
+              ? net::ReadAllWithin(fd, payload.data(), rq.payload_len,
+                                   base_rcvtmo, first_frame_deadline)
+              : net::ReadAll(fd, payload.data(), rq.payload_len);
+      if (!got_payload) return;
+    }
+    if (arm_deadline) {
+      // First complete frame received: end the deadline regime. ReadAllWithin
+      // shrank SO_RCVTIMEO toward the deadline, so restore the base per-syscall
+      // budget for all steady-state reads.
+      arm_deadline = false;
+      ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &base_rcvtmo,
+                   sizeof(base_rcvtmo));
+    }
 
     std::string data;
     Status st = Status::kInvalid;

--- a/src/mds/mds_server.h
+++ b/src/mds/mds_server.h
@@ -2,13 +2,17 @@
 #define DFKV_MDS_SERVER_H_
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "mds/etcd_client.h"
@@ -48,6 +52,39 @@ class LocalLeaseMap {
 };
 
 
+// TTL-debounced single-flight boolean probe (the etcd reachability check behind
+// /readyz). Within the TTL the last result — success OR failure — is replayed,
+// so a high kubelet scrape cadence can't amplify into etcd read load during an
+// outage, and a flapping etcd costs one probe per TTL instead of one per hit.
+// On expiry at most ONE real probe runs; a caller arriving mid-flight waits
+// for that result instead of stacking a parallel etcd range. ttl_ms == 0
+// disables caching (every call probes live — the pre-knob behavior). Clock and
+// prober are injected so tests drive it with a fake clock, deterministically.
+class EtcdProbeCache {
+ public:
+  using Clock = std::function<uint64_t()>;   // steady-clock milliseconds
+  using Prober = std::function<bool()>;
+
+  EtcdProbeCache(uint64_t ttl_ms, Clock clock, Prober prober)
+      : ttl_ms_(ttl_ms),
+        clock_(std::move(clock)),
+        prober_(std::move(prober)) {}
+
+  bool Get();
+
+ private:
+  const uint64_t ttl_ms_;
+  Clock clock_;
+  Prober prober_;
+  std::mutex mu_;
+  std::condition_variable cv_;
+  bool have_value_ = false;
+  bool refreshing_ = false;
+  uint64_t fetched_at_ms_ = 0;
+  bool value_ = false;
+};
+
+
 // Stateless MDS: nodes/clients connect over TCP (same wire framing as the cache
 // node). The MDS is the only etcd client; it holds each member's lease on the
 // node's behalf. The {key->leaseID} map is reconstructable from heartbeats, so
@@ -57,10 +94,7 @@ class MdsServer {
   // DFKV_MDS_ACCEPT_LEGACY (default off) widens the control-plane version
   // gate by exactly one epoch: v1.x peers are served with the legacy
   // 42/10-byte framing via wire_legacy.h. Off = historic strict behavior.
-  explicit MdsServer(const std::string& etcd_addr, int etcd_timeout_ms = 2000)
-      : http_(etcd_addr, etcd_timeout_ms),
-        etcd_(&http_),
-        accept_legacy_(config_dump::EnvBool("DFKV_MDS_ACCEPT_LEGACY", false)) {}
+  explicit MdsServer(const std::string& etcd_addr, int etcd_timeout_ms = 2000);
   ~MdsServer();
 
   Status Start(int port);
@@ -86,14 +120,20 @@ class MdsServer {
   // One read against etcd (a bounded RangePrefix on a probe key). Returns true
   // iff etcd answered. Used at startup to fail loud on a misconfigured --etcd
   // (a wrong endpoint/scheme otherwise runs "healthy" while every registration
-  // silently fails), and by /healthz to reflect etcd reachability.
+  // silently fails), and by the startup probe loop in dfkv_mds_main.
   bool ProbeEtcd() { return etcd_.RangePrefix("/dfkv/v1/_healthz_probe/").has_value(); }
+  // Debounced probe for /readyz: replayed within DFKV_MDS_PROBE_CACHE_MS so
+  // kubelet probe cadence can't amplify into etcd load (see EtcdProbeCache).
+  bool ProbeEtcdCached() { return probe_cache_.Get(); }
 
   static constexpr int kTtlSeconds = 30;
 
  private:
   void AcceptLoop();
-  void Handle(int fd);
+  // first_frame_deadline == time_point::max() means the first-frame deadline
+  // knob is off (DFKV_MDS_FIRST_REQ_MS=0): the whole conn uses plain reads.
+  void Handle(int fd, long io_timeout_s,
+              std::chrono::steady_clock::time_point first_frame_deadline);
   void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
   Status Upsert(const std::string& group, const MemberInfo& m);
   Status ListMembers(const std::string& group, std::string* out);
@@ -115,6 +155,7 @@ class MdsServer {
   // Resolved once at ctor; widens Handle()'s control-plane version gate by
   // the single legacy epoch (v1.x peers, wire_legacy.h framing).
   const bool accept_legacy_;
+  EtcdProbeCache probe_cache_;  // TTL + prober resolved in the ctor (env knob)
   std::atomic<bool> running_{false};
   int listen_fd_ = -1;
   int port_ = 0;

--- a/src/transport/dev_frame.h
+++ b/src/transport/dev_frame.h
@@ -18,6 +18,34 @@ constexpr size_t kDevNameBytes = 32;
 constexpr uint32_t kDevCapsV2Magic = 0x32504344u;  // ASCII "DCP2" (LE)
 constexpr uint8_t kDevProtoV2 = 2;
 
+// Room a device name must leave in the fixed 32-byte frame: NUL terminator +
+// "DCP2" u32 + max_block_bytes u64 + protocol u8. A name at most this long
+// encodes whole; a longer one would silently lose the capability trailer
+// (EncodeDevFrame drops it as deep defense), after which the peer rejects
+// every real connection as "missing v2 negotiation" while short-named
+// capability probes keep passing. Configuration must instead fail fast on
+// such names — DeviceNameFitsFrame / OversizedDeviceNameError below are the
+// shared checks used by the client whitelist and the server anchors.
+constexpr size_t kDevFrameCapsTrailerBytes = 1 + 4 + 8 + 1;
+constexpr size_t kMaxDeviceNameBytes = kDevNameBytes - kDevFrameCapsTrailerBytes;
+
+// True when dev can be announced inside the bootstrap frame without losing
+// the capability trailer. An empty name is legal: it asks the peer for its
+// default device.
+inline bool DeviceNameFitsFrame(const std::string& dev) {
+  return dev.size() <= kMaxDeviceNameBytes;
+}
+
+// Shared fail-fast diagnostic naming both the offending device and the real
+// limit — not the misleading "missing v2 negotiation" the peer would report.
+inline std::string OversizedDeviceNameError(const std::string& dev) {
+  return "rdma: device name \"" + dev + "\" is " + std::to_string(dev.size()) +
+         " bytes, over the v2 bootstrap frame limit of " +
+         std::to_string(kMaxDeviceNameBytes) +
+         " bytes; encode would silently drop the \"DCP2\" capability trailer. "
+         "Rename the device (udev/bond alias) or configure a shorter name";
+}
+
 inline void EncodeDevFrame(const std::string& dev, uint64_t max_block_bytes,
                            char out[kDevNameBytes],
                            uint8_t protocol_version = kDevProtoV2) {
@@ -25,8 +53,12 @@ inline void EncodeDevFrame(const std::string& dev, uint64_t max_block_bytes,
   const size_t n = dev.size() < kDevNameBytes - 1 ? dev.size()
                                                   : kDevNameBytes - 1;
   std::memcpy(out, dev.data(), n);
+  // Deep defense: names over kMaxDeviceNameBytes no longer arrive here —
+  // client whitelist and server anchor validation reject them at startup —
+  // but keep the silent trailer drop so any future unvalidated caller still
+  // fails closed (peer rejects) rather than negotiating phantom capabilities.
   if (protocol_version != kDevProtoV2 || max_block_bytes == 0 ||
-      n + 1 + 4 + 8 + 1 > kDevNameBytes)
+      n > kMaxDeviceNameBytes)
     return;
   std::memcpy(out + n + 1, &kDevCapsV2Magic, 4);
   std::memcpy(out + n + 5, &max_block_bytes, 8);

--- a/src/transport/rail_classify.h
+++ b/src/transport/rail_classify.h
@@ -1,0 +1,86 @@
+/* Datapath failure attribution for RDMA multi-rail health accounting: maps a
+ * failed completion window's evidence onto RailCompletion so a dead or slow
+ * PEER never drags a healthy LOCAL rail into quarantine. Verbs-dependent
+ * (ibv_wc_status); only RDMA-gated compilation units may include this. */
+#ifndef DFKV_RAIL_CLASSIFY_H_
+#define DFKV_RAIL_CLASSIFY_H_
+
+#include <infiniband/verbs.h>
+
+#include "transport/rail_select.h"
+
+namespace dfkv {
+namespace rdma {
+
+// Attribute a failed datapath completion window to the local rail or the
+// remote endpoint. `status` is the first non-SUCCESS status reaped while
+// draining the window (IBV_WC_SUCCESS when the window produced no error WC),
+// and `had_completions` reports whether ANY completion events arrived before
+// the window died.
+//
+// kEndpointFailure (peer/fabric evidence; credits returned, rail health
+// untouched):
+//   - REM_ACCESS/REM_OP/REM_INV_REQ/REM_ABORT: the peer's QP, MR or servicing
+//     logic rejected the request;
+//   - RETRY_EXC/RNR_RETRY_EXC/RESP_TIMEOUT: the peer vanished or stalled
+//     through the full retry chain;
+//   - WR_FLUSH_ERR: outstanding WRs flushed while the QP entered the error
+//     state — teardown fallout of a peer-triggered QP error, not a local
+//     hardware signal;
+//   - deadline expiry with no error WC at all.
+// kRailFailure (local evidence; counts toward quarantine):
+//   - the LOC_* family (local length/QP-access/EEC/protection/RDD faults),
+//     FATAL_ERR and GENERAL_ERR (device-level local faults);
+//   - post/CQ/verbs API failures never produce a WC; callers map them to a
+//     local status before classifying (see rdma_transport.cc).
+//
+// Everything else (MW_BIND/BAD_RESP/INV_EEC*/statuses added after this
+// table, out-of-range values) defaults to kEndpointFailure: a wrongly spared
+// rail merely keeps one connection's credits healthy, while a wrongly blamed
+// rail quarantines a healthy HCA and stalls every operation for the cooldown.
+// When evidence is ambiguous, spare the local rail.
+inline RailCompletion ClassifyCompletion(ibv_wc_status status,
+                                         bool had_completions) {
+  if (status == IBV_WC_SUCCESS) {
+    // No error WC: the window died by its deadline, not by a verbs fault.
+    if (had_completions) {
+      // Partial progress then silence: completions prove the rail was healthy
+      // when last observed, so the stall afterwards is the peer going quiet
+      // mid-window.
+      return RailCompletion::kEndpointFailure;
+    }
+    // Zero completions: the peer never answered and the local NIC surfaced no
+    // error of its own.
+    return RailCompletion::kEndpointFailure;
+  }
+  switch (status) {
+    // Peer-sourced evidence (see header comment).
+    case IBV_WC_REM_ACCESS_ERR:
+    case IBV_WC_REM_OP_ERR:
+    case IBV_WC_REM_INV_REQ_ERR:
+    case IBV_WC_REM_ABORT_ERR:
+    case IBV_WC_RETRY_EXC_ERR:
+    case IBV_WC_RNR_RETRY_EXC_ERR:
+    case IBV_WC_RESP_TIMEOUT_ERR:
+    case IBV_WC_WR_FLUSH_ERR:
+      return RailCompletion::kEndpointFailure;
+    // Local-sourced evidence (see header comment).
+    case IBV_WC_LOC_LEN_ERR:
+    case IBV_WC_LOC_QP_OP_ERR:
+    case IBV_WC_LOC_EEC_OP_ERR:
+    case IBV_WC_LOC_PROT_ERR:
+    case IBV_WC_LOC_ACCESS_ERR:
+    case IBV_WC_LOC_RDD_VIOL_ERR:
+    case IBV_WC_FATAL_ERR:
+    case IBV_WC_GENERAL_ERR:
+      return RailCompletion::kRailFailure;
+    default:
+      // Unknown or ambiguous: spare the local rail (see header comment).
+      return RailCompletion::kEndpointFailure;
+  }
+}
+
+}  // namespace rdma
+}  // namespace dfkv
+
+#endif  // DFKV_RAIL_CLASSIFY_H_

--- a/src/transport/rail_select.h
+++ b/src/transport/rail_select.h
@@ -225,11 +225,13 @@ class RailPolicy {
       State& rail = rails_[i];
       if (!Allowed(i, allowed)) continue;
       if (rail.quarantined_until_us > now_us) continue;
-      if (rail.quarantined_until_us != 0 && !rail.recovery_probe) {
-        // Cooldown elapsed. Permit exactly one probe until it completes.
-        rail.recovery_probe = true;
-      }
-      if (rail.recovery_probe && rail.inflight != 0) continue;
+      // Cooldown elapsed: this rail may serve as the single recovery probe.
+      // The recovery_probe flag is set only when the lease is actually granted
+      // to this rail below, never during the scan — a candidate that loses the
+      // score comparison must not keep a phantom "probe in flight" state that
+      // only a nonexistent completion could clear.
+      const bool probe = rail.recovery_probe || rail.quarantined_until_us != 0;
+      if (probe && rail.inflight != 0) continue;
       if (requested > rail.credits - rail.inflight) {
         ++rail.credits_exhausted;
         continue;
@@ -240,16 +242,20 @@ class RailPolicy {
           occupancy + rail.latency_ewma_us * config_.latency_weight +
           static_cast<uint64_t>(rail.consecutive_errors) *
               config_.error_penalty_us;
-      if ((rail.recovery_probe && !selected_recovery) ||
-          (rail.recovery_probe == selected_recovery &&
-           score < selected_score)) {
+      if ((probe && !selected_recovery) ||
+          (probe == selected_recovery && score < selected_score)) {
         selected = i;
         selected_score = score;
-        selected_recovery = rail.recovery_probe;
+        selected_recovery = probe;
       }
     }
     if (selected == rails_.size()) return std::nullopt;
     State& rail = rails_[selected];
+    if (!rail.recovery_probe && rail.quarantined_until_us != 0) {
+      // Granting the single post-cooldown admission on this rail: mark the
+      // probe in flight. Complete clears the flag exactly once.
+      rail.recovery_probe = true;
+    }
     rail.inflight += requested;
     ++rail.selections;
     return RailLease{selected, requested};
@@ -260,6 +266,25 @@ class RailPolicy {
   std::condition_variable cv_;
   std::vector<State> rails_;
 };
+
+// Bounded admission that prefers one candidate mask and degrades to a
+// fallback mask when no preferred rail can serve immediately — every
+// preferred rail quarantined or credit-bound — while fallback rails still
+// can. Locality stays strictly preferred whenever it is admissible; the
+// fallback is only a backstop. At most one lease is ever granted per call;
+// when neither mask can serve right away, the caller waits on the preferred
+// rails exactly as RailPolicy::Acquire with `preferred` alone would.
+inline std::optional<RailLease> AcquireWithFallback(
+    RailPolicy& policy, uint32_t requested, uint64_t timeout_us,
+    const std::vector<uint8_t>& preferred,
+    const std::vector<uint8_t>& fallback) {
+  const uint64_t now = RailPolicy::NowMicros();
+  if (auto lease = policy.TryAcquire(requested, now, preferred)) return lease;
+  if (!fallback.empty()) {
+    if (auto lease = policy.TryAcquire(requested, now, fallback)) return lease;
+  }
+  return policy.Acquire(requested, timeout_us, preferred);
+}
 
 }  // namespace rdma
 }  // namespace dfkv

--- a/src/transport/rdma_topology.cc
+++ b/src/transport/rdma_topology.cc
@@ -128,6 +128,7 @@ RailCandidates RdmaTopology::CandidatesFor(int numa_node,
   }
 
   out.locality = RailLocality::kLocal;
+  out.fallback = enabled_;
   for (size_t i = 0; i < devices_.size(); ++i) {
     if (devices_[i].numa_node != numa_node) out.allowed[i] = 0;
   }

--- a/src/transport/rdma_topology.h
+++ b/src/transport/rdma_topology.h
@@ -36,6 +36,12 @@ struct RailCandidates {
   // Stable device-index mask. A non-empty mask prevents the admission policy's
   // empty-mask "all rails" convention from reviving a disabled topology rail.
   std::vector<uint8_t> allowed;
+  // Degraded backstop mask, populated only when locality == kLocal: every
+  // currently enabled rail, locality aside. Callers retry admission against it
+  // once when no allowed (NUMA-local) rail can serve, so locality prefers but
+  // never prevents progress. Empty for every other locality, where allowed
+  // already spans all enabled rails.
+  std::vector<uint8_t> fallback;
   RailLocality locality = RailLocality::kDisabled;
 };
 
@@ -64,8 +70,10 @@ class RdmaTopology {
 
   // Build the production admission mask from discovered device NUMA metadata.
   // With NUMA disabled every enabled rail is allowed. With it enabled, local
-  // rails are exclusive when known; unknown caller/no-local topology falls back
-  // to every enabled rail so locality can never prevent progress.
+  // rails are exclusive when known and `fallback` carries every enabled rail
+  // as the backstop for when no local rail is admissible (quarantined or
+  // credit-bound); unknown caller/no-local topology falls back to every
+  // enabled rail in `allowed` itself. Locality can never prevent progress.
   RailCandidates CandidatesFor(int numa_node, bool numa_aware) const;
 
   // Exclude a rail after a runtime local-device failure. Existing connections

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -235,6 +235,19 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
     if (configured) list = configured;
   }
   const auto filter = ParseDeviceList(list);
+  // A configured rail name is announced to the peer inside the fixed-size v2
+  // bootstrap frame (EncodeDevFrame at Acquire). One that does not fit would
+  // silently lose the "DCP2" capability trailer: capability probes (short
+  // probe name) keep succeeding while every real connection is rejected as
+  // "missing v2 negotiation". Fail here, at startup, with the actual cause
+  // and limit. Auto-discovery needs no check: it announces an empty name.
+  for (const auto& device : filter) {
+    if (!rdma::DeviceNameFitsFrame(device)) {
+      const std::string error = rdma::OversizedDeviceNameError(device);
+      DFKV_LOG_ERROR(error);
+      throw std::runtime_error(error);
+    }
+  }
   auto_device_ = filter.empty();
   auto discovered = rdma::RdmaTopology::Discover(filter);
   if (discovered.empty()) {

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -383,6 +383,9 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
   // the caller's local NUMA rails when that topology exists, then choose least
   // normalized inflight with latency/error penalties and stable device index as
   // the final tie-break. Unknown/no-local topology falls back to all rails.
+  // When every NUMA-local rail is inadmissible (quarantined or credit-bound),
+  // admission retries once across every enabled rail — locality is a
+  // preference, never an availability gate.
   const int caller_node = numa_aware_ ? numa::CurrentNode() : -1;
   const auto candidates =
       topology_->CandidatesFor(caller_node, numa_aware_);
@@ -391,8 +394,10 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
   } else if (candidates.locality == rdma::RailLocality::kNoLocal) {
     numa_no_local_fallbacks_.fetch_add(1, std::memory_order_relaxed);
   }
-  auto lease = rail_policy_->Acquire(requested, rail_backpressure_us_,
-                                     candidates.allowed);
+  auto lease = rdma::AcquireWithFallback(*rail_policy_, requested,
+                                         rail_backpressure_us_,
+                                         candidates.allowed,
+                                         candidates.fallback);
   if (!lease) return nullptr;
 
   const size_t ridx = lease->rail;

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -14,6 +14,7 @@
 #include "utils/net_util.h"     // Dial / WriteAll / ReadAll / Put*/Get*
 #include "utils/numa_util.h"
 #include "transport/rdma_topology.h"
+#include "transport/rail_classify.h"
 #include "transport/rail_select.h"
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
 #include "transport/rdma_protocol.h"
@@ -91,14 +92,31 @@ std::string JoinDevices(const std::vector<std::string>& devices) {
   return out;
 }
 
+// Local post/CQ/verbs API failures happen below the work-completion layer, so
+// no real WC status exists for them. The reap helpers report such failures as
+// this local-fault bucket so every datapath teardown can funnel through
+// rdma::ClassifyCompletion and attribute them kRailFailure.
+constexpr ibv_wc_status kLocalFaultWcStatus = IBV_WC_GENERAL_ERR;
+
 // Reap one signaled request completion and one status RECV per posted request.
 // Every poll consumes the same absolute deadline; a partial CQ drain cannot
 // restart the timeout budget. slot_count may exceed posted when invalid items
 // were skipped inside a mixed window.
+// On failure the evidence out-params describe what killed the window:
+// worst_status is the first non-SUCCESS reaped status (IBV_WC_SUCCESS when no
+// error WC was observed — deadline expiry or a bogus wr_id), and
+// had_completions whether ANY completion events arrived. Classify them with
+// rdma::ClassifyCompletion before Destroying the connection: a reaped
+// remote-side status or a silent deadline is peer evidence, never rail
+// evidence. A WaitComp CQ/verbs API failure surfaces as kLocalFaultWcStatus.
 bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
                 std::vector<uint32_t>* rbytes, int timeout_ms,
-                bool* timed_out = nullptr) {
+                bool* timed_out = nullptr,
+                ibv_wc_status* worst_status = nullptr,
+                bool* had_completions = nullptr) {
   if (timed_out) *timed_out = false;
+  if (worst_status) *worst_status = IBV_WC_SUCCESS;
+  if (had_completions) *had_completions = false;
   rbytes->assign(slot_count, 0);
   if (posted == 0) return true;
   std::vector<ibv_wc> wcs(2 * posted);
@@ -114,10 +132,19 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
                                 remaining_ms);
     if (got <= 0) {
       if (got == 0 && timed_out) *timed_out = true;
+      if (got < 0 && worst_status) {
+        // CQ notification/polling itself failed: local rail evidence (the
+        // client never Wake()s a live endpoint; Wake is server shutdown only).
+        *worst_status = kLocalFaultWcStatus;
+      }
       return false;
     }
+    if (had_completions) *had_completions = true;
     for (int i = 0; i < got; ++i) {
-      if (wcs[i].status != IBV_WC_SUCCESS) return false;
+      if (wcs[i].status != IBV_WC_SUCCESS) {
+        if (worst_status) *worst_status = wcs[i].status;
+        return false;
+      }
       if (wcs[i].opcode == IBV_WC_RECV) {
         const size_t slot = static_cast<size_t>(wcs[i].wr_id);
         if (slot >= slot_count) return false;
@@ -131,17 +158,30 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
 
 bool ReapWindow(rdma::RcEndpoint& ep, size_t width,
                 std::vector<uint32_t>* rbytes, int timeout_ms,
-                bool* timed_out = nullptr) {
-  return ReapPosted(ep, width, width, rbytes, timeout_ms, timed_out);
+                bool* timed_out = nullptr,
+                ibv_wc_status* worst_status = nullptr,
+                bool* had_completions = nullptr) {
+  return ReapPosted(ep, width, width, rbytes, timeout_ms, timed_out,
+                    worst_status, had_completions);
 }
 
 // Post ordinary SEND requests with one status RECV per slot.
 bool RunWindow(rdma::RcEndpoint& ep, const std::vector<size_t>& slen,
                std::vector<uint32_t>* rbytes, int timeout_ms,
-               bool* timed_out = nullptr) {
-  for (size_t j = 0; j < slen.size(); ++j)
-    if (!ep.PostRecv(j) || !ep.PostSend(j, slen[j])) return false;
-  return ReapWindow(ep, slen.size(), rbytes, timeout_ms, timed_out);
+               bool* timed_out = nullptr,
+               ibv_wc_status* worst_status = nullptr,
+               bool* had_completions = nullptr) {
+  for (size_t j = 0; j < slen.size(); ++j) {
+    if (!ep.PostRecv(j) || !ep.PostSend(j, slen[j])) {
+      // A post failure is local verbs evidence: no WC exists to reap, so
+      // report the local-fault bucket for uniform classification.
+      if (worst_status) *worst_status = kLocalFaultWcStatus;
+      if (had_completions) *had_completions = false;
+      return false;
+    }
+  }
+  return ReapWindow(ep, slen.size(), rbytes, timeout_ms, timed_out,
+                    worst_status, had_completions);
 }
 }  // namespace
 
@@ -418,7 +458,7 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
     ::close(fd);
     DFKV_LOG_WARN("rdma: device " + dev +
                   " Open failed; rail failure policy will quarantine it");
-    Destroy(conn);
+    Destroy(conn, rdma::RailCompletion::kRailFailure);
     return nullptr;
   }
 
@@ -886,8 +926,17 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
 
     std::vector<uint32_t> reply_bytes;
     bool timed_out = false;
-    if (ok)
-      ok = ReapWindow(ep, 1, &reply_bytes, op_timeout_ms_, &timed_out);
+    // Post/encode failures above carry no WC evidence and stay a local rail
+    // failure; a failed reap window is classified from its own evidence so a
+    // dead peer cannot poison a healthy local rail.
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
+    if (ok) {
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
+      ok = ReapWindow(ep, 1, &reply_bytes, op_timeout_ms_, &timed_out,
+                      &wc_status, &had_wcs);
+      if (!ok) completion = rdma::ClassifyCompletion(wc_status, had_wcs);
+    }
     if (timed_out)
       completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
     const uint32_t recv_bytes =
@@ -898,7 +947,7 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
     }
 
     if (!ok) {
-      Destroy(conn);
+      Destroy(conn, completion);
       if (!from_pool) return Status::kIOError;
       continue;
     }
@@ -1017,7 +1066,10 @@ std::vector<Status> RdmaTransport::CacheMany(
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
     bool conn_ok = true;
-    bool endpoint_failure = false;
+    // Failure attribution for Destroy: post/encode/register failures keep the
+    // local-rail default; a failed reap window is classified from its WC
+    // evidence; wire decode failures blame the peer.
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     for (size_t base = 0; base < count && conn_ok; base += window) {
       const size_t width = std::min(window, count - base);
       std::vector<ibv_mr*> payload_mrs(width, nullptr);
@@ -1055,10 +1107,13 @@ std::vector<Status> RdmaTransport::CacheMany(
       }
       std::vector<uint32_t> reply_bytes;
       bool timed_out = false;
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
       if (conn_ok &&
           !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out)) {
+                      &timed_out, &wc_status, &had_wcs)) {
         conn_ok = false;
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
       if (timed_out)
         completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
@@ -1072,7 +1127,7 @@ std::vector<Status> RdmaTransport::CacheMany(
         if (reply_bytes[slot] < kRespPrefix ||
             !conn->Decode(ep.rbuf(slot), &status, &data_len, 0)) {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         result[item_index] = status;
@@ -1082,8 +1137,7 @@ std::vector<Status> RdmaTransport::CacheMany(
       Release(node, Lane::kData, conn);
       return result;
     }
-    Destroy(conn, endpoint_failure ? rdma::RailCompletion::kEndpointFailure
-                                   : rdma::RailCompletion::kRailFailure);
+    Destroy(conn, completion);
     if (from_pool) continue;
     return result;
   }
@@ -1134,7 +1188,10 @@ std::vector<Status> RdmaTransport::RangeMany(
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
     bool conn_ok = true;
-    bool endpoint_failure = false;
+    // Failure attribution for Destroy: post/encode/register failures keep the
+    // local-rail default; a failed reap window is classified from its WC
+    // evidence; wire decode failures blame the peer.
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     for (size_t base = 0; base < count && conn_ok; base += window) {
       const size_t width = std::min(window, count - base);
       std::vector<ibv_mr*> output_mrs(width, nullptr);
@@ -1164,9 +1221,13 @@ std::vector<Status> RdmaTransport::RangeMany(
       }
       std::vector<uint32_t> reply_bytes;
       bool timed_out = false;
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
       if (conn_ok &&
-          !ReapWindow(ep, width, &reply_bytes, BatchTimeout(), &timed_out)) {
+          !ReapWindow(ep, width, &reply_bytes, BatchTimeout(), &timed_out,
+                      &wc_status, &had_wcs)) {
         conn_ok = false;
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
       if (timed_out)
         completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
@@ -1175,7 +1236,7 @@ std::vector<Status> RdmaTransport::RangeMany(
       for (size_t slot = 0; slot < width; ++slot) {
         if (reply_bytes[slot] < kRespPrefix) {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         Status status;
@@ -1184,7 +1245,7 @@ std::vector<Status> RdmaTransport::RangeMany(
         if (!conn->Decode(ep.rbuf(slot), &status, &data_len, length,
                           &value_len)) {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         result[base + slot] = status;
@@ -1196,7 +1257,7 @@ std::vector<Status> RdmaTransport::RangeMany(
           output.resize(static_cast<size_t>(data_len));
         } else {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
       }
@@ -1205,8 +1266,7 @@ std::vector<Status> RdmaTransport::RangeMany(
       Release(node, Lane::kData, conn);
       return result;
     }
-    Destroy(conn, endpoint_failure ? rdma::RailCompletion::kEndpointFailure
-                                   : rdma::RailCompletion::kRailFailure);
+    Destroy(conn, completion);
     if (from_pool) continue;
     return result;
   }
@@ -1235,7 +1295,10 @@ std::vector<Status> RdmaTransport::ExistMany(
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
     bool conn_ok = true;
-    bool endpoint_failure = false;
+    // Failure attribution for Destroy: post/encode/register failures keep the
+    // local-rail default; a failed reap window is classified from its WC
+    // evidence; wire decode failures blame the peer.
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     for (size_t base = 0; base < count && conn_ok; base += window) {
       const size_t width = std::min(window, count - base);
       std::vector<size_t> send_lengths(width);
@@ -1246,8 +1309,11 @@ std::vector<Status> RdmaTransport::ExistMany(
       }
       std::vector<uint32_t> reply_bytes;
       bool timed_out = false;
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
       if (!RunWindow(ep, send_lengths, &reply_bytes, BatchTimeout(),
-                     &timed_out)) {
+                     &timed_out, &wc_status, &had_wcs)) {
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
         if (timed_out)
           completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
         conn_ok = false;
@@ -1259,7 +1325,7 @@ std::vector<Status> RdmaTransport::ExistMany(
         if (reply_bytes[slot] < kRespPrefix ||
             !conn->Decode(ep.rbuf(slot), &status, &data_len, 0)) {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         result[base + slot] = status;
@@ -1270,8 +1336,7 @@ std::vector<Status> RdmaTransport::ExistMany(
       Release(node, Lane::kControl, conn);
       return result;
     }
-    Destroy(conn, endpoint_failure ? rdma::RailCompletion::kEndpointFailure
-                                   : rdma::RailCompletion::kRailFailure);
+    Destroy(conn, completion);
     if (from_pool) continue;
     return result;
   }
@@ -1316,7 +1381,10 @@ std::vector<Status> RdmaTransport::RangeInto(
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
     bool conn_ok = true;
-    bool endpoint_failure = false;
+    // Failure attribution for Destroy: post/encode/register failures keep the
+    // local-rail default; a failed reap window is classified from its WC
+    // evidence; wire decode failures blame the peer.
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     for (size_t base = 0; base < count && conn_ok; base += window) {
       const size_t width = std::min(window, count - base);
       std::vector<ibv_mr*> output_mrs(width, nullptr);
@@ -1352,10 +1420,13 @@ std::vector<Status> RdmaTransport::RangeInto(
       }
       std::vector<uint32_t> reply_bytes;
       bool timed_out = false;
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
       if (conn_ok &&
           !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out)) {
+                      &timed_out, &wc_status, &had_wcs)) {
         conn_ok = false;
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
       if (timed_out)
         completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
@@ -1371,7 +1442,7 @@ std::vector<Status> RdmaTransport::RangeInto(
             !conn->Decode(ep.rbuf(slot), &status, &data_len,
                           destinations[item_index].n, &value_len)) {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         result[item_index] = status;
@@ -1382,8 +1453,7 @@ std::vector<Status> RdmaTransport::RangeInto(
       Release(node, Lane::kData, conn);
       return result;
     }
-    Destroy(conn, endpoint_failure ? rdma::RailCompletion::kEndpointFailure
-                                   : rdma::RailCompletion::kRailFailure);
+    Destroy(conn, completion);
     if (from_pool) continue;
     return result;
   }
@@ -1447,7 +1517,10 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
     bool conn_ok = true;
-    bool endpoint_failure = false;
+    // Failure attribution for Destroy: post/encode/register failures keep the
+    // local-rail default; a failed reap window is classified from its WC
+    // evidence; wire decode failures blame the peer.
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     for (size_t base = 0; base < count && conn_ok; base += window) {
       const size_t width = std::min(window, count - base);
       std::vector<std::vector<ibv_mr*>> mrs(width);
@@ -1489,10 +1562,13 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       }
       std::vector<uint32_t> reply_bytes;
       bool timed_out = false;
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
       if (conn_ok &&
           !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out)) {
+                      &timed_out, &wc_status, &had_wcs)) {
         conn_ok = false;
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
       if (timed_out)
         completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
@@ -1507,7 +1583,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
         if (reply_bytes[slot] < kRespPrefix ||
             !conn->Decode(ep.rbuf(slot), &status, &data_len, 0)) {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         result[item_index] = status;
@@ -1517,8 +1593,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       Release(node, Lane::kData, conn);
       return result;
     }
-    Destroy(conn, endpoint_failure ? rdma::RailCompletion::kEndpointFailure
-                                   : rdma::RailCompletion::kRailFailure);
+    Destroy(conn, completion);
     if (from_pool) continue;
     return result;
   }
@@ -1613,7 +1688,10 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
     bool conn_ok = true;
-    bool endpoint_failure = false;
+    // Failure attribution for Destroy: post/encode/register failures keep the
+    // local-rail default; a failed reap window is classified from its WC
+    // evidence; wire decode failures blame the peer.
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     for (size_t base = 0; base < count && conn_ok; base += window) {
       const size_t width = std::min(window, count - base);
       std::vector<std::vector<ibv_mr*>> mrs(width);
@@ -1653,10 +1731,13 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       }
       std::vector<uint32_t> reply_bytes;
       bool timed_out = false;
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
       if (conn_ok &&
           !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out)) {
+                      &timed_out, &wc_status, &had_wcs)) {
         conn_ok = false;
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
       if (timed_out)
         completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
@@ -1674,7 +1755,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
                           capacities[item_index], &value_len) ||
             value_len > std::numeric_limits<size_t>::max()) {
           conn_ok = false;
-          endpoint_failure = true;
+          completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         result[item_index] = status;
@@ -1687,8 +1768,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       Release(node, Lane::kData, conn);
       return result;
     }
-    Destroy(conn, endpoint_failure ? rdma::RailCompletion::kEndpointFailure
-                                   : rdma::RailCompletion::kRailFailure);
+    Destroy(conn, completion);
     if (from_pool) continue;
     return result;
   }

--- a/src/utils/metrics_http.cc
+++ b/src/utils/metrics_http.cc
@@ -5,16 +5,62 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstdlib>
 #include <string>
 
+#include "common/config_dump.h"
+#include "utils/log.h"
 #include "utils/net_util.h"
 #include "utils/thread_name.h"
 
 namespace dfkv {
 
+namespace {
+// Bounded uint64 env knob: empty => fallback; non-numeric or 0 (unless the
+// knob documents 0 as "off") => warn + fallback; above hard_max => warn +
+// clamp. Same parse policy as the cache TCP listener knobs (kv_node_server.cc).
+uint64_t BoundedEnv(const char* name, uint64_t fallback, uint64_t hard_max,
+                    bool allow_zero) {
+  const char* value = std::getenv(name);
+  if (value == nullptr || *value == '\0') return fallback;
+  if (*value < '0' || *value > '9') {
+    DFKV_LOG_WARN(std::string("invalid ") + name + "='" + value + "'; using " +
+                  std::to_string(fallback));
+    return fallback;
+  }
+  errno = 0;
+  char* end = nullptr;
+  const unsigned long long parsed = std::strtoull(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0' ||
+      (parsed == 0 && !allow_zero)) {
+    DFKV_LOG_WARN(std::string("invalid ") + name + "='" + value + "'; using " +
+                  std::to_string(fallback));
+    return fallback;
+  }
+  if (parsed > hard_max) {
+    DFKV_LOG_WARN(std::string(name) + " clamped to hard maximum " +
+                  std::to_string(hard_max));
+    return hard_max;
+  }
+  return parsed;
+}
+}  // namespace
+
 MetricsHttpServer::~MetricsHttpServer() { Stop(); }
 
 Status MetricsHttpServer::Start(int port, const std::string& bind_addr) {
+  // Connection-lifecycle knobs are resolved at Start so a test/operator can
+  // still adjust them per process boot (they are not hot-reloaded).
+  first_req_ms_ = BoundedEnv("DFKV_METRICS_FIRST_REQ_MS", kDefaultFirstReqMs,
+                             kHardFirstReqMs, /*allow_zero=*/true);
+  max_conns_ = static_cast<size_t>(BoundedEnv(
+      "DFKV_METRICS_MAX_CONNS", kDefaultMaxConns, kHardMaxConns,
+      /*allow_zero=*/false));
+  config_dump::RecordResolved("DFKV_METRICS_FIRST_REQ_MS",
+                              std::to_string(first_req_ms_));
+  config_dump::RecordResolved("DFKV_METRICS_MAX_CONNS",
+                              std::to_string(max_conns_));
   listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
   if (listen_fd_ < 0) return Status::kIOError;
   int one = 1;
@@ -77,6 +123,8 @@ void MetricsHttpServer::AcceptLoop() {
   while (running_) {
     int fd = ::accept(listen_fd_, nullptr, nullptr);
     if (fd < 0) { if (!running_) break; continue; }
+    // First-request deadline anchors at ACCEPT time (DFKV_METRICS_FIRST_REQ_MS).
+    const auto accepted_at = std::chrono::steady_clock::now();
     // A scrape is one short request/response; a silent peer must not pin the
     // handler thread (Handle's recv loop otherwise blocks indefinitely).
     timeval tv{10, 0};
@@ -85,11 +133,23 @@ void MetricsHttpServer::AcceptLoop() {
     std::lock_guard<std::mutex> lk(conn_mu_);
     if (!running_) { ::close(fd); break; }
     ReapDoneLocked();  // join finished scrape handlers (Connection: close => one per scrape)
+    if (active_connections_.load(std::memory_order_relaxed) >= max_conns_) {
+      // Oneshot, low-frequency port: past DFKV_METRICS_MAX_CONNS the accept is
+      // closed IMMEDIATELY instead of occupying a handler thread forever.
+      dropped_connections_.fetch_add(1, std::memory_order_relaxed);
+      ::close(fd);
+      continue;
+    }
+    // +1 exactly once here (under conn_mu_, so the cap check above is exact);
+    // the handler thread's -1 below pairs it on every exit path (clean EOF,
+    // recv error, deadline expiry, shutdown) with no double-count.
+    active_connections_.fetch_add(1, std::memory_order_relaxed);
     conn_fds_.insert(fd);
     auto done = std::make_shared<std::atomic<bool>>(false);
-    conns_.push_back({std::thread([this, fd, done] {
+    conns_.push_back({std::thread([this, fd, done, accepted_at] {
                         NameThisThread("met-conn");
-                        Handle(fd);
+                        Handle(fd, accepted_at);
+                        active_connections_.fetch_sub(1, std::memory_order_relaxed);
                         { std::lock_guard<std::mutex> lk(conn_mu_); conn_fds_.erase(fd); }
                         ::close(fd);
                         done->store(true, std::memory_order_release);  // last act
@@ -108,15 +168,28 @@ std::string Resp(const char* status_line, const char* ctype, const std::string& 
 }
 }  // namespace
 
-void MetricsHttpServer::Handle(int fd) {
+void MetricsHttpServer::Handle(
+    int fd, std::chrono::steady_clock::time_point accepted_at) {
   // Read just the request line (up to CRLF). Headers/body are ignored — we only
   // need method + path. Bound the read so a silent peer can't pin the thread.
+  // The request line also has an ABSOLUTE deadline (DFKV_METRICS_FIRST_REQ_MS,
+  // anchored at accept): SO_RCVTIMEO alone is per-syscall, so a drip feeder
+  // (1 byte < 10s apart) would otherwise pin a handler thread. Before every
+  // recv the per-syscall budget is recomputed as min(10s, deadline remaining);
+  // a spent budget closes the connection. 0 disables (legacy behavior).
+  const bool deadline_on = first_req_ms_ > 0;
+  const auto deadline =
+      accepted_at + std::chrono::milliseconds(first_req_ms_);
+  const timeval base_tv{10, 0};
   std::string line;
   char c;
   size_t guard = 0;
   while (guard++ < 8192) {
-    ssize_t r = ::recv(fd, &c, 1, 0);
-    if (r <= 0) return;  // peer closed / error
+    if (deadline_on) {
+      if (!net::ReadAllWithin(fd, &c, 1, base_tv, deadline)) return;
+    } else {
+      if (::recv(fd, &c, 1, 0) <= 0) return;  // peer closed / error
+    }
     if (c == '\n') break;
     if (c != '\r') line.push_back(c);
   }

--- a/src/utils/metrics_http.h
+++ b/src/utils/metrics_http.h
@@ -9,6 +9,9 @@
 #define DFKV_METRICS_HTTP_H_
 
 #include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -49,11 +52,35 @@ class MetricsHttpServer {
   // now that finished connections are joined as new ones arrive — Prometheus
   // scrapes are Connection: close, so without reaping this grew per scrape.
   size_t live_conn_count();
+  // Live connections admitted (not yet closed). Test/diagnostic; the accept
+  // loop gates on this so DFKV_METRICS_MAX_CONNS is an exact bound.
+  size_t ActiveConnections() const {
+    return active_connections_.load(std::memory_order_relaxed);
+  }
+  // Accepted connections closed instantly because the server was at
+  // DFKV_METRICS_MAX_CONNS (oneshot port: no queue for a handler thread).
+  size_t DroppedConnections() const {
+    return dropped_connections_.load(std::memory_order_relaxed);
+  }
 
  private:
   void AcceptLoop();
-  void Handle(int fd);
+  // accepted_at stamps the accept() return so the first complete request line
+  // is due within DFKV_METRICS_FIRST_REQ_MS of ACCEPT, not of scheduling.
+  void Handle(int fd, std::chrono::steady_clock::time_point accepted_at);
   void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
+
+  // Absolute deadline for the first complete request line after accept — a
+  // drip feeder otherwise never hit the per-syscall SO_RCVTIMEO (0 = off).
+  static constexpr uint64_t kDefaultFirstReqMs = 30000;
+  static constexpr uint64_t kHardFirstReqMs = 3600000;
+  // Connection cap for this oneshot/low-frequency port (none existed before).
+  static constexpr size_t kDefaultMaxConns = 64;
+  static constexpr size_t kHardMaxConns = 4096;
+  uint64_t first_req_ms_ = kDefaultFirstReqMs;
+  size_t max_conns_ = kDefaultMaxConns;
+  std::atomic<size_t> active_connections_{0};
+  std::atomic<size_t> dropped_connections_{0};
 
   // A live connection: its handler thread + a flag the thread sets last, so
   // AcceptLoop can join it without blocking. shared_ptr because conns_ may

--- a/src/utils/net_util.h
+++ b/src/utils/net_util.h
@@ -14,6 +14,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <string>
@@ -44,6 +46,42 @@ inline bool ReadAll(int fd, void* buf, size_t n) {
     if (r < 0) {
       if (errno == EINTR) continue;
       return false;
+    }
+    off += static_cast<size_t>(r);
+  }
+  return true;
+}
+
+// ReadAll with an ABSOLUTE deadline for the whole read. SO_RCVTIMEO alone is a
+// per-SYSCALL budget: a slow-dribble peer (one byte just under each interval)
+// would otherwise never time out. Here the per-syscall budget is recomputed
+// before EVERY recv as min(base_timeout, deadline - now), so the read must
+// complete before `deadline` (monotonic clock) no matter how the bytes arrive.
+// Same return contract as ReadAll (false on close, error, or timeout/expiry).
+// `base_timeout` of {0,0} means "no per-syscall cap, deadline only".
+inline bool ReadAllWithin(int fd, void* buf, size_t n, timeval base_timeout,
+                          std::chrono::steady_clock::time_point deadline) {
+  char* p = static_cast<char*>(buf);
+  size_t off = 0;
+  while (off < n) {
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) return false;  // budget already spent => close
+    const int64_t remain_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(deadline - now)
+            .count();
+    const int64_t base_us =
+        static_cast<int64_t>(base_timeout.tv_sec) * 1000000 +
+        base_timeout.tv_usec;
+    int64_t budget_us = remain_us;
+    if (base_us > 0 && base_us < budget_us) budget_us = base_us;
+    timeval tv{budget_us / 1000000, budget_us % 1000000};
+    if (tv.tv_sec == 0 && tv.tv_usec == 0) tv.tv_usec = 1;  // {0,0} = wait forever
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    ssize_t r = ::recv(fd, p + off, n - off, 0);
+    if (r == 0) return false;  // peer closed
+    if (r < 0) {
+      if (errno == EINTR) continue;  // budget recomputed next iteration
+      return false;  // includes EAGAIN/EWOULDBLOCK from SO_RCVTIMEO expiry
     }
     off += static_cast<size_t>(r);
   }

--- a/test/cache/disk_slab_store_test.cc
+++ b/test/cache/disk_slab_store_test.cc
@@ -9,6 +9,10 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
+#ifdef DFKV_WITH_URING
+#include <liburing.h>
+#endif
+
 #include <cerrno>
 #include <atomic>
 #include <chrono>
@@ -68,6 +72,12 @@ class DiskSlabStoreTestPeer {
   static void SetRecordWriteHook(DiskSlabStore* store,
                                  std::function<bool()> hook) {
     store->record_write_hook_for_test_ = std::move(hook);
+  }
+  // Production never sets this; when set it replaces every CQE reap of the
+  // batched io_uring write path (blocking wait AND post-failure drain).
+  static void SetUringReapHook(DiskSlabStore* store,
+                               std::function<int(void*, void*)> hook) {
+    store->uring_reap_hook_for_test_ = std::move(hook);
   }
   static void BreakStateFd(DiskSlabStore* store) {
     if (store->state_fd_ >= 0) ::close(store->state_fd_);
@@ -846,6 +856,94 @@ TEST_F(DiskSlabTest, ReadLeaseMovesAndReleasesOnDestructionAndError) {
   EXPECT_EQ(s.Count(), 0u);
 }
 
+// Deferred-remove re-PUT (#17): Remove(K) while a read lease pins the slot
+// defers the physical remove -- commit state is erased, but the allocator
+// slot stays resident. A re-PUT arriving in that window used to hard-fail
+// kIOError against the still-resident slot; it must instead wait (bounded)
+// for the in-flight holder to release and then land normally.
+TEST_F(DiskSlabTest, ReputDuringDeferredRemoveWaitsOutWindowThenLands) {
+  auto opts = Opts(1 << 20, 1 << 20, 4096);
+  opts.table_sync_ms = 0;
+  opts.reclaim_interval_ms = 0;
+  bool ok = false;
+  DiskSlabStore s(opts, &ok);
+  ASSERT_TRUE(ok);
+  std::string v1(4096, 'a');
+  ASSERT_EQ(s.Cache(K(60), v1.data(), v1.size()), Status::kOk);
+  dfkv::ReadLease lease;
+  ASSERT_EQ(s.RangeDirectPrep(K(60), 0, 0, 1 << 20, &lease), Status::kOk);
+  ASSERT_GE(lease.fd(), 0);
+  ASSERT_EQ(s.Remove(K(60)), Status::kOk);
+  EXPECT_FALSE(s.IsCached(K(60)));  // commit state erased immediately
+  EXPECT_EQ(s.Count(), 1u);         // slot still pinned: the window
+
+  std::string v2(4096, 'b');
+  Status reput = Status::kInvalid;
+  std::atomic<bool> reput_done{false};
+  std::thread t([&] {
+    reput = s.Cache(K(60), v2.data(), v2.size());
+    reput_done.store(true, std::memory_order_release);
+  });
+  // The window closes only when the lease below is destroyed, so the re-PUT
+  // cannot complete yet; the old hard-fail path would already be done.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_FALSE(reput_done.load(std::memory_order_acquire))
+      << "re-PUT in the window must wait for the pin, not fail at once";
+  { dfkv::ReadLease drop(std::move(lease)); }  // destruction releases the pin
+  t.join();
+  EXPECT_EQ(reput, Status::kOk);
+  std::string out;
+  ASSERT_EQ(s.Range(K(60), 0, 0, &out), Status::kOk);
+  EXPECT_EQ(out, v2) << "readers must observe the re-PUT bytes, not stale ones";
+  EXPECT_EQ(s.Count(), 1u);
+
+  // Guard rails: outside the window nothing changed -- remove-then-re-PUT was
+  // already fine, and a committed key still wins keep-first.
+  ASSERT_EQ(s.Remove(K(60)), Status::kOk);  // no pin now: immediate remove
+  EXPECT_EQ(s.Count(), 0u);
+  std::string v3(4096, 'c');
+  EXPECT_EQ(s.Cache(K(60), v3.data(), v3.size()), Status::kOk);
+  std::string v4(4096, 'd');
+  EXPECT_EQ(s.Cache(K(60), v4.data(), v4.size()), Status::kOk);
+  ASSERT_EQ(s.Range(K(60), 0, 0, &out), Status::kOk);
+  EXPECT_EQ(out, v3) << "a duplicate PUT must not overwrite committed bytes";
+}
+
+// Same window through the batched PUT path: CacheDirectBatch items must wait
+// out a deferred remove exactly like the scalar Cache path.
+TEST_F(DiskSlabTest, BatchReputDuringDeferredRemoveWaitsOutWindowThenLands) {
+  auto opts = Opts(1 << 20, 1 << 20, 4096);
+  opts.table_sync_ms = 0;
+  opts.reclaim_interval_ms = 0;
+  bool ok = false;
+  DiskSlabStore s(opts, &ok);
+  ASSERT_TRUE(ok);
+  std::string v1(4096, 'a');
+  ASSERT_EQ(s.Cache(K(61), v1.data(), v1.size()), Status::kOk);
+  dfkv::ReadLease lease;
+  ASSERT_EQ(s.RangeDirectPrep(K(61), 0, 0, 1 << 20, &lease), Status::kOk);
+  ASSERT_GE(lease.fd(), 0);
+  ASSERT_EQ(s.Remove(K(61)), Status::kOk);
+  EXPECT_EQ(s.Count(), 1u);
+
+  std::string v2(4096, 'e');
+  std::vector<Status> sts;
+  std::atomic<bool> done{false};
+  std::thread t([&] {
+    sts = s.CacheDirectBatch({{K(61), v2.data(), v2.size(), v2.size()}});
+    done.store(true, std::memory_order_release);
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_FALSE(done.load(std::memory_order_acquire));
+  { dfkv::ReadLease drop(std::move(lease)); }
+  t.join();
+  ASSERT_EQ(sts.size(), 1u);
+  EXPECT_EQ(sts[0], Status::kOk);
+  std::string out;
+  ASSERT_EQ(s.Range(K(61), 0, 0, &out), Status::kOk);
+  EXPECT_EQ(out, v2);
+}
+
 // Direct-mode RangeDirect: O_DIRECT aligned-window read with head trim -- the
 // returned pointer must land exactly on the requested offset's bytes, including
 // a non-4KiB-aligned client offset (head != 0).
@@ -1375,6 +1473,128 @@ TEST_F(DiskSlabTest, UringBatchCountsOnlyConfirmedWrites) {
     ASSERT_EQ(s.Range(K(700 + i), 0, kLen, &out), Status::kOk) << i;
     EXPECT_EQ(out, std::string(kLen, static_cast<char>('A' + i))) << i;
   }
+  for (auto* b : bufs) free(b);
+}
+
+// Reap-failure drain (#16): a hard io_uring_wait_cqe failure used to retire
+// the ring while the kernel's accepted writes were still un-reaped -- and
+// io_uring_queue_exit does NOT cancel in-flight requests, so a zombie write
+// could land after the flush rolled the failed items' slots back and handed
+// them to other keys. The failed batch must best-effort drain every accepted
+// CQE BEFORE the ring is retired: then no zombie remains, the store must NOT
+// fail closed, every item lands via the sequential rewrite, and the next
+// batch re-inits the ring and fast-paths again.
+TEST_F(DiskSlabTest, UringReapFailureDrainsBeforeReset) {
+  auto opts = Opts(1 << 20, 1 << 20, 4096);
+  opts.direct_writes = true;
+  bool ok = false;
+  DiskSlabStore s(opts, &ok);
+  ASSERT_TRUE(ok);
+  if (!s.DirectWritesActive()) GTEST_SKIP() << "fs rejected O_DIRECT (tmpfs)";
+  // The first reap (the blocking wait) hard-fails; every reap afterwards is
+  // the drain's non-blocking peek, behaving exactly like the real one.
+  std::atomic<int> reap_calls{0};
+  dfkv::DiskSlabStoreTestPeer::SetUringReapHook(
+      &s, [&reap_calls](void* r, void* c) -> int {
+        if (reap_calls.fetch_add(1) == 0) return -EIO;
+        return io_uring_peek_cqe(static_cast<io_uring*>(r),
+                                 static_cast<io_uring_cqe**>(c));
+      });
+  constexpr uint64_t N = 4;
+  constexpr size_t kLen = 4096;
+  std::vector<void*> bufs(N);
+  std::vector<DiskSlabStore::CacheBatchItem> items;
+  for (uint64_t i = 0; i < N; ++i) {
+    ASSERT_EQ(posix_memalign(&bufs[i], 4096, kLen), 0);
+    std::memset(bufs[i], static_cast<int>('A' + i), kLen);
+    items.push_back({K(800 + i), static_cast<char*>(bufs[i]), kLen, kLen});
+  }
+  auto sts = s.CacheDirectBatch(items);
+  if (reap_calls.load() == 0) {
+    for (auto* b : bufs) free(b);
+    GTEST_SKIP() << "uring path not taken (env-disabled or init fallback)";
+  }
+  for (auto st : sts) ASSERT_EQ(st, Status::kOk);
+  // The failed wait left N accepted writes outstanding; the drain must have
+  // reaped them (the real peek may also poll on -EAGAIN before completions).
+  EXPECT_GE(reap_calls.load(), 1 + static_cast<int>(N))
+      << "drain must reap what the failed wait left outstanding";
+  EXPECT_TRUE(s.Healthy()) << "a successful drain is not a fail-closed event";
+  EXPECT_EQ(s.GetStats().metadata_io_errors, 0u);
+  {  // nothing was CQE-confirmed, so the failed batch tallies nothing uring
+    const auto stats = s.GetStats();
+    EXPECT_EQ(stats.uring_write_batches, 0u);
+    EXPECT_EQ(stats.batched_writes, 0u);
+  }
+  // The sequential rewrite must be what readers observe (dangling-buffer and
+  // torn-payload semantics would show up here or in the next store's data).
+  for (uint64_t i = 0; i < N; ++i) {
+    std::string out;
+    ASSERT_EQ(s.Range(K(800 + i), 0, kLen, &out), Status::kOk) << i;
+    EXPECT_EQ(out, std::string(kLen, static_cast<char>('A' + i))) << i;
+  }
+
+  // The retired ring re-inits on the next batch and fast-paths again.
+  dfkv::DiskSlabStoreTestPeer::SetUringReapHook(&s, nullptr);
+  std::vector<DiskSlabStore::CacheBatchItem> items2;
+  for (uint64_t i = 0; i < N; ++i) {
+    std::memset(bufs[i], static_cast<int>('a' + i), kLen);
+    items2.push_back({K(900 + i), static_cast<char*>(bufs[i]), kLen, kLen});
+  }
+  sts = s.CacheDirectBatch(items2);
+  for (auto st : sts) ASSERT_EQ(st, Status::kOk);
+  {
+    const auto stats = s.GetStats();
+    EXPECT_EQ(stats.uring_write_batches, 1u) << "ring re-init did not happen";
+    EXPECT_EQ(stats.batched_writes, N);
+  }
+  for (uint64_t i = 0; i < N; ++i) {
+    std::string out;
+    ASSERT_EQ(s.Range(K(900 + i), 0, kLen, &out), Status::kOk) << i;
+    EXPECT_EQ(out, std::string(kLen, static_cast<char>('a' + i))) << i;
+    // And the first batch's bytes are untouched by anything that followed.
+    ASSERT_EQ(s.Range(K(800 + i), 0, kLen, &out), Status::kOk) << i;
+    EXPECT_EQ(out, std::string(kLen, static_cast<char>('A' + i))) << i;
+  }
+  for (auto* b : bufs) free(b);
+}
+
+// Dropped-CQE fail-closed (#16): if the kernel cannot return the accepted
+// completions at all, a zombie write may still land after the slot rollback,
+// so the drain coming up short must fail the store closed rather than risk
+// serving bytes a late landing overwrote.
+TEST_F(DiskSlabTest, UringReapDrainMissFailsStoreClosed) {
+  auto opts = Opts(1 << 20, 1 << 20, 4096);
+  opts.direct_writes = true;
+  bool ok = false;
+  DiskSlabStore s(opts, &ok);
+  ASSERT_TRUE(ok);
+  if (!s.DirectWritesActive()) GTEST_SKIP() << "fs rejected O_DIRECT (tmpfs)";
+  std::atomic<int> reap_calls{0};
+  dfkv::DiskSlabStoreTestPeer::SetUringReapHook(
+      &s, [&reap_calls](void*, void*) -> int {
+        reap_calls.fetch_add(1);
+        return -EIO;  // blocking wait AND drain peeks all fail
+      });
+  constexpr uint64_t N = 4;
+  constexpr size_t kLen = 4096;
+  std::vector<void*> bufs(N);
+  std::vector<DiskSlabStore::CacheBatchItem> items;
+  for (uint64_t i = 0; i < N; ++i) {
+    ASSERT_EQ(posix_memalign(&bufs[i], 4096, kLen), 0);
+    std::memset(bufs[i], static_cast<int>('C' + i), kLen);
+    items.push_back({K(810 + i), static_cast<char*>(bufs[i]), kLen, kLen});
+  }
+  auto sts = s.CacheDirectBatch(items);
+  if (reap_calls.load() == 0) {
+    for (auto* b : bufs) free(b);
+    GTEST_SKIP() << "uring path not taken (env-disabled or init fallback)";
+  }
+  for (auto st : sts) EXPECT_EQ(st, Status::kIOError);
+  EXPECT_FALSE(s.Healthy());
+  EXPECT_GE(s.GetStats().metadata_io_errors, 1u);
+  EXPECT_EQ(s.Count(), 0u) << "failed items must roll their slots back";
+  for (uint64_t i = 0; i < N; ++i) EXPECT_FALSE(s.IsCached(K(810 + i)));
   for (auto* b : bufs) free(b);
 }
 #endif  // DFKV_WITH_URING

--- a/test/cache/kv_node_server_listener_test.cc
+++ b/test/cache/kv_node_server_listener_test.cc
@@ -189,19 +189,108 @@ TEST(KvNodeServerListener, RangeLengthBeyondPayloadBoundDropsConnection) {
   server->Stop();
 }
 
+// SO_RCVTIMEO is a per-SYSCALL budget: a drip feeder sending one byte per
+// (timeout - epsilon) never timed out and pinned a connection slot forever.
+// DFKV_TCP_FIRST_REQ_MS gives the FIRST complete frame an absolute deadline
+// anchored at accept, so the drip connection is closed while the per-syscall
+// base timeout alone would never have fired (drip interval < base).
+TEST(KvNodeServerListener, SlowDripFirstFrameIsClosedByAbsoluteDeadline) {
+  ScopedEnv engine("DFKV_STORE_ENGINE", "file");
+  ScopedEnv max_connections("DFKV_TCP_MAX_CONNS", "4");
+  ScopedEnv io_timeout("DFKV_TCP_IO_TIMEOUT_S", "30");  // never fires under drip
+  ScopedEnv first_req("DFKV_TCP_FIRST_REQ_MS", "300");
+  auto server = StartServer("drip");
+
+  const int fd = Dial(*server);
+  ASSERT_GE(fd, 0);
+  ASSERT_TRUE(WaitFor([&] { return server->live_conn_count() == 1; }, 1000));
+  // Drip one partial-prefix byte every 100ms: each byte arrives far inside the
+  // 30s base budget, so only the 300ms absolute deadline can close this.
+  const char junk[16] = {0};
+  ::send(fd, junk, 1, MSG_NOSIGNAL);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ::send(fd, junk + 1, 1, MSG_NOSIGNAL);
+  EXPECT_TRUE(WaitFor([&] { return server->live_conn_count() == 0; }, 3000))
+      << "drip connection outlived its first-frame deadline";
+  ::close(fd);
+  server->Stop();
+}
+
+// The deadline covers only the FIRST frame on a connection: a client that
+// completes a request promptly, then goes quiet, must keep the connection for
+// normal keep-alive reuse (base per-syscall timeout semantics unchanged), and
+// the restored per-syscall budget must still serve later requests.
+TEST(KvNodeServerListener, FirstFrameDeadlineLeavesKeepAliveTrafficAlone) {
+  ScopedEnv engine("DFKV_STORE_ENGINE", "file");
+  ScopedEnv max_connections("DFKV_TCP_MAX_CONNS", "4");
+  ScopedEnv io_timeout("DFKV_TCP_IO_TIMEOUT_S", "10");
+  ScopedEnv first_req("DFKV_TCP_FIRST_REQ_MS", "300");
+  auto server = StartServer("drip_ok");
+  const std::string endpoint = "127.0.0.1:" + std::to_string(server->port());
+  TcpTransport transport;
+  const BlockKey key = ToBlockKey("listener/model", "drip-ok-key");
+  const std::string value = "normal payload after deadline knob";
+
+  // First frame completes well within the 300ms deadline.
+  ASSERT_EQ(transport.Cache(endpoint, key, value.data(), value.size()),
+            Status::kOk);
+  // Idle LONGER than the first-frame deadline: the connection must NOT be
+  // closed — the deadline stopped applying once the first frame completed.
+  std::this_thread::sleep_for(std::chrono::milliseconds(600));
+  bool exists = false;
+  ASSERT_EQ(transport.Exist(endpoint, key, &exists), Status::kOk);
+  EXPECT_TRUE(exists);
+  std::string got;
+  ASSERT_EQ(transport.Range(endpoint, key, 0, value.size(), &got), Status::kOk);
+  EXPECT_EQ(got, value);
+  // One accept for the whole session: the post-deadline requests were served
+  // on the ORIGINAL keep-alive connection, not a transparent redial.
+  EXPECT_EQ(server->AcceptCount(), 1u);
+  server->Stop();
+}
+
+// Knob off (0) restores the legacy behavior exactly: no absolute deadline, a
+// drip connection lives until the per-syscall base timeout fires.
+TEST(KvNodeServerListener, DisabledFirstFrameDeadlineKeepsLegacyBehavior) {
+  ScopedEnv engine("DFKV_STORE_ENGINE", "file");
+  ScopedEnv max_connections("DFKV_TCP_MAX_CONNS", "4");
+  ScopedEnv io_timeout("DFKV_TCP_IO_TIMEOUT_S", "30");  // would take 30s to fire
+  ScopedEnv first_req("DFKV_TCP_FIRST_REQ_MS", "0");
+  auto server = StartServer("drip_off");
+
+  const int fd = Dial(*server);
+  ASSERT_GE(fd, 0);
+  ASSERT_TRUE(WaitFor([&] { return server->live_conn_count() == 1; }, 1000));
+  // Drip for far longer than a 300ms-style deadline would allow; the conn must
+  // still be alive because the deadline is disabled.
+  const char junk[8] = {0};
+  for (int i = 0; i < 6; ++i) {
+    ::send(fd, junk, 1, MSG_NOSIGNAL);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_EQ(server->live_conn_count(), 1u)
+      << "disabled deadline must not close a drip connection";
+  ::close(fd);
+  server->Stop();
+}
+
 TEST(KvNodeServerListener, ConfigIsHardBoundedAndExported) {
   ScopedEnv engine("DFKV_STORE_ENGINE", "file");
   ScopedEnv max_connections("DFKV_TCP_MAX_CONNS", "999999");
   ScopedEnv io_timeout("DFKV_TCP_IO_TIMEOUT_S", "999999");
+  ScopedEnv first_req("DFKV_TCP_FIRST_REQ_MS", "99999999");
   auto server = StartServer("config");
 
   EXPECT_EQ(server->TcpMaxConnections(), 4096u);
   EXPECT_EQ(server->TcpIoTimeoutSeconds(), 3600);
+  EXPECT_EQ(server->TcpFirstReqMs(), 3600000u);
   const std::string metrics = server->MetricsText();
   EXPECT_NE(metrics.find("dfkv_tcp_max_connections 4096"), std::string::npos)
       << metrics;
   EXPECT_NE(metrics.find("dfkv_tcp_io_timeout_seconds 3600"),
             std::string::npos) << metrics;
+  EXPECT_NE(metrics.find("dfkv_tcp_first_req_ms 3600000"), std::string::npos)
+      << metrics;
   EXPECT_NE(metrics.find("dfkv_tcp_rejected_connections_total 0"),
             std::string::npos) << metrics;
   server->Stop();

--- a/test/cache/kv_node_server_listener_test.cc
+++ b/test/cache/kv_node_server_listener_test.cc
@@ -150,6 +150,45 @@ TEST(KvNodeServerListener, NormalPooledTcpRemainsFunctionalAtLimit) {
   server->Stop();
 }
 
+// A kRange whose declared range length exceeds the payload ceiling can never
+// name a real value: the TCP frontend drops the connection at the same gate
+// as an oversized payload (the RDMA frontend already rejects this shape at
+// its decode/serve gates). Well-formed frames on the same server are
+// unaffected. Regression guard for the hostile-length coalesced-read finding.
+TEST(KvNodeServerListener, RangeLengthBeyondPayloadBoundDropsConnection) {
+  ScopedEnv engine("DFKV_STORE_ENGINE", "file");
+  auto server = StartServer("range_len");
+  server->set_max_request_payload(4096);
+
+  {
+    const int fd = Dial(*server);
+    ASSERT_GE(fd, 0);
+    char pre[kReqPrefix];
+    EncodeReq(pre, WireOp::kRange, BlockKey{1, 2, 3}, 0, 8192, 0);
+    ASSERT_TRUE(net::WriteAll(fd, pre, sizeof(pre)));
+    char rp[kRespPrefix];
+    EXPECT_FALSE(net::ReadAll(fd, rp, sizeof(rp)));
+    ::close(fd);
+  }
+  {
+    const int fd = Dial(*server);
+    ASSERT_GE(fd, 0);
+    const std::string value = "ok";
+    char pre[kReqPrefix];
+    EncodeReq(pre, WireOp::kCache, BlockKey{1, 2, 3}, 0, 0, value.size());
+    ASSERT_TRUE(net::WriteAll(fd, pre, sizeof(pre)));
+    ASSERT_TRUE(net::WriteAll(fd, value.data(), value.size()));
+    char rp[kRespPrefix];
+    ASSERT_TRUE(net::ReadAll(fd, rp, sizeof(rp)));
+    Status st = Status::kIOError;
+    uint64_t data_len = 0;
+    ASSERT_TRUE(DecodeResp(rp, &st, &data_len));
+    EXPECT_EQ(st, Status::kOk);
+    ::close(fd);
+  }
+  server->Stop();
+}
+
 TEST(KvNodeServerListener, ConfigIsHardBoundedAndExported) {
   ScopedEnv engine("DFKV_STORE_ENGINE", "file");
   ScopedEnv max_connections("DFKV_TCP_MAX_CONNS", "999999");

--- a/test/cache/prepared_read_test.cc
+++ b/test/cache/prepared_read_test.cc
@@ -4,8 +4,10 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string>
 #include <thread>
@@ -155,7 +157,73 @@ TEST(PreparedRead, FallbackAbortAndDestructorReleaseFlight) {
   ::unsetenv("DFKV_READ_COALESCE_TIMEOUT_MS");
 }
 
-}  // namespace
+// Regression (PR237 review #2): a coalesced TCP kRange must size its scratch
+// from the REAL stored length, never from the client-declared range length --
+// a forged multi-exabyte length used to resize the reply string before any
+// storage lookup (one frame -> length_error/bad_alloc -> std::terminate, or
+// OOM). Unknown keys must miss BEFORE any sized allocation, like the plain
+// path. These asserts die on the unfixed code at the first hostile call.
+TEST(PreparedRead, CoalescedRangeClampsHostileLength) {
+  ::setenv("DFKV_READ_COALESCE", "1", 1);
+  ::unsetenv("DFKV_RAM_TIER");
+  const fs::path dir =
+      fs::temp_directory_path() / "dfkv_coalesce_range_clamp";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  {
+  KvNodeServer server(dir.string(), 1ull << 30);
+  ASSERT_TRUE(server.Healthy());
+
+  std::string value(10000, '\0');
+  for (size_t i = 0; i < value.size(); ++i)
+    value[i] = static_cast<char>('a' + (i % 26));
+  ASSERT_EQ(Put(&server, Key(7), value), Status::kOk);
+
+  const uint64_t kHostile = std::numeric_limits<uint64_t>::max();
+  auto range = [&](const BlockKey& key, uint64_t offset, uint64_t length,
+                   std::string* out, size_t* value_len) {
+    out->clear();
+    return server.ProcessRequestForKey(
+        static_cast<uint8_t>(WireOp::kRange), key, offset, length, nullptr, 0,
+        out, value_len);
+  };
+
+  std::string out;
+  size_t value_len = 0;
+  // Whole value under a hostile length: served, clamped to the remainder.
+  EXPECT_EQ(range(Key(7), 0, kHostile, &out, &value_len), Status::kOk);
+  EXPECT_EQ(out, value);
+  EXPECT_EQ(value_len, value.size());
+  // Length beyond the remainder clamps to [offset, value_len).
+  EXPECT_EQ(range(Key(7), 4000, kHostile, &out, &value_len), Status::kOk);
+  EXPECT_EQ(out, value.substr(4000));
+  EXPECT_EQ(value_len, value.size());
+  // Store Range semantics survive: past-the-end offset is kInvalid, an
+  // exact-end offset is an empty success with the authoritative length.
+  EXPECT_EQ(range(Key(7), value.size() + 1, 16, &out, &value_len),
+            Status::kInvalid);
+  EXPECT_EQ(range(Key(7), value.size(), 16, &out, &value_len), Status::kOk);
+  EXPECT_TRUE(out.empty());
+  EXPECT_EQ(value_len, value.size());
+  // The reported attack: an UNKNOWN key with a hostile length misses before
+  // any sized allocation, exactly like the non-coalesced path.
+  EXPECT_EQ(range(Key(404), 0, kHostile, &out, &value_len),
+            Status::kNotFound);
+  EXPECT_TRUE(out.empty());
+
+  }
+  fs::remove_all(dir);
+  ::unsetenv("DFKV_READ_COALESCE");
+}
+
+// Regression (PR237 review #3): the coalesced RangeDirect fill compacts the
+// DIO superset in place (dst = shared scratch base, src = scratch + head with
+// head in (0, 4095]) -- that forward overlap requires memmove; memcpy on it
+// is UB and can hand shifted bytes to the leader and every follower. Assert
+// byte-exact payload for non-4K-aligned offsets (sanitizer builds flag the
+// overlap outright). Skips where the filesystem demotes the slab store to
+// buffered I/O (tmpfs): there RangeDirect hands back io_buf itself and no
+// head-shifted copy exists.
 TEST(PreparedRead, CoalescedRangeDirectHeadShiftByteExact) {
   ::setenv("DFKV_READ_COALESCE", "1", 1);
   ::unsetenv("DFKV_RAM_TIER");

--- a/test/cache/prepared_read_test.cc
+++ b/test/cache/prepared_read_test.cc
@@ -156,3 +156,44 @@ TEST(PreparedRead, FallbackAbortAndDestructorReleaseFlight) {
 }
 
 }  // namespace
+TEST(PreparedRead, CoalescedRangeDirectHeadShiftByteExact) {
+  ::setenv("DFKV_READ_COALESCE", "1", 1);
+  ::unsetenv("DFKV_RAM_TIER");
+  const fs::path dir =
+      fs::temp_directory_path() / "dfkv_coalesce_direct_head";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  {
+  KvNodeServer server(dir.string(), 1ull << 30);
+  ASSERT_TRUE(server.Healthy());
+  if (server.write_mode() != "direct")
+    GTEST_SKIP() << "fs rejected O_DIRECT (tmpfs): no head-shifted read";
+
+  std::string value(16384, '\0');
+  for (size_t i = 0; i < value.size(); ++i)
+    value[i] = static_cast<char>('a' + (i % 26));
+  ASSERT_EQ(Put(&server, Key(8), value), Status::kOk);
+
+  AlignedBuffer io(1 << 20);
+  for (const uint64_t offset : {13ull, 4093ull}) {
+    const uint64_t length = 5000;
+    const char* data = nullptr;
+    size_t len = 0;
+    size_t value_len = 0;
+    ASSERT_EQ(server.RangeDirectForKey(Key(8), offset, length, io.data(),
+                                       io.size(), &data, &len, &value_len),
+              Status::kOk);
+    EXPECT_EQ(data, io.data());  // payload compacted back to the buffer base
+    EXPECT_EQ(len, static_cast<size_t>(length));
+    EXPECT_EQ(value_len, value.size());
+    EXPECT_EQ(std::memcmp(data, value.data() + offset,
+                          static_cast<size_t>(length)),
+              0);
+  }
+
+  }
+  fs::remove_all(dir);
+  ::unsetenv("DFKV_READ_COALESCE");
+}
+
+}  // namespace

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -331,6 +331,106 @@ TEST(RamTier, RemoveHidesActiveFlushAndDefersPinnedRelease) {
   EXPECT_EQ(rt.Count(), 0u);
 }
 
+// Regression: Remove() racing an in-flight PUT must not resurrect the key.
+// Admit used to read completion->canceled in one critical section and erase
+// writing + install the index entry in another; a Remove landing in between
+// flagged the canceled bit too late, the entry was installed untombstoned,
+// and the key kept answering GETs after Remove returned true (the disk copy
+// is deleted by the caller on remove, so the tier served a deleted value).
+// Here a pack of hammer threads keeps the single shard mutex saturated so
+// the writer blocks between that read and the install, opening the race
+// window; rounds where Remove observed the key must all end with the key
+// invisible.
+TEST(RamTier, RemoveRacingInFlightPutNeverResurrects) {
+  ::setenv("DFKV_RAM_TIER_EXTENT_BYTES", "1048576", 1);
+  ::setenv("DFKV_RAM_TIER_SHARDS", "1", 1);
+  FlushSink sink;  // gate open: installs flush (and complete) promptly
+  RamTier rt(Opts(64ull << 20), sink.fn());
+  ASSERT_TRUE(rt.ok());
+  const std::string v(1ull << 20, 'v');  // in-arena (== one extent), slow copy
+
+  std::atomic<bool> stop_hammer{false};
+  std::vector<std::thread> hammers;
+  for (int i = 0; i < 8; ++i) {
+    hammers.emplace_back([&, i] {
+      // Never admitted; pure lock pressure on the single shard mutex so the
+      // writer's read->install transition contends with Remove's phase one.
+      while (!stop_hammer.load(std::memory_order_relaxed))
+        (void)rt.Contains(K(0xFFF00000u + i));
+    });
+  }
+
+  int observed = 0;       // rounds where Remove found the key tracked
+  int resurrections = 0;  // observed rounds where the key survived Remove
+  for (uint64_t r = 0; r < 600; ++r) {
+    std::atomic<bool> started{false};
+    std::thread writer([&] {
+      started.store(true, std::memory_order_release);
+      rt.Put(K(r), v.data(), v.size());
+    });
+    while (!started.load(std::memory_order_acquire))
+      std::this_thread::yield();
+    // Sweep across the writer's copy window (~100+ us for 1 MiB under
+    // contention) so many rounds land mid-flight.
+    std::this_thread::sleep_for(std::chrono::microseconds(10 + (r % 28) * 5));
+    const bool removed = rt.Remove(K(r));
+    writer.join();
+    if (removed) {
+      ++observed;
+      if (rt.Contains(K(r))) ++resurrections;
+      RamTier::Hit h;
+      if (rt.GetPrep(K(r), 0, 0, &h)) ++resurrections;
+    }
+    rt.Remove(K(r));  // cleanup: writer may have missed the race window
+  }
+  stop_hammer.store(true, std::memory_order_relaxed);
+  for (auto& t : hammers) t.join();
+
+  EXPECT_GE(observed, 3);  // prove the race regime was actually entered
+  EXPECT_EQ(resurrections, 0);
+}
+
+// Regression: same cancel/install race through PutDurable (read-promotion),
+// which installed the entry without ever consulting completion->canceled. The
+// promotion's setup window spans a large posix_memalign + memcpy, so a Remove
+// started inside it deterministically flags the shared completion; before the
+// fix the entry was still installed (and completed) untombstoned.
+TEST(RamTier, RemoveRacingInFlightPutDurableNeverResurrects) {
+  ::setenv("DFKV_RAM_TIER_EXTENT_BYTES", "1048576", 1);
+  ::setenv("DFKV_RAM_TIER_SHARDS", "1", 1);
+  FlushSink sink;  // unused: promoted entries are born durable, never flushed
+  RamTier::Options o = Opts(96ull << 20);
+  o.large_reserve_bytes = 48ull << 20;  // fit the 8 MiB dedicated values
+  RamTier rt(o, sink.fn());
+  ASSERT_TRUE(rt.ok());
+  const std::string v(8ull << 20, 'p');  // dedicated: ms-wide install window
+
+  int observed = 0;
+  int resurrections = 0;
+  for (uint64_t r = 0; r < 40; ++r) {
+    std::atomic<bool> started{false};
+    std::thread writer([&] {
+      started.store(true, std::memory_order_release);
+      rt.PutDurable(K(r), v.data(), v.size());
+    });
+    while (!started.load(std::memory_order_acquire))
+      std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::microseconds(100 + (r % 9) * 100));
+    const bool removed = rt.Remove(K(r));
+    writer.join();
+    if (removed) {
+      ++observed;
+      if (rt.Contains(K(r))) ++resurrections;
+      RamTier::Hit h;
+      if (rt.GetPrep(K(r), 0, 0, &h)) ++resurrections;
+    }
+    rt.Remove(K(r));  // cleanup
+  }
+
+  EXPECT_GE(observed, 3);  // prove the race regime was actually entered
+  EXPECT_EQ(resurrections, 0);
+}
+
 TEST(RamTier, LargeValueReadRangeFlushAndRemoveIsByteExact) {
   ::setenv("DFKV_RAM_TIER_EXTENT_BYTES", "1048576", 1);
   std::mutex m;

--- a/test/mds/mds_server_test.cc
+++ b/test/mds/mds_server_test.cc
@@ -5,28 +5,37 @@
 #include "utils/net_util.h"
 #include <gtest/gtest.h>
 #include <unistd.h>
+#include <atomic>
+#include <cerrno>
 #include <cstdlib>
 #include <string>
+#include <thread>
 #include <vector>
 using namespace dfkv;  // NOLINT
 
 namespace {
 const char* EtcdEp() { return std::getenv("DFKV_TEST_ETCD"); }
 
-bool DoReq(int port, WireOp op, const std::string& payload, Status* st, std::string* data) {
-  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 2000, 2000);
-  if (fd < 0) return false;
+bool DoReqOnFd(int fd, WireOp op, const std::string& payload, Status* st, std::string* data) {
   char pre[kReqPrefix];
   EncodeReq(pre, op, BlockKey{}, 0, 0, payload.size());
   if (!net::WriteAll(fd, pre, kReqPrefix) ||
-      (!payload.empty() && !net::WriteAll(fd, payload.data(), payload.size()))) { ::close(fd); return false; }
+      (!payload.empty() && !net::WriteAll(fd, payload.data(), payload.size()))) return false;
   char rp[kRespPrefix];
-  if (!net::ReadAll(fd, rp, kRespPrefix)) { ::close(fd); return false; }
+  if (!net::ReadAll(fd, rp, kRespPrefix)) return false;
   Status s; uint64_t dlen = 0;
-  if (!DecodeResp(rp, &s, &dlen)) { ::close(fd); return false; }
+  if (!DecodeResp(rp, &s, &dlen)) return false;
   data->resize(dlen);
-  if (dlen && !net::ReadAll(fd, &(*data)[0], dlen)) { ::close(fd); return false; }
-  *st = s; ::close(fd); return true;
+  if (dlen && !net::ReadAll(fd, &(*data)[0], dlen)) return false;
+  *st = s; return true;
+}
+
+bool DoReq(int port, WireOp op, const std::string& payload, Status* st, std::string* data) {
+  int fd = net::Dial("127.0.0.1:" + std::to_string(port), 2000, 2000);
+  if (fd < 0) return false;
+  const bool ok = DoReqOnFd(fd, op, payload, st, data);
+  ::close(fd);
+  return ok;
 }
 }  // namespace
 
@@ -431,4 +440,219 @@ TEST(LocalLeaseMap, RecentUseSurvivesWhileStaleEntryIsForgotten) {
   EXPECT_EQ(leases.Size(), 1u);
   EXPECT_FALSE(leases.LookupAndTouch("cold", 122000, &lease_id));
   EXPECT_TRUE(leases.LookupAndTouch("hot", 122000, &lease_id));
+}
+
+// ---- EtcdProbeCache (TTL-debounced, single-flight probe behind /readyz) -----
+// No etcd needed: clock and prober are injected. These pin the debounce
+// contract: replay within the TTL (failures included), refetch after expiry,
+// concurrent callers collapse onto one probe, and ttl 0 = live probing (the
+// pre-knob behavior).
+
+TEST(EtcdProbeCache, ReplaysResultWithinTtlWithoutReprobing) {
+  uint64_t now_ms = 1000;
+  int probes = 0;
+  EtcdProbeCache c(2000, [&] { return now_ms; },
+                   [&] { ++probes; return true; });
+  EXPECT_TRUE(c.Get());
+  EXPECT_EQ(probes, 1);
+  now_ms += 1999;  // still inside the TTL
+  EXPECT_TRUE(c.Get());
+  EXPECT_EQ(probes, 1) << "fresh result must be replayed, not re-probed";
+}
+
+TEST(EtcdProbeCache, ExpiryTriggersNewProbe) {
+  uint64_t now_ms = 1000;
+  int probes = 0;
+  bool result = true;
+  EtcdProbeCache c(2000, [&] { return now_ms; },
+                   [&] { ++probes; return result; });
+  EXPECT_TRUE(c.Get());
+  EXPECT_EQ(probes, 1);
+  now_ms += 2000;  // the TTL boundary itself counts as expired
+  result = false;
+  EXPECT_FALSE(c.Get());
+  EXPECT_EQ(probes, 2) << "expired result must be re-probed";
+}
+
+TEST(EtcdProbeCache, FailureIsCachedForTheTtlToo) {
+  // The point of the debounce: during an etcd outage the probe rate is bounded
+  // by the TTL — a failure must be replayed, not retried on every probe hit.
+  uint64_t now_ms = 1000;
+  int probes = 0;
+  bool result = false;
+  EtcdProbeCache c(2000, [&] { return now_ms; },
+                   [&] { ++probes; return result; });
+  EXPECT_FALSE(c.Get());
+  EXPECT_EQ(probes, 1);
+  result = true;   // etcd recovers inside the TTL
+  now_ms += 1000;
+  EXPECT_FALSE(c.Get()) << "cached failure must be replayed within the TTL";
+  EXPECT_EQ(probes, 1);
+  now_ms += 1000;  // TTL expires -> recovery becomes visible
+  EXPECT_TRUE(c.Get());
+  EXPECT_EQ(probes, 2);
+}
+
+TEST(EtcdProbeCache, ZeroTtlDisablesCaching) {
+  uint64_t now_ms = 0;
+  int probes = 0;
+  EtcdProbeCache c(0, [&] { return now_ms; },
+                   [&] { ++probes; return true; });
+  EXPECT_TRUE(c.Get());
+  EXPECT_TRUE(c.Get());
+  EXPECT_EQ(probes, 2) << "ttl 0 must probe live on every call (old behavior)";
+}
+
+TEST(EtcdProbeCache, ConcurrentCallersCollapseOntoSingleFlight) {
+  uint64_t now_ms = 1000;
+  std::atomic<int> probes{0};
+  std::atomic<bool> entered{false};
+  std::atomic<bool> release{false};
+  EtcdProbeCache c(2000, [&] { return now_ms; }, [&] {
+    ++probes;
+    entered.store(true);
+    while (!release.load()) usleep(1000);  // hold the flight open
+    return true;
+  });
+  std::atomic<int> answered_true{0};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 4; ++i)
+    threads.emplace_back([&] { if (c.Get()) ++answered_true; });
+  for (int i = 0; i < 200 && !entered.load(); ++i) usleep(1000);
+  usleep(20 * 1000);  // give the other callers time to block on the flight
+  release.store(true);
+  for (auto& t : threads) t.join();
+  EXPECT_EQ(answered_true.load(), 4);
+  EXPECT_EQ(probes.load(), 1) << "concurrent probes must single-flight";
+}
+
+// Cached-probe wiring: the cache stores answers, it never invents health —
+// a dead endpoint must read false through ProbeEtcdCached as well.
+TEST(MdsServer, ProbeEtcdCachedReflectsReachability) {
+  ::setenv("DFKV_MDS_PROBE_CACHE_MS", "60000", 1);
+  { MdsServer dead("127.0.0.1:9", /*timeout_ms=*/300);
+    EXPECT_FALSE(dead.ProbeEtcdCached());
+    EXPECT_FALSE(dead.ProbeEtcdCached()); }
+  ::unsetenv("DFKV_MDS_PROBE_CACHE_MS");
+
+  const char* ep = EtcdEp();
+  if (!ep) GTEST_SKIP() << "set DFKV_TEST_ETCD for the reachable case";
+  MdsServer live(ep);
+  EXPECT_TRUE(live.ProbeEtcdCached());
+}
+
+// ---- First-frame absolute deadline (DFKV_MDS_FIRST_REQ_MS) ------------------
+// The base SO_RCVTIMEO is a PER-SYSCALL budget: a peer dribbling one byte per
+// sub-timeout interval never trips it and pins a handler thread forever. The
+// deadline stamps each conn at accept and requires the first COMPLETE frame
+// within the budget. No etcd needed (dead-endpoint MDS, local sockets only).
+
+namespace {
+// The server never sends data on these conns, so a readable fd means FIN:
+// recv==0 confirms it (server closed). false = still open or timeout.
+bool ServerClosed(int fd, int wait_ms) {
+  pollfd pfd{fd, POLLIN, 0};
+  if (::poll(&pfd, 1, wait_ms) <= 0) return false;
+  char tmp[16];
+  const ssize_t r = ::recv(fd, tmp, sizeof(tmp), MSG_DONTWAIT);
+  return r == 0 || (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK);
+}
+}  // namespace
+
+TEST(MdsServer, SlowDribbleFirstFrameDiesAtAbsoluteDeadline) {
+  ::setenv("DFKV_MDS_FIRST_REQ_MS", "300", 1);
+  ::setenv("DFKV_MDS_IO_TIMEOUT_S", "30", 1);  // per-syscall budget >> deadline
+  MdsServer srv("127.0.0.1:1");  // etcd never contacted: no frame completes
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int fd = net::Dial("127.0.0.1:" + std::to_string(srv.port()), 2000, 2000);
+  ASSERT_GE(fd, 0);
+  // Lead with the v2 epoch discriminator so the server passes the epoch gate
+  // and settles into the framed prefix read; then dribble one byte every
+  // 100 ms. A per-syscall 30 s timeout would never fire, so closure within
+  // ~2 s can only come from the absolute first-frame deadline.
+  bool closed = false;
+  int sent = 0;
+  {
+    const char epoch = static_cast<char>(kNativeProtoTcp);
+    ASSERT_EQ(::send(fd, &epoch, 1, MSG_NOSIGNAL), 1);
+  }
+  for (; sent < 20 && !closed; ++sent) {
+    usleep(100 * 1000);
+    const char b = 1;
+    if (::send(fd, &b, 1, MSG_NOSIGNAL) <= 0 || ServerClosed(fd, 50))
+      closed = true;
+  }
+  EXPECT_TRUE(closed) << "slow-dribble conn must be killed by the deadline";
+  EXPECT_LT(sent, 20) << "closed well before the per-syscall timeout";
+  for (int i = 0; i < 100 && srv.live_conn_count() > 0; ++i) usleep(20 * 1000);
+  EXPECT_EQ(srv.live_conn_count(), 0u) << "dead conn's handler must be reaped";
+  ::close(fd);
+  srv.Stop();
+  ::unsetenv("DFKV_MDS_FIRST_REQ_MS");
+  ::unsetenv("DFKV_MDS_IO_TIMEOUT_S");
+}
+
+TEST(MdsServer, FirstFrameDeadlineEndsAfterFirstCompleteFrame) {
+  // The deadline governs ONLY the gap accept -> first complete frame. A conn
+  // that spoke within the deadline must live past accept+deadline, with the
+  // steady-state per-syscall timeout (here 30 s) as the only remaining bound.
+  ::setenv("DFKV_MDS_FIRST_REQ_MS", "800", 1);
+  ::setenv("DFKV_MDS_IO_TIMEOUT_S", "30", 1);
+  MdsServer srv("127.0.0.1:1");  // dead etcd: requests answer kIOError but the
+                                 // conn itself stays usable
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int fd = net::Dial("127.0.0.1:" + std::to_string(srv.port()), 3000, 3000);
+  ASSERT_GE(fd, 0);
+  Status st = Status::kInvalid;
+  std::string data;
+  MemberInfo m{"n1", "10.1.1.1", 28000, 1};
+  // Frame #1 lands well inside the 800 ms deadline.
+  ASSERT_TRUE(DoReqOnFd(fd, WireOp::kRegister, EncodeMemberReq("dl-grp", m),
+                        &st, &data));
+  EXPECT_EQ(st, Status::kIOError) << "dead etcd -> kIOError, but conn answered";
+  usleep(1000 * 1000);  // now past the ORIGINAL accept deadline
+  // Frame #2 must still be served: the deadline must not outlive frame #1
+  // (this is the normal-traffic regression guard for the new read path).
+  ASSERT_TRUE(DoReqOnFd(fd, WireOp::kHeartbeat, EncodeMemberReq("dl-grp", m),
+                        &st, &data))
+      << "first-frame deadline must not kill a conn that already spoke";
+  EXPECT_EQ(st, Status::kIOError);
+  ::close(fd);
+  srv.Stop();
+  ::unsetenv("DFKV_MDS_FIRST_REQ_MS");
+  ::unsetenv("DFKV_MDS_IO_TIMEOUT_S");
+}
+
+TEST(MdsServer, ZeroFirstReqMsKeepsOldDribbleBehavior) {
+  // Knob explicitly OFF: no absolute deadline — a dribble at sub-timeout
+  // cadence outlives the (here much shorter) per-syscall I/O timeout because
+  // every recv returns in time. Pins the 0 = disabled compatibility mode.
+  ::setenv("DFKV_MDS_FIRST_REQ_MS", "0", 1);
+  ::setenv("DFKV_MDS_IO_TIMEOUT_S", "1", 1);
+  MdsServer srv("127.0.0.1:1");
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  int fd = net::Dial("127.0.0.1:" + std::to_string(srv.port()), 2000, 2000);
+  ASSERT_GE(fd, 0);
+  // Lead with the v2 epoch discriminator so the server passes the epoch gate
+  // and waits on the rest of the prefix; the dribble below then exercises
+  // pure per-syscall cadence (no absolute deadline) exactly as pre-shim.
+  bool died = false;
+  {
+    const char epoch = static_cast<char>(kNativeProtoTcp);
+    ASSERT_EQ(::send(fd, &epoch, 1, MSG_NOSIGNAL), 1);
+  }
+  for (int i = 0; i < 5 && !died; ++i) {
+    usleep(300 * 1000);  // 300 ms cadence < 1 s per-syscall timeout
+    const char b = 1;
+    if (::send(fd, &b, 1, MSG_NOSIGNAL) <= 0 || ServerClosed(fd, 50)) {
+      died = true;
+    }
+  }
+  // Dribble span 1.5 s > 1 s per-syscall budget: only per-syscall semantics
+  // were in play, so the conn must have survived all of it.
+  EXPECT_FALSE(died) << "knob=0: dribble at sub-timeout cadence must survive";
+  ::close(fd);
+  srv.Stop();
+  ::unsetenv("DFKV_MDS_FIRST_REQ_MS");
+  ::unsetenv("DFKV_MDS_IO_TIMEOUT_S");
 }

--- a/test/mds/member_view_guard_test.cc
+++ b/test/mds/member_view_guard_test.cc
@@ -61,6 +61,7 @@ TEST(MemberViewGuard, ShrinkArmDisabledByZeroPct) {
   MemberViewGuard g(3, 0);
   EXPECT_TRUE(g.Admit(64));
   EXPECT_TRUE(g.Admit(1));    // pct=0: legacy behavior, shrink passes
+  EXPECT_TRUE(g.Admit(500));  // pct=0 also disables the growth arm
   EXPECT_FALSE(g.Admit(0));   // empty arm is always on
 }
 
@@ -113,4 +114,96 @@ TEST(MemberViewGuard, CrossMultiplicationDoesNotOverflowSizeT) {
   MemberViewGuard boundary(3, 50);
   EXPECT_TRUE(boundary.Admit(max - 1));
   EXPECT_TRUE(boundary.Admit((max - 1) / 2));
+}
+
+TEST(MemberViewGuard, DiffuseDecayChainFreezesReference) {
+  // Mass lease expiry with heartbeat phases spread over polls: every hop
+  // drains well under 50% of its neighbor, so an adjacent-hop guard ratchets
+  // the ring down hop by hop. The trusted reference must hold at 64 until a
+  // repeated value crosses the bar.
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(64));
+  for (size_t v : {60ul, 56ul, 52ul, 48ul, 44ul, 40ul, 36ul, 33ul}) {
+    EXPECT_TRUE(g.Admit(v)) << "hop " << v << " is legal vs its neighbor";
+  }
+  EXPECT_EQ(g.rejected_shrink(), 0u);
+  // The reference did NOT slide along: a bounce back toward it is adopted
+  // immediately (against a ratcheted ~33 anchor this +50% jump would itself
+  // trip hysteresis).
+  EXPECT_TRUE(g.Admit(50));
+  // 31 first crosses below 50% of the frozen 64 reference: hysteresis until
+  // ONE value persists, even though every prior hop was legal.
+  EXPECT_FALSE(g.Admit(31));
+  EXPECT_FALSE(g.Admit(31));
+  EXPECT_TRUE(g.Admit(31));   // persisted: real mass drain
+  EXPECT_EQ(g.rejected_shrink(), 2u);
+}
+
+TEST(MemberViewGuard, SuspiciousViewMustRepeatOneValue) {
+  // The old guard counted consecutive *suspicious* polls; a still-draining
+  // view (20, 10, 10) would trip it and adopt mid-collapse. Only one value
+  // repeating views_to_accept times may be believed.
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_FALSE(g.Admit(20));
+  EXPECT_FALSE(g.Admit(10));  // different suspicious value: streak restarts
+  EXPECT_FALSE(g.Admit(10));
+  EXPECT_TRUE(g.Admit(10));
+  EXPECT_EQ(g.rejected_shrink(), 3u);
+}
+
+TEST(MemberViewGuard, RecoveryRampAdoptsOnceAtPlateau) {
+  // After a believed collapse, members re-register on their own schedule: the
+  // view grows epoch by epoch. Rebuilding the ring per epoch is as disruptive
+  // as the collapse itself, so a shifting ramp must never be adopted — only
+  // the plateau. (pct=20 so every hop of the 33->40->50->64 ramp clears the
+  // suspicion bar and exercises the growth arm.)
+  MemberViewGuard g(3, 20);
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_FALSE(g.Admit(33));  // collapse: shrink hysteresis
+  EXPECT_FALSE(g.Admit(33));
+  EXPECT_TRUE(g.Admit(33));   // persisted: believed, reference re-anchored
+  // Ramp: every hop differs, so nothing is adopted mid-ramp.
+  EXPECT_FALSE(g.Admit(40));
+  EXPECT_FALSE(g.Admit(50));
+  EXPECT_FALSE(g.Admit(64));
+  // Plateau: ONE repeated value adopts, exactly once.
+  EXPECT_FALSE(g.Admit(64));
+  EXPECT_TRUE(g.Admit(64));
+  // Afterwards the stable ring is ordinary traffic again.
+  EXPECT_TRUE(g.Admit(64));
+  EXPECT_EQ(g.rejected_shrink(), 2u);
+  EXPECT_EQ(g.rejected_growth(), 4u);
+}
+
+TEST(MemberViewGuard, SingleNodeEventsPassImmediately) {
+  MemberViewGuard down(3, 50);
+  EXPECT_TRUE(down.Admit(64));
+  EXPECT_TRUE(down.Admit(63));  // single-node failure propagates fast
+
+  MemberViewGuard up(3, 50);
+  EXPECT_TRUE(up.Admit(64));
+  EXPECT_TRUE(up.Admit(65));    // one node joining is below the growth bar
+}
+
+TEST(MemberViewGuard, GrowthArmWideMathDoesNotOverflow) {
+  const size_t max = std::numeric_limits<size_t>::max();
+  MemberViewGuard g(3, 50);
+  EXPECT_TRUE(g.Admit(max / 4));
+  // max/4 -> max/2 is a 2x jump: growth-suspicious, must persist as one value.
+  EXPECT_FALSE(g.Admit(max / 2));
+  EXPECT_FALSE(g.Admit(max / 2));
+  EXPECT_TRUE(g.Admit(max / 2));
+  EXPECT_EQ(g.rejected_growth(), 2u);
+
+  // Exactly +50% is not over the bar (mirrors the shrink boundary).
+  MemberViewGuard boundary(3, 50);
+  EXPECT_TRUE(boundary.Admit(max / 3));
+  EXPECT_TRUE(boundary.Admit(max / 2));
+
+  // Hundreds of nodes: exact percentage math, no float fuzz.
+  MemberViewGuard big(3, 50);
+  EXPECT_TRUE(big.Admit(300));
+  EXPECT_TRUE(big.Admit(299));
+  EXPECT_FALSE(big.Admit(100));  // -67% of the 300 reference: hysteresis
 }

--- a/test/python/test_dfkv_operational_tools.py
+++ b/test/python/test_dfkv_operational_tools.py
@@ -35,6 +35,11 @@ n1               10.0.0.1:28001             1      100   33.3%  ver=2.0,engine=s
 n2               10.0.0.2:28001             2      200   66.7%  ver=2.0,engine=slab,disks=3,cap=9,ram=0,rdma=on
 """
 
+RING_OLD = """group=glm members=1 ring_points=300
+ID               ADDR                   WEIGHT   VNODES   SHARE  INFO
+n1               10.0.0.1:28001             1      300  100.0%  ver=2.0,engine=slab,disks=3,cap=9,ram=0,rdma=on
+"""
+
 CLIENTS = """group=glm clients=2 (only upgraded clients register)
 ID                           TYPE       MODEL                    ROLE           TP       INFO
 host-a_1                     vllm       model-a                  producer       8        type=vllm,model=model-a
@@ -176,6 +181,80 @@ class ReplacementWorkflowTest(unittest.TestCase):
         workflow.rollback(RuntimeError("cutover failed"))
         self.assertEqual(workflow.actions, [("old", "start")])
         self.assertEqual(workflow.required, [{"n1"}])
+
+    def test_start_timeout_marks_started_new_and_rollback_stops_replacement(self) -> None:
+        class Fixture(Replacer):
+            def __init__(self, args):
+                super().__init__(args)
+                self.actions = []
+
+            def ring(self):
+                return parse_ring(RING_OLD)
+
+            def clients(self):
+                return {"client-1"}
+
+            def remote(self, host, action):
+                self.actions.append((host, action))
+                if (host, action) == ("new", "start"):
+                    raise subprocess.TimeoutExpired(["ssh", "new"], 1.0)
+
+        workflow = Fixture(self.args(dry_run=False))
+        with self.assertRaises(subprocess.TimeoutExpired):
+            workflow.run()
+        # The local SSH timeout must not hide a remotely running replacement.
+        self.assertTrue(workflow.started_new)
+        self.assertFalse(workflow.old_stopped)
+        workflow.rollback(RuntimeError("start ssh timed out"))
+        self.assertEqual(workflow.actions, [("new", "start"), ("new", "stop")])
+        events = workflow.events
+        self.assertTrue(any(event["phase"] == "rollback" for event in events))
+        self.assertFalse(any("safe abort" in str(event["message"]) for event in events))
+
+    def test_successful_cutover_keeps_started_new_without_rollback(self) -> None:
+        class Fixture(Replacer):
+            def __init__(self, args):
+                super().__init__(args)
+                self.actions = []
+
+            def ring(self):
+                return parse_ring(RING_OLD)
+
+            def clients(self):
+                return {"client-1"}
+
+            def remote(self, host, action):
+                self.actions.append((host, action))
+
+            def wait_stable_ring(self, required, forbidden):
+                return parse_ring(RING)
+
+            def wait_for(self, description, predicate):
+                return True
+
+        workflow = Fixture(self.args(dry_run=False))
+        workflow.run()
+        self.assertEqual(workflow.actions, [("new", "start"), ("old", "stop")])
+        self.assertTrue(workflow.started_new)
+        self.assertTrue(workflow.old_stopped)
+        phases = [event["phase"] for event in workflow.events]
+        self.assertNotIn("rollback", phases)
+        self.assertNotIn("abort", phases)
+
+    def test_rollback_fails_loudly_when_replacement_stop_fails(self) -> None:
+        class Fixture(Replacer):
+            def remote(self, host, action):
+                raise subprocess.TimeoutExpired(["ssh", host], 1.0)
+
+        workflow = Fixture(self.args(dry_run=False))
+        workflow.started_new = True
+        with self.assertRaises(WorkflowError) as raised:
+            workflow.rollback(RuntimeError("start ssh timed out"))
+        message = str(raised.exception)
+        self.assertIn("CRITICAL", message)
+        self.assertIn("still be registered in the ring", message)
+        self.assertIn("stop dfkv on new manually", message)
+        self.assertFalse(any("safe abort" in str(event["message"]) for event in workflow.events))
 
     def test_wait_for_retries_command_timeouts_until_predicate_succeeds(self) -> None:
         transient = subprocess.TimeoutExpired(["dfkvctl", "ring"], 1.0)

--- a/test/python/test_dfkv_operational_tools.py
+++ b/test/python/test_dfkv_operational_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import struct
+import subprocess
 import sys
 import unittest
 from tempfile import TemporaryDirectory
@@ -17,7 +18,7 @@ sys.path.insert(0, str(DEPLOY))
 
 from dfkv_load_regression import bench_once, histogram_delta, histogram_quantile, percentile  # noqa: E402
 from dfkv_membership_audit import decode_registration, info_fields, range_end  # noqa: E402
-from dfkv_node_replace import Replacer  # noqa: E402
+from dfkv_node_replace import Replacer, WorkflowError  # noqa: E402
 from dfkv_tenant_quota import load_quotas, main as quota_main  # noqa: E402
 from dfkv_ops_common import (  # noqa: E402
     members_epoch,
@@ -175,6 +176,33 @@ class ReplacementWorkflowTest(unittest.TestCase):
         workflow.rollback(RuntimeError("cutover failed"))
         self.assertEqual(workflow.actions, [("old", "start")])
         self.assertEqual(workflow.required, [{"n1"}])
+
+    def test_wait_for_retries_command_timeouts_until_predicate_succeeds(self) -> None:
+        transient = subprocess.TimeoutExpired(["dfkvctl", "ring"], 1.0)
+        with patch("dfkv_node_replace.run_command", side_effect=[transient, transient, RING]) as command:
+            workflow = Replacer(self.args())
+            view = workflow.wait_for("replacement ring", workflow.ring)
+        self.assertEqual([member.node_id for member in view.members], ["n1", "n2"])
+        self.assertEqual(command.call_count, 3)
+
+    def test_wait_for_deadline_still_fails_under_persistent_timeouts(self) -> None:
+        args = self.args()
+        args.timeout = 0.05
+        transient = subprocess.TimeoutExpired(["dfkvctl", "ring"], 1.0)
+        with patch("dfkv_node_replace.run_command", side_effect=transient) as command:
+            workflow = Replacer(args)
+            with self.assertRaises(WorkflowError) as raised:
+                workflow.wait_for("replacement ring", workflow.ring)
+        self.assertIn("timed out", str(raised.exception))
+        self.assertGreaterEqual(command.call_count, 2)
+
+    def test_wait_for_retries_os_errors_as_transient(self) -> None:
+        reset = OSError(104, "connection reset by peer")
+        with patch("dfkv_node_replace.run_command", side_effect=[reset, reset, RING]) as command:
+            workflow = Replacer(self.args())
+            view = workflow.wait_for("replacement ring", workflow.ring)
+        self.assertEqual([member.node_id for member in view.members], ["n1", "n2"])
+        self.assertEqual(command.call_count, 3)
 
 
 class MembershipDecodeTest(unittest.TestCase):

--- a/test/transport/dev_frame_caps_test.cc
+++ b/test/transport/dev_frame_caps_test.cc
@@ -2,8 +2,17 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <string>
 
 #include "transport/dev_frame.h"
+
+// Startup fail-fast wiring lives in the RDMA transport/server: only RDMA
+// builds compile that coverage below; elsewhere it is compiled away (same
+// pattern as rail_select_test.cc).
+#ifdef DFKV_WITH_RDMA
+#include "cache/rdma_server.h"
+#include "transport/rdma_transport.h"
+#endif
 
 namespace dfkv::rdma {
 
@@ -83,5 +92,95 @@ TEST(DevFrameCaps, MissingTerminatorIsRejected) {
   EXPECT_EQ(ParseDevFrameCaps(frame), 0u);
   EXPECT_EQ(ParseDevFrameProtocol(frame), 0);
 }
+
+TEST(DevFrameCaps, DeviceNameFitBoundaryIsExported) {
+  EXPECT_EQ(kMaxDeviceNameBytes, 18u);  // 32 - (1 NUL + 4 magic + 8 u64 + 1 u8)
+  EXPECT_TRUE(DeviceNameFitsFrame(""));  // empty = peer default device
+  EXPECT_TRUE(DeviceNameFitsFrame(std::string(18, 'a')));
+  EXPECT_FALSE(DeviceNameFitsFrame(std::string(19, 'a')));
+  EXPECT_FALSE(DeviceNameFitsFrame(std::string(64, 'a')));  // udev/bond names
+}
+
+TEST(DevFrameCaps, OversizedDiagnosticNamesDeviceAndLimit) {
+  const std::string dev(19, 'x');
+  const std::string error = OversizedDeviceNameError(dev);
+  EXPECT_NE(error.find(dev), std::string::npos);
+  EXPECT_NE(error.find(std::to_string(kMaxDeviceNameBytes)), std::string::npos);
+}
+
+// The deep-defense drop stays reachable for frames not built from a validated
+// name, mirroring the historical silent-drop behavior the fit check prevents.
+TEST(DevFrameCaps, FitCheckMirrorsEncodeBoundary) {
+  char frame[kDevNameBytes];
+  for (size_t len = 0; len <= kDevNameBytes; ++len) {
+    const std::string dev(len, 'q');
+    EncodeDevFrame(dev, 4u << 20, frame);
+    if (DeviceNameFitsFrame(dev)) {
+      EXPECT_EQ(ParseDevFrameProtocol(frame), kDevProtoV2) << "len=" << len;
+    } else {
+      EXPECT_EQ(ParseDevFrameProtocol(frame), 0) << "len=" << len;
+    }
+  }
+}
+
+#ifdef DFKV_WITH_RDMA
+
+TEST(DevFrameCaps, OversizedConfiguredDeviceFailsClientConstruction) {
+  // The whitelist check runs before any device discovery, so this is hermetic
+  // on hosts with no RDMA hardware. 19 chars overflows the frame; 64 chars
+  // matches a long custom udev/bond HCA name.
+  for (size_t len : {19u, 64u}) {
+    const std::string dev(len, 'x');
+    try {
+      dfkv::RdmaTransport transport(0, dev);
+      FAIL() << "construction accepted a " << len << "-byte device name";
+    } catch (const std::runtime_error& e) {
+      const std::string what = e.what();
+      EXPECT_NE(what.find(dev), std::string::npos);
+      EXPECT_NE(what.find(std::to_string(kMaxDeviceNameBytes)),
+                std::string::npos);
+    }
+  }
+}
+
+TEST(DevFrameCaps, BoundaryConfiguredDevicePassesNameValidation) {
+  // 18 chars exactly fills the frame budget: construction must clear name
+  // validation and fail only later at discovery (no hardware here, or no
+  // ACTIVE device by that literal name) with no oversized-name complaint.
+  const std::string dev(kMaxDeviceNameBytes, 'y');
+  try {
+    dfkv::RdmaTransport transport(0, dev);
+    GTEST_SKIP() << "host has an ACTIVE device matching the test name";
+  } catch (const std::runtime_error& e) {
+    const std::string what = e.what();
+    EXPECT_NE(what.find("ACTIVE"), std::string::npos);
+    EXPECT_EQ(what.find(std::to_string(kMaxDeviceNameBytes)),
+              std::string::npos);
+  }
+}
+
+TEST(DevFrameCaps, OversizedAnchorWarnsButServerStillStarts) {
+  // The server never encodes its anchor into a frame (empty-name clients fall
+  // back to the default anchor), so startup diagnoses the name but continues.
+  const std::string dev(20, 'a');
+  dfkv::RdmaServer server(
+      [](uint8_t, const dfkv::BlockKey&, uint64_t, uint64_t, const char*,
+         uint64_t, std::string*, size_t*) { return dfkv::Status::kNotFound; },
+      1u << 20, dev);
+  testing::internal::CaptureStderr();
+  const dfkv::Status status = server.Start(0);
+  const std::string logs = testing::internal::GetCapturedStderr();
+  EXPECT_NE(logs.find(dev), std::string::npos)
+      << "startup diagnostics must name the oversized anchor";
+  EXPECT_NE(logs.find(std::to_string(kMaxDeviceNameBytes)), std::string::npos)
+      << "startup diagnostics must state the frame limit";
+  EXPECT_NE(logs.find("serving anyway"), std::string::npos);
+  // Startup continued past the warning: device discovery (not name
+  // validation) reports availability. No ACTIVE device carries the test name.
+  EXPECT_NE(logs.find("ACTIVE"), std::string::npos);
+  EXPECT_EQ(status, dfkv::Status::kIOError);
+}
+
+#endif  // DFKV_WITH_RDMA
 
 }  // namespace dfkv::rdma

--- a/test/transport/rail_select_test.cc
+++ b/test/transport/rail_select_test.cc
@@ -1,4 +1,9 @@
 #include "transport/rail_select.h"
+// ClassifyCompletion is verbs-dependent (ibv_wc_status): only RDMA builds
+// compile its coverage below; elsewhere those tests are compiled away.
+#ifdef DFKV_WITH_RDMA
+#include "transport/rail_classify.h"
+#endif
 
 #include <gtest/gtest.h>
 
@@ -221,3 +226,111 @@ TEST(RailPolicy, EndpointFailureDoesNotConsumeRecoveryProbe) {
   EXPECT_EQ(stats[failed_rail->rail].quarantined_until_us, 0u);
   EXPECT_FALSE(stats[failed_rail->rail].quarantined);
 }
+
+#ifdef DFKV_WITH_RDMA
+using dfkv::rdma::ClassifyCompletion;
+
+TEST(ClassifyCompletion, RemoteEvidenceNeverBlamesTheRail) {
+  const ibv_wc_status remote[] = {
+      IBV_WC_REM_ACCESS_ERR,   IBV_WC_REM_OP_ERR,
+      IBV_WC_REM_INV_REQ_ERR,  IBV_WC_REM_ABORT_ERR,
+      IBV_WC_RETRY_EXC_ERR,    IBV_WC_RNR_RETRY_EXC_ERR,
+      IBV_WC_RESP_TIMEOUT_ERR, IBV_WC_WR_FLUSH_ERR,
+  };
+  for (ibv_wc_status status : remote) {
+    for (bool had : {false, true}) {
+      EXPECT_EQ(ClassifyCompletion(status, had),
+                RailCompletion::kEndpointFailure)
+          << "wc status " << status;
+    }
+  }
+}
+
+TEST(ClassifyCompletion, LocalEvidenceBlamesTheRail) {
+  const ibv_wc_status local[] = {
+      IBV_WC_LOC_LEN_ERR,    IBV_WC_LOC_QP_OP_ERR,
+      IBV_WC_LOC_EEC_OP_ERR, IBV_WC_LOC_PROT_ERR,
+      IBV_WC_LOC_ACCESS_ERR, IBV_WC_LOC_RDD_VIOL_ERR,
+      IBV_WC_FATAL_ERR,      IBV_WC_GENERAL_ERR,
+  };
+  for (ibv_wc_status status : local) {
+    for (bool had : {false, true}) {
+      EXPECT_EQ(ClassifyCompletion(status, had), RailCompletion::kRailFailure)
+          << "wc status " << status;
+    }
+  }
+}
+
+TEST(ClassifyCompletion, DeadlineExpiryIsPeerSilence) {
+  // Zero completions: the peer went silent and the NIC surfaced no local
+  // error evidence.
+  EXPECT_EQ(ClassifyCompletion(IBV_WC_SUCCESS, /*had_completions=*/false),
+            RailCompletion::kEndpointFailure);
+  // Partial progress then stall: completions prove the rail was healthy when
+  // last observed, so the same verdict holds.
+  EXPECT_EQ(ClassifyCompletion(IBV_WC_SUCCESS, /*had_completions=*/true),
+            RailCompletion::kEndpointFailure);
+}
+
+TEST(ClassifyCompletion, UnknownStatusSparesTheRail) {
+  // Unlisted/ambiguous evidence must never quarantine a healthy HCA.
+  const ibv_wc_status unknown[] = {
+      IBV_WC_MW_BIND_ERR, IBV_WC_BAD_RESP_ERR, IBV_WC_REM_INV_RD_REQ_ERR,
+      IBV_WC_INV_EECN_ERR, static_cast<ibv_wc_status>(0x7f),
+  };
+  for (ibv_wc_status status : unknown) {
+    for (bool had : {false, true}) {
+      EXPECT_EQ(ClassifyCompletion(status, had),
+                RailCompletion::kEndpointFailure)
+          << "wc status " << status;
+    }
+  }
+}
+
+TEST(ClassifyCompletion, DeadPeerWindowLeavesRailHealthy) {
+  // End to end through the policy: dead-peer evidence (retry-chain exhaustion
+  // or a silent deadline) repeated past the error threshold must not
+  // quarantine the local rail.
+  RailPolicy policy(1, RailPolicyConfig{1, 3, 1000, 1, 100});
+  for (uint64_t now = 10; now < 15; ++now) {
+    const auto lease = policy.TryAcquire(1, now);
+    ASSERT_TRUE(lease);
+    policy.Complete(*lease, 20,
+                    ClassifyCompletion(IBV_WC_RETRY_EXC_ERR,
+                                       /*had_completions=*/true),
+                    now + 1);
+  }
+  const auto silent_lease = policy.TryAcquire(1, 20);
+  ASSERT_TRUE(silent_lease);
+  policy.Complete(*silent_lease, 20,
+                  ClassifyCompletion(IBV_WC_SUCCESS,
+                                     /*had_completions=*/false),
+                  21);
+  const auto stats = policy.Snapshot(22);
+  EXPECT_EQ(stats[0].endpoint_errors, 6u);
+  EXPECT_EQ(stats[0].errors, 0u);
+  EXPECT_EQ(stats[0].consecutive_errors, 0u);
+  EXPECT_EQ(stats[0].quarantines, 0u);
+  EXPECT_TRUE(policy.TryAcquire(1, 23));
+}
+
+TEST(ClassifyCompletion, LocalFaultWindowFeedsQuarantine) {
+  // Local evidence (the local-fault bucket also used for post/CQ API
+  // failures) still counts toward quarantine.
+  RailPolicy policy(1, RailPolicyConfig{1, 3, 1000, 1, 100});
+  for (uint64_t now = 10; now < 13; ++now) {
+    const auto lease = policy.TryAcquire(1, now);
+    ASSERT_TRUE(lease);
+    policy.Complete(*lease, 20,
+                    ClassifyCompletion(IBV_WC_GENERAL_ERR,
+                                       /*had_completions=*/true),
+                    now + 1);
+  }
+  const auto stats = policy.Snapshot(14);
+  EXPECT_EQ(stats[0].errors, 3u);
+  EXPECT_EQ(stats[0].consecutive_errors, 3u);
+  EXPECT_EQ(stats[0].quarantines, 1u);
+  EXPECT_TRUE(stats[0].quarantined);
+  EXPECT_FALSE(policy.TryAcquire(1, 15));
+}
+#endif  // DFKV_WITH_RDMA

--- a/test/transport/rail_select_test.cc
+++ b/test/transport/rail_select_test.cc
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+using dfkv::rdma::AcquireWithFallback;
 using dfkv::rdma::PickRail;
 using dfkv::rdma::RailCompletion;
 using dfkv::rdma::RailPolicy;
@@ -177,6 +178,76 @@ TEST(RailPolicy, LocalMaskDoesNotEscapeWhenLocalCreditsAreBusy) {
   EXPECT_EQ(next->rail, 0u);
 }
 
+TEST(RailPolicy, FallbackMaskServesWhenLocalRailsAreQuarantined) {
+  RailPolicy policy(4, RailPolicyConfig{2, 1, 60'000'000, 1, 100});
+  const std::vector<uint8_t> local{1, 1, 0, 0};
+  const std::vector<uint8_t> all{1, 1, 1, 1};
+  // AcquireWithFallback reads the real clock (like RailPolicy::Acquire), so
+  // the quarantine below is pinned to NowMicros instead of a virtual time.
+  const uint64_t now = RailPolicy::NowMicros();
+  const auto first = policy.TryAcquire(1, now, local);
+  ASSERT_TRUE(first);
+  ASSERT_EQ(first->rail, 0u);
+  policy.Complete(*first, 10, RailCompletion::kRailFailure, now);
+  const auto second = policy.TryAcquire(1, now + 1, local);
+  ASSERT_TRUE(second);
+  ASSERT_EQ(second->rail, 1u);
+  policy.Complete(*second, 10, RailCompletion::kRailFailure, now + 1);
+
+  // Both local rails quarantined for ~60s: local-only admission fails, and
+  // without a fallback mask the helper cannot serve either.
+  EXPECT_FALSE(policy.TryAcquire(1, now + 2, local));
+  EXPECT_FALSE(AcquireWithFallback(policy, 1, 0, local, {}));
+
+  // The backstop mask degrades to the healthy remote rails, granting exactly
+  // one lease.
+  const auto lease = AcquireWithFallback(policy, 1, 0, local, all);
+  ASSERT_TRUE(lease);
+  EXPECT_EQ(lease->rail, 2u);
+  const auto stats = policy.Snapshot(now + 3);
+  EXPECT_EQ(stats[0].inflight, 0u);
+  EXPECT_EQ(stats[1].inflight, 0u);
+  EXPECT_EQ(stats[2].inflight, 1u);
+  EXPECT_EQ(stats[3].inflight, 0u);
+  policy.Complete(*lease, 25, RailCompletion::kSuccess, now + 4);
+}
+
+TEST(RailPolicy, FallbackMaskServesWhenLocalCreditsAreExhausted) {
+  RailPolicy policy(2, RailPolicyConfig{1, 3, 1000, 1, 100});
+  const std::vector<uint8_t> local{1, 0};
+  const std::vector<uint8_t> all{1, 1};
+  const auto held = AcquireWithFallback(policy, 1, 0, local, all);
+  ASSERT_TRUE(held);
+  EXPECT_EQ(held->rail, 0u);
+  EXPECT_EQ(policy.Snapshot(1)[1].inflight, 0u);
+
+  // Local credit-bound: the backstop overflows to the idle remote rail.
+  const auto overflow = AcquireWithFallback(policy, 1, 0, local, all);
+  ASSERT_TRUE(overflow);
+  EXPECT_EQ(overflow->rail, 1u);
+
+  // Nothing admissible anywhere: a non-blocking attempt still fails, and each
+  // rail granted exactly one credit.
+  EXPECT_FALSE(AcquireWithFallback(policy, 1, 0, local, all));
+  const auto stats = policy.Snapshot(2);
+  EXPECT_EQ(stats[0].inflight, 1u);
+  EXPECT_EQ(stats[1].inflight, 1u);
+  policy.Complete(*held, 20, RailCompletion::kSuccess, 3);
+  policy.Complete(*overflow, 20, RailCompletion::kSuccess, 4);
+}
+
+TEST(RailPolicy, FallbackKeepsLocalityWhenLocalRailCanServe) {
+  RailPolicy policy(2, RailPolicyConfig{1, 3, 1000, 1, 100});
+  const std::vector<uint8_t> local{1, 0};
+  const std::vector<uint8_t> all{1, 1};
+
+  const auto lease = AcquireWithFallback(policy, 1, 0, local, all);
+  ASSERT_TRUE(lease);
+  EXPECT_EQ(lease->rail, 0u);
+  EXPECT_EQ(policy.Snapshot(1)[1].inflight, 0u);
+  policy.Complete(*lease, 20, RailCompletion::kSuccess, 2);
+}
+
 TEST(RailPolicy, EndpointFailuresReturnCreditsWithoutPenalizingRail) {
   RailPolicy policy(2, RailPolicyConfig{1, 1, 1000, 1, 100});
   const std::vector<uint8_t> first_rail{1, 0};
@@ -225,6 +296,45 @@ TEST(RailPolicy, EndpointFailureDoesNotConsumeRecoveryProbe) {
   EXPECT_EQ(stats[failed_rail->rail].recoveries, 1u);
   EXPECT_EQ(stats[failed_rail->rail].quarantined_until_us, 0u);
   EXPECT_FALSE(stats[failed_rail->rail].quarantined);
+}
+
+TEST(RailPolicy, RecoveryProbeMarksOnlyTheGrantedRail) {
+  RailPolicy policy(2, RailPolicyConfig{2, 1, 1000, 1, 100});
+  const auto first = policy.TryAcquire(1, 10);
+  ASSERT_TRUE(first);
+  ASSERT_EQ(first->rail, 0u);
+  policy.Complete(*first, 10, RailCompletion::kRailFailure, 20);
+  const auto second = policy.TryAcquire(1, 21);
+  ASSERT_TRUE(second);
+  ASSERT_EQ(second->rail, 1u);
+  policy.Complete(*second, 10, RailCompletion::kRailFailure, 30);
+
+  // Both cooldowns (until 1020/1030) have elapsed: a single admission marks
+  // only the rail it actually grants, never the candidate it outscored.
+  const auto probe = policy.TryAcquire(1, 2000);
+  ASSERT_TRUE(probe);
+  EXPECT_EQ(probe->rail, 0u);
+  auto stats = policy.Snapshot(2001);
+  EXPECT_TRUE(stats[0].recovery_probe);
+  EXPECT_FALSE(stats[1].recovery_probe);
+
+  policy.Complete(*probe, 25, RailCompletion::kSuccess, 2010);
+  stats = policy.Snapshot(2011);
+  EXPECT_EQ(stats[0].recoveries, 1u);
+  EXPECT_FALSE(stats[0].recovery_probe);
+
+  // The losing rail's quarantine marker survives unscathed, so the next
+  // admission discovers it as a genuine fresh probe.
+  const auto next = policy.TryAcquire(1, 2012);
+  ASSERT_TRUE(next);
+  EXPECT_EQ(next->rail, 1u);
+  stats = policy.Snapshot(2013);
+  EXPECT_TRUE(stats[1].recovery_probe);
+  policy.Complete(*next, 25, RailCompletion::kSuccess, 2020);
+  stats = policy.Snapshot(2021);
+  EXPECT_EQ(stats[1].recoveries, 1u);
+  EXPECT_FALSE(stats[1].recovery_probe);
+  EXPECT_FALSE(stats[1].quarantined);
 }
 
 #ifdef DFKV_WITH_RDMA

--- a/test/transport/rdma_topology_test.cc
+++ b/test/transport/rdma_topology_test.cc
@@ -114,4 +114,39 @@ TEST(RdmaTopology, NoLocalRailFallsBackToAllEnabledRails) {
   EXPECT_EQ(candidates.allowed, (std::vector<uint8_t>{1, 1}));
 }
 
+TEST(RdmaTopology, LocalMaskCarriesAllEnabledRailsAsFallback) {
+  RdmaTopology topology({Device("ib0", true, 0), Device("ib1", true, 0),
+                         Device("ib2", true, 1)});
+
+  const auto candidates = topology.CandidatesFor(0, true);
+
+  EXPECT_EQ(candidates.locality, RailLocality::kLocal);
+  EXPECT_EQ(candidates.allowed, (std::vector<uint8_t>{1, 1, 0}));
+  // The backstop spans every enabled rail, NUMA locality aside.
+  EXPECT_EQ(candidates.fallback, (std::vector<uint8_t>{1, 1, 1}));
+}
+
+TEST(RdmaTopology, FallbackMaskStillExcludesRuntimeDisabledRails) {
+  RdmaTopology topology({Device("ib0", true, 0), Device("ib1", true, 1)});
+  topology.DisableDevice("ib1");
+
+  const auto candidates = topology.CandidatesFor(0, true);
+
+  EXPECT_EQ(candidates.locality, RailLocality::kLocal);
+  EXPECT_EQ(candidates.allowed, (std::vector<uint8_t>{1, 0}));
+  EXPECT_EQ(candidates.fallback, (std::vector<uint8_t>{1, 0}));
+}
+
+TEST(RdmaTopology, FallbackMaskIsEmptyWithoutLocalPreference) {
+  RdmaTopology topology({Device("ib0", true, 0), Device("ib1", true, 1)});
+
+  const auto disabled = topology.CandidatesFor(0, false);
+  EXPECT_EQ(disabled.locality, RailLocality::kDisabled);
+  EXPECT_TRUE(disabled.fallback.empty());
+
+  const auto unknown = topology.CandidatesFor(-1, true);
+  EXPECT_EQ(unknown.locality, RailLocality::kCallerUnknown);
+  EXPECT_TRUE(unknown.fallback.empty());
+}
+
 }  // namespace

--- a/test/utils/metrics_http_test.cc
+++ b/test/utils/metrics_http_test.cc
@@ -3,14 +3,57 @@
 
 #include <gtest/gtest.h>
 
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <functional>
 #include <string>
+#include <thread>
 
 #include "utils/net_util.h"
 
 using namespace dfkv;  // NOLINT
 
 namespace {
+class ScopedEnv {
+ public:
+  ScopedEnv(const char* name, const char* value) : name_(name) {
+    if (const char* old = std::getenv(name)) {
+      had_old_ = true;
+      old_ = old;
+    }
+    ::setenv(name, value, 1);
+  }
+  ~ScopedEnv() {
+    if (had_old_)
+      ::setenv(name_.c_str(), old_.c_str(), 1);
+    else
+      ::unsetenv(name_.c_str());
+  }
+
+ private:
+  std::string name_;
+  std::string old_;
+  bool had_old_ = false;
+};
+
+bool WaitFor(const std::function<bool()>& predicate, int timeout_ms) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return predicate();
+}
+
+int Dial(int port) {
+  return net::Dial("127.0.0.1:" + std::to_string(port), 1000, 2000);
+}
+
 // Minimal HTTP/1.0 client: send one request, read the whole response (server
 // closes the connection after the body, so recv to EOF).
 std::string HttpGet(int port, const std::string& path) {
@@ -145,6 +188,113 @@ TEST(MetricsHttp, ReadyCheckRecoversAcrossLiveDependencyLoss) {
   EXPECT_NE(dflt.find("200"), std::string::npos) << dflt;
   plain.Stop();
   srv.Stop();
+}
+
+// DFKV_METRICS_MAX_CONNS bounds the oneshot port: excess accepts are closed
+// IMMEDIATELY (no handler thread), the drop is counted, and the capped
+// connections — plus later scrapes after they drain — keep working.
+TEST(MetricsHttp, MaxConnsClosesExcessAcceptsImmediately) {
+  ScopedEnv max_conns("DFKV_METRICS_MAX_CONNS", "2");
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  const int port = srv.port();
+
+  const int c1 = Dial(port);
+  const int c2 = Dial(port);
+  ASSERT_GE(c1, 0);
+  ASSERT_GE(c2, 0);
+  ASSERT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 2; }, 2000));
+
+  const int c3 = Dial(port);
+  ASSERT_GE(c3, 0);
+  ASSERT_TRUE(WaitFor([&] { return srv.DroppedConnections() == 1; }, 2000));
+  EXPECT_EQ(srv.ActiveConnections(), 2u);
+  // The dropped peer sees an instant EOF — the accept was closed, not queued.
+  char byte = 0;
+  EXPECT_LE(::recv(c3, &byte, 1, 0), 0);
+  ::close(c3);
+
+  // The two admitted connections still serve normally (request completes well
+  // inside the default first-request deadline).
+  const std::string req = "GET /healthz HTTP/1.0\r\n\r\n";
+  ASSERT_TRUE(net::WriteAll(c1, req.data(), req.size()));
+  char buf[128];
+  ssize_t r = ::recv(c1, buf, sizeof(buf), 0);
+  ASSERT_GT(r, 0);
+  EXPECT_NE(std::string(buf, static_cast<size_t>(r)).find("200"),
+            std::string::npos);
+  ::close(c1);
+  ::close(c2);
+  // After the surge drains to zero, a fresh scrape is admitted again.
+  ASSERT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 0; }, 2000));
+  EXPECT_NE(HttpGet(port, "/metrics").find("dfkv_x 1"), std::string::npos);
+  srv.Stop();
+}
+
+// SO_RCVTIMEO is a per-SYSCALL budget: a drip feeder sending one byte per
+// (timeout - epsilon) never timed out and pinned a handler thread forever.
+// DFKV_METRICS_FIRST_REQ_MS gives the request line an absolute deadline
+// anchored at accept, so the drip connection is closed while the 10s
+// per-syscall base alone would never have fired (drip interval < 10s).
+TEST(MetricsHttp, SlowDripRequestLineIsClosedByAbsoluteDeadline) {
+  ScopedEnv first_req("DFKV_METRICS_FIRST_REQ_MS", "300");
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+
+  const int fd = Dial(srv.port());
+  ASSERT_GE(fd, 0);
+  ASSERT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 1; }, 2000));
+  // Drip a partial request line one byte at a time below the 10s base.
+  const char* drip = "GE";
+  ::send(fd, drip, 1, MSG_NOSIGNAL);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ::send(fd, drip + 1, 1, MSG_NOSIGNAL);
+  EXPECT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 0; }, 3000))
+      << "drip connection outlived its first-request deadline";
+  EXPECT_EQ(srv.DroppedConnections(), 0u);  // timeout close is NOT a cap drop
+  ::close(fd);
+  // Normal scrapes are unaffected on the same server.
+  EXPECT_NE(HttpGet(srv.port(), "/metrics").find("dfkv_x 1"),
+            std::string::npos);
+  srv.Stop();
+}
+
+// The active-connection count is +1 at admit and −1 exactly once on EVERY
+// exit path — normal EOF after a scrape, abrupt close mid-request, deadline
+// expiry, and Stop() interrupting an idle handler. No leak, no double-dec.
+TEST(MetricsHttp, ConnCountBalancesAcrossEveryClosePath) {
+  ScopedEnv first_req("DFKV_METRICS_FIRST_REQ_MS", "300");
+  ScopedEnv max_conns("DFKV_METRICS_MAX_CONNS", "8");
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  const int port = srv.port();
+
+  // path 1: clean one-shot scrape, closed by the server after the response.
+  EXPECT_NE(HttpGet(port, "/metrics").find("dfkv_x 1"), std::string::npos);
+  // path 2: peer connects then vanishes WITHOUT a request (handler's first
+  // recv sees EOF).
+  const int gone = Dial(port);
+  ASSERT_GE(gone, 0);
+  ::close(gone);
+  // path 3: drip feeder closed by the absolute deadline (server-side close,
+  // NOT a client close — the count must still unwind to zero).
+  const int drip = Dial(port);
+  ASSERT_GE(drip, 0);
+  ::send(drip, "G", 1, MSG_NOSIGNAL);
+  ASSERT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 1; }, 3000))
+      << "expected only the drip conn to remain; got "
+      << srv.ActiveConnections();
+  ASSERT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 0; }, 3000))
+      << "deadline close leaked the connection count";
+  ::close(drip);
+
+  // path 4: Stop() interrupts an idle pre-request handler mid-recv.
+  const int idle = Dial(port);
+  ASSERT_GE(idle, 0);
+  ASSERT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 1; }, 2000));
+  srv.Stop();
+  EXPECT_EQ(srv.ActiveConnections(), 0u);
+  ::close(idle);
 }
 
 TEST(MetricsHttp, StorageHealthDynamicallyRemovesReadiness) {


### PR DESCRIPTION
## Summary

Post-merge deep review of #237 (head `b26a41f` / merge `2a615dd`) found **17 real defects beyond the documented residual risks** — 6 correctness bugs (P1) and 11 hardening gaps (P2). This PR fixes **all 17** in 14 review-ordered commits, each with regression tests.

### Correctness (was silently breaking production paths)

| Commit | Fix |
|---|---|
| `ab36eb6` | vLLM: replicated-MLA lookup probed `tp_rank=0` while SAVE stores `tp_rank=-1` — external L3 hit detection was **always 0** for plain-TP MLA models (silent 100% recompute). Probe the stored coordinate verbatim. |
| `3779ea1` | Coalesced TCP kRange sized its scratch by the client's unbounded u64 `length` before any lookup — one frame could `std::terminate` the server. Lookup-first + clamp; drop connections whose kRange length exceeds max_payload. |
| `1fb18a5` | Coalesced RangeDirect fill did a forward-overlapping `memcpy(buf, buf+head, n)` on non-4K-aligned offsets (UB, could corrupt every follower) — memmove. |
| `4d3b5d0` | RamTier Remove's canceled flag and index install were not atomic (and PutDurable never checked it): Remove could return kOk while GET kept resurrecting the key from RAM. Single `s.mu` section + fallback tombstone. |
| `cdf251b` | MemberViewGuard compared each hop against the last adopted count: diffuse lease mass-expiry (the real-world signature) ratcheted under the 50% threshold hop by hop, and the recovery ramp rebuilt the ring once per poll. Frozen trusted reference + same-value persistence + symmetric growth arm. |
| `76a9111` | Every datapath failure defaulted to `kRailFailure`, so a dead peer quarantined **healthy local rails** (3 failures = 5s full RDMA stall, self-renewing on hot-key traffic). `ClassifyCompletion(wc_status, had_completions)` blames only local verbs/CQ evidence; adds `rail_classify.h`. |

### Hardening + ops

| Commit | Fix |
|---|---|
| `c5e943a` | node_replace `wait_for` let `TimeoutExpired` escape straight into rollback/abort on one slow MDS reply. Retry transient OSError/TimeoutExpired; deadline semantics unchanged. |
| `24bc9f5` | NUMA-local admission never degraded (all local rails down = kIOError despite healthy remote rails, contradicting the documented promise); `recovery_probe` flag set during scan left a phantom "probe in flight" on losing rails forever. Fallback mask + grant-point marking. |
| `9a3e036` | SO_RCVTIMEO is per-syscall: 1-byte-per-interval dribble pinned handler threads forever on cache/MDS/metrics listeners (metrics had no conn cap). `net::ReadAllWithin` absolute first-frame deadline ×3 listeners + `DFKV_METRICS_MAX_CONNS`; /healthz is now pure process liveness (etcd blip used to CrashLoop every MDS replica), /readyz keeps deep probing behind a single-flight TTL cache. |
| `5b384d8` | node_replace could print "safe abort" while the replacement had already joined the ring (SSH timeout during start). `started_new` is now set before the call and rollback acts on it. |
| `aa5e49d` | Device names ≥19 bytes silently lost the DCP2 trailer — probe OK, every connection rejected, error pointing at the wrong cause. Client side fails fast at construction; server anchors warn (servers never encode frames). |
| `c65460b` | vLLM probes only checked scatter-group 0: a partial multi-group chunk write masqueraded as cached for its whole LRU life. Probe all groups, require all; best-effort `batch_remove` of siblings on partial save failure (remove bindings mirror the lmcache optional-capability pattern; inert on older libs). |
| `82a3d8d` | LMCache `_mv_ptr` copy fallback silently discarded GET payloads for non-writable/non-contiguous destinations while reporting hit=1. GET destinations now fail loudly (→ miss) before any native call. |
| `ce961ad` | Uring batch reap failure reset the ring with accepted writes still referencing caller buffers (late landing could overwrite reused slots) — drain before reset, fail closed if undrainable; re-PUT during a deferred-remove window got a hard kIOError on legitimate remove-then-reput — wait the window out (bounded 5s) and re-judge. |

## Validation

- CTest **RDMA=OFF 565/565, RDMA=ON 627/627** (full suites, both configs).
- Deploy tools pytest **17/17**; LMCache runnable suites **19/19**.
- New regressions are **mutation-verified** (each fails on the pre-fix code) for the Remove race, guard ratchet, wait_for escape, started_new blind spot, SG partial writes, GET fallback; concurrency fixes TSan-clean; uring fixes exercise real in-flight kernel writes via a test-only reap seam.
- Connector suites needing torch/vLLM (`test_dcp_lookup_geometry.py` incl. the new replicated-MLA + multi-group cases) can't run on a CPU-only host — verified instead by executing the real `lookup()` source extracted via AST with the real key-encoding path (old code reproduces the bug, new code fixes it, single-group geometry byte-identical): **26/26 + 12/12**. Needs one engine-image pytest run before release.
- `docs/` intentionally untouched (parallel worktree activity); metric/help text updates ride with the code comments.

## Compatibility

No ABI/wire-format/breaking changes: fixes are behavioral + additive (new knobs default off or to safe values; `DFKV_MDS_PROBE_CACHE_MS` defaults 2500ms inside MDS only). `/healthz` semantics change by design (liveness no longer depends on etcd) — clusters whose livenessProbe deliberately wanted etcd-depth should point it at `/readyz`.

## Pre-merge gates not run (by design here)

- Engine-image pytest (`integration/vllm/tests/test_dcp_lookup_geometry.py`).
- Cross-node vLLM MLA L3 hit smoke before connector rollout.
- Physical-HCA RDMA suite on the new classification paths (unit-level covered; rail behavior changes are attribution-only).
