### PR TITLE
docs: sync all docs to v2.0.0 release truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ weighted consistent-hash ring whenever its epoch advances. Two-layer offline
 detection: **layer-2** — etcd lease expiry → MDS view changes → client epoch →
 ring rebuild (authoritative removal, ≤ 30 s); **layer-1** — `PeerHealth` fast
 avoidance short-circuits transport failures to misses during a cooldown. There
-is no post-open membership mutation API in v2.
+is no post-open membership mutation API in v2. For rings still running v1.x
+nodes/clients, `DFKV_MDS_ACCEPT_LEGACY=1` enables a dual-protocol shim on the
+MDS control plane (ring-level isolation still applies) — see
+`docs/DEPLOY.md` §2b.
 
 **Client registration** (who is using dfkv): cache *consumers* (inference
 connector instances — vLLM / LMCache / SGLang HiCache) register themselves with
@@ -178,6 +181,12 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
   Collector → Grafana — opt-in via `DFKV_METRICS_ENABLED=1`, **zero-dependency stdlib
   exporter by default**; see [deploy/observability/CONNECTOR-USAGE.md](deploy/observability/CONNECTOR-USAGE.md)
   and [docs/METRICS.md](docs/METRICS.md) §3.4.
+  Health endpoints differ by daemon: `dfkv_server /readyz` means startup
+  finished + first MDS registration done + current store/RAM health OK
+  (`src/cache/dfkv_server_main.cc:389`); `dfkv_mds /healthz` is pure process
+  liveness (it no longer probes etcd, avoiding CrashLoop storms), while
+  `dfkv_mds /readyz` runs a TTL-debounced etcd probe
+  (`DFKV_MDS_PROBE_CACHE_MS`, default 2500 ms).
 - **Dynamic membership**: the immutable `dfkv_client_options_v2` descriptor
   selects MDS discovery at construction; the client polls MDS and atomically
   rebuilds its weighted Ketama ring on etcd-epoch changes. No mutable
@@ -191,7 +200,8 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
   with no device override each host chooses its first `ACTIVE` local HCA and
   sends an empty device selector to its peer. An explicit comma whitelist opts
   into multi-rail round-robin and therefore must name the intended fabric on
-  both hosts. QPs bootstrap over a tiny TCP channel, so the data fabric needs no
+  both hosts. Device names are limited to 18 bytes in the wire dev frame —
+  longer names fail fast instead of silently truncating (7837f0b). QPs bootstrap over a tiny TCP channel, so the data fabric needs no
   IP. A v2 capability probe is mandatory; protocol, QP, receive-segment, or
   registration mismatch rejects the connection. Unset `DFKV_RDMA` selects TCP;
   once RDMA is requested it never switches transports.
@@ -207,11 +217,14 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
   (`batch_concurrency`) and **fewer/larger keys**. See `docs/datapath-perf-notes.md`.
 - **NUMA-aware rail selection** (`DFKV_RDMA_NUMA=1`): with an explicit
   multi-rail whitelist, prefers an `ACTIVE` rail local to the calling thread,
-  then round-robins the listed healthy rails. Server threads follow their QP's
+  then round-robins the listed healthy rails; when every NUMA-local rail is
+  inadmissible, it degrades to the full enabled rail set instead of refusing
+  traffic (5ef39f1). Server threads follow their QP's
   rail NUMA node; the single shared receive segment is registered on each
   selected rail but is not separately NUMA-allocated per rail. Off by default;
   vendor-neutral (sysfs + `sched_getcpu`, no libnuma/CUDA).
-- **HiCache v2** (PoolTransfer) for multi-pool models (Mamba/SWA/DeepSeek-V4).
+- **SGLang HiCache pool-aware v2 interface** (`batch_set_v2`/`batch_get_v2` +
+  PoolTransfer) for multi-pool models (Mamba/SWA/DeepSeek-V4).
 - **Packaging**: CPack (deb/rpm/tgz) + Dockerfile; **graceful shutdown**; leveled logging.
 
 ## Recommended tuning (v2.0)
@@ -228,9 +241,11 @@ fabric selection and capacity explicit.
 |---|---|---|
 | `--rdma-dev` | leave unset for one local HCA; list the fabric explicitly for multi-rail | Unset selects the first `ACTIVE` local HCA (peer names may differ). A comma list opts into multi-rail, anchors only listed active devices, and requires compatible names/fabric on both hosts; inactive entries are rejected. |
 | `DFKV_DISK_HASH_WEIGHT` | `10` | Flattens the intra-server disk ring share from ±20 % to ±3 % so the hottest disk stops gating the whole node (+5–6 % cold read, ~2× lower p99). **Re-routes existing keys** (cache miss + refill) — flip together with a restart/upgrade window. |
-| `--rdma-depth` | `4` (keep) | Deeper is not itself a throughput knob. It consumes more slots from the fixed shared receive segment. |
+| `--rdma-depth` | `4` | Set explicitly; the server defaults to 1 and the handshake takes min(client/server). Deeper is not itself a throughput knob. It consumes more slots from the fixed shared receive segment. |
 | `--ram-tier` / `--ram-tier-bytes` / `--ram-tier-shards` | on / sized to the node / `16` for ≥100 GiB arenas | Large arenas contend on the shard locks under mixed load (+40 % mixed R/W at 16 shards on a 128 GiB arena); small (≤16 GiB) arenas are fine at the default 8. |
 | `--store-engine` | `slab` | Index rebuilds on restart; removes file-per-block hazards. |
+| `DFKV_TCP_FIRST_REQ_MS` / `DFKV_MDS_FIRST_REQ_MS` / `DFKV_METRICS_FIRST_REQ_MS` | `30000` (default) / `0` = off | First-request deadline per listener: a connection that sends nothing before the deadline is dropped, capping idle pre-auth connections. |
+| `DFKV_METRICS_MAX_CONNS` | `64` (default) | Connection cap on the metrics listener; protects the exporter from connection floods. |
 
 **Production client** (inference connectors, one process per TP rank):
 
@@ -248,7 +263,7 @@ repeat reads of promoted pages hit zero disk**):
 
 | Knob | Recommended | Why |
 |---|---|---|
-| `DFKV_READ_COALESCE` | `1` | Master switch. Concurrent identical GETs share one disk read (sync + io_uring paths), and a whole-value read with convoy evidence is promoted into the RAM arena as a born-durable resident (zero flush cost, evictable at once). Unset = exact pre-1.35 data path. |
+| `DFKV_READ_COALESCE` | `1` | Master switch. Concurrent identical GETs share one disk read (sync + io_uring paths), and a whole-value read with convoy evidence is promoted into the RAM arena as a born-durable resident (zero flush cost, evictable at once). Unset = coalescing/promotion off, restoring the original single-read path. |
 | `DFKV_READ_COALESCE_RECUR_MS` | `1000` (default) | Recurrence window: a lone whole read leaves a 64-byte key fingerprint; an identical read inside the window promotes on completion even when rank drift missed the in-flight overlap. Fingerprints, not payloads — widening it costs ~nothing (64 Ki-entry bound). `0` restores the overlap-only gate. |
 | `DFKV_READ_COALESCE_TIMEOUT_MS` | `500` (default) | Follower wait bound; a waiter whose leader connection dies falls back to its own read instead of hanging. |
 
@@ -258,10 +273,6 @@ Watch `dfkv_read_coalesce_{leaders,coalesced,recur,timeouts}_total` and
 promotion; coalescing alone works without it. Note for env-file deployments:
 the file is *sourced*, so new knobs must be explicitly **exported** by the
 start script or a systemd drop-in to reach the server process.
-
-Order matters when rolling this out: upgrade **servers to v1.34+ first**, then
-widen clients to multi-rail — pre-1.34 servers have no anchor on non-default
-rails and will exhibit the idle re-registration storm described above.
 
 **Benchmark reproduction** (`dfkv_bench`): `DFKV_RDMA=1` (explicit, or it
 silently measures TCP), 8-rail `DFKV_RDMA_DEV`, `DFKV_RDMA_DEPTH=4`,
@@ -273,7 +284,7 @@ then exits `1` if any PUT/GET failed, `2` for invalid CLI usage, and `0` only
 when every requested operation succeeded.
 
 ## Status
-TDD; **264 C++ ctest entries (default) / 288 (RDMA+io_uring) + Python plugin &
-connector tests green**, 0 warnings, **ThreadSanitizer-clean**.
+TDD; **570 C++ ctest entries (default) / 632 (RDMA+io_uring) + Python plugin &
+connector tests green**, **ThreadSanitizer-clean (C++ core)**.
 CI: gcc/clang build+test, TSan, RDMA datapath (Soft-RoCE loopback), RDMA compile-check, static-artifact build. License: Apache-2.0.
 Architecture & design: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). Rollout: `docs/DEPLOY.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,9 +184,15 @@ Production discovery uses MDS.
   `DFKV_RDMA_BATCH_OP_TIMEOUT_MS` applies to every multi-item method, including
   Cache/Range/Exist batches, zero-copy variants, and both SG variants; unset
   follows `DFKV_RDMA_OP_TIMEOUT_MS`.
-- With an empty device selector each side chooses its own first ACTIVE local HCA,
-  so host-local names may differ. An explicit comma list is a cross-host
-  whitelist and therefore requires the same names/fabric on both peers.
+- With an empty device selector each side chooses its own first ACTIVE local
+  HCA, so host-local names may differ. An explicit comma list is a cross-host
+  whitelist and therefore requires the same names/fabric on both peers. A
+  device name is announced inside the fixed 32-byte v2 bootstrap frame
+  alongside the NUL terminator and the `"DCP2"`/`max_block_bytes`/protocol
+  capability trailer, so names longer than 18 bytes (32 − 1 − 4 − 8 − 1, see
+  `src/transport/dev_frame.h`) are rejected fail-fast at client whitelist and
+  server anchor validation time rather than silently losing the trailer;
+  the fix is a shorter udev/bond alias, not a longer name.
 - Rail health is host-local evidence only. Local device open, verbs/QP
   transition, post, or CQ failures increment the selected rail's failure streak
   and may quarantine that rail. TCP bootstrap, unreachable/incompatible peer,
@@ -196,7 +202,9 @@ Production discovery uses MDS.
   If any enabled configured rail has matching discovery metadata, only that
   stable-index subset competes for credits. Unknown caller topology or no local
   rail falls back to all enabled rails; an explicit device whitelist remains the
-  authoritative candidate set.
+  authoritative candidate set. When every NUMA-local rail is inadmissible
+  (quarantined or credit-bound), admission retries once across every enabled
+  rail — locality is a preference, never an availability gate.
 
 `dfkv_rdma_v2_ready`, receive-segment total/free bytes, registered-rail count,
 opened connections, v2 PUT/GET WRITE counters, client rail-vs-endpoint failure
@@ -295,7 +303,7 @@ quota admission immediately.
 
 ---
 
-## 6. RAM hot tier (P3, opt-in)
+## 6. RAM hot tier (opt-in)
 
 A COLD dfkv load is disk-bound (~480 MB/s O_DIRECT) and dominates PD-decode TTFT.
 The RAM tier fronts the disk with a pre-registered RAM arena so a PD-warm GET is
@@ -373,6 +381,9 @@ data plane or the connection fails.
 | RDMA transport | build `-DDFKV_WITH_RDMA=ON`, `DFKV_RDMA=1` | TCP | active-HCA discovery; `DFKV_RDMA_DEV` is an optional whitelist |
 | RDMA v2 | `DFKV_RDMA=1` | TCP when RDMA was not requested | bounded 32,786-byte control buffers (32-KiB Members data) + mandatory shared registered receive segment |
 | io_uring async GET | build `-DDFKV_WITH_URING`; `DFKV_SERVER_URING=0` disables | on when built, unavailable otherwise | RDMA v2 disk-read path |
+| first-request absolute deadline | `DFKV_TCP_FIRST_REQ_MS` / `DFKV_MDS_FIRST_REQ_MS` / `DFKV_METRICS_FIRST_REQ_MS` | 30000 ms; `0` = off | anchored at accept: the first complete frame/request line is due within this window, so a drip feeder cannot pin a handler thread; `dfkv_server` also publishes its resolved value as the `dfkv_tcp_first_req_ms` gauge |
+| MDS legacy control-plane shim | `DFKV_MDS_ACCEPT_LEGACY=1` | off (strict epoch gate) | widens the MDS control-plane version gate by exactly one epoch so v1.x peers are served with legacy 42/10-byte framing during a mixed-generation migration; data-plane listeners stay strictly epoch 6/7; drop the env once `dfkv_mds_legacy_frames_total` drains to zero |
+| MDS /readyz etcd probe debounce | `DFKV_MDS_PROBE_CACHE_MS` | 2500 ms (clamp 600000; `0` = per-request probe) | TTL-debounced etcd reachability probe so kubelet scrape cadence cannot amplify into etcd read load during an incident |
 
 ---
 

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -31,11 +31,10 @@
 **原生身份/裸值切换是 clean break。** 新 client、server 与 connector 应一起
 升级并接受一次冷缓存；不会读取旧 key，也不会双写旧身份或旧 value 格式。
 
-**版本兼容（v1.34 / v1.35）**：同样零客户端改动，但对接方应知道两件事——
-① **v1.34 服务端多轨 anchor**（`--rdma-dev` 逗号列表）：客户端按 §1.2 配轨亲和后才吃满
-8 轨；推广顺序是**先升服务端**再放开客户端多轨（pre-1.34 服务端对非默认轨无 anchor，
-空闲回收后下一波请求付串行重注册风暴）。
-② **v1.35 读侧 convoy 合并 + RAM 晋升**（服务端 opt-in `DFKV_READ_COALESCE=1`，见根
+**同版本同时具备的服务端能力**（零客户端改动，对接方了解即可）——
+① **服务端多轨 anchor**（`--rdma-dev` 逗号列表）：客户端按 §1.2 配轨亲和后即可吃满
+8 轨；客户端与服务端应同版本整体升级。
+② **读侧 convoy 合并 + RAM 晋升**（服务端 opt-in `DFKV_READ_COALESCE=1`，见根
 README "Recommended tuning"）：TP-N 各 rank 独立进程重复读同页时，服务端把 N 次盘读
 合并/晋升——客户端观察到的效果是**同页重复冷读与重放显著变快**（xb01 实测每重复页盘读
 8→~2.4 次、晋升页复读零盘），无任何客户端配置或行为变化。
@@ -57,7 +56,7 @@ TCP 仍使用当前 versioned native wire。
 | env | 默认 | 说明 |
 |-----|------|------|
 | `DFKV_LIB`（或 `DFKV_BUILD`） | — | `libdfkv.so` 绝对路径（`DFKV_BUILD` 指目录，取 `$DFKV_BUILD/libdfkv.so`）。连接器 config 里的 lib 键优先于 env：HiCache=`lib_path`、vLLM=`lib`、LMCache=`remote_storage_plugin.dfkv.lib` / L2 `lib`。 |
-| `DFKV_MEMBERS` | — | **遗留静态**成员表 `name=ip:port,...`，单节点/简单部署用。生产优先 MDS 发现。 |
+| ~~`DFKV_MEMBERS`~~ | — | 仅测试脚本读取（如 `test/python/rdma_e2e_validate.py`），连接器不读；连接器静态成员走各自 config 的 `members` 键，生产优先 MDS 发现。 |
 
 **MDS 动态发现（生产推荐）**走连接器 config 而非 env：`mds_endpoints=ip:port,...` +
 `mds_group=<group>`（须与 `dfkv_server --group` 一致）。客户端后台轮询 MDS
@@ -72,7 +71,7 @@ cooldown 快速转为 miss。
 
 **客户端注册**（"谁在用 dfkv"）：三条路径在 MDS 发现成功后，自动把本连接器作为消费方
 注册到 `/dfkv/v1/groups/<g>/clients/<id>`（与节点成员表隔离，不入放置环）。死掉的连接器
-key 在 TTL（30s）内自动过期，无显式反注册、无脏 key。v1.15.0 起三条路径（SGLang HiCache /
+key 在 TTL（30s）内自动过期，无显式反注册、无脏 key。三条路径（SGLang HiCache /
 vLLM / LMCache）行为一致，默认开，env `DFKV_CLIENT_REGISTER=0` 或连接器 config
 `client_register=0` 关闭。SGLang HiCache 的注册信息串为 `type=hicache,model=<m>,tp_size=..,
 tp_rank=..,ver=<lib>`（无 `role`——HiCache 是前缀 L3 缓存，无生产/消费角色之分）。观察：
@@ -84,7 +83,7 @@ tp_rank=..,ver=<lib>`（无 `role`——HiCache 是前缀 L3 缓存，无生产/
 | env | 默认 | 推荐 | 说明 |
 |-----|------|------|------|
 | `DFKV_RDMA` | 一般路径未设 = TCP；**vLLM 直连无默认，必须 `1`** | 按连接器选择 | `1` 显式选择 native-verbs RDMA v2；请求 RDMA 后设备或协议不可用会失败，不会自动选择 TCP。`DfkvStoreConnector` 只接收 GPU 设备指针，构造时会关闭并拒绝任何非 RDMA handle。 |
-| `DFKV_RDMA_DEV` | 首个 `ACTIVE` 本地 HCA | 留空让两端各自选本地首口；多轨才显式写同 fabric 白名单 | 留空时 bootstrap 不发送设备名，client/server 可使用不同本地命名。逗号列表显式开启多轨，新连接在健康轨间轮转；显式设备名会发给 peer，故两端必须存在同名且互通的 fabric。 |
+| `DFKV_RDMA_DEV` | 首个 `ACTIVE` 本地 HCA | 留空让两端各自选本地首口；多轨才显式写同 fabric 白名单 | 留空时 bootstrap 不发送设备名，client/server 可使用不同本地命名。逗号列表显式开启多轨，新连接在健康轨间轮转；显式设备名会发给 peer，故两端必须存在同名且互通的 fabric。设备名上限 **18 字节**（v2 bootstrap dev frame 限制），超长即 fail-fast 拒绝启动/建连，不会静默截断（见 `src/transport/dev_frame.h`）。 |
 | `DFKV_RDMA_DEPTH` | `1` | 两侧可不同，按容量选 | 握手协商 `min(client,server)` 作为安全窗口。每连接注册 `2 × depth × (18 B + 32 KiB)` 的有界 SEND/RECV control buffer，并从共享 receive segment 租 `depth` 个 slot。 |
 | `DFKV_RDMA_MAX_BLOCK_BYTES` | 64 MiB 安全上限 | 按连接器块几何精确设置 | DCP2 声明本连接最大 PUT/GET block，决定共享 segment 的 slot 大小；超声明请求在客户端失败且不上 wire。声明越准，同一 segment 可容纳的 live/pooled v2 连接越多。 |
 | `DFKV_RDMA_RECV_SEGMENT_SIZE` | 2 GiB | 按下文 live/pooled 连接公式设置 | server 启动时申请，并在每个选中 rail 的共享 PD 上注册；失败会拒绝启动，segment 无可用 lease 时拒绝新连接。 |
@@ -145,23 +144,23 @@ capability；HCA `max_sge` 低于 dfkv 上限时会缩小宽度，高于上限�
 
 **换模型的 tuning 步骤**：
 1. 按上表算出理论值（两条路径都算，取大者——同一集群可能两种都跑）
-2. 起一轮真实负载，读服务端/客户端日志里的 `rdma: max block observed <N>B` 高水位（v1.40+）
+2. 起一轮真实负载，读服务端/客户端日志里的 `rdma: max block observed <N>B` 高水位
 3. 取实测值的 2~4 倍设定，注意**必须同时覆盖原版 L2 路径的整页对象**
 4. 复核服务端日志 `rdma conn: protocol=v2 declared=… control=… shared-slot=… qd=…` 确认生效
 
 🔴 **设小后上层仍只看到 miss——这是最危险的部分。** 超声明的块被判 `kInvalid`，
 而 `kInvalid` 被客户端健康计数刻意忽略，上层 `hits[i] != 1` 与“这页压根没缓存”
-无法区分：不崩、不熔断。v1.40+ 会打 `rdma: block …B exceeds the declared bound
+无法区分：不崩、不熔断。因此会打 `rdma: block …B exceeds the declared bound
 …B` 告警（首次 + 每 1024 次），所以必须纳入日志告警。
 典型踩法：照 L2-bypass 实测的 1.02 MiB 调到 2 MiB，切回原版 L2 后
 2.74 MiB 的整页对象全部静默失效。
 
-> **服务端侧上限 `--max-msg`（v1.40+）**：默认 64 MiB，即"客户端不声明时给多少"。
+> **服务端侧上限 `--max-msg`**：默认 64 MiB，即"客户端不声明时给多少"。
 > 它同时是本服务端接受的**上限**：客户端声明**高于**它会被**明确拒绝连接**并打日志，
 > 而不是悄悄按小的开——后者会让客户端按自己声明的大小发包、打爆对端 recv buffer（RNR/QP 断）。
 > 大集群建议显式设定，否则服务端的内存预算完全由客户端决定，而客户端常由别的团队部署、版本不一。
 
-> ⚠️ 旧 `rail_affinity`（extra_config）**已废弃为 no-op**（v1.2.0）：它按 `tp_rank`
+> ⚠️ 旧 `rail_affinity`（extra_config）**已废弃为 no-op**：它按 `tp_rank`
 > 收窄选轨，但 DP-attention 下每 rank `tp_rank=0`→塌缩单轨。配了只打 stderr 告警。
 > 用 `rdma_numa` / `DFKV_RDMA_NUMA` 替代。
 
@@ -174,7 +173,10 @@ capability；HCA `max_sge` 低于 dfkv 上限时会缩小宽度，高于上限�
 
 两种 prefix 都携带 64-bit tenant hash + 128-bit object digest。旧 epoch 直接
 拒绝而不解码；client/server 必须按 [DEPLOY.md](DEPLOY.md) §4e 的隔离 ring
-方式切换，不能依赖 rolling 混跑兼容。
+方式切换，不能依赖 rolling 混跑兼容。唯一例外是 MDS 控制面：
+`DFKV_MDS_ACCEPT_LEGACY=1` 可让 v2 MDS 以旧 epoch 帧服务 v1.x 节点/客户端的
+注册与心跳（按 epoch 判别，status 按 v1 枚举顺序回声），**数据面仍严格拒绝**——
+v1/v2 须分属不同 group，见 [DEPLOY.md](DEPLOY.md) §2b。
 
 ### 1.4 原生 namespace、对象 key 与 raw value
 
@@ -185,7 +187,10 @@ client registration identity. Unknown flags/version/short structs fail closed.
 There are no post-open membership mutators, operator namespace aliases, or
 geometry parameters. The namespace binds the exact runtime model identity and
 connector raw-layout ID (`sglang-hicache/raw-v1`, `vllm/raw-v1`,
-`lmcache/raw-v1`).
+`lmcache/raw-v1`). 可调字段只有 `tenant_id`（默认 `default`）与
+`model_revision`（默认取 model identity），走各连接器的 extra_config/config 键
+（§2.2 / §3.4 / §4.5）——多租户隔离或模型版本滚动时显式分开
+namespace；operator namespace alias 一律被拒绝（fail-closed）。
 
 所有 connector 的对象 key 都是 self-delimiting binary bytes，编码顺序为：
 
@@ -234,13 +239,15 @@ page/chunk size、shape、层顺序或内存布局是**operator error**，不会
 | `DFKV_CONNECTOR_BATCH_MAX_KEYS` | 连接器各异（LMCache 512） | 单次 native 批量最大 key 数 |
 | `DFKV_CONNECTOR_GET_PARALLELISM` | 连接器各异（LMCache 1） | 并发 batched-get 组数（=线程池 worker 数），提高可降 TTFT |
 | `DFKV_CONNECTOR_ASSUME_EXISTS` | `0` | 跳过 load 前的 Exist 探测（省一次探测、换可能 miss；调试用） |
-| `DFKV_TP_RANK` | — | tensor-parallel rank（MLA 场景仅 rank 0 写） |
+| `DFKV_TP_RANK` | — | 仅 vLLM connector：用作 `connector_id` 遥测 label 的 rank 后缀；写复制/缓存身份由 canonical key 决定，不受它影响 |
+| `DFKV_CLIENT_NODE_DEDUP` | `0` | 客户端侧节点内 rendezvous 去重：同一引擎进程内**并发去同一目标节点的相同 batch 操作合并领头**，免重复 wire 往返。replicated-MLA 场景（vLLM / HiCache）自动置 `1`，显式 `0` 可关 |
+| `DFKV_CLIENT_NODE_DEDUP_GPU` | `0` | 上一条的 GPU（device-pointer）路径开关；vLLM replicated-MLA 在 host dedup 开启且未显式设置时自动 `1` |
 | `DFKV_READ_SHARD_KEYS` | `16` | 每读分片的目标 key 数：把单节点的一组批量 GET 切成多分片并发（少节点环/大 batch 集中单节点时突破 ~166 MB/s/conn 的单连接串行 drain 天花板；宽环上无感） |
 | `DFKV_READ_MAX_CONNS` | `8` | 单节点读分片的并发连接上限（与上一条配对；`1` = 关闭分片） |
 | `DFKV_FANOUT_THREADS` | `32` | 客户端批量操作 fan-out 线程池上限（clamp [1,1024]）；高并发引擎（callers × node-groups ≫ 32）不调会退化 caller-serial，per-call 延迟从 max(group) 变 sum(group) |
 
 以上三条为 **native C 客户端**（`libdfkv.so`）knob，对 HiCache / LMCache / vLLM
-三条接入路径同等生效；生产漂移排查时先看启动 config dump（v1.37+ 全 knob 带来源打印）。
+三条接入路径同等生效；生产漂移排查时先看启动 config dump（全 knob 带来源打印）。
 
 ### 1.6 可观测性（opt-in，全部不占数据路径）
 
@@ -268,8 +275,10 @@ page/chunk size、shape、层顺序或内存布局是**operator error**，不会
 | `DFKV_RAM_TIER` / `DFKV_RAM_TIER_BYTES` | **server** | 写穿 RAM 热层 |
 | `DFKV_SERVER_URING` | **server** | io_uring 异步 GET serve 路径 |
 | `DFKV_SLAB_WRITE` | **server** | slab I/O 模式（默认 direct；`buffered` 为退出开关） |
-| `DFKV_READ_COALESCE` / `_RECUR_MS` / `_TIMEOUT_MS` | **server** | v1.35 读侧 convoy 合并 + RAM 晋升（见根 README "Recommended tuning"） |
+| `DFKV_READ_COALESCE` / `_RECUR_MS` / `_TIMEOUT_MS` | **server** | 读侧 convoy 合并 + RAM 晋升（见根 README "Recommended tuning"） |
 | `DFKV_TENANT_QUOTAS_FILE` / `DFKV_TENANT_DEFAULT_QUOTA_BYTES` | **server** | immutable per-node tenant capacity admission；客户端不要设置 |
+| `DFKV_TCP_FIRST_REQ_MS` / `DFKV_MDS_FIRST_REQ_MS` / `DFKV_METRICS_FIRST_REQ_MS` | **server / mds** | 各 listener 首请求 deadline（默认 30000ms，`0`=关）：deadline 内不发首个请求的连接被踢，防空连接堆积 |
+| `DFKV_METRICS_MAX_CONNS` / `DFKV_MDS_MAX_CONNS` | **mds / metrics** | listener 并发连接上限（metrics 64、MDS 4096），防连接洪泛 |
 
 显式配置的混合车队（部分节点 slab、部分诊断节点 file；部分带 RAM 层）对所有客户端**完全等价**。不配置 flag/env 的节点一律选择 slab；slab 配置无效时拒绝启动，不会自行加入为 file 节点。
 
@@ -339,6 +348,12 @@ sglang serve ... \
 `pcp_size`/`pcp_rank`、`dcp_size`/`dcp_rank`、`layer_num`（仅 L2-bypass 的 SG
 分组控制，不进 namespace/value）、`lib_path`、`batch_concurrency`、
 `rdma_depth`/`require_rdma`/`rdma_numa`、
+canonical namespace 的可配键 `tenant_id`（默认 `default`）、`model_revision`
+（默认取 model identity），以及 identity/layout 字段
+`page_size`（默认 64）/`kv_cache_dtype`/`dtype_tag`/`head_num`/`head_dim`/
+`dp_size`——这些都进 canonical namespace，改动即换 namespace（表现为一次冷缓存）；
+`node_dedup`（对应 env `DFKV_CLIENT_NODE_DEDUP`，见 §1.5）、
+`backup_exist_gate`（save 前的 exist 探测门）、
 `client_stats_poll_s`（10s，`0`=关）、
 访问日志/telemetry 键（`access_log`、`access_log_path`、`metrics`、`tracing`、
 `otlp_endpoint`、`trace_slow_request_ms`、`trace_sample_percent` 等，env 同义项见
@@ -348,6 +363,34 @@ sglang serve ... \
 `pcp_size`/`dcp_size` 默认 `1`，此时对应 rank 固定为 `0`。任一 size
 大于 `1` 时必须显式提供 `0 <= rank < size`；size/rank 不是整数、越界或缺失
 都会在打开 dfkv client 前拒绝启动。PCP/DCP 是物理分片坐标，同一 page hash
+
+#### 多模型/多租户配置（对应 §5 四维度）
+
+分组按最关心配置写：
+
+| 维度 | 配置位点 | 示例 |
+|---|---|---|
+| ① Group | `mds_group` extra_config | `"mds_group":"glm-prod"` |
+| ③ tenant_id | `tenant_id` extra_config | `"tenant_id":"prod-chat"` |
+| ④ model_name | SGLang `--served-model-name`（或 `--model-path` 解析而来） | `--served-model-name glm-5.2` |
+| ④ model_revision | `model_revision` extra_config（默认 = model_name） | `"model_revision":"nvfp4-2026-08"` |
+
+生产双业务线共环配置示例（同模型一权、两 tenant）：
+
+```bash
+sglang serve /models/glm-5.2-nvfp4 --served-model-name glm-5.2 \
+  ... \
+  --hicache-storage-backend-extra-config '{
+    "backend_name":"dfkv","module_path":"dfkv_hicache","class_name":"DfkvHiCache",
+    "interface_v1":1,
+    "mds_endpoints":"10.201.3.10:28150,10.201.3.11:28150",
+    "mds_group":"glm-prod",
+    "tenant_id":"prod-chat",
+    "model_revision":"nvfp4-2026-08"}'
+```
+
+布局参数变化（dtype/量化/层数/TP）**必须 bump `model_revision`**，
+同 model_name+ 默认 revision = 自动隐含同 layout，可能命中 byte-incompatible bytes。
 在不同 rank 上生成不同 canonical object bytes，不能依赖默认 rank。
 
 ### 2.3 HiCache 关键 flag
@@ -365,9 +408,13 @@ sglang serve ... \
 
 - **`interface_v1:1` 必填**，插件 `__init__` 强校验：缺失即 `raise ValueError` 启动失败。
   原因——对 `dynamic` 后端，SGLang 仅在 `interface_v1` 为真时才走零拷贝
-  `batch_set_v1/get_v1`；否则退回 generic `set/get`，而 dfkv 的 generic
-  `get/batch_get` 是未实现的桩 → **写成功、L3 读静默失败**（线上踩过：
-  launch 脚本漏配，14GB 写入但 prefetch 全 miss）。`interface_v1:1` 下 GET
+  `batch_set_v1/get_v1`；否则退回 generic `set/get`。dfkv 的 generic 路径
+  已实现，但相比 `interface_v1` 多一次 host 中间拷贝；且 MLA 模型下 generic
+  路径每个 rank 都会重复写同一页（无 `backup_skip` 单写者判定）。强制
+  `interface_v1` 是为了**拒绝静默降级**——早期版本 generic 还是未实现的桩
+  （线上踩过：launch 脚本漏配，14GB 写入但 prefetch 全 miss）；如今虽已
+  实现，漏配仍会静默带来多一次拷贝与 MLA 重复写，插件仍 fail fast。
+  `interface_v1:1` 下 GET
   payload 经 RDMA 直落 HiCache 宿主页（client 零拷贝）；server O_DIRECT /
   io_uring 直读入注册 buffer，RDMA v2 以 one-sided WRITE 直落 client 目标
   MR，无 payload memcpy。
@@ -410,7 +457,7 @@ sglang serve ... \
   约 +6%，失败自动回同步并有指标。
 - **`DFKV_RDMA_DEPTH` — 两侧无需强制相等。** 握手取最小值，按共享 segment
   容量和连接 fan-out 分别配置即可。
-- **HiCache 命中/吞吐/延迟与 client 注册指标**已在 v1.5.2+ 内，无需额外动作。
+- **HiCache 命中/吞吐/延迟与 client 注册指标**已内置，无需额外动作。
 
 ---
 
@@ -466,11 +513,11 @@ L2-bypass 不需要独立 server 协议，但两项决定 v2 容量：
 nerdctl logs <容器> 2>&1 | grep -c 'L2-bypass ENABLED'
 # 2. 声明真的到了服务端（这行只在客户端真声明时出现）
 journalctl -u dfkv-server | grep 'rdma conn: protocol=v2 declared=.*shared-slot='
-# 3. 块大小与余量（v1.40+）
+# 3. 块大小与余量
 nerdctl logs <容器> 2>&1 | grep 'max block observed'
 nerdctl logs <容器> 2>&1 | grep -c 'exceeds the declared bound'   # 必须为 0
-# 4. 握手耗时（服务端 v1.40+ 诊断构建）
-journalctl -u dfkv-server | grep BOOT-SLOW
+# 4. 协商后的深度窗口（服务端 rdma 协商日志，qd= 为握手取 min(client,server) 的真值）
+journalctl -u dfkv-server | grep 'rdma conn: protocol=v2 declared=' | grep -o 'qd=[0-9]*'
 ```
 
 ## 3. vLLM 直连 — DfkvStoreConnector
@@ -594,13 +641,50 @@ namespace/key 不一致是预期 cold miss。**空环 / MDS 不可达**可直接
 | `transfer_queue_capacity` | `256` | 保持默认，按压测调 | 每个 worker、每个方向的排队上限（`1..65536`）。满队列时非阻塞拒绝新任务：save 立即释放 finish/free fence，load 标记失败并重算；非法值启动即失败。 |
 | `enable_cross_layers_blocks` | `False` | 默认 False | 仅当引擎分页布局层内交错时开 |
 | `lookup_rpc_port` | ipc 自动 | 一般不设 | rank0 前缀查询 RPC，仅 socket 名冲突时设 |
+| `client_register` | `1`（MDS 发现时） | 默认即可 | MDS 客户端注册开关（`0` 关；env `DFKV_CLIENT_REGISTER=0` 等价，见 §1.1） |
+| `tenant_id` | `default` | 多租户时显式设 | canonical namespace 的 tenant 字段（§1.4） |
+| `model_revision` | model identity | 模型版本滚动时显式设 | canonical namespace 的模型版本字段（§1.4）；改动即换 namespace（冷缓存） |
+
+DCP（decode context parallel）宽度/Rank **不是**本表键：连接器从 vLLM 运行时取
+（`get_dcp_group().world_size`），与 `tp_rank=-1`（replicated-MLA 存储坐标）一起进入
+canonical key metadata（§1.4），勿在 extra_config 手工设定。
 
 连接器实现 vLLM `shutdown()` 生命周期钩子：先停止接单并取消排队任务，再等待当前
 native 操作完成、join 收发线程，最后仅关闭一次 native client。因而正常退出不依赖
 daemon 线程或进程终止；过载和退出期间都不会静默留下永久占用的 KV block。
 
+**MLA / SG 坐标语义（v2.0.0 修正点）**：
+- **replicated-MLA**（MLA + TP>1 + DCP≤1）：每次 SAVE 都挂在单一 canonical
+  存储坐标 `tp_rank=-1`；lookup dedup 探测也按 `tp_rank=-1` 原样探测。
+  早期版本按 `tp_rank=0..tp_count-1` 展开探测，永远对不上 `-1` 坐标，
+  replicated-MLA 外部 L3 命中恒为 0——升级到 v2.0.0 连接器前勿在 MLA 生产
+  上预期外部命中。
+- **多 kv_cache_group / SG 分组**：dedup/lookup 探测 chunk 的**全部**显式
+  scatter group（不只是 group 0）；任一组缺失（partial write 或被淘汰）即判
+  未缓存并整 chunk 重写，避免半存 chunk 当命中。
+- **partial save 清理**：PUT 部分失败时，连接器 best-effort `batch_remove`
+  清掉失败 chunk 的各兄弟 group key（`_remove_partial_sg_groups`，不抛、
+  无 remove RPC 时直接跳过），防止半存 chunk 占环容量直到 eviction。
+
 ### 3.5 按场景的推荐配置
 
+- **多模型 / 多租户（生产）**：四维度必须按 §5 显式在 `kv_connector_extra_config` 里设定；
+  **布局参数变化必 bump `model_revision`**。
+  ```json
+  {
+    "kv_connector":"DfkvStoreConnector",
+    "kv_role":"kv_both",
+    "kv_connector_extra_config":{
+      "mds_endpoints":"10.201.3.10:28150,10.201.3.11:28150",
+      "mds_group":"glm-prod",
+      "tenant_id":"prod-chat",
+      "model_revision":"nvfp4-2026-08"
+    }
+  }
+  ```
+  位点映射：`mds_group`（① 环）、`tenant_id`（③）、`model_revision`（④）。
+  `model_name`（④）由 **vLLM 启动 `--model`/`--served-model-name`** 提供，不是 extra_config
+  键；引擎/布局身份全量进 canonical namespace（§1.4）。
 - **单实例 / 单 DP**：`--prefix-caching-hash-algo sha256` + `DFKV_RDMA=1` +
   `batch_concurrency=8` 默认，depth 保持 1。
 - **多 DP / 多实例共享池**：所有实例使用 `--prefix-caching-hash-algo sha256`，
@@ -681,13 +765,38 @@ extra_config:
 生产多 fabric 节点必须用 `DFKV_RDMA_DEV` 过滤出与 cache server 同 fabric
 的本机设备（同型号节点可逗号列全轨，见 §1.2）。
 
-**生产推荐 MDS 动态发现**（节点增减自动生效）：`membership` 改 `mds`，URL endpoint 改成
-dfkv_mds 层 `ip:port` 列表，组名走 URL 末尾 `/<group>`：
+**🔴 生产多模型 / 多租户隔离（in-process 隔离能力的天花板）**
+
+in-process connector 的 canonical namespace（`remote_connector.py:93-117`）字段中
+`model_name` 来自 LMCache upstream `KVCacheMetadata`（必有）；`tenant_id`/`model_revision`
+经 `getattr(metadata, "tenant_id", "default")` 读取——**上游 KunCacheMetadata 不含这两个
+字段**，因此 in-process **`tenant_id` / `model_revision` 全部固定为 `"default"`，无法配置**。
+**layout 参数变化不能用 revision 隔离**。
+
+因此 LMCache in-process **只暴露一个隔离维度**：
+
+| 维度 | 配置位点 | 示例 |
+|---|---|---|
+| ① Group（ring） | **`lmcache.yaml` 的 `url`**（`dfkv://<mds列表>/<group>`）| `dfkv://10.201.3.10:28150/glm-prod-chat` |
+| ③ tenant | ❌ 不可配 | — |
+| ④ revision | ❌ 不可配 | — |
+
+**生产两套模型/两业务线和配置变化的 tenant 隔离 → 用 MP-server L2 adapter（§4.5）**
+（全部字段可设）；in-process 场景要用，只能按业务线分 **group**（同 ring 硬件共
+享但 namespace=业务隔离）：
 
 ```yaml
-  remote_storage_plugin.dfkv.membership: mds
-  remote_storage_plugin.dfkv.url:        dfkv://192.168.0.8:28150,192.168.0.9:28150,192.168.0.10:28150/glm
+# 业务 chat
+remote_storage_plugin.dfkv.url: dfkv://10.201.3.10:28150,10.201.3.11:28150/glm-chat
+
+# 业务 coder (同模型、同布局时)
+remote_storage_plugin.dfkv.url: dfkv://10.201.3.10:28150,10.201.3.11:28150/glm-coder
 ```
+
+🔴 **同 group 同 model_name 参数变化（dtype/量化/层宽度任一变）不允许同 key 复用，
+必须分新的 `<新名>` group tag**（如 `glm` → `glm-nvfp4-m2`）——因为
+in-process 没有 revision 字段可以在编码路径起隔离效应。换一种理解：
+**in-process 的 group tag 包揽 tenant+revision 应该充填的 namespace 角色**。
 
 ### 4.3 启动 vLLM（in-process 路径）
 
@@ -768,11 +877,70 @@ vllm serve <model> --tensor-parallel-size 8 --no-enable-prefix-caching \
     "kv_connector_extra_config":{"lmcache.mp.port":6555}}'
 ```
 
-`adapter_params` 键：`url`（必填，语法同 in-process）、`membership`（`mds` 默认
-或 `static`）、`lib`（否则 `DFKV_LIB`）、必填 `model_name`（MP-server 不会从
-runtime metadata 自动提供）、`mds_poll_ms`（3000）、`num_workers`（8）、
-`max_capacity_gb`（0 = 容量交给 dfkv 自管；>0 开 LMCache 聚合 L2 淘汰，见
-§4.6.6）。MP-server API 不提供足以证明 byte-identical MLA replica 的 model/PP
+`adapter_params` 完整字段（全部可选除非标注必填，经 `from_dict` 校验
+`l2_adapter.py:150-165`）：
+
+| 字段 | 必填 | 默认 | 说明 |
+|---|---|---|---|
+| `url` | ✅ | — | `dfkv://<endpoint>/<group>`。`membership="mds"`（默认）时 `<endpoint>` 是**逗号分隔的 MDS ip:port 列表**（多副本自动 failover/round-robin），`group` 是 client 可见的 ring 名。例：`"dfkv://10.201.3.10:28150,10.201.3.11:28150/glm"`。`membership="static"` 时 `<endpoint>` 是字面 member 字符串（如 `"smoke0064=192.168.5.1:28301"`），`group` 同义 |
+| `membership` | — | `"mds"` | `"mds"`（生产推荐，动态发现 server）或 `"static"`（简单/测试场景） |
+| `lib` | — | `DFKV_LIB` env / 系统路径 | `libdfkv.so` 路径（必须 v2 SOVERSION，无 v1.x 兼容） |
+| `model_name` | ✅ | — | **MP-server 不会从 runtime metadata 自动提供**，须显式写（见下方「多模型隔离」约束），影响 canonical namespace |
+| `tenant_id` | — | `"default"` | tenant 配额/billing 身份（`docs/ARCHITECTURE.md` §8），同模型多业务共用环时可显式区分（§5 key 隔离 §①） |
+| `model_revision` | — | 同 `model_name` | 模型 revision/版本标签——同 model_name 但权重/布局变化时**必须区分**（§5 key 隔离 §②） |
+| `mds_poll_ms` | — | `3000` | 客户端 MDS 环重新发现间隔（毫秒） |
+| `num_workers` | — | `8` | 客户端 I/O 并发度 |
+| `max_capacity_gb` | — | `0` | > 0 时启用 LMCache 聚合 L2 切割（见 §4.6.6）；0 = 容量交给 dfkv 自管 |
+
+**MDS 列表的填写规则**：全部可用 MDS 副本的 `ip:port` 以逗号拼接，无空格。
+client 启动时挨个尝试，失败自动下位。若以后只改了一处且其他已死/未在，
+该副本依旧可用（membership 由 lease 管投入，不由列表管断路）。
+示例（生产 3 副本 MDS 署）：
+
+```json
+"adapter_params":{
+  "url":"dfkv://10.201.3.10:28150,10.201.3.11:28150,10.201.3.12:28150/glm",
+  "membership":"mds",
+  "lib":"/dfkv/lib/libdfkv.so",
+  "model_name":"glm-5.2",
+  "model_revision":"2026-08-04-nvfp4-m2",
+  "tenant_id":"prod-chat",
+  "num_workers":16}
+```
+
+#### 多模型/多租户配置（对应 §5 四维度）
+
+| 维度 | 配置位点 | 示例 |
+|---|---|---|
+| ① Group | `url` 末尾 `/<group>` | `dfkv://10.201.3.10:28150/glm-prod-chat` |
+| ③ tenant_id | `adapter_params.tenant_id` | `"tenant_id":"prod-chat"` |
+| ④ model_name | `adapter_params.model_name`（**必填**） | `"model_name":"glm-5.2"` |
+| ④ model_revision | `adapter_params.model_revision` | `"model_revision":"nvfp4-2026-08"` |
+
+完整生产示例（同模型同参数量化，两业务线分 group + 分 tenant）：
+
+```json
+// chat
+{
+  "adapter_params":{
+    "url":"dfkv://10.201.3.10:28150,10.201.3.11:28150/glm-chat",
+    "model_name":"glm-5.2",
+    "model_revision":"nvfp4-2026-08",
+    "tenant_id":"prod-chat"}
+}
+// coder
+{
+  "adapter_params":{
+    "url":"dfkv://10.201.3.10:28150,10.201.3.11:28150/glm-coder",
+    "model_name":"glm-5.2",
+    "model_revision":"nvfp4-2026-08",
+    "tenant_id":"prod-coder"}
+}
+```
+
+**vs in-process**：只有 MP-server L2 adapter 能配置 tenant_id/model_revision；
+in-process 上游 metadata 无这两项（见 §4.3 🔴）。对生产参与 tenant 配额或
+参数变化隔离场景的**唯一选项是本 adapter**。MP-server API 不提供足以证明 byte-identical MLA replica 的 model/PP
 元数据，因此对象 key 始终保留 `world_size/global_rank` identity，并拒绝手工折叠开关。
 server 的 pinned L1 arena 在 LMCache 传入 `l1_memory_desc` 时自动注册 RDMA 零拷贝。
 
@@ -825,7 +993,9 @@ connector 移植自 dingofs 项目的 LMCache connector，与 HiCache 插件走�
 buffer）；dfkv 无此限制，直接存 LMCache 的 `full_chunk_size_bytes`（可几十 MiB）。
 dfkv value 是 raw payload；权威存储长度保存在 store metadata 中并独立于 payload
 返回。LMCache 的末个 chunk 可能不满，若用满块大小调用 fixed-size GET，会因
-stored length 不等而 miss。变长 get 解决这个问题：
+stored length 不等而 miss。变长 get 解决这个问题（另注：GET 目标 buffer
+不可写/非连续时 native 层 fail-loud 抛错，向上冒泡为该 chunk miss，而非假命中，
+见 **②** 的 pointers 一条）：
 - C++：`KVClient::GetAuto(key, out, cap, *out_len)` /
   `BatchGetAuto(items, *out_lens)`；只要实际长度 `<= cap` 就返回 raw bytes 与长度。
 - C ABI：`dfkv_get_auto` / `dfkv_batch_get_auto`。
@@ -835,7 +1005,7 @@ stored length 不等而 miss。变长 get 解决这个问题：
 
 **② pybind11 → ctypes。** dingofs 用 pybind11 原生模块（eventfd 完成队列）；dfkv 直接
 ctypes 调 `libdfkv.so`（与 HiCache 插件一致）。C ABI 同步且内部线程安全：`dfkv_batch_*`
-阻塞、内部线程池跨 owning node 并行 fan-out；成员 ring 有互斥锁，**一个 `dfkv_open`
+阻塞、内部线程池跨 owning node 并行 fan-out；成员 ring 有互斥锁，**一个 `dfkv_open_v2`
 handle 可多线程共享**。`ctypes.CDLL` 调用期间释放 GIL，把阻塞调用派发到
 `ThreadPoolExecutor` 即得真并发——无需原生 demux 线程或跨线程 Future 桥接。
 
@@ -869,8 +1039,11 @@ integration/lmcache/
 3. 专用 `ThreadPoolExecutor(max_workers=get_parallelism)`，`loop.run_in_executor` 派发
    阻塞 ctypes 调用。`close()` 先停止接收新任务并等待已提交调用结束，再
    `dfkv_close`，避免 native handle 与在飞调用竞态。
-4. 零拷贝指针：`(c_char*nbytes).from_buffer(mv)` 直接别名可写连续 buffer；只读 buffer
-   退回 `from_buffer_copy`。keepalive 对象保活到 C 调用返回。
+4. 零拷贝指针：`(c_char*nbytes).from_buffer(mv)` 直接别名可写连续 buffer。PUT 对
+   只读 buffer 退回 `from_buffer_copy` staging（数据先拷入 staging，再发 native）；
+   **GET 不作 staging**——目标 buffer 不可写或非 C 连续时，在**所有 native 调用之前**
+   `raise ValueError`（fail-loud，连接器上层把它当 miss 处理），绝不返回指向
+   staging 副本的假命中。keepalive 对象保活到 C 调用返回。
 5. 返回结构：`batch_set→(ok, per_key)`；`batch_get→(ok, per_key, lengths)`；
    `batch_exists→per_key`。
 
@@ -927,9 +1100,12 @@ refresh 前 ring 可能为空，早期操作安全 miss（LMCache 重算）。
 - **L2 adapter**：`integration/lmcache/tests/test_l2_adapter.py`（单测，fake client）、
   `test_l2_adapter_integration.py`（真环集成）。
 
-### 4.7 实测结果（参考）
+### 4.7 实测结果（历史实测，参考）
 
-环境：a100（vLLM 0.21 + LMCache 0.4.5）；dfkv = 2 节点 static 成员（TCP 18800 / RDMA
+> ⚠️ 下表是 **vLLM 0.21 + LMCache 0.4.5** 旧栈上的历史实测（相对收益方向仍
+> 可参考），v2.0.0 原生身份/传输栈下的绝对值需以新实测与新部署为准。
+
+环境：a100（vLLM 0.21 + LMCache 0.4.5，历史实测）；dfkv = 2 节点 static 成员（TCP 18800 / RDMA
 18801）；DeepSeek-R1-Distill-Qwen-32B（TP=1）；`chunk_size=16`（每 chunk ≈4 MiB）；
 bench random 16000-in / 100-out，20 prompts，并发 10，同 `--seed`。冷遍写入约 **81 GB**。
 
@@ -956,7 +1132,7 @@ prompt ≈4 GB KV」的 TTFT）：
 
 ### 4.8 已知问题 / 排查
 
-- **vLLM 在请求被中止时崩溃**：LMCache 0.4.5 + vLLM 0.21 在 `FINISHED_ABORTED` 时
+- **vLLM 在请求被中止时崩溃**（历史实测栈 LMCache 0.4.5 + vLLM 0.21 观察）：在该旧栈上 `FINISHED_ABORTED` 时
   scheduler 进程 `vllm_v1_adapter.request_finished` 会 `assert self.lmcache_engine is not
   None` 崩溃。**与 dfkv 无关**（任何 remote backend 都触发），正常完成请求不走该路径；上游已知。
 - **启动日志没有 `DfkvConnector ready`**：查 `lmcache.yaml` 的 `module_path/class_name/url`，
@@ -990,6 +1166,99 @@ parallel coordinates、component 或 scatter width 的任何差异。
 payload bytes 完全兼容。
 
 共池铁律：**control plane 可共享；identity 不同是冷缓存；identity 相同必须 byte-compatible。**
+
+### 5.1 多模型/多租户生产隔离四维度
+
+生产环境跑多套模型或同模型多业务时，按四个维度组合隔离（独立起效，全组合生效）。
+**建议全部四列都设**，否则撞上跨写/错读开头后很难查。
+
+#### ① Group（环归属）
+
+同一个 etcd 里多个 group = 各自的 membership/ring。**不同业务线分 group**
+（`mds_group`；in-process LMCache 的 `url` 尾段；MP-server 的 `url` 尾段）。
+server 只入一个 group（flag），client 只看到本组 server，无跨组走 wire 的场景。
+特殊场景（如 K3 KV pool 供同一模型多个 DP rank 共享）则有意共用同 group。
+
+#### ② canonical namespace（模型身份 + 布局）
+
+每条 connector 启动时浇出一个 sources-controlled namespace descriptor：
+`model_identity` + `model_revision` + `tenant_id` + `dtype` + `block_tokens` +
+`num_layers` + `tp/dp/pp_size` + `group_layout`。这些都进 BlockKey 的 SHA-256，任一不同
+均冷 miss。**同名模型但参数/布局不同（dtype、量化、TP 组布局、header/cache dtype）必须
+靠显式 `model_revision` 或 `tenant_id` 隔离**，否则高概率复用到不可解释的
+bytes（见下）。
+
+#### ③ tenant_id（配额与计费）
+
+`tenant_id` 进 BlockKey（64-bit tenant hash）**且**进配额 admission（default+strict hash
+表，`dfkv_tenant_quota.py` 管理）。生产多模型共环时，为每个业务线分配一个
+tenant_id（如 `prod-chat`、`prod-coder`、`dev-ab`），可以同时拿到
+*该业务的 usage 配额*与*身份隔离*。tenant_id 只影响 identity/quota，**不构成 ACL**——
+任何能到达端口的 client 都可以自报 tenant_hash（`docs/ARCHITECTURE.md` §8）。
+
+#### ④ model_name / model_revision（显式模型版本标签）
+
+- `model_name`：精确模型 identity（如 `glm-5.2`、`deepseek-v2-lite`）。MP-server/
+  in-process LMCache 必填（不自动从 runtime metadata 提供）。
+- `model_revision`：同 `model_name` 但权重、量化、并发点切边时间不同（如
+  `2026-08-04-nvfp4-m2`、`fp8-ep16-团子`）时的**必修标签**。默认值 = `model_name`；
+  不同时**必须显式设置**，否则同 model_name 不同布局会命中成 byte-incompatible 冷数据。
+
+### 5.2 三套生产配置实例
+
+**A. 同模型不同业务线（同 group + 不同 tenant）**
+
+```jsonc
+// 业务 chat: url="dfkv://mds.../glm", tenant_id="prod-chat",
+//                model_name="glm-5.2", model_revision="nvfp4-2026-08"
+// 业务 coder: url="dfkv://mds.../glm", tenant_id="prod-coder",
+//                 model_name="glm-5.2", model_revision="nvfp4-2026-08"
+```
+**效果**：同一 ring；quota 独立；key identity 互不可见（tenant hash 不同）。
+生产建议：为每个 tenant_id 在 `dfkv_tenant_quota.py` 预置配额。
+
+**B. 同模型不同参数量化（同 group + 不同 model_revision）**
+
+```jsonc
+// v1: model_name="deepseek-v4-flash", model_revision="fp8-ep8-0731"
+// v2: model_name="deepseek-v4-flash", model_revision="nvfp4-0731"
+```
+**效果**：同 ring；identity 互 miss；不会被拉错 layout。布局切换（如 FP8
+屁股换 NVFP4）必须 bump model_revision，不允许沿用默认。
+
+**C. 业务线与模型交叉（多 group + 多 tenant）**
+
+```jsonc
+// chat:  mds_group=glm-chat,  tenant_id=prod-chat,   model_name="glm-5.2"
+// coder: mds_group=glm-coder, tenant_id=prod-coder,  model_name="glm-5.2"
+// k3:    mds_group=gcp-chat,  tenant_id=kimi-k3,     model_name="kimi-k3"
+```
+**效果**：三 ring；各 server 只入自身 group；互不可见（group 本身就是权限边）。
+注意 server 只入一个 group——多业务线要么加节点独属 group，要么共用 group 靠 A/B 两
+种组合区分。
+
+### 5.3 排障看 namespace 的第一眼
+
+冷缓存/miss 但 server 写入看起来正常的首要排查对象就是 namespace：
+
+1. **init 行**（access log，见 access_log.md §1）：核对 `init(r0 <model> ...) : ok <membership>` 里的 model 与 endpoint 是否对得上该实例应入的 group/预期 revision。
+2. **client INFO**（`dfkvctl clients --group <g>`）：现册 client 自报的 model_hash（tenant hash 的入口）与 target model_name/model_revision 是否匹配。
+3. **命中率的 identity 欺诈**（hit_rate_funnel.md §①）：model_identity/pcp/dcp/
+  group_layout 任一与预期不同但在同一 MDS group，可用 `dfkv_mds_group_version_skew`
+  指标看环内 client 是否跑错版本。
+
+### 5.4 🔴 对生产环境的硬性警告
+
+1. **布局变化必须 bump 显式 revision**：dtype、量化、层数、TP/PCP/DCP/PP 维度任一
+变化都改变 layout。`model_revision`（connector 级）或 connector 内部
+source-controlled layout ID 必须同步更新；dfkv 本身不保存 header。
+2. **v2 与 v1.x 不能混 wire**：v2 client/server 只收 epoch 6/7 frame，v1.40 前的
+frame 会被 fast-reject（`wire.h:92-108`）。混合代际升级走 MDS 双协议
+（DFKV_MDS_ACCEPT_LEGACY）的受控迁移，不允许双写数据面。
+3. **operator 自定义 namespace 别名被拒**（03d7035）：v2.0.0 起 connector 只接受
+source-controlled layout ID，不允许 runtime 传入部署标签当 payload schema。
+4. **🔴 跨实例 L3 复用必须全实例 `PYTHONHASHSEED=0`**：vLLM block hash 跨进程
+确定性靠固定种子；不设时跨实例命中率呈静默 0（与 replicated-MLA 修复前同签名）。
 
 ---
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -4,7 +4,8 @@
 > `dingo-cache` 混部互不干扰。**对现网 dingofs/sglang 命名空间、dingo-cache 进程、
 > MDS、对象存储一律不动（只读边界）**；dfkv 用独立端口/目录/进程。
 > 前提：GLM-5.1 = MLA（每页 KV ≈ 2.74 MiB 单对象、跨 TP 复制、仅 tp_rank0 写）。
-> 已在 400G InfiniBand 上端到端验证（两端零拷贝，单口 GET ~93% 线速）。
+> 已在 400G InfiniBand 上端到端验证（两端零拷贝；单口 GET ~93% 线速为
+v1.35 two-sided 数据面实测，v2 one-sided 需重测）。
 
 > **本文只讲 dfkv 集群自身的部署;各推理引擎如何对接/配置 dfkv(HiCache/vLLM/LMCache + 客户端配置总表)见 [docs/CONNECTORS.md](CONNECTORS.md)。**
 
@@ -84,7 +85,10 @@ After=network-online.target
 Type=simple
 # --listen: TCP 监听端口（与 dfkv_server 端口段错开）
 # --etcd:   etcd 地址（默认 127.0.0.1:2379）
-# --metrics-port: 可选，开 Prometheus /metrics（缺省=不开端口，见 §7 / docs/METRICS.md）
+# --metrics-port: 可选，开 Prometheus /metrics（缺省=不开端口，见 §7 / docs/METRICS.md）；
+#   --metrics-bind <addr> 绑定监听地址（缺省 0.0.0.0）
+# 加固 env（按需加 Environment=）：DFKV_MDS_FIRST_REQ_MS（首帧 absolute deadline，
+#   默认 30000ms，0=关，硬上限 3600000）、DFKV_MDS_MAX_CONNS（并发连接上限，默认 4096）
 ExecStart=/usr/local/bin/dfkv_mds --listen 9400 --etcd 127.0.0.1:2379 --metrics-port 9410
 Restart=on-failure
 RestartSec=2
@@ -106,9 +110,15 @@ journalctl -u dfkv_mds -n 5 --no-pager   # 应见 "dfkv_mds listening on 9400, e
 > failed keepalive → lease grant → Put，共 3×2s。node/client registrar 的默认
 > socket I/O timeout 为 7s，组合上覆盖这 6s server budget；不要把 caller timeout
 > 调到单个 etcd timeout。
-> MDS 的 `/readyz` 与 `/healthz` 都执行现场 etcd probe：运行期 etcd 不可达时
-> 立即返回 503，使 scheduler 摘除该 MDS；etcd 恢复后同一进程自动回到 200。
-> `dfkv_mds` 不因运行期 etcd 短暂故障退出。
+> MDS 的 `/healthz` 是纯进程 liveness（不 probe etcd）：否则一次秒级 etcd
+> 抖动会让 kubelet 同时重启全部 MDS 副本，CrashLoop 比抖动更久，重注册风暴
+> 还会引发 lease 集体过期。`/readyz` 保留 etcd 依赖检查（活着但探不到 etcd
+> 的 MDS 无法服务 membership，必须摘出路由），但经 TTL-debounced probe
+> （`DFKV_MDS_PROBE_CACHE_MS`，默认 2500 ms；0=恢复逐请求现场 probe；钳制
+> 上限 600000 ms），kubelet 抓取节奏不会放大成 etcd 读负载，not-ready 副本
+> 每 TTL 最多重探一次。运行期 etcd 不可达时 `/readyz` 503 使 scheduler
+> 摘流，etcd 恢复后同一进程自动回 200；`dfkv_mds` 不因运行期 etcd 短暂故障
+> 退出。
 
 > **混合代际滚动（v1.x ↔ v2）**：`DFKV_MDS_ACCEPT_LEGACY=1` 把 MDS 控制面版本闸
 > 按已知 epoch 放宽一档——v1.x 节点/客户端以旧 42/10 字节帧直接被服务（操作码、
@@ -128,32 +138,86 @@ test -e /etc/dfkv/tenant-quotas ||
 ```
 
 
-`/etc/systemd/system/dfkv.service`：
+`/etc/systemd/system/dfkv.service`（参考 **xb01-0064 生产配置**（8 条 400G IB 轨/主机）映射到 v2.0.0 大生产参数：**v1.37 生产开了什么现阶段保留什么**；**v2 才落地的能力（SYS_URING/CONVoy 合并/监听加固/slab 水位线）设置为 drop-in 注释默认留**。更小形（单 HCA、无 RAM tier）只需对 `--rdma-dev`、`--ram-tier`/`--ram-tier-bytes` 做减法）：
+
+> **xb01-0064 (v1.37-1.40) → v2.0.0 映射关系**：
+> | 项 | xb01 生产 (v1.37/1.40) | 本示例 (v2.0.0) | 变动 |
+> |---|---|---|---|
+> | `--rdma-dev` | 8 轨全列 | 8 轨全列 | 一致 |
+> | RDMA depth | `DFKV_RDMA_DEPTH=32` | `DFKV_RDMA_DEPTH=4` | depth-flat；超过共享 segment 槽位会被吃（segment 2 GiB / 4 MiB ≈ 127 个 data QP），不宜再叠高 |
+> | RDMA_NUMA | `1` | 保留 `DFKV_RDMA_NUMA=1` | 一致 |
+> | RAM tier | on + 1TiB | on + 1TiB（`--ram-tier-bytes 1099511627776`） | 一致 |
+> | SERVER_URING | 开，depth=32 | 默认关，经 drop-in 打开（须编 `-DDFKV_WITH_URING`） | v2 保留 |
+> | READ_COALESCE | 开 | 默认关，经 drop-in 打开（TCP 端共读 convoy） | v2 新增 |
+> | 监听加固 | — | `DFKV_TCP_FIRST_REQ_MS=30000` + `DFKV_METRICS_MAX_CONNS=64` | PR#240 新增 |
+> | slab 驱逐水位 | — | `DFKV_SLAB_EVICT_HIGH_PCT=92` / `LOW_PCT=88` | v2 新增（默认 92/88，显式解释为风控用途） |
+> | systemd Timeout | `TimeoutStartSec=600` / `TimeoutStopSec=600` | 同上 | **arena MR 注册时间在 v2.0.0 显著拉长**（≥64 GiB arena 默认 90s 不够），必须与 arena 大小同步扩大 |
+> | OOM | `OOMScoreAdjust=-500` | 保留 | 一致 |
+> | tenant quota | `DFKV_TENANT_QUOTAS_FILE` + default=0 | 保留 | 一致 |
 ```ini
 [Unit]
-Description=dfkv KV cache node (SGLang HiCache L3)
-After=network-online.target
+Description=dfkv KV cache node (SGLang HiCache L3, 8x400G)
+# 启动顺序：在 MDS 之前动 After；v2 首注册 deadline 60s，必须先起 MDS 再动 server
+After=network-online.target dfkv-mds.service
+Wants=network-online.target
 [Service]
 Type=simple
-# v2 shared segment 示例：server 上限 4 MiB、depth=4、2 GiB segment。
-# 按所有 rank/process 的 peak live + pooled QP 公式复算，见 CONNECTORS §1.2.1。
+# v2 shared segment 示例：RDMA depth=4 上限 4 MiB、segment=2 GiB
+# （对应 ~127 data QP；client 侧也对应 dfkv_rdma_depth=4/segment-size 同口径，CONNECTORS §1.2.1
+#  的公式按 peak live + pooled QP 复算）。
 Environment=DFKV_RDMA_DEPTH=4
 Environment=DFKV_RDMA_RECV_SEGMENT_SIZE=2147483648
+# 8×400G 轨全轨白名单 + NUMA：B200 生产 host 一台带 8 个 HCA 轨；
+# server 两端白名单到**同名互通**一组轨；client 的 `DFKV_RDMA_NUMA=1` 后每 rank 优先本 NUMA 轨，
+# 本地轨全不可准入时降级重试全部 enabled rail（rail_select.h/rdma_transport.cc:399-413）。
+# --rdma-dev 直传 RDMA server，胜过同名 env；client 侧 `DFKV_RDMA_DEV` 另行注入（CONNECTORS §1.2）。
+Environment=DFKV_RDMA_NUMA=1
+# v2.0.0 监听器加固（PR#240）：首帧 30s absolute deadline 断 slow-dribble,
+# metrics 端口连接数上限 64（防连接占用打满）,
+# 解析结果经 `dfkv_tcp_first_req_ms` gauge 上报（METRICS.md §3.1）。
+Environment=DFKV_TCP_FIRST_REQ_MS=30000
+Environment=DFKV_METRICS_MAX_CONNS=64
+# slab 满环自噬第一道防线：水位线 92% 主动驱逐到 88% 保留 headroom（默认两行已在默认启用，
+# 本行显式解释. high=0 关）。对应)--;
+#Environment=DFKV_SLAB_EVICT_HIGH_PCT=92
+#Environment=DFKV_SLAB_EVICT_LOW_PCT=88
 # 0/unset = unlimited. If FILE is configured it must exist and parse strictly.
 Environment=DFKV_TENANT_QUOTAS_FILE=/etc/dfkv/tenant-quotas
 Environment=DFKV_TENANT_DEFAULT_QUOTA_BYTES=0
-# --port = TCP(bootstrap+TCP数据) 端口; --rdma-port = RDMA bootstrap 端口; --rdma-dev = 数据面 400G 口
-# --metrics-port = 可选 Prometheus /metrics（缺省=不开端口；--id/--group 成为指标标签）
+# --port = TCP(bootstrap+TCP数据) 端口; --rdma-port = RDMA bootstrap 端口; --rdma-dev = 数据面 8×400G
+# --metrics-port = 可选 Prometheus /metrics（缺省=不开端口；--id/--group 成为指标标签）;
+#   --metrics-bind <addr> 绑定监听地址（缺省 0.0.0.0）
 # 此生产示例故意不设置 --store-engine/DFKV_STORE_ENGINE：resolved 默认即 slab。
 ExecStart=/usr/local/bin/dfkv_server \
   --dir /mnt/disk1/dfkv,/mnt/disk2/dfkv,/mnt/disk3/dfkv \
-  --port 28000 --rdma-port 28001 --rdma-dev ib7s400p0 --max-msg 4194304 \
+  --port 28000 --rdma-port 28001 --max-msg 4194304 \
+  --rdma-dev ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7 \
+  --rdma-depth 4 --rdma-numa 1 \
+  --ram-tier on --ram-tier-bytes 1099511627776 --ram-tier-shards 16 \
   --cap 6597069766656 --mds 10.0.0.1:9400,10.0.0.2:9400 \
   --metrics-port 28010 --group default --id n57 \
   --advertise 192.168.1.57:28001 \
   --mds-registration-timeout-ms 60000
+# v2.0.0 生产扩展能力（默认关，会自动在 systemd drop-in 覆盖）：
+# - io_uring async GET/direct read（xb01 生产为 on;
+#   需要编 `-DDFKV_WITH_URING`）：
+#Environment=DFKV_SERVER_URING=1
+#Environment=DFKV_SERVER_URING_DEPTH=32
+# - TCP 端共读 convoy 合并：server 同 key 复本位于重复读共享一个 disk read
+#Environment=DFKV_READ_COALESCE=1
+#Environment=DFKV_READ_COALESCE_RECUR_MS=1000
+#Environment=DFKV_READ_COALESCE_TIMEOUT_MS=500
 Restart=on-failure
 RestartSec=2
+# 大 arena（≥64 GiB）RAM tier 预触+RDMA MR 注册都起页走：每 16 GiB arena +5-10s 启动时间。
+# xb01 生产 TimeoutStartSec/TimeoutStopSec=600，90s 默认会 OOM-timeout 掉 dfkv；
+# 配大 arena（≥64 GiB）时必须同步调大。
+TimeoutStartSec=600
+TimeoutStopSec=600
+# OOM 调整：内存压力下 Linux OOM Killer 倾向杀占内存过多的进程，dfkv 的 RAM arena 会被白锁。
+# xb01 生产-500，降低 dfkv 被错杀风险（NVMe cache-process 死了 模型自己还能重算，预 pin 大 RAM 的
+# dfkv arena 更不该成为被出手的对象）
+OOMScoreAdjust=-500
 CPUQuota=1600%
 MemoryMax=64G
 Nice=5
@@ -181,6 +245,10 @@ WantedBy=multi-user.target
 > - `--ram-tier-numa interleave|off`（默认 `interleave`）：这是当前完整 mode 集；不接受数字 node ID。arena 预触并绑策略，须核 `MemoryMax`。
 > - `--ram-flush-threads <n>` / `DFKV_RAM_FLUSH_THREADS`：请求值会提高到至少 shard 数；实际值由 `dfkv_ram_flush_threads` 报告（默认请求=4×盘数，上限 16）。
 > - 微调项（env only）：`DFKV_SLAB_TABLE_SYNC_MS` 控制 table sync 节奏（默认 100 ms，0=关；dirty epoch 重启仍无条件冷重置）。
+> - 微调项（env only）：`DFKV_SLAB_EVICT_HIGH_PCT` / `DFKV_SLAB_EVICT_LOW_PCT`
+>   （默认 92 / 88，占容量百分比；high=0 关闭）：水位线主动驱逐在 demand 之前
+>   保留 headroom，是满环时 cross-class extent 互抢（自噬）的第一道防线；对应
+>   计数器 `dfkv_slab_watermark_evictions_total` / `dfkv_slab_cold_steals_total`。
 > - `--slab-reclaim-ms <n>` / `--ram-reclaim-ms <n>`（默认 50 / 10，`0`=关）：后台预回收和类再平衡。allocator 按 useful bytes + decayed read heat 选择 donor，跳过 pinned extent；通常保留默认。
 > - `--slab-granularity <bytes>`（默认 1 MiB）：最小 slot 量子。现有 `slots.tbl` 的 format/geometry 不匹配会 fail closed；修改必须换空目录，服务不会原地冷重建或忽略旧数据。
 > - `--put-inflight-limit <n>`（默认 0=关）：并发盘写超过 n 的 PUT 以 kCacheFull 快速拒绝（客户端视为普通 put 失败、不进 cooldown）= 用受控 miss 换掉过载排队尾延迟。RDMA 与 TCP 两条数据路径同受此门约束；RAM 热层的异步 flusher 落盘**不受**此门限制（否则背压会放大为 flush 丢弃）。
@@ -188,6 +256,11 @@ WantedBy=multi-user.target
 >   TCP handler/FD；`--tcp-io-timeout-s <n>` / `DFKV_TCP_IO_TIMEOUT_S`（默认
 >   60s，硬上限 3600s）回收 silent/半帧连接。达到上限的新连接会被立即拒绝，
 >   pooled TCP 客户端重连；监控 §7 的 reject counter。
+> - `DFKV_TCP_FIRST_REQ_MS`（默认 30000 ms，0=关，硬上限 3600000）：首帧
+>   absolute deadline，从 accept 起第一段完整 request frame 必须到齐。逐字节
+>   滴喂的慢连接不再永久占用 handler 槽位（SO_RCVTIMEO 只约束单次 syscall）；
+>   每次读的 per-syscall 预算取 min(base timeout, deadline 剩余）。resolved
+>   值由 `dfkv_tcp_first_req_ms` gauge 上报（见 METRICS.md §3.1）。
 > - RAM 热层 arena 预触 + RDMA MR 注册都在启动期走页：**arena 每 16 GiB 约 +5-10s 启动时间**，配大 arena（≥64 GiB）时同步调大 systemd `TimeoutStartSec`（默认 90s）并让就绪探测等待 metrics 端口。
 > GPU 节点推荐：保留默认 slab/direct，按节点突发画像启用 RAM tier 并设置总预算。
 ```bash
@@ -211,11 +284,15 @@ journalctl -u dfkv -n 10 --no-pager
 > rail 错误分数选轨（分数相同时按发现顺序稳定选择）。留空时两端各选本地首个
 > ACTIVE HCA，适合 local device 名不同的单 fabric 主机；显式
 > `--rdma-dev` / `DFKV_RDMA_DEV` 是权威白名单并把具体设备选择发给 peer，故
-> 生产多 fabric 主机必须在两端过滤到**同名且互通**的一组设备。
-> `DFKV_RDMA_NUMA=1` 在每次 Acquire 读取 caller NUMA；只要白名单内存在
-> local rail 就只在 local mask 内准入（local credit 忙时不会越级借 remote
-> rail）。caller NUMA 未知或没有 local rail 才回退全部白名单，保证进度。
-> receive segment 仍是单块 process-wide 分配，不是 per-NUMA/per-rail 分片。
+> 生产多 fabric 主机必须在两端过滤到**同名且互通**的一组设备。设备名上限
+> 18 字节（v2 dev frame 中 name + capability trailer 共 32 字节），超长的
+> 白名单/anchor 设备名在启动时 fail-fast 拒绝，不会截断后误配。
+> `DFKV_RDMA_NUMA=1` 在每次 Acquire 读取 caller NUMA；白名单内存在 local
+> rail 时严格优先 local mask。caller NUMA 未知或没有 local rail 时回退全部
+> 白名单；全部 local rail 都不可准入（被隔离或 credit 耗尽）时也会降级为
+> 全 enabled rail 重试一次——local 是严格偏好而不是可用性闸门，不阻止
+> progress。receive segment 仍是单块 process-wide 分配，不是
+> per-NUMA/per-rail 分片。
 >
 > **失败域隔离**：TCP bootstrap、peer 不可达、epoch/QP frame/receive-segment
 > 不兼容属于 endpoint 失败：立即归还 rail credit，由 client `PeerHealth` 对该
@@ -273,21 +350,167 @@ quota 计 committed payload bytes；slab slot 内碎片另占物理空间，因�
 REMOVE 和 store eviction 立即释放 usage；重启从 file 名或 v3 slab record 重建。
 受限 tenant 为保证 PUT 的同步 admission 语义会绕过异步 RAM write-back。
 
+### 3b. dfkv_server flag / env 参考矩阵（按类别）
+
+以下均为 v2.0.0（cbe53fa）时刻从 `dfkv_server --help`、源码 `Env*`/`args.get` 解析点与常量实测
+整理的**权威服务端配置参考**。flag 优先于同名 env（`--rdma-dev` 直传 RDMA server，其余行为
+flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误报。**客户端
+侧（DFKV_RDMA_DEV/DFKV_LIB/DFKV_FANOUT_THREADS 等在同一 host 上的 inference rank 进程）仍然
+按 CONNECTORS.md §1 的 vLLM/SGLang/LMCache 通用表设置**，本表只列 **dfkv_server / dfkv_mds**
+进程读到的组。
+
+#### a. 核心必填/常用（`dfkv_server --help` 全集）
+
+| flag/env 孪生 | 默认 | 说明 |
+|---|---|---|
+| `--dir <paths>` | —（必填）逗号分隔多盘 | 每节点 NVMe 数据目录，逗号加多个自动 Ketama 分盘；`--cap` 是**总容量**，按盘均分 |
+| `--cap <bytes>` | —（必填） | 节点总容量（LRU 超限触发自裁） |
+| `--port <p>` | 0(临时） | TCP bootstrap+数据端口；0=随机 |
+| `--rdma-port <p>` | —（RDMA build 必填） | RDMA bootstrap 端口（含 RDMA 时开启） |
+| `--rdma-dev` | first ACTIVE 本地 | RDMA 白名单（逗号）；与 `DFKV_RDMA_DEV` 不同：这是 server 的 anchor |
+| `--mds <ip:port,...>` | —（生产必须） | 注册进的 MDS 列表；配后须配 `--group/--id/--advertise` |
+| `--group` | `"default"` | ring 名 |
+| `--id <id>` | 主机名 | server 节点 id（与 `--advertise` 联动） |
+| `--advertise <ip:port>` | auto（rdma-port） | 其他节点到本节点的地址 |
+| `--weight` | `1` | consistent-hash vnode 数权 |
+| `--metrics-port` | omit=off | Prometheus /metrics、healthz、readyz |
+| `--metrics-bind` | `0.0.0.0` | metrics/health 绑 IP（内网收敛） |
+| `--mds-registration-timeout-ms` / `DFKV_MDS_REGISTRATION_TIMEOUT_MS` | `60000` | 首次 MDS 注册截止（1000–600000） |
+| `--store-engine` / `DFKV_STORE_ENGINE` | `slab` | `slab` 为默认；`file` 为显式诊断 fallback |
+| `--slab-write` / `DFKV_SLAB_WRITE` | `direct` | slab 数据面 O_DIRECT / buffered；文件系统不支持 DIO 时整店回退 buffered 并以 `wr=` 上报 |
+| `--ram-tier` / `DFKV_RAM_TIER` | `off` | RAM 热层（写穿+RDMA zero-copy GET） |
+| `--ram-tier-bytes` / `DFKV_RAM_TIER_BYTES` | `4 GiB` | arena 预算（pin 一次即注册） |
+| `--ram-tier-numa` / `DFKV_RAM_TIER_NUMA` | `interleave` | NUMA 策略：`interleave`/`off`（不接 node id） |
+| `--ram-tier-shards` / `DFKV_RAM_TIER_SHARDS` | `8`, 硬上限 64 | arena 锁分片数（大 arena ≥100 GiB 建议 16） |
+| `--slab-granularity` / `DFKV_SLAB_GRANULARITY` | `1 MiB` | slab slot 量子；现有目录 geometry 不符启动拒绝 |
+| `--put-inflight-limit` / `DFKV_PUT_INFLIGHT_LIMIT` | `0`=关 | 并发盘写上限，超出返回 kCacheFull 快速拒绝 |
+| `--tcp-max-conns` / `DFKV_TCP_MAX_CONNS` | `512`, 硬上限 4096 | cache TCP handler 上限；超限 accept 恒拒 |
+| `--tcp-io-timeout-s` / `DFKV_TCP_IO_TIMEOUT_S` | `60`, 硬上限 3600 | per-syscall RCVTIMEO（秒） |
+| `--rdma-depth` / `DFKV_RDMA_DEPTH` | `1` | server 提交 QP post 深度；与 client 协商取 `min` |
+| `--rdma-numa` / `DFKV_RDMA_NUMA` | `0` | NUMA-aware rail choice（off/1） |
+| `--rdma-idle-ms` / `DFKV_RDMA_IDLE_MS` | — | idle connection reaper tick |
+| `--rdma-op-timeout-ms` / `DFKV_RDMA_OP_TIMEOUT_MS` | `5000` | per-op RDMA deadline |
+| `--server-uring` / `DFKV_SERVER_URING` | `0` | io_uring async-GET（编须 `-DDFKV_WITH_URING`） |
+| `--server-uring-depth` / `DFKV_SERVER_URING_DEPTH` | — | uring SQ 深度 |
+| `--ram-flush-threads` / `DFKV_RAM_FLUSH_THREADS` | 默认 4×盘数， 钳至 shard 数上限 16 | RAM tier flush 线程 |
+| `--slab-table-sync-ms` / `DFKV_SLAB_TABLE_SYNC_MS` | `100 ms`, `0`=关 | slab 元数据 sync 节奏 |
+| `--slab-reclaim-ms` / `DFKV_SLAB_RECLAIM_MS` | `50 ms`, `0`=关 | slab 后台回收 tick |
+| `--ram-reclaim-ms` / `DFKV_RAM_RECLAIM_MS` | `10 ms`, `0`=关 | RAM tier 后台回收 tick |
+| `--log` / `DFKV_LOG` | `INFO` | INFO/DEBUG/WARN/ERROR |
+| `--max-msg`（或 `DFKV_RDMA_MAX_PAYLOAD_BYTES`） | `64 MiB` | 单笔 payload 硬上限（RDMA 与 TCP 数据路径同受此限） |
+| `--version, -V` / `--help` | — | 打印版本/帮助并退出 |
+
+#### b. RDMA 传输面（均在 dfkv_server 进程读取）
+
+| env | 默认 | 说明 |
+|---|---|---|
+| `DFKV_RDMA_RECV_SEGMENT_SIZE` | 动态 | v2 共享 receive segment 总大小；`slot=align4K(4096+max_raw_payload)`，容量按 expected live QP×depth×slot 预算 |
+| `DFKV_RDMA_CONNECT_MS` | — | IB QP 建连超时 |
+| `DFKV_RDMA_IO_MS` | — | 控制面帧读写超时 |
+| `DFKV_RDMA_BATCH_OP_TIMEOUT_MS` | 0=跟随 RDMA_OP | multi-item Cache/Range/Exist、SG 窗口总期限 |
+| `DFKV_RDMA_POOL_MAX` | — | client 侧 per-endpoint 连接池上限 |
+| `DFKV_RDMA_RAIL_CREDITS` | 默认 `64`, 硬上限 4096 | client 每 rail QP 信用数（inflight 上限），>server depth 会回退 |
+| `DFKV_RDMA_RAIL_BACKPRESSURE_MS` | `10` | Acquire 失败重试 backoff |
+| `DFKV_RDMA_RAIL_COOLDOWN_MS` | `5000` | rail quarantine 冷却期；期间只允许 1 个 recovery probe |
+| `DFKV_RDMA_RAIL_ERROR_THRESHOLD` | `3` | 连锁本地 verbs/CQ/post 错误才 quarantine rail |
+| `DFKV_RDMA_RAIL_LATENCY_WEIGHT` | — | rail selection 的延迟 EWMA 权重 |
+| `DFKV_RDMA_RAIL_ERROR_PENALTY_US` | — | rail selection 的错误分数惩罚微秒 |
+| `DFKV_RDMA_IDLE_MS` | — | idle QP 重回收周期 |
+
+#### c. TCP 连接池（client 读，但 server 运维也受影响）
+
+| env | 默认 | 说明 |
+|---|---|---|
+| `DFKV_TCP_POOL_MIN_CONNS` | `1` | per-node pool 下限 |
+| `DFKV_TCP_POOL_MAX_CONNS` | `8`, 硬上限 64 | per-node pool 上限 |
+| `DFKV_TCP_POOL_IDLE_MS` | — | idle 连接踢出周期 |
+| `DFKV_TCP_POOL_ACQUIRE_TIMEOUT_MS` | — | acquire 超时 |
+| `DFKV_TCP_POOL_BACKOFF_BASE_MS` / `DFKV_TCP_POOL_BACKOFF_MAX_MS` | — | stale 再拨指数 backoff |
+
+#### d. slab 存储引擎细节调优
+
+| env | 默认 | 说明 |
+|---|---|---|
+| `DFKV_SLAB_EVICT_HIGH_PCT` / `DFKV_SLAB_EVICT_LOW_PCT` | `92` / `88`, high=0 关 | 水位线主动驱逐阈值；`dfkv_slab_watermark_evictions_total`/`dfkv_slab_cold_steals_total` 对应 |
+| `DFKV_SLAB_COLD_STEAL_WINDOW` | — | 小受害者选择窗口（跨 size class 强占） |
+| `DFKV_SLAB_URING_WRITE` | — | slab io_uring 异步 PUT（需要 `-DDFKV_WITH_URING`） |
+| `DFKV_SLAB_RECLAIM_MS` | `50` | 背景预回收 tick（见 §3） |
+| `DFKV_SLAB_GRANULARITY` | `1 MiB` | slot 量子 |
+
+#### e. RAM 热层细节调优
+
+| env | 默认 | 说明 |
+|---|---|---|
+| `DFKV_RAM_TIER_EXTENT_BYTES` | — | arena extent 大小（通常保留默认；与 `DFKV_RAM_TIER_BYTES` 比例决定并发度） |
+| `DFKV_RAM_TIER_LARGE_RESERVE_BYTES` | — | 超大对象（超出 arena extent）的 dedicated allocation 预算 |
+| `DFKV_RAM_TIER_SHARDS` | `8`, 硬上限 64 | 锁分片 |
+| `DFKV_RAM_TIER_NUMA` | `interleave` | interleave / off |
+| `DFKV_RAM_FLUSH_THREADS` | `4×盘数`，钳至 shard 上限 16 | flush 线程 |
+
+#### f. 同主机/会合复本（node dedup，v2.0.0 新生产杠杆）
+
+| env | 默认 | 说明 |
+|---|---|---|
+| `DFKV_CLIENT_NODE_DEDUP` | `off` | 主开关：跨 rank/process 的同主机同 key 请求会合（仅 client 侧；vLLM replicated-MLA 拓扑自动开） |
+| `DFKV_CLIENT_NODE_DEDUP_GPU` | `off` | GPU 目标和 rendezvous（须 CUDA IPC）；off=host 和 rendezvous |
+| `DFKV_CLIENT_NODE_DEDUP_LOG` | `off` | 会合决策 log |
+| `DFKV_NODE_DEDUP_SLOTS` | `65536`（2 的幂） | dedup 表容量（power-of-2 强制） |
+| `DFKV_NODE_DEDUP_GPU_SLOTS` | — | GPU dedup 表容量 |
+| `DFKV_NODE_DEDUP_TTL_MS` | `5000` | dedup entry 过期 |
+| `DFKV_NODE_DEDUP_WAIT_MS` | — | follower 等待 leader 上限 |
+| `DFKV_NODE_DEDUP_TAKEOVER_MS` | — | leader 失联 follower 接管时间 |
+| `DFKV_NODE_DEDUP_ARENA_MB` / `DFKV_NODE_DEDUP_GPU_ARENA_MB` | — | dedup 复用 staging arena 大小（重点检查 GPU 复本顿） |
+
+#### g. 一般基础设施
+
+| env | 默认 | 说明 |
+|---|---|---|
+| `DFKV_LOG` | `INFO` | log level |
+| `DFKV_FANOUT_THREADS` | `32` | client 批量 fan-out 线程数（**worker 侧 dfkv client**；大广播/高并发时增） |
+| `DFKV_BATCH_CONCURRENCY` | connector 默认 `8` | batch 分段并发到跨节点并发度（**worker 侧**） |
+| `DFKV_GET_MISS_RETRIES` | `1` | client GET miss 后发重试次数 |
+| `DFKV_PROBE_INTERVAL_MS` | `0`=关 | client 对 server 的主动健康 probe 间隔 |
+| `DFKV_PEER_COOLDOWN_MS` | `2000` | PeerHealth endpoint 快速回避窗口 |
+| `DFKV_PEER_COOLDOWN_MAX_MS` | `30000` | PeerHealth 回避上限 |
+| `DFKV_PEER_BAD_GRACE_MS` | `1000` | PeerHealth 转 bad 前的宽限期 |
+| `DFKV_DISK_HASH_WEIGHT` | — | 盘内 Ketama 虚拟节点权重（数据中平衡关键调优，改动需重启） |
+| `DFKV_READ_COALESCE` | `0` | TCP 端读 convoy 合并主开关（见 README Recommended tuning 表） |
+| `DFKV_READ_COALESCE_RECUR_MS` | `1000` | 复制重现窗口（copy fingerprint 64 字节） |
+| `DFKV_READ_COALESCE_TIMEOUT_MS` | `500` | follower 等待 leader 上限 |
+| `DFKV_READ_MAX_CONNS` | — | 服务端为单 key convoy read 准备的承接连接数 |
+| `DFKV_READ_SHARD_KEYS` | — | convoy convoy 锁分片数 |
+| `DFKV_MDS_IO_TIMEOUT_S` | `60` | MDS 控制面帧读写超时（MDS 进程该） |
+| `DFKV_MDS_ETCD_PROBE_MS` | `30000` | MDS 与 etcd 存活探测窗（MDS 进程该） |
+| `DFKV_TENANT_QUOTAS_COUNT` | — | tenant 配额文件预期条数（容量校验） |
+| `DFKV_BENCH_STALL_MS` | — | dfkv_bench 的连续性门槛（仅 bench 读） |
+
+#### 未收录的常见误配 → 详见 CONNECTORS.md §1.7
+
+客户端设置于 dfkv_server 不生效的 env 包括（不是服务端配置，**将此会静默无效**）：
+`DFKV_RDMA_DEV`（server 读 `--rdma-dev`）、`DFKV_NODE_DEDUP_*`（全部 client 侧）、
+`DFKV_ACCESS_LOG_*`、`DFKV_CLIENT_*`、`DFKV_METRICS_*`、`DFKV_TRACING_*`、
+`DFKV_LIB`/`DFKV_BUILD`（客户端 lib 路径）等。
+
 ## 4. 集群成员管理
 
 ### 4a. MDS 动态发现（推荐）
 
 节点通过 `--mds` + `--group` + `--id` + `--advertise` 向 MDS 自注册。客户端在
 调用 `dfkv_open_v2` 前，把 endpoints、group、poll interval 和可选客户端注册身份
-一次性写入 `dfkv_client_options_v2`；构造成功后自动轮询 MDS。epoch（etcd
-revision）变化时自动重建加权 Ketama 环。增减节点只需启停 `dfkv_server`，
-无需修改已运行客户端的配置。
+一次性写入 `dfkv_client_options_v2`；构造成功后自动轮询 MDS。epoch
+（placement 内容 hash）变化时自动重建加权 Ketama 环。增减节点只需启停
+`dfkv_server`，无需修改已运行客户端的配置。
 
 两层离线检测：
 - **层 2（权威）**：etcd lease 到期（TTL 30s）→ 下次 MDS poll（默认 3s）→
   placement-content epoch 推进 → 环重建。小幅缩容通常约 TTL+一次 poll；
-  超过 shrink guard 百分比的批量缩容还须连续 3 次成功 poll 通过 hysteresis，
-  默认最坏约 30s+3×3s，而不是固定“≤30s”。
+  偏离 `DFKV_MDS_SHRINK_GUARD_PCT`（默认 50，0=同时关闭 shrink/growth
+  两臂，空视图臂常在）的批量视图要走 adoption guard：比较基准是**冻结的
+  trusted reference**（不随每跳下移，挡住 diffuse mass-expiry 逐跳蚕食），
+  shrink 与对称 growth（停机恢复期的批量重注册）两臂可疑视图都必须以
+  **同一值连续 3 次 poll** 才采纳；仍在逐跳变化的缩容/恢复斜坡每次 poll
+  重置 streak，到 plateau 才一次采纳、中途不重建环。批量缩容被 guard
+  挂起时默认最坏约 30s+3×3s，而不是固定“≤30s”。
 - **层 1（快速）**：`PeerHealth` 传输 IO 失败即短路该节点为 miss 并进入 cooldown，不触发环重建
 
 ### 4b. 静态成员表（遗留/单节点备用）<a name="4-legacy"></a>
@@ -306,8 +529,13 @@ n57=192.168.1.57:28001,n58=192.168.1.58:28001,...
 client 基线 → 新节点入环 → `dfkvctl stat --all` 就绪 → 连续稳定环观测 → 停旧
 节点 → 等 lease expiry、客户端 poll 与（批量缩容时）hysteresis 全部收敛 → 再验
 新节点和 client。它不会直接删 etcd key；旧节点由正常 service stop 和 lease
-expiry 退出权威视图。停旧之后任一步失败或收到中断，脚本会先重启旧 service、
-等待其重新入环/就绪，再非零退出；新节点保留在线，避免回滚再制造一次环缩容。
+expiry 退出权威视图。等待轮询内的瞬态 SSH/命令失败（超时、OSError 等）在
+`--timeout` 上限内自动重试。失败回滚由 `started_new`/`old_stopped` 标记定
+边界（远端 systemctl 可能在本地 SSH 超时/中断时已经生效，两个标记都在发起
+SSH 前置位）：旧节点未停且新节点未标记启动 = safe abort 直接退出；新节点
+已启动但旧节点未停 = 先尽力停掉新节点恢复原环再退出；停旧之后任一步失败
+或收到中断，脚本会先重启旧 service、等待其重新入环/就绪，再非零退出——
+新节点保留在线，避免回滚再制造一次环缩容。
 重复执行时若旧节点已退出且新节点健康会直接成功。
 
 ```bash
@@ -466,7 +694,7 @@ deploy/dfkv_load_regression.py \
 
 ## 7. 监控 / 边界
 **完整指标/CLI 参考见 [METRICS.md](METRICS.md)。** 要点：
-- **Prometheus 抓取**（opt-in）：`dfkv_server`/`dfkv_mds` 加 `--metrics-port <p>` → `GET /metrics`、`/healthz`、`/readyz`。MDS 的两个 probe 均反映**现场 etcd 可达性**，运行期故障时 `/readyz` 503、恢复后 200，scheduler 必须用它摘流。cache `/healthz` 反映当前 store/RAM terminal health；`/readyz` 还要求本地启动完成且（配置 MDS 时）**首次 MDS 注册成功**。首次注册在有界 deadline 内失败会退出 1；成功后的 heartbeat 丢失不清 startup-ready latch，须用 registrar heartbeat 指标独立告警。`--id/--group` 成为 `{node,group}` 标签（不设=无标签，向后兼容）。**缺省不开端口 → 行为与旧版一致、对数据面零影响**。Prometheus 直接抓每节点 `:<p>/metrics`。
+- **Prometheus 抓取**（opt-in）：`dfkv_server`/`dfkv_mds` 加 `--metrics-port <p>` → `GET /metrics`、`/healthz`、`/readyz`。`dfkv_mds` 的 `/healthz` 是纯进程 liveness（**不探 etcd**：避免 etcd 抖动引发全副本 CrashLoop + lease 集体过期）；`/readyz` 是 TTL-debounced etcd probe（`DFKV_MDS_PROBE_CACHE_MS`，默认 2500 ms，0=逐请求现场 probe），运行期故障时 503、恢复后 200，scheduler 必须用它摘流。cache `/healthz` 反映当前 store/RAM terminal health；`/readyz` 还要求本地启动完成且（配置 MDS 时）**首次 MDS 注册成功**。首次注册在有界 deadline 内失败会退出 1；成功后的 heartbeat 丢失不清 startup-ready latch，须用 registrar heartbeat 指标独立告警。`--id/--group` 成为 `{node,group}` 标签（不设=无标签，向后兼容）。**缺省不开端口 → 行为与旧版一致、对数据面零影响**。Prometheus 直接抓每节点 `:<p>/metrics`。metrics HTTP 监听本身有加固：`DFKV_METRICS_FIRST_REQ_MS`（默认 30000 ms，0=关，硬上限 3600000）给首行请求设 absolute deadline，`DFKV_METRICS_MAX_CONNS`（默认 64，硬上限 4096）限制并发 scrape 连接，超限连接直接关闭；`--metrics-bind <addr>` 可把监听绑到指定地址（缺省 0.0.0.0，`dfkv_server`/`dfkv_mds` 均支持）。
   - 服务端含：put/hit/miss、bytes、淘汰、quota limit/usage/rejection、错误分型、TCP handler limit/timeout/reject、registrar heartbeat/deadline、`open_connections`、per-disk、**采样延迟直方图 `dfkv_op_latency_seconds{op}`**、RDMA 完成/错误/活跃连接。
   - MDS 含：register/keepalive/list/lease/etcd-error、local lease current/pruned + members gauge。
   - 客户端（SGLang 插件 `/metrics`）：`dfkv_client_*{tp_rank}`，见 [CONNECTORS.md](CONNECTORS.md) §2.4 / METRICS.md §3.3。

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,16 +1,20 @@
 # Optional: fuse dfkv semantics into production dingo-cache (brpc + MDS)
 
-> **Status — read first.** The primary, supported way to run dfkv is the
-> **standalone repo** with its own daemon + native-verbs RDMA transport
-> (`dfkv_server`, see `docs/DEPLOY.md`). It is feature-complete and validated on
-> 400G. The standalone path now includes its **own lightweight MDS** (`dfkv_mds` +
-> etcd) for dynamic membership and service discovery — it does **not** require or
-> touch the production dingo-cache MDS. This document is an **optional,
-> aspirational** guide for an alternative path: re-implementing the same
+> **Status — archived design note (pre-v2), read first.** The primary, supported
+> way to run dfkv is the **standalone repo** with its own daemon + native-verbs
+> RDMA transport (`dfkv_server`, see `docs/DEPLOY.md`). The standalone path
+> includes its **own lightweight MDS** (`dfkv_mds` + etcd) for dynamic membership
+> and service discovery — it does **not** require or touch the production
+> dingo-cache MDS. This document is an **optional, aspirational** guide for an
+> alternative path that was never productized: re-implementing the same
 > Cache/Range/Exist semantics *inside* the production `dingo-cache` (brpc + MDS +
 > DiskCache) so HiCache could talk to the existing cache fleet over brpc instead
-> of dfkv_server. It is **not required** for deployment and parts may be stale —
-> re-confirm line refs on the build tag. Most users want `DEPLOY.md`, not this.
+> of dfkv_server. It was last reconciled against the **pre-v2 codebase** (the
+> v1.x/two-sided-transport era) and does **not** describe the current v2
+> one-sided datapath, `dfkv_open_v2` constructor, or canonical identity codec —
+> re-confirm every line ref and mechanism claim on the current build tag before
+> acting on it. It is **not required** for deployment. Most users want
+> `DEPLOY.md`, not this.
 
 To wire the semantics into the full dingofs build, apply the following.
 **Compile in the full toolchain (gcc-13 / cmake-3.30 / dingo-eureka).**

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -17,10 +17,25 @@
 还要求本地 startup 完成以及（配置 MDS 时）首次注册成功。首次注册 latch 后，
 瞬时 heartbeat 丢失不会清 readiness；用下述 heartbeat 指标单独告警。未配置
 MDS 的 node 仅等待本地 startup 和动态 storage health。
-`dfkv_mds` 的语义不同：`/healthz` 和 `/readyz` 都现场 probe etcd。运行期依赖
-丢失时两者从 200 变 503，scheduler 必须用 `/readyz` 摘流；etcd 恢复后同一
-MDS 进程自动回到 200。
+`dfkv_mds` 的语义不同：`/healthz` 是纯进程 liveness，**不 probe etcd**——
+否则一次秒级 etcd 抖动会让 kubelet 同时重启全部 MDS 副本，CrashLoop 比抖动
+更久并引发 lease 集体过期。`/readyz` 保留 etcd 依赖检查，但经 TTL-debounced
+probe（`DFKV_MDS_PROBE_CACHE_MS`，默认 2500 ms 内复用上次结果，0=恢复逐请求
+现场 probe）：not-ready 副本每 TTL 最多重探一次，kubelet 抓取节奏不会放大成
+etcd 读负载。运行期依赖丢失时 `/readyz` 从 200 变 503，scheduler 必须用它
+摘流；etcd 恢复后同一 MDS 进程自动回到 200。
 
+监听加固 knobs（均 env，resolved 后进 config dump；两进程的 metrics HTTP 还
+支持 `--metrics-bind <addr>` 绑定监听地址，缺省 0.0.0.0）：
+
+| knob | 默认 | 作用 |
+|---|---|---|
+| `DFKV_METRICS_FIRST_REQ_MS` | 30000（0=关，硬上限 3600000） | metrics HTTP 首行请求 absolute deadline（accept 起算），防 drip/silent 连接占 handler |
+| `DFKV_METRICS_MAX_CONNS` | 64（硬上限 4096） | metrics HTTP 并发连接上限，超限直接关闭 |
+| `DFKV_MDS_FIRST_REQ_MS` | 30000（0=关，硬上限 3600000） | `dfkv_mds` 控制面首帧 absolute deadline |
+| `DFKV_MDS_MAX_CONNS` | 4096 | `dfkv_mds` 并发连接上限 |
+| `DFKV_MDS_PROBE_CACHE_MS` | 2500（0=逐请求现场 probe，钳制上限 600000） | `dfkv_mds` `/readyz` etcd probe TTL 去抖 |
+| `DFKV_TCP_FIRST_REQ_MS` | 30000（0=关，硬上限 3600000） | `dfkv_server` 数据面首帧 absolute deadline；resolved 值见 `dfkv_tcp_first_req_ms` |
 
 ```bash
 dfkv_server --dir /mnt/d1,/mnt/d2 --port 12000 --rdma-port 12001 \
@@ -32,7 +47,9 @@ curl -s 127.0.0.1:9100/metrics
 ## 2. 集群 / 环视图（CLI）
 
 > **v1.8.0 起**：`dfkvctl ring` 多一列 `INFO` = 各节点在注册/心跳时自报的
-> `ver=…,engine=…,disks=…,cap=…,ram=…,rdma=…`（运行时真相，非 flag 意图）。
+> `ver=…,engine=…,wr=…,disks=…,cap=…,ram=…,rdma=…,qd=…`（运行时 resolved
+> 真相，非 flag 意图；`wr=` 是 slab 的 direct/buffered resolved 写模式，`qd=`
+> 是 server 端协商后的 pipeline depth）。
 > 全环版本/引擎审计一条命令完成（抓"静默跳升级/引擎不一致"）。`-` = 节点还是
 > 旧版未上报（本身就是版本信号）。信息不参与环 epoch（变更不会触发客户端重建环）。
 > 生效条件：server 与 MDS 都 ≥ v1.8.0（老 MDS 会丢弃该扩展字段）。
@@ -46,17 +63,22 @@ dfkvctl stat <ip:port>                        # 单节点原始 /metrics 文本�
 ## 3. 指标清单
 
 ### 3.1 cache 节点（`dfkv_server` /metrics）
+> 下表只收录告警/排障相关序列，不是全量清单；容量级与诊断序列（per-class
+> slab gauge、rebuild 细节等）以线上 `/metrics` 实际输出为准。
+
 | 指标 | 类型 | 含义 |
 |---|---|---|
-| `dfkv_build_info{version,transport,engine,write_mode}` | gauge | 版本 + 构建传输（rdma/tcp）+ resolved 存储引擎；slab 的 `write_mode` 为 `direct`/`buffered`，显式 file 为 `n/a`；恒为 1 |
+| `dfkv_build_info{version,transport,engine,write_mode[,node,group]}` | gauge | 版本 + 构建传输（rdma/tcp）+ resolved 存储引擎；slab 的 `write_mode` 为 `direct`/`buffered`，显式 file 为 `n/a`；设置 `--id`/`--group` 时追加 `node`/`group` label；恒为 1 |
 | `dfkv_uptime_seconds` | gauge | 启动至今秒数 |
 | `dfkv_storage_healthy` | gauge | 当前 disk group 与显式请求 RAM tier 的 terminal health；0 时 `/healthz`、`/readyz` 均为 503 |
 | `dfkv_cache_put_total` / `cache_hit_total` / `cache_miss_total` | counter | PUT / GET 命中 / GET 未命中 |
 | `dfkv_exist_hit_total` / `exist_miss_total` | counter | Exist 命中 / 未命中 |
+| `dfkv_remove_ok_total` / `remove_miss_total` | counter | Remove 删掉了块 / 目标本就不存在（partial save 清理等路径的诊断分型） |
 | `dfkv_bytes_written_total` / `bytes_read_total` | counter | 读写字节 |
 | `dfkv_accepts_total` | counter | 累计 TCP accept |
 | `dfkv_open_connections` | gauge | 当前打开连接数 |
 | `dfkv_tcp_max_connections` / `dfkv_tcp_io_timeout_seconds` | gauge | cache TCP handler 硬准入上限 / socket I/O 超时的 resolved 配置 |
+| `dfkv_tcp_first_req_ms` | gauge | 首帧 absolute deadline 的 resolved 配置（`DFKV_TCP_FIRST_REQ_MS`，默认 30000，0=关；防 drip 连接占 handler 槽位） |
 | `dfkv_tcp_rejected_connections_total` | counter | 达 handler 上限后拒绝的新 TCP 连接；增长表示 silent/flood 或连接池规模超过预算 |
 | `dfkv_mds_registration_latched{group,node}` | gauge | server 首次 MDS 注册是否完成；成功后保持 1 |
 | `dfkv_mds_first_registration_timeout_ms{group,node}` | gauge | 首次注册 deadline 的 resolved 值；cache daemon 默认 60000，合法配置范围 1000–600000 |
@@ -110,12 +132,16 @@ RDMA 构建额外（折叠进同一 /metrics）：
 | `dfkv_read_coalesce_recur_total` | counter | 命中复现指纹（tombstone）的读——漂移超窗后的晋升证据（v2 驻留窗 `DFKV_READ_COALESCE_RECUR_MS`,默认 1000ms） |
 | `dfkv_read_coalesce_timeouts_total` | counter | follower 等待超时回退自读的次数（`DFKV_READ_COALESCE_TIMEOUT_MS`,默认 500ms;**健康态应恒 0**,持续非零 = leader 连接异常死亡或盘读时延超阈） |
 
-slab 引擎内部（**仅 `--store-engine slab` 时输出**；file 引擎无此系列）：
+slab 引擎内部（**resolved engine=slab 时输出**——按运行时实际引擎判定，不设 flag/env 的默认也命中；file 引擎无此系列）：
 | 指标 | 类型 | 含义 |
 |------|------|------|
 | `dfkv_slab_dio_write_fallback_total` / `dfkv_slab_dio_read_fallback_total` | counter | direct 模式下回退 buffered 的写/读——**非零升高 = page cache 悄悄回来了**（对齐条件被破坏），direct 部署重点盯 |
 | `dfkv_slab_table_sync_total` | counter | slots.tbl fdatasync 周期数（`DFKV_SLAB_TABLE_SYNC_MS`，默认 100ms；限定崩溃复活毒化窗口） |
 | `dfkv_slab_extent_steals_total` / `dfkv_slab_extent_returns_total` | counter | 跨 class extent 抢占（伴随驱逐，容量失衡信号）/ 全空 extent 主动回池（无损再平衡） |
+| `dfkv_slab_cold_steals_total` | counter | 命中"全局最冷 extent"护栏的跨 class 抢占（donor 全部内容都冷于 `DFKV_SLAB_COLD_STEAL_WINDOW` 窗口才走此路，满环自噬护栏；0=窗口关闭） |
+| `dfkv_slab_watermark_evictions_total` | counter | 水位线主动驱逐（`DFKV_SLAB_EVICT_HIGH_PCT`/`_LOW_PCT`，默认 92/88）——赶在 demand 前腾 headroom，满环自噬的第一道防线 |
+| `dfkv_slab_table_rebuilt_objects` / `dfkv_slab_rebuild_scanned_bytes` / `rebuild_scan_chunks` / `rebuild_sparse_ranges` / `rebuild_mmap_scans` | gauge | 上次启动冷升从 slots.tbl 恢复的对象数 / 扫描字节 / chunk / sparse range / mmap 的表数（冷升目录规模诊断） |
+| `dfkv_slab_rebuild_corrupt_records_total` / `rebuild_rejected_records_total` / `rebuild_sequential_fallbacks_total` | counter | 启动 rebuild 丢弃的损坏记录 / 因几何不安全被清除的合法记录 / sparse seek 退化为顺序扫描的次数（任一非零都值得看日志） |
 | `dfkv_slab_deferred_removes_total` | counter | 被在飞 I/O 延迟执行的 Remove |
 | `dfkv_slab_inflight_keys` / `dfkv_slab_prep_holds` | gauge | 锁外 I/O 在飞 key 数 / 未释放的异步 prep 持有数（持续增长 = 泄漏） |
 | `dfkv_slab_reclaimed_total` | counter | 后台回收线程预驱逐的 slot 数（`DFKV_SLAB_RECLAIM_MS`，默认 50ms）——持续为 0 且 PUT 延迟高 = 回收被关或池未满，先查 `--slab-reclaim-ms` |
@@ -138,12 +164,17 @@ RAM 热层（**仅 `DFKV_RAM_TIER=1` 时输出**；关时无此系列，向后�
 | `dfkv_ram_reclaimed_total` | counter | 其中由后台回收线程预驱逐的数量（`DFKV_RAM_RECLAIM_MS`，默认 10ms；flush 积压 >4096 时自动歇拍，此计数暂停属预期） |
 | `dfkv_ram_rebalanced_total` | counter | RAM 层类再平衡搬动的 extent 数（增长阶段不受 flush 积压歇拍影响——从冷 donor 搬 durable extent 恰是 flush-gated 时唯一能扩收速的动作） |
 | `dfkv_ram_objects` / `dfkv_ram_flush_backlog` | gauge | 当前 RAM 常驻块 / 待 flush（未 DURABLE）队列深度 |
+| `dfkv_ram_budget_bytes` / `dfkv_ram_arena_bytes` / `dfkv_ram_large_budget_bytes` | gauge | RAM 层总预算（arena+dedicated）/ arena 固定预留 / 总预算内大对象 dedicated 预留 |
+| `dfkv_ram_used_bytes` / `dfkv_ram_large_used_bytes` | gauge | 已用（常驻 slot + dedicated 分配）/ 其中 dedicated 大对象已用——与上组预算行做水位比 |
 
 > 关键运维信号：COLD `load_get_avg_ms` 骤降 + `dfkv_ram_hit_total` 上升 = RAM 热层生效；`dfkv_ram_put_bypass_total` 或 `dfkv_ram_flush_backlog` 持续升高 = flush 落盘带宽不足，需扩 flush 或降 PUT 速率（见 [docs/ARCHITECTURE.md](ARCHITECTURE.md) §6 背压）。
 
 ### 3.2 MDS（`dfkv_mds` /metrics）
-`dfkv_mds` 自身的 scheduler readiness 不是启动 latch：每次 `/readyz` 请求均
-执行 etcd reachability probe，因此支持 200 → 503 → 200 原地恢复。
+`dfkv_mds` 自身的 scheduler readiness 不是启动 latch：`/readyz` 经
+TTL-debounced etcd probe 判定（`DFKV_MDS_PROBE_CACHE_MS`，默认 2500 ms 内复用
+上次结果，0=逐请求现场 probe），probe 频率由 TTL 去抖决定而非 kubelet 抓取
+节奏；`/healthz` 不探 etcd，恒反映进程存活。因此支持 200 → 503 → 200 原地
+恢复。
 
 
 每环汇总（**v1.10.0 起**；scrape 时 MDS 现场 range 一次 etcd，数值来自各节点心跳携带的 STA1 统计，新鲜度≈心跳周期 10s。全部为 **gauge 语义**——节点重启会使 `_sum` 回落，速率分析请用节点级 counter）：
@@ -246,8 +277,15 @@ C 客户端快照还含传输级指标（RDMA 构建）：
 | `dfkv_connector_info` / `_info_ratio` | gauge | — | 实例信息 / 命中比 |
 | `dfkv_client_peer_latency_avg_seconds` / `_max_seconds` | gauge | `peer` | **逐 dfkv server 节点延迟**（诊断慢节点/慢路径，如跨机房） |
 | `dfkv_client_peer_latency_seconds_count` / `_sum` | counter | `peer` | 逐 peer 延迟采样数 / 总和 |
+| `dfkv_connector_dedup_hits_total` / `fetches_total` / `wait_hits_total` / `wait_timeouts_total` | counter | — | 同主机 rendezvous dedup（命中率漏斗顶部：TP 复制读被合并到 1× 还是按 rank 扇出；timeouts 应趋零） |
+| `dfkv_connector_gpu_dedup_hits_total` / `fetches_total` / `wait_hits_total` / `wait_timeouts_total` | counter | — | 同上 CUDA IPC flavor（GPU destination 走 GPUDirect 时） |
 
 > 逐 peer 延迟由 C++ 客户端主动探测（`DFKV_PROBE_INTERVAL_MS`）：SGLang HiCache 开 metrics 即自动开；vLLM/LMCache 需手动 `export DFKV_PROBE_INTERVAL_MS=5000`。
+
+> dedup 族的 C 快照原始名是 `dfkv_client_dedup_*` / `dfkv_client_gpu_dedup_*`
+> （无 label），OTLP 导出时改写为 `dfkv_connector_` 前缀并按本连接器身份上报。
+> 该族**只经 opt-in OTLP push 输出**：SGLang 插件本地 `/metrics`（§3.3）不镜像，
+> 本地排查只能直接读 C 快照（或在连接器日志/OTLP 管道里看）。
 
 ### 3.5 vLLM 连接器客户端健康（`dfkv-vllm` /metrics，经 prometheus_client，pull）
 §3.4 是 OTLP **push**（opt-in）；此外 vLLM 连接器后台轮询线程读同一 C 客户端快照（`DFKV_CLIENT_STATS_POLL_S`，默认 15s，0=关），把**环/MDS 健康**镜像为带 `{tp_rank}` 的 Gauge，直接落在 vLLM 自带 `/metrics` 上（**无需开 telemetry**）。这样"空环（写无处可去、ok=0）/ MDS 不可达"在 scrape 上可见，而非只在客户端日志里——正是一次生产事故（静默空环）的教训。

--- a/docs/access_log.md
+++ b/docs/access_log.md
@@ -12,7 +12,7 @@
 实测样例（一个 TP rank 的文件，含 `init` 与各数据面接口）：
 
 ```
-2026-06-15 20:16:16.727 init(r0 glm-5.1 tp=0/8 mla=1) : ok static <0.000461>
+2026-06-15 20:16:16.727 init(r0 glm-5.2 tp=0/8 pcp=0/1 dcp=0/1 mla=1) : ok mds-discovery transport=rdma <0.000461>
 2026-06-15 20:16:16.734 batch_set_v1(r0 3 keys) : ok 3/3 <0.005716>
 2026-06-15 20:16:16.734 batch_get_v1(r0 3 keys) : hits=3/3 <0.000392>
 2026-06-15 20:16:16.734 batch_exists(r0 3 keys) : prefix=2/3 <0.000110>
@@ -24,6 +24,11 @@
 ```
 
 每行 `<参数>` 都以 `r{tp_rank}` 开头，合并多 rank 文件查看时也能区分来源。
+
+> v2.0.0 起 operator 通过配置自定义 namespace 别名会被**拒绝（fail-closed）**——缓存身份只能由
+> connector 源码里的 canonical namespace 携带。排查命中率第一眼就看 `init` 行：
+> 它打印了 canonical identity 的坐标（`tp=… pcp=… dcp=… mla=…`）与发现/传输方式
+> （`ok static` / `ok mds-discovery transport=…`），写读两侧任何一处不一致都是 cold miss。
 
 ## 配置项
 
@@ -144,11 +149,19 @@ rm -f /etc/dfkv/hot.json
 
 | op | 触发时机 | `<结果>` 取值 |
 |---|---|---|
-| `init` | 插件构造（打开连接 + MDS 发现） | `ok static` / `ok mds-discovery` |
+| `init` | 插件构造（打开连接 + MDS 发现） | `ok static` / `ok mds-discovery`，后接 ` transport=tcp\|rdma` |
+| `register_mem_pool_host` | host KV 池 RDMA 注册 | `registered N region(s)` / `no backing buffer found` / `skip (<异常类型>)` |
+| `register_mem_host_pool_v2` | 多池 host pool（v2 接口） | 同 `register_mem_pool_host`；探测失败会 `raise` |
+| `pool_components` | 多池 layout 探测（随 `register_mem_host_pool_v2`） | `components=(…) replicated=<bool> (ok)` |
+| `register_mem_pool_device` / `register_mem_pool_device_sidecar` / `register_mem_pool_device_draft` / `register_mem_pool_device_draft_sidecar` | GPU 池 / DSA sidecar / draft / draft-indexer 池注册（bypass 下失败即拒启动） | `registered N device region(s)`（sidecar/draft 相应加修饰词）/ `no … device buffer registered`；失败 `failed (<异常类型>)` 并 `raise` |
 | `batch_set_v1` | 零拷贝写（生产热路径） | `ok H/N`；MLA 非 0 号 rank 为 `backup_skip` |
 | `batch_get_v1` | 零拷贝读（生产热路径） | `hits=H/N` |
+| `batch_set_v1_device` | device-directed 零拷贝写（GPUDirect，同语义、同结果格式） | `ok H/N (device-direct)`；MLA 非 0 号 rank 为 `backup_skip` |
+| `batch_get_v1_device` | device-directed 零拷贝读 | `hits=H/N (device-direct)`；截断读追加 ` short_read=S` |
+| `batch_set_v1_device_draft` / `batch_get_v1_device_draft` | DSA draft 池 device-directed 读写（同语义零拷贝） | `ok H/N (draft device-direct)` / `hits=H/N (draft device-direct)`；带 indexer sidecar 时追加 ` +indexer H/N`；复制 draft 的非 0 号 rank 写为 `backup_skip` |
 | `batch_exists` | 前缀命中探测 | `prefix=N/total` |
-| `batch_set_v2` / `batch_get_v2` | 多池（Mamba/SWA/DeepSeek-V4） | 逐池 `kv ok=3/3, extra ok=3/3` |
+| `batch_set_v2` / `batch_get_v2` | 多池（Mamba/SWA/DeepSeek-V4） | 逐池 `kv ok=3/3, extra ok=3/3`；put 重试恢复时追加 ` retry_ok=N` |
+| `batch_set_v2_device` / `batch_get_v2_device` | 多池 device-directed（DSA L2-bypass：anchor kv 池 + sidecar 均走 GPU 直达） | `kv N/n (device-direct); <pool> ok=…`；put 重试恢复时追加 ` retry_ok=N` |
 | `batch_exists_v2` | 多池前缀探测 | `kv=K/total <pool>=…` |
 | `set` / `get` | generic 单页读写 | `ok`/`fail`/`fail none`；`hit`/`miss`，参数带字节数 |
 | `batch_set` / `batch_get` | generic 批量（循环 set/get） | `ok H/N` / `hits=H/N` |
@@ -156,6 +169,7 @@ rm -f /etc/dfkv/hot.json
 
 > 异常会被记成 `... : FAIL <异常类型>: <信息>` 并**照常向上抛出**（不吞异常）。
 > `init` 里若 `dfkv_open` / 发现启动失败即属此类。最早的 `interface_v1` 必填校验在日志配置之前就 `raise`，不记录。
+> `retry_ok=N`（put 重试恢复计数，见 `dfkv_hicache.py` `_put_retry_recovered`）对 `batch_set_v1` / `batch_set_v1_device` / `batch_set_v2` / `batch_set_v2_device` 一律追加在结果尾部。
 
 ## 性能
 

--- a/docs/datapath-perf-notes.md
+++ b/docs/datapath-perf-notes.md
@@ -1,6 +1,27 @@
 # dfkv RDMA datapath — perf notes & investigated-but-deferred items
 
-## Current datapath (as of 187d241)
+## Current one-sided RDMA v2 payload plane
+
+RDMA v2 uses small two-sided SEND/RECV messages only for requests, descriptors,
+and status:
+
+- PUT uses client `RDMA_WRITE_WITH_IMM` into a lease from the server's registered
+  process-wide receive segment.
+- GET sends the client `{addr,rkey,len}` targets, then the server uses
+  `RDMA_WRITE` to place the value directly into the registered HiCache buffers.
+- Cold values still require a request because their source is NVMe rather than a
+  remotely addressable persistent MR; the server stages the disk read before its
+  one-sided WRITE.
+
+The retired two-sided payload protocol is not a fallback. Capability, QP,
+receive-segment, or registration mismatch rejects the RDMA connection.
+
+The negotiated pipeline depth contract is `qd = min(client depth, server depth)`
+(`DFKV_RDMA_DEPTH` on the client is an upper bound). The server's resolved
+runtime value can be audited live through the `qd=` column of `dfkvctl ring`
+INFO — check it before reasoning about pipelining behavior.
+
+## Retired two-sided plane (187d241, superseded by v2)
 
 - RC **two-sided SEND/RECV**, two-end **zero-copy** (server reads disk straight into
   the registered send buffer; client SEND/RECV scatters straight into the caller's
@@ -65,22 +86,30 @@ Empirical (8x400G IB testbed, 3-node, 1 MiB PUT, single writer thread, batch 64)
   node: the SSD's read latency varies several-fold with other tenants' I/O, which can
   masquerade as a depth effect — interleave depth values within one run to cancel it.
 
-## Current one-sided RDMA v2 payload plane
+The depth-flat and multi-connection results above were collected before the
+one-sided cutover. Under the v2 shared-segment PUT the server no longer receives
+the payload inline in its serve loop (it lands directly in the leased slot via
+`WRITE_WITH_IMM`), and the slab store commits through the async/io_uring write
+path — the mechanism premise behind those numbers has changed. They remain
+useful topology guidance, but absolute throughput and latency claims for
+current v2 require a new hardware run.
 
-RDMA v2 uses small two-sided SEND/RECV messages only for requests, descriptors,
-and status:
+## v2 datapath performance: TBD
 
-- PUT uses client `RDMA_WRITE_WITH_IMM` into a lease from the server's registered
-  process-wide receive segment.
-- GET sends the client `{addr,rkey,len}` targets, then the server uses
-  `RDMA_WRITE` to place the value directly into the registered HiCache buffers.
-- Cold values still require a request because their source is NVMe rather than a
-  remotely addressable persistent MR; the server stages the disk read before its
-  one-sided WRITE.
+No post-cutover hardware run exists yet. The items a v2 perf chapter must
+measure before any absolute claims are made:
 
-The retired two-sided payload protocol is not a fallback. Capability, QP,
-receive-segment, or registration mismatch rejects the RDMA connection.
-
-The depth-flat and multi-connection results above were collected before this
-one-sided cutover. They remain useful topology guidance, but absolute throughput
-and latency claims for current v2 require a new hardware run.
+- **PUT slot-to-durable latency**: client `WRITE_WITH_IMM` slot submission →
+  server commit acknowledgment, at 1 MiB and page-scale payloads, across
+  negotiated `qd` values.
+- **Server `RDMA_WRITE` GET**: warm (RAM-tier) and cold (NVMe → stage → WRITE)
+  paths, single connection vs `batch_concurrency` fan-out; compare against the
+  retired two-sided numbers above.
+- **Commit granularity**: per-slot store batches vs depth on the slab
+  io_uring write path (`dfkv_slab_uring_write_batches_total`).
+- **Depth curve under v2**: re-prove or refute depth-flatness on the one-sided
+  plane (`qd = min(client, server)`; audit the runtime value via `dfkvctl ring`
+  INFO `qd=`).
+- **Shared receive-segment capacity effects**: `DFKV_RDMA_RECV_SEGMENT_SIZE`
+  sizing vs concurrent connection count (`qd`×slot-size lease per connection);
+  exhaustion behavior and its impact on admitted concurrency.

--- a/docs/hit_rate_funnel.md
+++ b/docs/hit_rate_funnel.md
@@ -19,10 +19,10 @@
 - `dfkv_exist_hit_total` / `dfkv_exist_miss_total` → 命中率 = hit / (hit + miss)
 - `dfkv_cache_hit_total`（按 key 的读命中）、`dfkv_objects`、`dfkv_used_bytes`
 
-**健康态**：稳态热工作集下应 ≈ 100%（实测清环 99.8%）。
+**健康态**：稳态热工作集下应 ≈ 100%（实测清环 99.8%）。环级真值看 [METRICS.md](METRICS.md) §3.2 的 `dfkv_mds_group_*` 系列（每环容量/水位/`hits_sum`/`misses_sum`，来自 MDS 聚合心跳，比逐节点 scrape 更快定位整环塌陷）。
 
 **失败模式与判读**：
-- **环写满 → 命中率断崖归零**：`dfkv_used_bytes / cap > ~0.95` 且 `dfkv_evictions_total` 与写入量同步暴涨 = 满环自噬（刚写的热页被逐出）。**修**：容量水位（`DFKV_SLAB_EVICT_HIGH_PCT`，看 `dfkv_slab_watermark_evictions_total` 是否在动）+ 别让环写满。
+- **环写满 → 命中率断崖归零**：`dfkv_used_bytes / cap > ~0.95` 且 `dfkv_evictions_total` 与写入量同步暴涨 = 满环自噬（刚写的热页被逐出）。**修**：容量水位（`DFKV_SLAB_EVICT_HIGH_PCT` 默认 92 / `DFKV_SLAB_EVICT_LOW_PCT` 默认 88，看 `dfkv_slab_watermark_evictions_total` 是否在动）+ 别让环写满。
 - **identity 不一致**：环不满但命中率低 → 对齐 exact runtime model identity 和 canonical object-key 坐标；任何 namespace/key 差异都是 cold miss。
 - **identity 相同但 layout 不同**：若命中后 shape/内容异常，同一 namespace+key 被不同 dtype/page/shape/layout 复用；这是 type-safety violation。停止混写，bump source-controlled raw-layout ID，并同时发布所有 writer/reader。
 
@@ -35,7 +35,7 @@ exist 命中 **≠** 数据真被拉回。SGLang HiCache 的 `prefetch-policy=ti
 **指标**：
 - 客户端 access log（`access_log=1`）：`batch_get_auto_sg(N keys) hits=N/N`、`batch_exists prefix=X/N`
 - 服务端读回量：`dfkv_bytes_read_total` 增量 vs 工作集应拉回的字节。远小于应拉回量 = 大量预取被 timeout 砍掉。
-- 客户端会合（**本期新增遥测**）：`dfkv_connector_dedup_hits_total` / `_fetches_total` / `_wait_hits_total` / `_wait_timeouts_total`（GPU 目标另有 `dfkv_connector_gpu_dedup_*`）。
+- 客户端会合：`dfkv_connector_dedup_hits_total` / `_fetches_total` / `_wait_hits_total` / `_wait_timeouts_total`（GPU 目标另有 `dfkv_connector_gpu_dedup_*`）。这组 de-dup 指标**只经 OTLP push** 上报（见 [METRICS.md](METRICS.md) §3.4），SGLang 本地 `/metrics` **不镜像**；C 客户端快照里的原始名是 `dfkv_client_dedup_*`（push 时改名为 `dfkv_connector_dedup_*`）。
 
 **判读**：
 - 会合（node-dedup）**默认关**（R2 A/B 实测 2026-07-17：推理批形状下会合协调开销反噬——dedup-on 热轮 TTFT +19-36% 恶化、批 p99 22s；dedup-off 直连 8× 读放大反而 TTFT −43%、吞吐 +50-71%）。仅多节点环 fabric 带宽吃紧时显式开 `DFKV_CLIENT_NODE_DEDUP=1`，且必须实测热轮为正收益。开了之后才看 `dedup_hits/wait_hits/fetches` 三兄弟。


### PR DESCRIPTION
## What
Sync README.md and docs/* to the actual v2.0.0 implementation (cbe53fa, tagged v2.0.0). A three-way review catalogued every mismatch against source; every edit was verified against code anchors before writing.

## Changes
- **README.md**: CTest counts 264/288 → 570/632 (v2.0.0 CI truth); drop stale v1.34+ rollout-order block; HiCache pool-aware v2 interface naming; rdma-depth recommendation nuance; MDS ACCEPT_LEGACY pointer; server/MDS readiness probe semantics; listener-hardening knobs (FIRST_REQ_MS family, METRICS_MAX_CONNS); 18-byte dev-frame name ceiling; NUMA admission all-inadmissible fallback.
- **docs/CONNECTORS.md**: correct generic path status (implemented, fail-fast to prevent silent degradation); drop DFKV_MEMBERS/TP_RANK misstatements; canonical namespace keys (tenant_id/model_revision); vLLM replicated-MLA and all-SG-group probe contracts; GET fail-loud (a869b13); remove non-existent BOOT-SLOW diagnostic; dfkv_open_v2 naming; clear stale v1.x version anchors throughout.
- **docs/DEPLOY.md**: /healthz is pure process liveness (no etcd probe — prevents CrashLoop cascades and lease-mass-expiry), /readyz is TTL-debounced etcd probe (DFKV_MDS_PROBE_CACHE_MS); NUMA admission falls back to all enabled rails; epoch is placement-content hash (not etcd revision); shrink-guard frozen trusted reference with symmetric growth arm; listener-hardening knobs; device-name fail-fast; --metrics-bind; slab watermark knobs; mark 93% speed claim as v1.35-era.
- **docs/METRICS.md**: same readiness truth; probe TTL behaviour; dfkvctl ring INFO now includes wr=/qd=; build_info adds node/group labels with --id/--group; slab/RAM/remove and rendezvous (dedup) metric rows; alarm-only table header declaration.
- **docs/ARCHITECTURE.md**: NUMA all-inadmissible fallback row; listener knobs and DFKV_MDS_ACCEPT_LEGACY rows in §7 config matrix; drop stale P3 roadmap tag.
- **docs/access_log.md**: canonical init sample with coordinates and transport suffix; register_mem_pool and device/DSA op families; retry_ok note; namespace-alias fail-closed note.
- **docs/hit_rate_funnel.md**: rendezvous metrics only via OTLP push, not the local /metrics mirror; slab watermark defaults; group-level truth pointer.
- **docs/datapath-perf-notes.md**: promote one-sided plane to the first section; demote retired two-sided plane with a v2 mechanism caveat and TBD baseline.
- **docs/INTEGRATION.md**: archived-design banner.

## Verification
- git diff --check: clean
- No v1.x version anchors remain outside the etcd '/dfkv/v1/groups' prefix
- All relative links between docs intact
- +301 / -111 across 9 files

No code changes; docs-only PR.