### PR TITLE
docs(deploy): fix --max-msg mismatch causing PUT rejection

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -190,7 +190,7 @@ Environment=DFKV_TENANT_DEFAULT_QUOTA_BYTES=0
 # 此生产示例故意不设置 --store-engine/DFKV_STORE_ENGINE：resolved 默认即 slab。
 ExecStart=/usr/local/bin/dfkv_server \
   --dir /mnt/disk1/dfkv,/mnt/disk2/dfkv,/mnt/disk3/dfkv \
-  --port 28000 --rdma-port 28001 --max-msg 4194304 \
+  --port 28000 --rdma-port 28001 --max-msg 67108864 \
   --rdma-dev ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7 \
   --rdma-depth 4 --rdma-numa 1 \
   --ram-tier on --ram-tier-bytes 1099511627776 --ram-tier-shards 16 \
@@ -227,9 +227,11 @@ LimitMEMLOCK=infinity        # RDMA 需要锁页内存
 WantedBy=multi-user.target
 ```
 
-> `DFKV_RDMA_MAX_BLOCK_BYTES=4194304` 是 **client-only DCP2 声明**，须注入每个
-> SGLang/vLLM/LMCache inference client 进程；server 用 `--max-msg 4194304`
-> 验证上限，不读取该 client env。
+> **`--max-msg` 必须与 client 默认 `DFKV_RDMA_MAX_BLOCK_BYTES`（64 MiB = 67108864）匹配或更大**：
+> server `--max-msg` 是 RDMA receive-segment 单 slot 上限；client 在 DCP2 协商时声明自己的
+> `DFKV_RDMA_MAX_BLOCK_BYTES`（默认 64 MiB）。若 server `--max-msg` < client 声明值，server
+> 拒绝连接（日志 `client declared max block ... above this server's cap ...`），所有 PUT 失败
+> 但 exist 不受影响（不走 max_block 协商）。**生产 systemd unit 必须 `--max-msg 67108864`**。
 >
 > Completion timeout：`DFKV_RDMA_OP_TIMEOUT_MS`（默认 5000）约束单操作；
 > `DFKV_RDMA_BATCH_OP_TIMEOUT_MS`（unset/0 = 跟随前者）覆盖 **所有** multi-item
@@ -637,7 +639,7 @@ Rollback trigger and procedure:
 3. 冒烟（任一能访问内网的机器）：
    ```bash
    dfkv_smoke --members n57=192.168.1.57:28000 --size 2752512                          # TCP
-   DFKV_RDMA=1 DFKV_RDMA_MAX_BLOCK_BYTES=4194304 \
+   DFKV_RDMA=1 DFKV_RDMA_MAX_BLOCK_BYTES=67108864 \
      DFKV_RDMA_DEV=ib7s400p0 dfkv_smoke --members n57=192.168.1.57:28001 --size 2752512
    ```
 4. 端到端零拷贝校验（插件 → libdfkv → RDMA → server，验证 payload 直落缓冲）：


### PR DESCRIPTION
## Problem

The systemd unit example in DEPLOY.md used `--max-msg 4194304` (4 MiB) but the client default `DFKV_RDMA_MAX_BLOCK_BYTES` is 64 MiB (67108864). When the server cap is below the client's declared max block, the server refuses the RDMA connection on every PUT (exist probes are unaffected because they do not negotiate max\_block), producing:

```
client declared max block 67108864B, above this server's cap 4194304B; refusing the connection
```

## How it was caught

During the v2.0.0 SGLang HiCache L3 integration test on a B200 host (xb01-0064):
- `dfkv_exist_miss_total=1129` (RDMA control path worked fine)
- `dfkv_rdma_v2_put_writes_total=0` (every PUT rejected)
- `batch_set_v1 ok=0/1` for every page (L3 write-through failed)
- After fixing `--max-msg` to 67108864: `cache_put_total=508`, `exist_hit_total=169`, `cache_hit_total=11`, `bytes_read=30MB` — full L3 hit verified.

## Fix

- `--max-msg 67108864` in the systemd unit example
- `DFKV_RDMA_MAX_BLOCK_BYTES=67108864` in the client env example
- New callout explaining the matching requirement and the symptom when mismatched