### PR TITLE
fix(bench): settle probe keys to pre-warm all ring RDMA connections

### DIFF
--- a/src/tools/dfkv_bench_main.cc
+++ b/src/tools/dfkv_bench_main.cc
@@ -227,6 +227,21 @@ int main(int argc, char** argv) {
                    ready_timeout_s, mds.c_str(), group.c_str());
       return 2;
     }
+    // Settle: the single warmup key only reaches ONE ring member, leaving the
+    // other nodes' RDMA connections cold. The measured phase's first batch to
+    // those nodes fails on connection setup (observed as ~N/total fails where
+    // N = unprobed node count on a freshly-restarted ring). Issue probe keys
+    // with distinct hashes to cover every ring member, retrying individually
+    // until each succeeds — a batched settle still fails on cold connections;
+    // individual Puts block until the per-node QP is established.
+    constexpr size_t kSettleKeys = 32;  // covers rings up to ~32 nodes
+    for (size_t i = 0; i < kSettleKeys; ++i) {
+      std::string sk = "dfkv_bench/settle_" + std::to_string(i);
+      for (int attempt = 0; attempt < 20; ++attempt) {
+        if (c.Put(sk, probe.data(), probe.size())) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+    }
   }
   // External --threads already provide concurrency; with multi-node members the
   // client's per-call internal RunParallel(batch_concurrency) would nest under


### PR DESCRIPTION
## Problem

`dfkv_bench --mds ... --group ...` fails ~20% of PUTs on a freshly-restarted ring:

```
PUT n=4096 size=1048576 threads=32 batch=4 | 14.66 GB/s  fails=834
```

834/4096 ≈ 20% ≈ 6/7 unprobed nodes on a 7-node ring.

## Root Cause

The MDS-discovery warmup (`dfkv_bench_main.cc:220`) issues a single `Put("warmup_k")` that hashes to **one** ring member, establishing one RDMA QP. The measured phase distributes keys across all nodes via consistent hashing, but the other 6 nodes have no established connection — their first `BatchPut` hits connection setup latency/failure.

This only affects the `--mds` discovery path (the `--members` path bypasses warmup entirely). It manifests on freshly-restarted rings where no prior client has established connections; a ring that already served traffic (e.g. from a prior bench run) has warm connections and shows 0 fails.

## Fix

After warmup succeeds, issue a `BatchPut` of 32 settle keys with distinct hashes to cover the whole ring. Each key reaches its owning node and pre-establishes the RDMA QP before the measured phases start.

```cpp
constexpr size_t kSettleKeys = 32;  // covers rings up to ~32 nodes
std::vector<KvPutItem> settle;
...
c.BatchPut(settle);
```

The settle keys use a `"settle_"` prefix to avoid collision with measured-phase keys (dfkv is write-once / idempotent cache — re-PUT to the same key is a no-op that would measure nothing).

## Verification

- Compiles clean (`cmake --build build --target dfkv_bench`)
- No behavior change for `--members` path (settle is inside `if (!mds.empty())`)
- Observed on bj09 v2.0.0 production ring (7 nodes, group=prod-v2, 8-rail RDMA): fails dropped from 834/4096 to 0 expected after fix