### PR TITLE
docs: change recommended RDMA depth from 4 to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ fabric selection and capacity explicit.
 |---|---|---|
 | `--rdma-dev` | leave unset for one local HCA; list the fabric explicitly for multi-rail | Unset selects the first `ACTIVE` local HCA (peer names may differ). A comma list opts into multi-rail, anchors only listed active devices, and requires compatible names/fabric on both hosts; inactive entries are rejected. |
 | `DFKV_DISK_HASH_WEIGHT` | `10` | Flattens the intra-server disk ring share from ±20 % to ±3 % so the hottest disk stops gating the whole node (+5–6 % cold read, ~2× lower p99). **Re-routes existing keys** (cache miss + refill) — flip together with a restart/upgrade window. |
-| `--rdma-depth` | `4` | Set explicitly; the server defaults to 1 and the handshake takes min(client/server). Deeper is not itself a throughput knob. It consumes more slots from the fixed shared receive segment. |
+| `--rdma-depth` | `1` | The server defaults to 1 and the handshake takes min(client/server). Depth is **not** a throughput knob (measured flat on PUT and GET across depth 1/2/4/8/16 on 8×B200 loopback); it only hides network latency. Raising it inflates per-connection receive-segment lease (depth × slot_size), which can exhaust the shared segment under high connection counts — depth=8 × 64 MiB slot = 512 MiB/conn, a 16 GiB segment holds only ~31 connections. Keep 1 unless the link is latency-bound and the segment has headroom. |
 | `--ram-tier` / `--ram-tier-bytes` / `--ram-tier-shards` | on / sized to the node / `16` for ≥100 GiB arenas | Large arenas contend on the shard locks under mixed load (+40 % mixed R/W at 16 shards on a 128 GiB arena); small (≤16 GiB) arenas are fine at the default 8. |
 | `--store-engine` | `slab` | Index rebuilds on restart; removes file-per-block hazards. |
 | `DFKV_TCP_FIRST_REQ_MS` / `DFKV_MDS_FIRST_REQ_MS` / `DFKV_METRICS_FIRST_REQ_MS` | `30000` (default) / `0` = off | First-request deadline per listener: a connection that sends nothing before the deadline is dropped, capping idle pre-auth connections. |
@@ -252,7 +252,7 @@ fabric selection and capacity explicit.
 | Knob | Recommended | Why |
 |---|---|---|
 | `DFKV_RDMA_DEV` | best: **rail affinity per rank** — inject the matching local/server HCA name per process; simpler on symmetric hosts: the full comma list + `DFKV_RDMA_NUMA=1` | Explicit values are sent to the peer, so verify those names exist on both hosts/containers. Leave unset to let each host select its own first ACTIVE HCA when names differ. |
-| `DFKV_RDMA_DEPTH` | `4` | Pairs with the server's posted depth (window = min of both, negotiated). |
+| `DFKV_RDMA_DEPTH` | `1` | Pairs with the server's posted depth (window = min of both, negotiated). Default 1; raising it inflates receive-segment lease and can exhaust the shared segment without improving throughput. |
 | `DFKV_FANOUT_THREADS` | unset (default 32) | Only wide single-process clients (benchmarks, many concurrent Batch* callers) need more. |
 
 **Read-side convoy collapse (v2.0, opt-in)** — for MLA + TP-N inference
@@ -275,7 +275,7 @@ the file is *sourced*, so new knobs must be explicitly **exported** by the
 start script or a systemd drop-in to reach the server process.
 
 **Benchmark reproduction** (`dfkv_bench`): `DFKV_RDMA=1` (explicit, or it
-silently measures TCP), 8-rail `DFKV_RDMA_DEV`, `DFKV_RDMA_DEPTH=4`,
+silently measures TCP), 8-rail `DFKV_RDMA_DEV`, `DFKV_RDMA_DEPTH=1`,
 `DFKV_FANOUT_THREADS=256`; cold-read sweet spot `--threads 16 --batch 8
 --size 4194304` per client node. Keep `--count` ≤ the seed's written key count,
 and let the drives settle ~10 min after bulk writes before cold-read A/Bs (FTL

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -115,9 +115,9 @@ B_required >= N_data × depth × S_data + N_control × depth × S_control
 
 `N_data` / `N_control` 是该 server 上所有 rank、进程的**峰值 live + client
 pool 中空闲连接**；lease 一直保留到 QP 被销毁或 `DFKV_RDMA_IDLE_MS` 回收，
-线程峰值留下的 pooled QP 也要计入。4 MiB 声明、depth=4 时
-`S_data=4,198,400 B`，2 GiB segment 最多约 127 条 data QP（未扣 control
-lease）；depth=8 时约 63 条。上线同时观察
+线程峰值留下的 pooled QP 也要计入。64 MiB 声明、depth=1 时
+`S_data=67,112,960 B`，2 GiB segment 最多约 31 条 data QP（未扣 control
+lease）；depth=4 时约 7 条，depth=8 时约 3 条。上线同时观察
 `dfkv_rdma_recv_segment_free_bytes` 与 `dfkv_rdma_v2_ready`；free 接近 0
 即扩容或缩小声明/depth/pool，避免新连接被拒绝。
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -144,7 +144,7 @@ test -e /etc/dfkv/tenant-quotas ||
 > | 项 | xb01 生产 (v1.37/1.40) | 本示例 (v2.0.0) | 变动 |
 > |---|---|---|---|
 > | `--rdma-dev` | 8 轨全列 | 8 轨全列 | 一致 |
-> | RDMA depth | `DFKV_RDMA_DEPTH=32` | `DFKV_RDMA_DEPTH=4` | depth-flat；超过共享 segment 槽位会被吃（segment 2 GiB / 4 MiB ≈ 127 个 data QP），不宜再叠高 |
+> | RDMA depth | `DFKV_RDMA_DEPTH=32` | `DFKV_RDMA_DEPTH=1` | depth-flat（实测 depth 1/2/4/8/16 对 PUT/GET 吞吐无差异）；depth>1 膨胀每连接 segment lease（depth×slot），高并发时易耗尽共享 segment |
 > | RDMA_NUMA | `1` | 保留 `DFKV_RDMA_NUMA=1` | 一致 |
 > | RAM tier | on + 1TiB | on + 1TiB（`--ram-tier-bytes 1099511627776`） | 一致 |
 > | SERVER_URING | 开，depth=32 | 默认关，经 drop-in 打开（须编 `-DDFKV_WITH_URING`） | v2 保留 |
@@ -162,10 +162,10 @@ After=network-online.target dfkv-mds.service
 Wants=network-online.target
 [Service]
 Type=simple
-# v2 shared segment 示例：RDMA depth=4 上限 4 MiB、segment=2 GiB
-# （对应 ~127 data QP；client 侧也对应 dfkv_rdma_depth=4/segment-size 同口径，CONNECTORS §1.2.1
-#  的公式按 peak live + pooled QP 复算）。
-Environment=DFKV_RDMA_DEPTH=4
+# v2 shared segment 示例：RDMA depth=1（默认，slot=64MiB@max-msg 64MiB）、segment=2 GiB
+# （depth=1 时 ~31 data QP；depth>1 膨胀 lease，高并发易耗尽，CONNECTORS §1.2.1
+# 的公式按 peak live + pooled QP 复算）。
+Environment=DFKV_RDMA_DEPTH=1
 Environment=DFKV_RDMA_RECV_SEGMENT_SIZE=2147483648
 # 8×400G 轨全轨白名单 + NUMA：B200 生产 host 一台带 8 个 HCA 轨；
 # server 两端白名单到**同名互通**一组轨；client 的 `DFKV_RDMA_NUMA=1` 后每 rank 优先本 NUMA 轨，
@@ -192,7 +192,7 @@ ExecStart=/usr/local/bin/dfkv_server \
   --dir /mnt/disk1/dfkv,/mnt/disk2/dfkv,/mnt/disk3/dfkv \
   --port 28000 --rdma-port 28001 \
   --rdma-dev ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7 \
-  --rdma-depth 4 --rdma-numa 1 \
+  --rdma-depth 1 --rdma-numa 1 \
   --ram-tier on --ram-tier-bytes 1099511627776 --ram-tier-shards 16 \
   --cap 6597069766656 --mds 10.0.0.1:9400,10.0.0.2:9400 \
   --metrics-port 28010 --group default --id n57 \
@@ -307,8 +307,8 @@ journalctl -u dfkv -n 10 --no-pager
 >
 > **v2 segment 预算**：`slot=align4K(4096 + max_raw_payload)`；
 > `segment >= Σ(live + client-pool-idle data/control QP × depth × slot)`。lease
-> 保留到 QP 销毁或 idle reclaim，不能只数在飞请求。4 MiB/depth=4/2 GiB
-> 约容纳 127 条 data QP（未扣 control lease）。上线先看
+> 保留到 QP 销毁或 idle reclaim，不能只数在飞请求。64 MiB/depth=1/2 GiB
+> 约容纳 31 条 data QP（未扣 control lease）；depth=4 时约 7 条，depth=8 时约 3 条。上线先看
 > `dfkv_rdma_recv_segment_free_bytes`、`dfkv_rdma_v2_ready` 和
 > `dfkv_rdma_v2_conns_opened_total`；free 接近 0 会使新连接被拒绝。
 
@@ -661,7 +661,7 @@ trial 汇总 median/p95/p99；延迟从 workload 前后的 server
 并在隔离压测窗口执行，避免其它流量混入 histogram delta。
 
 ```bash
-DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 DFKV_RDMA_DEPTH=4 \
+DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 DFKV_RDMA_DEPTH=1 \
 deploy/dfkv_load_regression.py \
   --baseline-mds 10.0.1.1:9400 --baseline-group glm \
   --baseline-metrics 10.0.1.11:28010,10.0.1.12:28010 \


### PR DESCRIPTION
## Change recommended RDMA pipeline depth from 4 to 1

### Rationale

The server and client code already default `DFKV_RDMA_DEPTH` to 1, but the deployment docs (README, DEPLOY.md, CONNECTORS.md) recommended depth=4 in examples and tuning tables. Hardware measurements on xb01-0064 (8×B200, 2×NVMe, RDMA v2 8-rail, loopback) show depth is **not a throughput knob**:

| depth | PUT t=1 | PUT t=32 | GET t=1 | GET t=32 |
|-------|---------|----------|---------|----------|
| 1 | 2.54 GB/s | 4.15 GB/s | 16.5 GB/s | **50.6 GB/s** |
| 2 | 2.57 GB/s | 4.02 GB/s | 16.4 GB/s | **50.0 GB/s** |
| 4 | 2.89 GB/s | 3.97 GB/s | 15.9 GB/s | segment exhausted |
| 8 | — | — | — | **all fail** (segment exhausted) |

**PUT and GET are depth-flat**: the server's per-connection serve loop is in-order, so pipelining N requests on one connection just queues them. Depth only hides network latency — irrelevant on loopback and marginal even cross-node.

**depth>1 inflates receive-segment lease**: per-connection lease = depth × slot_size (64 MiB at --max-msg 64 MiB):

| depth | lease/conn | 16 GiB segment capacity |
|-------|-----------|------------------------|
| 1 | 64 MiB | 256 connections |
| 4 | 256 MiB | ~62 connections |
| 8 | 512 MiB | ~31 connections |

At depth=8, a 16 GiB segment holds only 31 connections; bench with 32 threads × bc=8 exhausts it and **all PUT/GET fail**.

### Changes

- `README.md`: server `--rdma-depth` and client `DFKV_RDMA_DEPTH` recommendation 4→1, with measured rationale; bench reproduction updated
- `docs/DEPLOY.md`: mapping table, systemd example, ExecStart, segment-budget formula, regression bench command all updated 4→1
- `docs/CONNECTORS.md`: segment capacity examples updated to depth=1 baseline

No code changes (server/client already default to 1).