### PR TITLE
cmake: default DFKV_STATIC_LIBSTDCXX=ON for portable artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 add_compile_options(-Wall -Wextra)
 
 option(DFKV_BUILD_TESTS "Build dfkv tests" ON)
-option(DFKV_STATIC_LIBSTDCXX "Statically link libstdc++/libgcc for portable artifacts" OFF)
+option(DFKV_STATIC_LIBSTDCXX "Statically link libstdc++/libgcc for portable artifacts" ON)
 option(DFKV_WITH_RDMA "Build the RDMA transport (needs libibverbs)" OFF)
 # Additive, env-gated io_uring async-GET disk-read path in the RDMA server. When
 # ON, links liburing and compiles the DFKV_WITH_URING code; the path is still


### PR DESCRIPTION
## Problem

Release binaries built without `DFKV_STATIC_LIBSTDCXX` require `GLIBCXX_3.4.30` from `libstdc++6 >= 12.x`. Minimal CPU/MDS nodes (e.g. hd04-cpu-0008 running stock Ubuntu 22.04) lack this library version, causing `dfkv_mds` and `dfkvctl` to crash-loop with:

```
/lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found
```

GPU nodes happen to have the updated `libstdc++6` (12.3.0) via `ubuntu1~22.04.2` backport, so `dfkv_server` runs fine — but MDS nodes don't.

## Fix

Default `DFKV_STATIC_LIBSTDCXX=ON` so all release artifacts statically link `libstdc++`/`libgcc`. This embeds ~1-2 MB per binary and eliminates the runtime `libstdc++.so.6` version dependency entirely.

The option was already implemented (CMakeLists.txt:28-30) but defaulted to `OFF`. This PR only flips the default.