### PR TITLE
feat(rdma): unilateral PUT — plain WRITE + SEND notification

### DIFF
--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -577,6 +577,28 @@ void RdmaServer::Serve(int boot_fd) {
       }
       return request->get.targets.size() <= rdma::kV2MaxGetTargets;
     }
+    // Unilateral PUT path: the notification is a 50B request prefix sent via
+    // SEND. The offset field carries the data_slot index where [header|payload]
+    // was written via plain RDMA WRITE to the shared receive segment.
+    if (request->fields.op == static_cast<uint8_t>(WireOp::kCache)) {
+      if (completion.byte_len < kReqPrefix) return false;
+      const size_t data_slot = static_cast<size_t>(request->fields.offset);
+      if (data_slot >= K) return false;
+      const char* data_frame = recv_lease.data() + data_slot * slot_size +
+                               rdma::kV2PutPrefixOffset;
+      if (!DecodeReqVersion(
+              data_frame, kNativeProtoRdmaV2, &request->fields,
+              static_cast<uint64_t>(logical_data_cap)) ||
+          request->fields.op != static_cast<uint8_t>(WireOp::kCache) ||
+          request->fields.payload_len > static_cast<uint64_t>(logical_data_cap)) {
+        return false;
+      }
+      request->data_slot = data_slot;
+      request->contiguous_payload = data_frame + kReqPrefix;
+      v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+      return true;
+    }
+    // Other control ops (Exist/Remove/Members/Lookup) with inline payload
     if (completion.byte_len <
         kReqPrefix + request->fields.payload_len) {
       return false;

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -906,10 +906,13 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
         return Status::kIOError;
       }
       conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
-      ok = ep.PostRecv(0) &&
-           ep.PostWriteImmScatter(
+      ok = ep.PostWriteScatter(
                0, kReqPrefix, payload, static_cast<size_t>(payload_len),
-               payload_mr, conn->put_addr(0), conn->recv_segment.rkey, 0);
+               payload_mr, conn->put_addr(0), conn->recv_segment.rkey);
+      if (ok) {
+        std::memcpy(ep.nbuf(0), ep.sbuf(0), kReqPrefix);
+        ok = ep.PostRecv(0) && ep.PostSendNotify(0, kReqPrefix);
+      }
       if (ok)
         v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
     } else if (op == WireOp::kRange) {
@@ -1113,10 +1116,15 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0,
                      item.len);
-        if (!ep.PostWriteImmScatter(
+        if (!ep.PostWriteScatter(
                 slot, kReqPrefix, item.data, item.len, mr,
-                conn->put_addr(slot), conn->recv_segment.rkey,
-                static_cast<uint32_t>(slot))) {
+                conn->put_addr(slot), conn->recv_segment.rkey) ||
+            !ep.PostRecv(slot)) {
+          conn_ok = false;
+          break;
+        }
+        std::memcpy(ep.nbuf(slot), ep.sbuf(slot), kReqPrefix);
+        if (!ep.PostSendNotify(slot, kReqPrefix)) {
           conn_ok = false;
           break;
         }

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -272,8 +272,10 @@ void RcEndpoint::Close() {
   // only after the last endpoint that can still return it has gone idle/closed.
   for (const auto& pool : pool_mr_) SharedReleasePoolMr(ctx_, pool.mr);
   pool_mr_.clear();
-  smr_.clear(); rmr_.clear(); dmr_.clear();
+  smr_.clear(); rmr_.clear(); dmr_.clear(); nmr_.clear(); nbuf_.clear();
   for (auto* b : sbuf_) delete[] b;
+  for (auto* m : nmr_) if (m) ibv_dereg_mr(m);
+  for (auto* b : nbuf_) delete[] b;
   for (auto* b : rbuf_) delete[] b;
   for (auto* b : dbuf_) std::free(b);
   sbuf_.clear(); rbuf_.clear(); dbuf_.clear();
@@ -335,7 +337,7 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth,
   // of either HCA's max_sge because every WRITE itself has one SGE.
   static_assert(kV2MaxGetTargets == kMaxSge - 1);
   const size_t wr_per_slot =
-      v2_responder ? kV2MaxGetTargets + 1 : 1;
+      v2_responder ? (kV2MaxGetTargets + 1) : 2;
   if (depth_ > (std::numeric_limits<uint32_t>::max() - 1) / wr_per_slot) {
     DFKV_LOG_ERROR("rdma: requested send queue depth overflows uint32");
     Close();
@@ -411,6 +413,7 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth,
   // sizes (>=128 KiB) new[] is mmap-backed = page-aligned, which mbind needs.
   numa_node_ = numa::DeviceNode(dev_name);
   sbuf_.resize(depth_, nullptr); rbuf_.resize(depth_, nullptr);
+  nbuf_.resize(depth_, nullptr); nmr_.resize(depth_, nullptr);
   smr_.resize(depth_, nullptr); rmr_.resize(depth_, nullptr);
   if (direct_io_buffers) {
     const size_t dio_cap = direct_io_cap ? direct_io_cap : cap_;
@@ -433,6 +436,11 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth,
       dmr_[i] = ibv_reg_mr(pd_, dbuf_[i], dbuf_cap_, IBV_ACCESS_LOCAL_WRITE);
       if (!dmr_[i]) { Close(); return false; }
     }
+  }
+  for (size_t i = 0; i < depth_; ++i) {
+    nbuf_[i] = new char[64];
+    nmr_[i] = ibv_reg_mr(pd_, nbuf_[i], 64, IBV_ACCESS_LOCAL_WRITE);
+    if (!nmr_[i]) { Close(); return false; }
   }
 
   // local addressing info
@@ -857,6 +865,49 @@ bool RcEndpoint::PostWriteImmScatter(
   wr.imm_data = htonl(immediate);
   wr.wr.rdma.remote_addr = remote_addr;
   wr.wr.rdma.rkey = remote_rkey;
+  return ibv_post_send(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostWriteScatter(
+    size_t slot, size_t header_len, const void* payload, size_t payload_len,
+    ibv_mr* payload_mr, uint64_t remote_addr, uint32_t remote_rkey) {
+  if (slot >= depth_ || header_len > cap_ ||
+      header_len > std::numeric_limits<uint32_t>::max() ||
+      payload_len > std::numeric_limits<uint32_t>::max() ||
+      (payload_len != 0 && (!payload || !payload_mr)) ||
+      remote_addr == 0 || remote_rkey == 0) {
+    return false;
+  }
+  ibv_sge sge[2]{};
+  sge[0].addr = reinterpret_cast<uintptr_t>(sbuf_[slot]);
+  sge[0].length = static_cast<uint32_t>(header_len);
+  sge[0].lkey = smr_[slot]->lkey;
+  sge[1].addr = reinterpret_cast<uintptr_t>(payload);
+  sge[1].length = static_cast<uint32_t>(payload_len);
+  sge[1].lkey = payload_len ? payload_mr->lkey : 0;
+  ibv_send_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot;
+  wr.sg_list = sge;
+  wr.num_sge = payload_len ? 2 : 1;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = 0;
+  wr.wr.rdma.remote_addr = remote_addr;
+  wr.wr.rdma.rkey = remote_rkey;
+  return ibv_post_send(qp_, &wr, &bad) == 0;
+}
+
+bool RcEndpoint::PostSendNotify(size_t slot, size_t len) {
+  if (slot >= depth_ || len > 64 || !nbuf_[slot] || !nmr_[slot]) return false;
+  ibv_sge sge{};
+  sge.addr = reinterpret_cast<uintptr_t>(nbuf_[slot]);
+  sge.length = static_cast<uint32_t>(len);
+  sge.lkey = nmr_[slot]->lkey;
+  ibv_send_wr wr{}, *bad = nullptr;
+  wr.wr_id = slot;
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_SEND;
+  wr.send_flags = IBV_SEND_SIGNALED;
   return ibv_post_send(qp_, &wr, &bad) == 0;
 }
 

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -127,6 +127,7 @@ class RcEndpoint {
   int numa_node() const { return numa_node_; }  // device's NUMA node, or -1
   char* sbuf(size_t slot) { return sbuf_[slot]; }
   char* rbuf(size_t slot) { return rbuf_[slot]; }
+  char* nbuf(size_t slot) { return nbuf_[slot]; }
   char* dbuf(size_t slot) { return dbuf_.empty() ? nullptr : dbuf_[slot]; }
   size_t dbuf_cap() const { return dbuf_cap_; }
   ibv_mr* dmr(size_t slot) { return dmr_.empty() ? nullptr : dmr_[slot]; }
@@ -239,6 +240,14 @@ class RcEndpoint {
       const std::vector<std::pair<const void*, uint32_t>>& segs,
       const std::vector<ibv_mr*>& mrs, uint64_t remote_addr,
       uint32_t remote_rkey, uint32_t immediate);
+  // Unsignaled scatter WRITE (no IMM): header from sbuf_[slot], payload from
+  // caller. A following signaled PostSendNotify fences the source buffer.
+  bool PostWriteScatter(
+      size_t slot, size_t header_len, const void* payload,
+      size_t payload_len, ibv_mr* payload_mr, uint64_t remote_addr,
+      uint32_t remote_rkey);
+  // Signaled SEND from nbuf_[slot] (notification buffer).
+  bool PostSendNotify(size_t slot, size_t len);
 
   // QP scatter-gather capability negotiated in Open() = min(kMaxSge, device cap).
   // The SG datapath caps raw-payload segments at max_sge()-1 (SGE0 is the wire prefix).
@@ -275,6 +284,8 @@ class RcEndpoint {
   size_t max_sge_ = 2;  // QP max_send_sge/max_recv_sge = min(kMaxSge, device cap)
   std::vector<char*> sbuf_, rbuf_, dbuf_;
   std::vector<ibv_mr*> smr_, rmr_, dmr_;
+  std::vector<char*> nbuf_;
+  std::vector<ibv_mr*> nmr_;
   // Big pre-registered caller regions (the host KV pool). Each cache entry owns
   // one shared-registry reference. Successful growth replaces the idle
   // endpoint's older same-base generation; endpoints with an in-flight user


### PR DESCRIPTION
## Problem

dfkv PUT uses two-sided `WRITE_WITH_IMM`: the server pre-allocates `depth × slot_size` recv buffer per connection. With default `max_block=64MB` and `depth=4`, each connection consumes 256MB → 255 connections exhaust a 64GB receive segment.

## Solution

Replace two-sided `WRITE_WITH_IMM` with:
1. **Unsignaled plain RDMA WRITE** — payload data (header + value) written directly to the server's shared receive segment, no per-connection recv buffer needed
2. **Signaled SEND notification** — 50B request prefix (key + data_slot + payload_len) sent via normal SEND; fences the WRITE on the RC QP

The server reads the notification from `rbuf` (same path as GET requests), extracts the data_slot from the `offset` field, and reads payload from the receive segment.

### Memory impact

| | Before (WRITE_WITH_IMM) | After (plain WRITE + SEND) |
|---|---|---|
| Per-connection recv | `depth × 64MB = 256MB` | `depth × 64B = 256B` |
| 255 conns × depth=4 | 63.75GB (99.6% of 64GB) | ~65KB |
| Receive segment | 64GB required | 2GB sufficient |

### Protocol safety

RC QP preserves send ordering: the unsignaled WRITE arrives before the signaled SEND. The server processes the SEND notification only after the WRITE data is visible in the receive segment. No additional synchronization needed.

## Changes (4 files, +100 lines)

- **`rdma_verbs.h`**: `PostWriteScatter` + `PostSendNotify` declarations, `nbuf_` notification buffer members
- **`rdma_verbs.cc`**: `PostWriteScatter` (unsignaled scatter WRITE, no IMM) + `PostSendNotify` (signaled SEND from `nbuf_`), `nbuf_` alloc/dereg lifecycle, client `wr_per_slot` 1→2
- **`rdma_transport.cc`**: `RoundTrip` + `CacheMany` PUT paths use `PostWriteScatter` + `PostSendNotify` instead of `PostWriteImmScatter`
- **`rdma_server.cc`**: `decode_request` handles `kCache` via normal RECV (reads `data_slot` from `offset` field) instead of `RECV_RDMA_WITH_IMM`

GET path unchanged (already unilateral server→client RDMA WRITE).
`CacheFrom`/`CacheFromMulti` (zero-copy multi-SG PUT) unchanged — still uses WRITE_WITH_IMM (separate follow-up).

## Testing

- ✅ Loopback smoke test: PUT+GET correct (`dfkv_smoke` exit 0)
- ✅ Build: 35/35, zero warnings (RelWithDebInfo + RDMA + uring)
- ⏳ Cross-node RDMA bench: pending (loopback bench hits LOCAL_MEMCPY fast path, not RDMA)

## Breaking change

Old clients cannot connect to new server (PUT data-plane semantics differ). Coordinated client+server upgrade required.