### PR TITLE
fix(rdma): revert #7 batch handler brace bug causing PUT 100% fail

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -366,11 +366,6 @@ int main(int argc, char** argv) {
           return srv.RangeDirectForKey(key, off, len, io_buf, cap, out_data,
                                        out_len, value_len);
         });
-    rsrv->set_cache_direct_batch_handler(
-      [&srv](const std::vector<dfkv::StoreEngine::CacheBatchItem>& items)
-          -> std::vector<dfkv::Status> {
-        return srv.CacheDirectBatchForKeys(items);
-      });
   rsrv->set_cache_direct_handler(  // server-side direct PUT: RDMA dbuf -> O_DIRECT write
         [&srv](const dfkv::BlockKey& key, char* data, size_t len, size_t cap) {
           return srv.CacheDirectForKey(key, data, len, cap);

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -745,11 +745,9 @@ void RdmaServer::Serve(int boot_fd) {
         std::memcpy(cache_data, request.contiguous_payload,
                     static_cast<size_t>(fields.payload_len));
       }
-      const Status status = cache_direct_batch_handler_
-          ? cache_direct_batch_handler_({{{key, cache_data, static_cast<size_t>(fields.payload_len), direct_buffer_cap}}})[0]
-          : cache_direct_handler_(
-              key, cache_data, static_cast<size_t>(fields.payload_len),
-              direct_buffer_cap);
+      const Status status = cache_direct_handler_(
+          key, cache_data, static_cast<size_t>(fields.payload_len),
+          direct_buffer_cap);
       encode_status(status, 0);
       reply->first_len = response_prefix;
       return true;


### PR DESCRIPTION
## Bug

PR#255 (#7 write coalescing) introduced a ternary in `rdma_server.cc`:
```cpp
cache_direct_batch_handler_({{{key, cache_data, len, cap}}})[0]
```
The triple-brace `{{{...}}}` is invalid C++ aggregate initialization, causing all PUT operations to return error → 100% PUT fail in bench.

## Fix

Revert to direct `cache_direct_handler_` call (same as v2.2.0). Remove batch handler registration in `dfkv_server_main.cc`. Types retained for future use.

## Testing
- Build: OK
- v2.2.0 bench with reverted code: GET 0 fails ✅, PUT fails reduced to CQ contention level