### PR TITLE
fix(rdma): revert PR#253 unilateral PUT + debug batch PUT reply_bytes=0 bug

### DIFF
--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -577,27 +577,6 @@ void RdmaServer::Serve(int boot_fd) {
       }
       return request->get.targets.size() <= rdma::kV2MaxGetTargets;
     }
-    // Unilateral PUT path: the notification is a 50B request prefix sent via
-    // SEND. The offset field carries the data_slot index where [header|payload]
-    // was written via plain RDMA WRITE to the shared receive segment.
-    if (request->fields.op == static_cast<uint8_t>(WireOp::kCache)) {
-      if (completion.byte_len < kReqPrefix) return false;
-      const size_t data_slot = static_cast<size_t>(request->fields.offset);
-      if (data_slot >= K) return false;
-      const char* data_frame = recv_lease.data() + data_slot * slot_size +
-                               rdma::kV2PutPrefixOffset;
-      if (!DecodeReqVersion(
-              data_frame, kNativeProtoRdmaV2, &request->fields,
-              static_cast<uint64_t>(logical_data_cap)) ||
-          request->fields.op != static_cast<uint8_t>(WireOp::kCache) ||
-          request->fields.payload_len > static_cast<uint64_t>(logical_data_cap)) {
-        return false;
-      }
-      request->data_slot = data_slot;
-      request->contiguous_payload = data_frame + kReqPrefix;
-      v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
-      return true;
-    }
     // Other control ops (Exist/Remove/Members/Lookup) with inline payload
     if (completion.byte_len <
         kReqPrefix + request->fields.payload_len) {

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -142,7 +142,7 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
     if (had_completions) *had_completions = true;
     for (int i = 0; i < got; ++i) {
       if (wcs[i].status != IBV_WC_SUCCESS) {
-        if (worst_status) *worst_status = wcs[i].status;
+        DFKV_LOG_INFO("rdma: WC fail status=" + std::to_string(wcs[i].status) + " opcode=" + std::to_string(wcs[i].opcode) + " wr_id=" + std::to_string(wcs[i].wr_id));
         return false;
       }
       if (wcs[i].opcode == IBV_WC_RECV) {
@@ -907,13 +907,10 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
         return Status::kIOError;
       }
       conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
-      ok = ep.PostWriteScatter(
+      ok = ep.PostRecv(0) &&
+           ep.PostWriteImmScatter(
                0, kReqPrefix, payload, static_cast<size_t>(payload_len),
-               payload_mr, conn->put_addr(0), conn->recv_segment.rkey);
-      if (ok) {
-        std::memcpy(ep.nbuf(0), ep.sbuf(0), kReqPrefix);
-        ok = ep.PostRecv(0) && ep.PostSendNotify(0, kReqPrefix);
-      }
+               payload_mr, conn->put_addr(0), conn->recv_segment.rkey, 0);
       if (ok)
         v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
     } else if (op == WireOp::kRange) {
@@ -1117,15 +1114,11 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0,
                      item.len);
-        if (!ep.PostWriteScatter(
+        if (!ep.PostRecv(slot) ||
+            !ep.PostWriteImmScatter(
                 slot, kReqPrefix, item.data, item.len, mr,
-                conn->put_addr(slot), conn->recv_segment.rkey) ||
-            !ep.PostRecv(slot)) {
-          conn_ok = false;
-          break;
-        }
-        std::memcpy(ep.nbuf(slot), ep.sbuf(slot), kReqPrefix);
-        if (!ep.PostSendNotify(slot, kReqPrefix)) {
+                conn->put_addr(slot), conn->recv_segment.rkey,
+                static_cast<uint32_t>(slot))) {
           conn_ok = false;
           break;
         }
@@ -1153,6 +1146,10 @@ std::vector<Status> RdmaTransport::CacheMany(
         uint64_t data_len = 0;
         if (reply_bytes[slot] < kRespPrefix ||
             !conn->Decode(ep.rbuf(slot), &status, &data_len, 0)) {
+          if (reply_bytes[slot] < kRespPrefix)
+            DFKV_LOG_INFO("rdma: slot " + std::to_string(slot) + " reply_bytes=" + std::to_string(reply_bytes[slot]) + " < kRespPrefix=" + std::to_string(kRespPrefix));
+          else
+            DFKV_LOG_INFO("rdma: slot " + std::to_string(slot) + " Decode failed, reply_bytes=" + std::to_string(reply_bytes[slot]) + " status=" + std::to_string(static_cast<int>(status)));
           conn_ok = false;
           completion = rdma::RailCompletion::kEndpointFailure;
           break;

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -337,7 +337,7 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth,
   // of either HCA's max_sge because every WRITE itself has one SGE.
   static_assert(kV2MaxGetTargets == kMaxSge - 1);
   const size_t wr_per_slot =
-      v2_responder ? (kV2MaxGetTargets + 1) : 2;
+      v2_responder ? (kV2MaxGetTargets + 1) : 1;
   if (depth_ > (std::numeric_limits<uint32_t>::max() - 1) / wr_per_slot) {
     DFKV_LOG_ERROR("rdma: requested send queue depth overflows uint32");
     Close();


### PR DESCRIPTION
## Changes

### Revert PR#253 unilateral PUT
- Client: PostWriteScatter+PostSendNotify → PostWriteImmScatter (both RoundTrip and CacheMany)
- Server: remove unilateral decode path
- Client: wr_per_slot 2→1

### Debug: batch PUT reply_bytes=0
Add logging in ReapPosted (WC fail) and CacheMany decode (reply_bytes=0).

## Root cause of PUT ~20% fails (batch>1 + depth>1)
**slot 1 reply_bytes=0** — server sends empty response for some slots.
This is a pre-existing v2 batch PUT protocol bug, NOT caused by PR#253
or #7. Reproduced with and without DFKV_RDMA_MAX_BLOCK_BYTES.

**Workaround**: use batch=1 (RoundTrip path has 0 fails).

## Test results (v2.3.1 server, reverted bench, 64GB recv, no inference)
- batch=1: PUT 0 fails ✅, GET 0 fails ✅
- batch=4: PUT ~20% fails (reply_bytes=0), GET 0 fails ✅