### PR TITLE
feat(rdma): unilateral PUT via unsignaled WRITE + SEND notification

### DIFF
--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -302,7 +302,7 @@ int ServerIdleMs() {
   // the client re-dials a stale pooled connection via RdmaTransport's 2-attempt
   // retry. Default 10 min keeps active/recently-used pooled conns alive; set
   // DFKV_RDMA_IDLE_MS=0 disables the reaper and waits indefinitely.
-  int out = 600000;  // 10 minutes
+  int out = 30000;   // 30 seconds (was 10 min; Mooncake has no idle timeout but uses SIEVE eviction)
   const char* e = std::getenv("DFKV_RDMA_IDLE_MS");
   if (e && *e) {
     long v = std::strtol(e, nullptr, 10);
@@ -543,6 +543,7 @@ void RdmaServer::Serve(int boot_fd) {
     request->recv_slot = recv_slot;
     request->data_slot = recv_slot;
     request->recv_bytes = completion.byte_len;
+    DFKV_LOG_INFO("rdma: recv slot=" + std::to_string(recv_slot) + " byte_len=" + std::to_string(completion.byte_len) + " opcode=" + std::to_string(completion.opcode) + " has_imm=" + std::to_string(has_immediate));
     if (write_imm_recv) {
       const size_t data_slot = static_cast<size_t>(ntohl(completion.imm_data));
       if (data_slot >= K || completion.byte_len < kReqPrefix) return false;
@@ -576,6 +577,73 @@ void RdmaServer::Serve(int boot_fd) {
         return false;
       }
       return request->get.targets.size() <= rdma::kV2MaxGetTargets;
+    }
+    // Unilateral PUT path: the notification is a 50B request prefix sent via
+    // SEND. The offset field carries the data_slot index where [header|payload]
+    // was written via plain RDMA WRITE to the shared receive segment.
+    if (request->fields.op == static_cast<uint8_t>(WireOp::kCache)) {
+      if (completion.byte_len < kReqPrefix) return false;
+      const size_t data_slot = static_cast<size_t>(request->fields.offset);
+      if (data_slot >= K) return false;
+      const char* data_frame = recv_lease.data() + data_slot * slot_size +
+                               rdma::kV2PutPrefixOffset;
+      DFKV_LOG_INFO("rdma: unilateral PUT data_slot=" + std::to_string(data_slot) +
+                    " slot_size=" + std::to_string(slot_size) +
+                    " data_frame_ver=" + std::to_string(static_cast<int>(static_cast<unsigned char>(data_frame[0]))) +
+                    " data_frame_op=" + std::to_string(static_cast<int>(static_cast<unsigned char>(data_frame[1]))) +
+                    " payload_len=" + std::to_string(*reinterpret_cast<const uint64_t*>(data_frame + 42)));
+      if (!DecodeReqVersion(
+              data_frame, kNativeProtoRdmaV2, &request->fields,
+              static_cast<uint64_t>(logical_data_cap)) ||
+          request->fields.op != static_cast<uint8_t>(WireOp::kCache) ||
+          request->fields.payload_len > static_cast<uint64_t>(logical_data_cap)) {
+        return false;
+      }
+      request->data_slot = data_slot;
+      request->contiguous_payload = data_frame + kReqPrefix;
+      v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+      return true;
+    }
+    // Unilateral PUT path: the notification is a 50B request prefix sent via
+    // SEND on the control QP. The offset field carries the data_slot index
+    // where [header|payload] was written via plain RDMA WRITE to the shared
+    // receive segment. nbuf_ is separate from sbuf_ so no race.
+    if (request->fields.op == static_cast<uint8_t>(WireOp::kCache)) {
+      if (completion.byte_len < kReqPrefix) return false;
+      const size_t data_slot = static_cast<size_t>(request->fields.offset);
+      if (data_slot >= K) return false;
+      const char* data_frame = recv_lease.data() + data_slot * slot_size +
+                               rdma::kV2PutPrefixOffset;
+      if (!DecodeReqVersion(
+              data_frame, kNativeProtoRdmaV2, &request->fields,
+              static_cast<uint64_t>(logical_data_cap)) ||
+          request->fields.op != static_cast<uint8_t>(WireOp::kCache) ||
+          request->fields.payload_len > static_cast<uint64_t>(logical_data_cap)) {
+        return false;
+      }
+      request->data_slot = data_slot;
+      request->contiguous_payload = data_frame + kReqPrefix;
+      v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+      return true;
+    }
+    // Unilateral PUT: notification SEND carries offset=data_slot.
+    // Data was written via unsignaled WRITE to recv segment slot.
+    if (request->fields.op == static_cast<uint8_t>(WireOp::kCache)) {
+      const size_t data_slot = static_cast<size_t>(request->fields.offset);
+      if (data_slot >= K) return false;
+      const char* data_frame = recv_lease.data() + data_slot * slot_size +
+                               rdma::kV2PutPrefixOffset;
+      if (!DecodeReqVersion(
+              data_frame, kNativeProtoRdmaV2, &request->fields,
+              static_cast<uint64_t>(logical_data_cap)) ||
+          request->fields.op != static_cast<uint8_t>(WireOp::kCache) ||
+          request->fields.payload_len > static_cast<uint64_t>(logical_data_cap)) {
+        return false;
+      }
+      request->data_slot = data_slot;
+      request->contiguous_payload = data_frame + kReqPrefix;
+      v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+      return true;
     }
     // Other control ops (Exist/Remove/Members/Lookup) with inline payload
     if (completion.byte_len <

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -907,10 +907,12 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
         return Status::kIOError;
       }
       conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
-      ok = ep.PostRecv(0) &&
-           ep.PostWriteImmScatter(
+      std::memcpy(ep.nbuf(0), ep.sbuf(0), kReqPrefix);
+      ok = ep.PostWriteScatter(
                0, kReqPrefix, payload, static_cast<size_t>(payload_len),
-               payload_mr, conn->put_addr(0), conn->recv_segment.rkey, 0);
+               payload_mr, conn->put_addr(0), conn->recv_segment.rkey);
+      if (ok)
+        ok = ep.PostRecv(0) && ep.PostSendNotify(0, kReqPrefix);
       if (ok)
         v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
     } else if (op == WireOp::kRange) {
@@ -1114,11 +1116,15 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0,
                      item.len);
-        if (!ep.PostRecv(slot) ||
-            !ep.PostWriteImmScatter(
+        std::memcpy(ep.nbuf(slot), ep.sbuf(slot), kReqPrefix);
+        if (!ep.PostWriteScatter(
                 slot, kReqPrefix, item.data, item.len, mr,
-                conn->put_addr(slot), conn->recv_segment.rkey,
-                static_cast<uint32_t>(slot))) {
+                conn->put_addr(slot), conn->recv_segment.rkey) ||
+            !ep.PostRecv(slot)) {
+          conn_ok = false;
+          break;
+        }
+        if (!ep.PostSendNotify(slot, kReqPrefix)) {
           conn_ok = false;
           break;
         }


### PR DESCRIPTION
## Changes

### Unilateral PUT (RoundTrip path)
Client sends data via unsignaled RDMA WRITE to server recv segment,
then sends a 50B notification via signaled SEND. Server reads
data_slot from the notification's offset field and decodes the data
from the recv segment.

This eliminates per-connection recv buffer for PUT data (the original
goal of PR#253, now with correct buffer separation: sbuf for WRITE
SGE0, nbuf for notification SEND).

### Server idle timeout
10 minutes → 30 seconds (Mooncake-inspired; faster connection reclaim
for K8s environments with frequent pod rebuilds).

### Known limitation
Multi-thread batch mode (CacheMany with threads>1, batch>1) has ~96%
fails due to QP WR interleaving when multiple threads share the same
connection's SQ. The fix requires either:
- Dual-QP: separate QP for data WRITE vs control SEND
- Or per-thread connections in CacheMany

RoundTrip (single-thread) and single-thread batch work correctly.

## Testing
- Loopback smoke: PUT+GET+Exist OK
- Single-thread bench: 0 fails
- Build: OK