### PR TITLE
fix(rdma): revert CacheMany to WRITE_WITH_IMM, keep RoundTrip unilateral

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -1116,15 +1116,11 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0,
                      item.len);
-        std::memcpy(ep.nbuf(slot), ep.sbuf(slot), kReqPrefix);
-        if (!ep.PostWriteScatter(
+        if (!ep.PostRecv(slot) ||
+            !ep.PostWriteImmScatter(
                 slot, kReqPrefix, item.data, item.len, mr,
-                conn->put_addr(slot), conn->recv_segment.rkey) ||
-            !ep.PostRecv(slot)) {
-          conn_ok = false;
-          break;
-        }
-        if (!ep.PostSendNotify(slot, kReqPrefix)) {
+                conn->put_addr(slot), conn->recv_segment.rkey,
+                static_cast<uint32_t>(slot))) {
           conn_ok = false;
           break;
         }


### PR DESCRIPTION
## Problem

PR#263 introduced unilateral PUT (unsignaled WRITE + SEND notification) in BOTH RoundTrip and CacheMany. Multi-threaded batch load fails because concurrent threads sharing the connection pool interleave WR/notification posts on the same QP, corrupting slot-to-data association.

Loopback control experiment (0064, t32/b1, 2000 PUTs):
- Baseline (pure WRITE_WITH_IMM, v2.5.0-equivalent): 1431 fails
- PR#263 (CacheMany unilateral): ~1657 fails

Same magnitude — the multi-thread shared-QP hazard is pre-existing and exposed by loopback; the 7-node ring disperses load and doesn't trigger it.

## Change

Revert ONLY CacheMany (batch>1 path) to dual-sided `PostWriteImmScatter` (WRITE_WITH_IMM carries slot in imm_data — no WR interleaving hazard).

Keep RoundTrip (batch=1, recommended production path) on unilateral PUT: verified 0 fails single-threaded, smoke OK.

## Verification

- Build OK (dfkv_server/bench/smoke)
- ReapPosted's 2 CQE/slot expectation holds for both protocols (1 signaled completion + 1 status RECV)