### PR TITLE
fix(rdma): CacheMany posts one RECV per slot, not two

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -1110,13 +1110,9 @@ std::vector<Status> RdmaTransport::CacheMany(
                                        /*remote_write=*/false)
                 : nullptr;
         payload_mrs[slot] = mr;
-        if ((item.len != 0 && !mr) || !ep.PostRecv(slot)) {
-          conn_ok = false;
-          break;
-        }
         conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0,
                      item.len);
-        if (!ep.PostRecv(slot) ||
+        if ((item.len != 0 && !mr) || !ep.PostRecv(slot) ||
             !ep.PostWriteImmScatter(
                 slot, kReqPrefix, item.data, item.len, mr,
                 conn->put_addr(slot), conn->recv_segment.rkey,


### PR DESCRIPTION
## Problem

PR#264's revert kept the unilateral-PUT layout in CacheMany: a PostRecv before Encode plus another PostRecv inside the WRITE_WITH_IMM guard. 4 slots x 2 RECVs = 8 RECVs against RQ depth depth+1=5. Server status SENDs consumed the first-posted RECVs (wr_id 0,0,1,1), so slots 2-3 never got completions: rbytes=[18,18,0,0], batch>1 PUT ~50% fails (t1/b4: 1000/2000 on both mlx5_0 and ib7s400p0, 32GB recv segment, 0 exhausted).

## Fix

Restore v2.5.0 order: Encode first, then one PostRecv + one PostWriteImmScatter per slot.

## Verification (0064 loopback, 32GB recv segment, 32GB cap, credits=256)

| Test | Before | After |
|---|---|---|
| t1/b4 PUT 2000 | 1000 fails | **0 fails** |
| t1/b1 PUT 2000 | 0 fails | 0 fails |
| t32/b1 PUT/GET 20000 | - | **0 fails** |
| t32/b4 PUT/GET 20000 | - | **0 fails** |

Note: earlier reported batch>1 fails at high thread counts were two environment configs, not code: recv-segment/cap too small (slab evictions) and DFKV_RDMA_RAIL_CREDITS=64 default capping 32t x b4 = 128 credits.