### PR TITLE
feat(ram): restore write-back RAM tier as default, keep write-around opt-in

### DIFF
--- a/src/cache/dfkv_server_main.cc
+++ b/src/cache/dfkv_server_main.cc
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
                    "--mds", "--group",
                    "--id", "--advertise", "--weight",
                    "--metrics-port", "--metrics-bind", "--store-engine",
-                   "--slab-write", "--ram-tier", "--ram-tier-bytes",
+                   "--slab-write", "--ram-tier", "--ram-tier-bytes", "--ram-write-mode",
                    "--slab-granularity", "--put-inflight-limit",
                    "--tcp-max-conns", "--tcp-io-timeout-s",
                    "--rdma-depth", "--rdma-numa", "--rdma-idle-ms",
@@ -129,6 +129,12 @@ int main(int argc, char** argv) {
   std::string ram_tier_bytes = args.Get("--ram-tier-bytes", "");
   if (!ram_tier_bytes.empty())
     ::setenv("DFKV_RAM_TIER_BYTES", ram_tier_bytes.c_str(), 1);
+  // RAM write policy: writeback (default) absorbs PUT bursts in the arena and
+  // serves zero-copy GET; writearound writes straight to disk and fills the
+  // arena via GET read-promotion.
+  std::string ram_write_mode = args.Get("--ram-write-mode", "");
+  if (!ram_write_mode.empty())
+    ::setenv("DFKV_RAM_WRITE_MODE", ram_write_mode.c_str(), 1);
   // Slot quantum is persistent geometry. An existing store with a different
   // value is rejected fail-closed; operators must explicitly use an empty dir.
   std::string slab_gran = args.Get("--slab-granularity", "");

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -128,6 +128,13 @@ void KvNodeServer::InitRamTier() {
     unsigned long long n = std::strtoull(b, nullptr, 10);
     if (n > 0) o.bytes = n;
   }
+  // RAM write policy: writeback (default) admits PUT into the arena and flushes
+  // asynchronously; writearound writes directly to disk and fills the arena via
+  // GET read-promotion. Any value other than "writearound" keeps write-back.
+  const char* wm = std::getenv("DFKV_RAM_WRITE_MODE");
+  ram_write_back_ = !(wm && std::string(wm) == "writearound");
+  config_dump::RecordResolved("DFKV_RAM_WRITE_MODE",
+                              ram_write_back_ ? "writeback" : "writearound");
   // Flush workers default to 4x the disk count (cap 16). One sync DIO stream
   // per worker leaves NVMe queues nearly idle for small objects; measured on a
   // 3-disk node (64 KiB saturated writes): 3 workers 6.8k ops/s -> 16 workers
@@ -897,11 +904,27 @@ Status KvNodeServer::CacheDirectForKey(const BlockKey& key, char* data,
   // capped single-node PUT at 3.4 GB/s vs 4.4 GB/s direct-disk.
   Status st = Status::kCacheFull;
   const bool quota_ok = !ram_ || group_.TenantQuotaBytes(key.tenant_hash) == 0;
-  if (quota_ok && put_busy_limit_ > 0 &&
+  bool needs_disk = true;
+  // Write-back: admit to the RAM arena first; the arena absorbs PUT bursts
+  // and serves zero-copy GET until the async flusher drains to disk. Only
+  // genuine arena backpressure (kCacheFull) falls through to direct disk
+  // write. Write-around (DFKV_RAM_WRITE_MODE=writearound) writes straight to
+  // disk and fills the arena lazily via GET read-promotion instead.
+  if (ram_write_back_ && ram_ && quota_ok) {
+    st = ram_->PutCommitted(key, data, len);
+    needs_disk = st == Status::kCacheFull;
+    if (st == Status::kOk) {
+      cache_put_.fetch_add(1, std::memory_order_relaxed);
+      bytes_written_.fetch_add(len, std::memory_order_relaxed);
+    } else if (!needs_disk && st == Status::kIOError) {
+      put_io_err_.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+  if (needs_disk && quota_ok && put_busy_limit_ > 0 &&
       disk_put_inflight_.load(std::memory_order_relaxed) >= put_busy_limit_) {
     st = Status::kCacheFull;
     put_busy_.fetch_add(1, std::memory_order_relaxed);
-  } else if (quota_ok) {
+  } else if (needs_disk && quota_ok) {
     disk_put_inflight_.fetch_add(1, std::memory_order_relaxed);
     st = group_.CacheDirect(key, data, len, cap);
     disk_put_inflight_.fetch_sub(1, std::memory_order_relaxed);

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -151,6 +151,9 @@ class KvNodeServer {
   // is due within DFKV_TCP_FIRST_REQ_MS of ACCEPT, not of handler scheduling.
   void Handle(int fd, std::chrono::steady_clock::time_point accepted_at);
   void InitRamTier();     // construct ram_ if DFKV_RAM_TIER is enabled (env)
+  // RAM tier write policy: write-back (PUT lands in arena, async flush) or
+  // write-around (PUT direct to disk, arena filled by GET read-promotion).
+  void set_ram_write_back(bool wb) { ram_write_back_ = wb; }
   void InitAdmission();   // read DFKV_PUT_INFLIGHT_LIMIT (0 = gate off)
   void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
   void InitTcpListenerConfig();
@@ -169,6 +172,7 @@ class KvNodeServer {
   // PUT admission gate (I6): reject with kCacheFull once this many disk writes
   // are in flight (0 = unlimited/off). See --put-inflight-limit.
   size_t put_busy_limit_ = 0;
+  bool ram_write_back_ = true;  // default write-back; DFKV_RAM_WRITE_MODE=writearound switches
   std::atomic<size_t> disk_put_inflight_{0};
   std::atomic<size_t> put_busy_{0};
   std::atomic<size_t> open_connections_{0};


### PR DESCRIPTION
## Motivation

PR#246 (ed4d72b) switched PUT to write-around (direct-to-disk + GET read-promotion) to remove the per-PUT 1MiB arena memcpy (44% serve CPU, PUT 3.42→4.54 GB/s). That traded away the RAM tier's burst absorption and GET-cache role: bursts hit the disk-inflight gate (kCacheFull → PUT failure) and cold GETs served from disk until promotion.

## Change

- **write-back is the default** again: `CacheDirectForKey` admits PUT into the RAM arena first (`ram_->PutCommitted`), the async flusher drains to disk; only genuine arena backpressure (`kCacheFull`) falls through to direct disk write (existing `put_busy_limit_` gate preserved for the disk path).
- **write-around stays available** via `--ram-write-mode=writearound` (env `DFKV_RAM_WRITE_MODE`; default writeback) — flag→env facade follows the existing pattern.

## Verification (0064 B200, RDMA v2, 8GB RAM tier, 32GB cap, 64KB slab granularity, credits=256, t32/b8, 30000 × 64KB)

| Mode | PUT fails | GET fails | RAM behavior |
|---|---|---|---|
| **write-back (default)** | **0** (burst absorbed) | **0** | ram_hit=30000/30000 (100% arena), flushed=30033, bypass=0, evict=0 |
| writearound | 0 | 0 (disk reads) | arena untouched (ram_put=0) |

## Known limitation (pre-existing, out of scope)

Read-promotion (`PutDurable`) runs on the URING/coalescer async paths only. A UREAD=OFF server's sync-pread GET path never fills the arena in write-around mode — this gap came from ed4d72b and is unchanged here; write-back (the default) fills the arena on every PUT regardless of build flags.