### PR TITLE
fix(rdma): v2.6.3 review fixes — real-us idle threshold, eviction UAF, mode typo guard

### DIFF
--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -132,9 +132,15 @@ void KvNodeServer::InitRamTier() {
   // asynchronously; writearound writes directly to disk and fills the arena via
   // GET read-promotion. Any value other than "writearound" keeps write-back.
   const char* wm = std::getenv("DFKV_RAM_WRITE_MODE");
-  ram_write_back_ = !(wm && std::string(wm) == "writearound");
-  config_dump::RecordResolved("DFKV_RAM_WRITE_MODE",
-                              ram_write_back_ ? "writeback" : "writearound");
+  std::string mode = wm ? std::string(wm) : "";
+  if (mode != "writeback" && mode != "writearound") {
+    if (!mode.empty())
+      DFKV_LOG_WARN("DFKV_RAM_WRITE_MODE='" + mode +
+                    "' not recognized; using writeback");
+    mode = "writeback";
+  }
+  ram_write_back_ = mode == "writeback";
+  config_dump::RecordResolved("DFKV_RAM_WRITE_MODE", mode);
   // Flush workers default to 4x the disk count (cap 16). One sync DIO stream
   // per worker leaves NVMe queues nearly idle for small objects; measured on a
   // 3-disk node (64 KiB saturated writes): 3 workers 6.8k ops/s -> 16 workers

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -43,8 +43,11 @@ using wire_limits::ResolveMaxPayload;
 // twice per deferred GET (prep + completion), both off the SSD-bound path, so
 // the vDSO clock read is amortized away.
 inline uint64_t SteadyUs() {
+  // steady_clock::count() is nanoseconds on Linux; cast to real microseconds.
   return static_cast<uint64_t>(
-      std::chrono::steady_clock::now().time_since_epoch().count());
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count());
 }
 inline double NowSteadySec() {
   return std::chrono::duration<double>(
@@ -435,7 +438,9 @@ void RdmaServer::Serve(int boot_fd) {
     // (no completions for 2 s -> no in-flight request) is safe.
     const uint64_t now = SteadyUs();
     constexpr uint64_t kEvictIdleMinUs = 2000000;
+    const uint64_t evict_started = SteadyUs();
     for (int round = 0; round < 32 && !recv_lease; ++round) {
+      if (SteadyUs() - evict_started > 5000000) break;  // bound: <= 5 s total
       rdma::RcEndpoint* victim = nullptr;
       uint64_t victim_active = std::numeric_limits<uint64_t>::max();
       {
@@ -443,12 +448,15 @@ void RdmaServer::Serve(int boot_fd) {
         for (rdma::RcEndpoint* ep : live_eps_) {
           const uint64_t a =
               ep->last_active_us_.load(std::memory_order_relaxed);
-          if (a <= now && now - a >= kEvictIdleMinUs && a < victim_active) {
+          // a == 0: endpoint inserted but Serve has not stamped it yet.
+          if (a != 0 && a <= now && now - a >= kEvictIdleMinUs &&
+              a < victim_active) {
             victim = ep;
             victim_active = a;
           }
         }
-      }
+        if (victim) live_eps_.erase(victim);  // claim it: no other evictor
+      }                                        // can Wake a freed stack endpoint
       if (!victim) break;  // every connection is recently active; refuse
       victim->Wake();  // Serve exits; the Lease destructor returns its range
       segment_evictions_.fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
## Review fixes for v2.6.2 (#269/#270)

1. **Idle threshold was 2 ms, not 2 s.** `SteadyUs()` returned `steady_clock::count()` raw ticks, which are nanoseconds on Linux. Under normal traffic nearly every pooled connection counts as idle → a full segment could evict recently-active connections. Now `duration_cast<microseconds>`.
2. **Eviction UAF.** The evictor woke a `live_eps_` pointer whose Serve thread then exited and destroyed the stack endpoint; a concurrent evictor could `Wake` a freed endpoint. The evictor now erases the victim from `live_eps_` under `conn_mu_` before `Wake` (Serve's own erase becomes a no-op) — exactly one evictor ever touches an endpoint.
3. **Total eviction wait bounded to 5 s** (was up to 32 s, exceeding the client's 10 s bootstrap).
4. **`last_active_us_ == 0`** (inserted, not yet stamped by Serve) is never treated as idle.
5. **`DFKV_RAM_WRITE_MODE` typo guard**: only `writeback`|`writearound` accepted; anything else warns and falls back to writeback.

## Verified (0064, 64MB segment = 15 conns, t16/b1 rounds)

- A all-active refusal: 26 fails (expected — no idle victim)
- B–F: 1–2 fails each (concurrent-eviction boundary)
- 75 evictions, **zero crashes/segfaults**

## v2.6.2 advisory

v2.6.2 shipped #270 with the 2ms-threshold bug; **do not deploy it**. This fix is the corrected v2.6.3.