### PR TITLE
perf(rdma): isolate SG writes and restore batch depth

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -336,29 +336,31 @@ class DfkvHiCache(HiCacheStorage):
             mds = cfg.get("mds_endpoints", "")
             members = cfg.get("members", "")
             _tcfg.require_ring_endpoint(members, mds)
-            # RDMA write pipelining: depth>1 keeps multiple PUTs in flight on one
-            # connection, hiding per-op latency (single-rank MLA writes are
-            # latency-bound). The C client reads DFKV_RDMA_DEPTH when it builds the
-            # transport inside dfkv_open below, so set it from extra_config first.
-            # NOTE: the dfkv_server must set the SAME (or larger) DFKV_RDMA_DEPTH in
-            # its own env -- client depth must be <= server depth.
-            if cfg.get("rdma_depth"):
-                os.environ["DFKV_RDMA_DEPTH"] = str(int(cfg["rdma_depth"]))
+            # Multi-SGE device writes use a dedicated connection lane in the
+            # native transport, so each QP still has one in-flight CUDA range.
+            # Depth fans a batch across independent QPs and is required to keep
+            # the SSD/RDMA pipeline full.
+            requested_depth = int(
+                cfg.get("rdma_depth", os.environ.get("DFKV_RDMA_DEPTH", "1")))
+            os.environ["DFKV_RDMA_DEPTH"] = str(max(1, requested_depth))
             if _truthy(cfg.get("require_rdma")):
                 if not _truthy(os.environ.get("DFKV_RDMA")):
                     os.environ["DFKV_RDMA"] = "1"
-            # rail_affinity (per-tp_rank narrowing) is DEPRECATED and now a no-op:
-            # it keyed off tp_rank, which is always 0 under DP-attention (every rank
-            # is its own attention TP group of size 1), so it collapsed all ranks to
-            # one rail. NUMA-aware rail selection now lives in the C++ client: keep
-            # the full multi-rail DFKV_RDMA_DEV and set DFKV_RDMA_NUMA=1, and the
-            # client picks a NUMA-local rail per connection (works for TP and DP).
-            if cfg.get("rail_affinity"):
-                import sys as _sys
-                print("[dfkv] WARNING: 'rail_affinity' is deprecated and ignored; "
-                      "set DFKV_RDMA_NUMA=1 + multi-rail DFKV_RDMA_DEV for NUMA-aware "
-                      "rail selection in the client.", file=_sys.stderr, flush=True)
-            if cfg.get("rdma_numa"):
+            # Optional one-rank/one-rail affinity keeps a large CUDA pool from
+            # being registered against every HCA PD. Use the physical attention
+            # rank, not tp_rank (tp_rank is always zero under DP-attention).
+            # Eight 128-GiB pools × eight rails exhausted mlx5 registration on
+            # B200; one rail per PCP rank registered cleanly and still aggregates
+            # all rails across the eight workers.
+            if _truthy(cfg.get("rail_affinity")):
+                rails = [x.strip() for x in
+                         os.environ.get("DFKV_RDMA_DEV", "").split(",")
+                         if x.strip()]
+                if len(rails) > 1:
+                    rank = self.pcp_rank if self.pcp_size > 1 else self.tp_rank
+                    os.environ["DFKV_RDMA_DEV"] = rails[rank % len(rails)]
+                    os.environ["DFKV_RDMA_NUMA"] = "0"
+            elif cfg.get("rdma_numa"):
                 os.environ.setdefault("DFKV_RDMA_NUMA", "1")
             # Same-host GET rendezvous (phase 5): dedups TP-replicated L3 loads
             # across the rank processes of one node (HiCache destinations are

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -350,6 +350,8 @@ RdmaTransport::~RdmaTransport() {
   std::lock_guard<std::mutex> lk(mu_);
   for (auto& [node, cs] : pool_)
     for (Conn* c : cs) Destroy(c);
+  for (auto& [node, cs] : sg_pool_)
+    for (Conn* c : cs) Destroy(c);
   for (auto& [node, cs] : control_pool_)
     for (Conn* c : cs) Destroy(c);
 }
@@ -427,7 +429,9 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
     std::lock_guard<std::mutex> lk(mu_);
     pools = pools_;
     if (!force_new) {
-      auto& idle = lane == Lane::kData ? pool_ : control_pool_;
+      auto& idle = lane == Lane::kData
+                       ? pool_
+                       : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
       auto it = idle.find(node);
       if (it != idle.end()) {
         auto& candidates = it->second;
@@ -472,7 +476,8 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
   conn->lease = *lease;
   conn->lease_started_us = lease_started;
   conn->credit_held = true;
-  if (!conn->ep.Open(dev.c_str(), rdma::kV2ControlCap, depth_)) {
+  const size_t conn_depth = lane == Lane::kSgData ? 1 : depth_;
+  if (!conn->ep.Open(dev.c_str(), rdma::kV2ControlCap, conn_depth)) {
     ::close(fd);
     DFKV_LOG_WARN("rdma: device " + dev +
                   " Open failed; rail failure policy will quarantine it");
@@ -490,7 +495,7 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
                        devbuf, rdma::kDevProtoV2);
   char mine[rdma::kQpInfoBytes], peer[rdma::kQpInfoBytes];
   rdma::QpInfo my = conn->ep.Local();
-  my.depth = static_cast<uint16_t>(std::min<size_t>(depth_, 256));
+  my.depth = static_cast<uint16_t>(std::min<size_t>(conn_depth, 256));
   my.protocol_version = rdma::kDevProtoV2;
   rdma::SerializeQpInfo(my, mine);
   if (!net::WriteAll(fd, devbuf, rdma::kDevNameBytes) ||
@@ -847,7 +852,9 @@ void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
   bool reusable = false;
   {
     std::lock_guard<std::mutex> lk(mu_);
-    auto& idle = lane == Lane::kData ? pool_ : control_pool_;
+    auto& idle = lane == Lane::kData
+                     ? pool_
+                     : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
     auto& v = idle[node];
     // A connection that was active during successful growth still owns the old
     // generation. Refresh it only after its WRs complete, before it becomes
@@ -1526,8 +1533,13 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     for (size_t i = 0; i < count; ++i)
       if (bad[i]) result[i] = Status::kInvalid;
     bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0,
-                         std::min(valid_count, depth_));
+    // Multi-SGE GPU writes are fanned out across independent connections by
+    // KVClient. Keep each connection at one in-flight item: the B200 mlx5
+    // device-direct path reports protection/error WCs when one QP overlaps
+    // writes from distinct registered CUDA ranges. That reduced a 3,937-page
+    // backup to 34 successful writes at depth 4; depth 1 completed all pages.
+    // RDMA depth is not a throughput lever for this path.
+    Conn* conn = Acquire(node, Lane::kSgData, &from_pool, attempt > 0, 1);
     if (!conn) return result;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -116,9 +116,10 @@ class RdmaTransport : public Transport {
 
  private:
   struct Conn;
-  // force_new skips the idle pool after a stale connection. lane separates
-  // payload traffic from key-sized control traffic.
-  enum class Lane { kData, kControl };
+  // force_new skips the idle pool after a stale connection. Lanes separate
+  // payload, device-direct SG, and key-sized control traffic. SG uses a
+  // depth-one QP because overlapping multi-SGE CUDA writes fail on mlx5.
+  enum class Lane { kData, kSgData, kControl };
   Conn* Acquire(const std::string& node, Lane lane, bool* from_pool,
                 bool force_new = false, size_t requested_credits = 1);
   void Release(const std::string& node, Lane lane, Conn* c);
@@ -132,6 +133,7 @@ class RdmaTransport : public Transport {
   bool ProbeV2(const std::string& node) const;
   std::mutex mu_;
   std::unordered_map<std::string, std::vector<Conn*>> pool_;
+  std::unordered_map<std::string, std::vector<Conn*>> sg_pool_;
   // Separate idle-connection pool for control-lane ops
   // (Exist/Remove/Members). Responses stay bounded, including the explicit
   // 32-KiB Members capacity, and never share a QP with payload transfers.

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -315,11 +315,9 @@ class DingoFSHiCacheTest(unittest.TestCase):
             ),
         )
 
-    def test_rdma_depth_extra_config_sets_env(self):
-        # extra_config rdma_depth must propagate to DFKV_RDMA_DEPTH so the C client
-        # builds its transport with write pipelining (#1). Set before dfkv_open.
+    def test_rdma_depth_is_preserved_for_connection_fanout(self):
         members, _, _ = self._node("rdepth")
-        os.environ.pop("DFKV_RDMA_DEPTH", None)
+        os.environ["DFKV_RDMA_DEPTH"] = "4"
         try:
             cfg = self._cfg(members)
             cfg.extra_config["rdma_depth"] = 8
@@ -328,13 +326,17 @@ class DingoFSHiCacheTest(unittest.TestCase):
         finally:
             os.environ.pop("DFKV_RDMA_DEPTH", None)
 
-    def _rail_for(self, members, rails_csv, tp_rank, tp_size):
+    def _rail_for(self, members, rails_csv, rank, size):
         saved = os.environ.get("DFKV_RDMA_DEV")
         os.environ["DFKV_RDMA_DEV"] = rails_csv
         os.environ.pop("DFKV_RDMA_NUMA", None)
         try:
-            cfg = self._cfg(members, tp_rank=tp_rank, tp_size=tp_size)
-            cfg.extra_config["rail_affinity"] = True
+            cfg = self._cfg(members, tp_rank=0, tp_size=1)
+            cfg.extra_config.update({
+                "rail_affinity": True,
+                "pcp_rank": rank,
+                "pcp_size": size,
+            })
             dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
             return os.environ.get("DFKV_RDMA_DEV"), os.environ.get("DFKV_RDMA_NUMA")
         finally:
@@ -344,23 +346,19 @@ class DingoFSHiCacheTest(unittest.TestCase):
             else:
                 os.environ["DFKV_RDMA_DEV"] = saved
 
-    def test_rail_affinity_deprecated_is_noop_8rails(self):
-        # rail_affinity is DEPRECATED: it must NOT narrow DFKV_RDMA_DEV anymore.
-        # The full multi-rail list is preserved (the C++ client now selects a
-        # NUMA-local rail per connection). It also no longer forces DFKV_RDMA_NUMA.
+    def test_rail_affinity_uses_physical_attention_rank(self):
         members, _, _ = self._node("rail8")
-        rails = "ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7"
-        dev, numa = self._rail_for(members, rails, tp_rank=3, tp_size=8)
-        self.assertEqual(dev, rails)   # unchanged: no per-rank narrowing
-        self.assertIsNone(numa)        # rail_affinity no longer sets DFKV_RDMA_NUMA
+        rails = "ib0,ib1,ib2,ib3,ib4,ib5,ib6,ib7"
+        dev, numa = self._rail_for(members, rails, rank=3, size=8)
+        self.assertEqual(dev, "ib3")
+        self.assertEqual(numa, "0")
 
-    def test_rail_affinity_deprecated_is_noop_2rails(self):
-        # Regardless of tp_rank, the full rail list survives (no DP-attention collapse).
+    def test_rail_affinity_wraps_over_available_rails(self):
         members, _, _ = self._node("rail2")
         rails = "ibA,ibB"
-        self.assertEqual(self._rail_for(members, rails, tp_rank=2, tp_size=8)[0], rails)
-        self.assertEqual(self._rail_for(members, rails, tp_rank=5, tp_size=8)[0], rails)
-        self.assertEqual(self._rail_for(members, rails, tp_rank=7, tp_size=8)[0], rails)
+        self.assertEqual(self._rail_for(members, rails, rank=2, size=8)[0], "ibA")
+        self.assertEqual(self._rail_for(members, rails, rank=5, size=8)[0], "ibB")
+        self.assertEqual(self._rail_for(members, rails, rank=7, size=8)[0], "ibB")
 
     def test_rdma_numa_extra_config_sets_env(self):
         # The new rdma_numa knob opts into client-side NUMA-aware rail selection


### PR DESCRIPTION
## Summary

- isolate multi-SGE device-direct traffic in a dedicated RDMA connection lane
- keep each SG QP at depth 1 while restoring configured batch fanout across independent QPs
- make HiCache rail affinity use the physical PCP rank instead of `tp_rank`, which is always 0 with DP attention
- add connector regressions for depth propagation and physical-rank rail selection

## Problem

Multi-SGE CUDA writes shared the normal data connection pool. With batch depth greater than one, mlx5 could overlap writes from distinct registered CUDA ranges on one QP and report protection/completion errors. The HiCache connector worked around this by effectively running at depth one, which serialized batch GETs and left SSD/RDMA throughput underutilized.

The previous `rail_affinity` implementation also used `tp_rank`. Under DP attention every process has `tp_rank=0`, collapsing all workers onto the same rail.

## Design

`Lane::kSgData` owns a separate idle pool. Its QPs negotiate depth one, but `CacheFromMulti` still fans a batch across independent connections according to the configured transport depth. This preserves the one-CUDA-range-per-QP invariant without serializing the whole batch.

When explicitly enabled, connector rail affinity now maps `pcp_rank % rail_count` and disables additional NUMA rail selection for that process.

## Validation

Tested on one 8x B200 development node with eight active RDMA rails and two NVMe data devices. The inference container used unlimited memlock so the device pools could be registered once.

- targeted connector tests: PASS
- candidate server/client build: PASS
- 228k-token GLM-5.2 cache retrieval: 227,968 cached tokens
- full hot retrieval: 26.60 s at depth 1 -> 5.24 s at depth 4 (5.08x)
- full cold retrieval: 7.24 s at depth 4
- cold NVMe peaks: 2,184.73 and 2,204.58 MB/s, 85.8% and 87.8% utilization
- RDMA completion error delta after the fix: 0

Runtime prerequisite: deployments using explicit large memory-pool registration must set an adequate `memlock` limit (for example, container `--ulimit memlock=-1:-1`).