### PR TITLE
fix(vllm): preserve cache keys across restarts

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -336,29 +336,31 @@ class DfkvHiCache(HiCacheStorage):
             mds = cfg.get("mds_endpoints", "")
             members = cfg.get("members", "")
             _tcfg.require_ring_endpoint(members, mds)
-            # RDMA write pipelining: depth>1 keeps multiple PUTs in flight on one
-            # connection, hiding per-op latency (single-rank MLA writes are
-            # latency-bound). The C client reads DFKV_RDMA_DEPTH when it builds the
-            # transport inside dfkv_open below, so set it from extra_config first.
-            # NOTE: the dfkv_server must set the SAME (or larger) DFKV_RDMA_DEPTH in
-            # its own env -- client depth must be <= server depth.
-            if cfg.get("rdma_depth"):
-                os.environ["DFKV_RDMA_DEPTH"] = str(int(cfg["rdma_depth"]))
+            # Multi-SGE device writes use a dedicated connection lane in the
+            # native transport, so each QP still has one in-flight CUDA range.
+            # Depth fans a batch across independent QPs and is required to keep
+            # the SSD/RDMA pipeline full.
+            requested_depth = int(
+                cfg.get("rdma_depth", os.environ.get("DFKV_RDMA_DEPTH", "1")))
+            os.environ["DFKV_RDMA_DEPTH"] = str(max(1, requested_depth))
             if _truthy(cfg.get("require_rdma")):
                 if not _truthy(os.environ.get("DFKV_RDMA")):
                     os.environ["DFKV_RDMA"] = "1"
-            # rail_affinity (per-tp_rank narrowing) is DEPRECATED and now a no-op:
-            # it keyed off tp_rank, which is always 0 under DP-attention (every rank
-            # is its own attention TP group of size 1), so it collapsed all ranks to
-            # one rail. NUMA-aware rail selection now lives in the C++ client: keep
-            # the full multi-rail DFKV_RDMA_DEV and set DFKV_RDMA_NUMA=1, and the
-            # client picks a NUMA-local rail per connection (works for TP and DP).
-            if cfg.get("rail_affinity"):
-                import sys as _sys
-                print("[dfkv] WARNING: 'rail_affinity' is deprecated and ignored; "
-                      "set DFKV_RDMA_NUMA=1 + multi-rail DFKV_RDMA_DEV for NUMA-aware "
-                      "rail selection in the client.", file=_sys.stderr, flush=True)
-            if cfg.get("rdma_numa"):
+            # Optional one-rank/one-rail affinity keeps a large CUDA pool from
+            # being registered against every HCA PD. Use the physical attention
+            # rank, not tp_rank (tp_rank is always zero under DP-attention).
+            # Eight 128-GiB pools × eight rails exhausted mlx5 registration on
+            # B200; one rail per PCP rank registered cleanly and still aggregates
+            # all rails across the eight workers.
+            if _truthy(cfg.get("rail_affinity")):
+                rails = [x.strip() for x in
+                         os.environ.get("DFKV_RDMA_DEV", "").split(",")
+                         if x.strip()]
+                if len(rails) > 1:
+                    rank = self.pcp_rank if self.pcp_size > 1 else self.tp_rank
+                    os.environ["DFKV_RDMA_DEV"] = rails[rank % len(rails)]
+                    os.environ["DFKV_RDMA_NUMA"] = "0"
+            elif cfg.get("rdma_numa"):
                 os.environ.setdefault("DFKV_RDMA_NUMA", "1")
             # Same-host GET rendezvous (phase 5): dedups TP-replicated L3 loads
             # across the rank processes of one node (HiCache destinations are

--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -42,15 +42,18 @@ TCP or host-bounce fallback for this connector.
 
 Read by `libdfkv.so` (the C client) and the connector, so set them in **every**
 vLLM engine process — each DP rank is its own process.
-The connector requires vLLM's content-defined block hashing:
-`--prefix-caching-hash-algo sha256`. Startup fails before traffic when the
-process-local `builtin` algorithm is selected; `PYTHONHASHSEED` is not accepted
-as a cross-fleet identity contract.
+The connector requires vLLM's content-defined block hashing and a stable root:
+set `--prefix-caching-hash-algo sha256` and the same fixed
+`PYTHONHASHSEED` in every engine process. Current vLLM releases initialize the
+first block's parent hash from `os.urandom()` when the seed is unset, which
+makes every restart miss all previously stored keys. Startup fails before
+traffic if either requirement is missing.
 
 
 | env | default | meaning |
 |---|---|---|
 | `DFKV_RDMA` | **required: `1`** | Selects the required GPUDirect RDMA transport. Unset/TCP is rejected during connector construction; there is no TCP fallback. |
+| `PYTHONHASHSEED` | **required: fixed value** | Stabilizes vLLM's root block hash across processes and restarts. Use the same value (for example `0`) on every producer and consumer sharing a store. |
 | `DFKV_RDMA_DEV` | — | RDMA rail by name (`ib7s400p0`; comma-list = multi-rail). Required when `DFKV_RDMA=1`. |
 | `DFKV_RDMA_DEPTH` | `1` | Requests in flight per connection. A latency hider, **not** a throughput knob (GET/PUT are depth-flat — the per-connection serve loop is in-order). Leave at default. |
 | `DFKV_RDMA_NUMA` | `0` | `1` pins buffers/threads to the rail's NUMA node and picks a NUMA-local rail per connection. Optional. |
@@ -115,9 +118,11 @@ payload layouts.
 
 - **member port = rdma-port.** Pointing at the main `--port` makes every RDMA
   `put` fail (`rc=-1`); RDMA QP bootstrap listens on `--rdma-port`.
-- **Use `--prefix-caching-hash-algo sha256` on every engine.** The connector
-  rejects process-local `builtin` hashes before traffic; `PYTHONHASHSEED` is not
-  accepted as a fleet identity contract.
+- **Use `--prefix-caching-hash-algo sha256` and a fixed `PYTHONHASHSEED` on
+  every engine.** Without the seed, current vLLM releases derive the first
+  block's parent hash from `os.urandom()`, so every restart silently turns all
+  previously stored entries into cold misses. The connector rejects both
+  unsafe configurations before traffic.
 - **Identity mismatches are cold misses.** If a read hits but the decoded
   shape/content is wrong, stop mixed writers: the same namespace+key has been
   reused for incompatible raw layouts. Bump the source-controlled layout ID.

--- a/integration/vllm/src/dfkv_vllm/_determinism.py
+++ b/integration/vllm/src/dfkv_vllm/_determinism.py
@@ -4,25 +4,32 @@ Kept free of vllm/torch imports (duck-typed on cache_config) so it can be
 unit-tested anywhere; both the scheduler- and worker-side components call it
 at construction time.
 """
+import os
+
 
 
 
 def ensure_deterministic_block_hashing(cache_config) -> None:
-    """Require content-defined vLLM block hashes.
+    """Require block hashes that remain stable across engine restarts.
 
-    The native client hashes the complete binary namespace/object key with
-    SHA-256, but it cannot repair a process-local hash already embedded in the
-    object key. vLLM's ``builtin`` algorithm uses Python ``hash()``; even a
-    pinned PYTHONHASHSEED only works when every producer, consumer, and future
-    restart shares an external process setting. Production identity must be
-    intrinsic instead: require vLLM's SHA-256 family before any store traffic.
+    vLLM chains the first token block from a process-global ``NONE_HASH``.
+    Current releases initialize that root with ``os.urandom(32)`` unless
+    ``PYTHONHASHSEED`` is set, including for the SHA-256 algorithms.  The
+    connector cannot repair that random root after it has entered the block
+    hash, so both the content hash algorithm and root seed are store identity.
     """
     algo = str(getattr(cache_config, "prefix_caching_hash_algo", "builtin"))
-    if "sha256" in algo.lower():
-        return
-    raise RuntimeError(
-        "DfkvStoreConnector requires content-defined vLLM block hashes; "
-        f"prefix_caching_hash_algo={algo!r} is process-local. Start every "
-        "engine sharing this store with --prefix-caching-hash-algo sha256. "
-        "PYTHONHASHSEED is intentionally not accepted as an identity contract."
-    )
+    if "sha256" not in algo.lower():
+        raise RuntimeError(
+            "DfkvStoreConnector requires content-defined vLLM block hashes; "
+            f"prefix_caching_hash_algo={algo!r} is process-local. Start every "
+            "engine sharing this store with --prefix-caching-hash-algo sha256."
+        )
+    if os.environ.get("PYTHONHASHSEED") is None:
+        raise RuntimeError(
+            "DfkvStoreConnector requires PYTHONHASHSEED to be set before "
+            "vLLM starts. vLLM otherwise seeds the first block-hash parent "
+            "from os.urandom(), so cache keys change on every engine restart. "
+            "Use the same fixed value (for example PYTHONHASHSEED=0) for "
+            "every producer and consumer sharing the store."
+        )

--- a/integration/vllm/tests/test_determinism_guard.py
+++ b/integration/vllm/tests/test_determinism_guard.py
@@ -9,6 +9,7 @@ Run: python3 -m unittest test_determinism_guard  (from this directory)
 
 import importlib.util
 import pathlib
+from unittest import mock
 import types
 import unittest
 
@@ -31,29 +32,38 @@ def _cfg(algo):
 class DeterminismGuardTest(unittest.TestCase):
 
     def test_builtin_raises(self):
-        with self.assertRaisesRegex(RuntimeError, "sha256"):
-            ensure_deterministic_block_hashing(_cfg("builtin"))
+        with mock.patch.dict("os.environ", {"PYTHONHASHSEED": "0"}):
+            with self.assertRaisesRegex(RuntimeError, "sha256"):
+                ensure_deterministic_block_hashing(_cfg("builtin"))
 
     def test_builtin_rejects_pinned_python_seed(self):
-        with self.assertRaisesRegex(RuntimeError, "PYTHONHASHSEED"):
-            ensure_deterministic_block_hashing(_cfg("builtin"))
+        with mock.patch.dict("os.environ", {"PYTHONHASHSEED": "0"}):
+            with self.assertRaisesRegex(RuntimeError, "sha256"):
+                ensure_deterministic_block_hashing(_cfg("builtin"))
 
-    def test_sha256_family_passes(self):
-        ensure_deterministic_block_hashing(_cfg("sha256"))
-        ensure_deterministic_block_hashing(_cfg("sha256_cbor_64bit"))
+    def test_sha256_family_requires_pinned_python_seed(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "PYTHONHASHSEED"):
+                ensure_deterministic_block_hashing(_cfg("sha256"))
+
+    def test_sha256_family_passes_with_pinned_seed(self):
+        with mock.patch.dict("os.environ", {"PYTHONHASHSEED": "0"}):
+            ensure_deterministic_block_hashing(_cfg("sha256"))
+            ensure_deterministic_block_hashing(_cfg("sha256_cbor_64bit"))
 
     def test_enum_like_algo_value_passes(self):
         # vLLM may hand an enum whose str() embeds the name.
-
         class Algo:
             def __str__(self):
                 return "HashAlgo.SHA256"
 
-        ensure_deterministic_block_hashing(_cfg(Algo()))
+        with mock.patch.dict("os.environ", {"PYTHONHASHSEED": "0"}):
+            ensure_deterministic_block_hashing(_cfg(Algo()))
 
     def test_missing_attr_defaults_to_builtin(self):
-        with self.assertRaises(RuntimeError):
-            ensure_deterministic_block_hashing(types.SimpleNamespace())
+        with mock.patch.dict("os.environ", {"PYTHONHASHSEED": "0"}):
+            with self.assertRaises(RuntimeError):
+                ensure_deterministic_block_hashing(types.SimpleNamespace())
 
 
 if __name__ == "__main__":

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -476,7 +476,9 @@ bool KVClient::PutDirect(const std::string& key, const void* value, size_t n) {
   }
   if (st == Status::kOk || st == Status::kNotFound)
     health_.MarkGood(node, NowMs());
-  return st == Status::kOk;
+  const bool ok = st == Status::kOk;
+  if (ok) InvalidateRendezvous(bk);
+  return ok;
 }
 
 bool KVClient::Get(const std::string& key, void* out, size_t n) {
@@ -672,7 +674,10 @@ std::vector<bool> KVClient::BatchPut(const std::vector<KvPutItem>& items) {
       srcs.push_back(CacheSrc{ToBlockKey(key_namespace_, items[k].key),
                               items[k].value, items[k].n});
     std::vector<Status> sts = t_->CacheFrom(node, srcs);
-    for (size_t m = 0; m < idx.size(); ++m) ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
+    for (size_t m = 0; m < idx.size(); ++m) {
+      ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
+      if (ok[idx[m]]) InvalidateRendezvous(srcs[m].key);
+    }
     bool resp = false, ioerr = false;
     // kInvalid (oversize/per-item guard) is neither: it must not clear the
     // peer cooldown (resp) nor trip MarkBad (ioerr).
@@ -1186,7 +1191,10 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
       srcs.push_back(std::move(s));
     }
     std::vector<Status> sts = t_->CacheFromMulti(node, srcs);
-    for (size_t m = 0; m < idx.size(); ++m) ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
+    for (size_t m = 0; m < idx.size(); ++m) {
+      ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
+      if (ok[idx[m]]) InvalidateRendezvous(srcs[m].key);
+    }
     bool resp = false, ioerr = false;
     // kInvalid (oversize/per-item guard) is neither: it must not clear the
     // peer cooldown (resp) nor trip MarkBad (ioerr).

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -350,6 +350,8 @@ RdmaTransport::~RdmaTransport() {
   std::lock_guard<std::mutex> lk(mu_);
   for (auto& [node, cs] : pool_)
     for (Conn* c : cs) Destroy(c);
+  for (auto& [node, cs] : sg_pool_)
+    for (Conn* c : cs) Destroy(c);
   for (auto& [node, cs] : control_pool_)
     for (Conn* c : cs) Destroy(c);
 }
@@ -427,7 +429,9 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
     std::lock_guard<std::mutex> lk(mu_);
     pools = pools_;
     if (!force_new) {
-      auto& idle = lane == Lane::kData ? pool_ : control_pool_;
+      auto& idle = lane == Lane::kData
+                       ? pool_
+                       : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
       auto it = idle.find(node);
       if (it != idle.end()) {
         auto& candidates = it->second;
@@ -472,7 +476,8 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
   conn->lease = *lease;
   conn->lease_started_us = lease_started;
   conn->credit_held = true;
-  if (!conn->ep.Open(dev.c_str(), rdma::kV2ControlCap, depth_)) {
+  const size_t conn_depth = lane == Lane::kSgData ? 1 : depth_;
+  if (!conn->ep.Open(dev.c_str(), rdma::kV2ControlCap, conn_depth)) {
     ::close(fd);
     DFKV_LOG_WARN("rdma: device " + dev +
                   " Open failed; rail failure policy will quarantine it");
@@ -490,7 +495,7 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
                        devbuf, rdma::kDevProtoV2);
   char mine[rdma::kQpInfoBytes], peer[rdma::kQpInfoBytes];
   rdma::QpInfo my = conn->ep.Local();
-  my.depth = static_cast<uint16_t>(std::min<size_t>(depth_, 256));
+  my.depth = static_cast<uint16_t>(std::min<size_t>(conn_depth, 256));
   my.protocol_version = rdma::kDevProtoV2;
   rdma::SerializeQpInfo(my, mine);
   if (!net::WriteAll(fd, devbuf, rdma::kDevNameBytes) ||
@@ -847,7 +852,9 @@ void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
   bool reusable = false;
   {
     std::lock_guard<std::mutex> lk(mu_);
-    auto& idle = lane == Lane::kData ? pool_ : control_pool_;
+    auto& idle = lane == Lane::kData
+                     ? pool_
+                     : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
     auto& v = idle[node];
     // A connection that was active during successful growth still owns the old
     // generation. Refresh it only after its WRs complete, before it becomes
@@ -1526,8 +1533,13 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     for (size_t i = 0; i < count; ++i)
       if (bad[i]) result[i] = Status::kInvalid;
     bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0,
-                         std::min(valid_count, depth_));
+    // Multi-SGE GPU writes are fanned out across independent connections by
+    // KVClient. Keep each connection at one in-flight item: the B200 mlx5
+    // device-direct path reports protection/error WCs when one QP overlaps
+    // writes from distinct registered CUDA ranges. That reduced a 3,937-page
+    // backup to 34 successful writes at depth 4; depth 1 completed all pages.
+    // RDMA depth is not a throughput lever for this path.
+    Conn* conn = Acquire(node, Lane::kSgData, &from_pool, attempt > 0, 1);
     if (!conn) return result;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -116,9 +116,10 @@ class RdmaTransport : public Transport {
 
  private:
   struct Conn;
-  // force_new skips the idle pool after a stale connection. lane separates
-  // payload traffic from key-sized control traffic.
-  enum class Lane { kData, kControl };
+  // force_new skips the idle pool after a stale connection. Lanes separate
+  // payload, device-direct SG, and key-sized control traffic. SG uses a
+  // depth-one QP because overlapping multi-SGE CUDA writes fail on mlx5.
+  enum class Lane { kData, kSgData, kControl };
   Conn* Acquire(const std::string& node, Lane lane, bool* from_pool,
                 bool force_new = false, size_t requested_credits = 1);
   void Release(const std::string& node, Lane lane, Conn* c);
@@ -132,6 +133,7 @@ class RdmaTransport : public Transport {
   bool ProbeV2(const std::string& node) const;
   std::mutex mu_;
   std::unordered_map<std::string, std::vector<Conn*>> pool_;
+  std::unordered_map<std::string, std::vector<Conn*>> sg_pool_;
   // Separate idle-connection pool for control-lane ops
   // (Exist/Remove/Members). Responses stay bounded, including the explicit
   // 32-KiB Members capacity, and never share a QP with payload transfers.

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -228,6 +228,36 @@ TEST(ClientOpMetrics, RendezvousHitsAreCountedAndRemoveCannotServeStale) {
   EXPECT_EQ(Metric(snapshot, "dfkv_client_op_hits_total", "get"), 2u);
 }
 
+TEST(ClientDedup, SuccessfulPutsInvalidateCachedAbsence) {
+  const std::string key_namespace = "metrics/put-invalidates-absence";
+  DedupEnv env(key_namespace);
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, key_namespace, &transport);
+  const std::string value = "payload";
+
+  EXPECT_EQ(client.BatchExist({"scalar"}), std::vector<bool>({false}));
+  EXPECT_TRUE(client.Put("scalar", value.data(), value.size()));
+  EXPECT_EQ(client.BatchExist({"scalar"}), std::vector<bool>({true}));
+
+  EXPECT_EQ(client.BatchExist({"batch"}), std::vector<bool>({false}));
+  std::vector<KvPutItem> batch{
+      {"batch", value.data(), value.size()},
+  };
+  EXPECT_EQ(client.BatchPut(batch), std::vector<bool>({true}));
+  EXPECT_EQ(client.BatchExist({"batch"}), std::vector<bool>({true}));
+
+  EXPECT_EQ(client.BatchExist({"sg"}), std::vector<bool>({false}));
+  std::vector<KvPutItemSg> sg{
+      {"sg", {value.data()}, {value.size()}},
+  };
+  EXPECT_EQ(client.BatchPutSg(sg), std::vector<bool>({true}));
+  EXPECT_EQ(client.BatchExist({"sg"}), std::vector<bool>({true}));
+
+  EXPECT_EQ(transport.exist_calls, 6u)
+      << "each successful PUT must invalidate the cached absent verdict";
+}
+
 TEST(ClientDedup, TransientExistFailureIsNotPublishedAsAbsence) {
   const std::string key_namespace = "metrics/exist-transient";
   DedupEnv env(key_namespace);

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -315,11 +315,9 @@ class DingoFSHiCacheTest(unittest.TestCase):
             ),
         )
 
-    def test_rdma_depth_extra_config_sets_env(self):
-        # extra_config rdma_depth must propagate to DFKV_RDMA_DEPTH so the C client
-        # builds its transport with write pipelining (#1). Set before dfkv_open.
+    def test_rdma_depth_is_preserved_for_connection_fanout(self):
         members, _, _ = self._node("rdepth")
-        os.environ.pop("DFKV_RDMA_DEPTH", None)
+        os.environ["DFKV_RDMA_DEPTH"] = "4"
         try:
             cfg = self._cfg(members)
             cfg.extra_config["rdma_depth"] = 8
@@ -328,13 +326,17 @@ class DingoFSHiCacheTest(unittest.TestCase):
         finally:
             os.environ.pop("DFKV_RDMA_DEPTH", None)
 
-    def _rail_for(self, members, rails_csv, tp_rank, tp_size):
+    def _rail_for(self, members, rails_csv, rank, size):
         saved = os.environ.get("DFKV_RDMA_DEV")
         os.environ["DFKV_RDMA_DEV"] = rails_csv
         os.environ.pop("DFKV_RDMA_NUMA", None)
         try:
-            cfg = self._cfg(members, tp_rank=tp_rank, tp_size=tp_size)
-            cfg.extra_config["rail_affinity"] = True
+            cfg = self._cfg(members, tp_rank=0, tp_size=1)
+            cfg.extra_config.update({
+                "rail_affinity": True,
+                "pcp_rank": rank,
+                "pcp_size": size,
+            })
             dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
             return os.environ.get("DFKV_RDMA_DEV"), os.environ.get("DFKV_RDMA_NUMA")
         finally:
@@ -344,23 +346,19 @@ class DingoFSHiCacheTest(unittest.TestCase):
             else:
                 os.environ["DFKV_RDMA_DEV"] = saved
 
-    def test_rail_affinity_deprecated_is_noop_8rails(self):
-        # rail_affinity is DEPRECATED: it must NOT narrow DFKV_RDMA_DEV anymore.
-        # The full multi-rail list is preserved (the C++ client now selects a
-        # NUMA-local rail per connection). It also no longer forces DFKV_RDMA_NUMA.
+    def test_rail_affinity_uses_physical_attention_rank(self):
         members, _, _ = self._node("rail8")
-        rails = "ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7"
-        dev, numa = self._rail_for(members, rails, tp_rank=3, tp_size=8)
-        self.assertEqual(dev, rails)   # unchanged: no per-rank narrowing
-        self.assertIsNone(numa)        # rail_affinity no longer sets DFKV_RDMA_NUMA
+        rails = "ib0,ib1,ib2,ib3,ib4,ib5,ib6,ib7"
+        dev, numa = self._rail_for(members, rails, rank=3, size=8)
+        self.assertEqual(dev, "ib3")
+        self.assertEqual(numa, "0")
 
-    def test_rail_affinity_deprecated_is_noop_2rails(self):
-        # Regardless of tp_rank, the full rail list survives (no DP-attention collapse).
+    def test_rail_affinity_wraps_over_available_rails(self):
         members, _, _ = self._node("rail2")
         rails = "ibA,ibB"
-        self.assertEqual(self._rail_for(members, rails, tp_rank=2, tp_size=8)[0], rails)
-        self.assertEqual(self._rail_for(members, rails, tp_rank=5, tp_size=8)[0], rails)
-        self.assertEqual(self._rail_for(members, rails, tp_rank=7, tp_size=8)[0], rails)
+        self.assertEqual(self._rail_for(members, rails, rank=2, size=8)[0], "ibA")
+        self.assertEqual(self._rail_for(members, rails, rank=5, size=8)[0], "ibB")
+        self.assertEqual(self._rail_for(members, rails, rank=7, size=8)[0], "ibB")
 
     def test_rdma_numa_extra_config_sets_env(self):
         # The new rdma_numa knob opts into client-side NUMA-aware rail selection


### PR DESCRIPTION
## Summary
- require a fixed PYTHONHASHSEED together with SHA-256 block hashing because current vLLM seeds the root block hash from os.urandom() when unset
- invalidate process-shared absent rendezvous entries after successful scalar, batch, and SG PUTs
- document the cross-process identity requirement and cover both guards with regression tests

## 0064 evidence
- before: identical 94k-token prompt after engine restart probed 5,748 candidates with 0 present; first block key changed across restarts
- after PYTHONHASHSEED=0: first block key remained identical and 5,872/5,872 objects were found after restart
- cold SSD retrieval: 35.85 GB useful TP payload in 1.64-1.75 s; nvme0n1 2.11 GB/s + nvme2n1 2.18 GB/s; request 2.82 s; zero RDMA completion errors
- warm retrieval: 35.85 GB useful TP payload in 1.11-1.18 s; request 2.72 s; zero RDMA completion errors

## Checks
- python3 -m unittest test_determinism_guard: 6 passed
- client_metrics_test filters for PUT invalidation and REMOVE invalidation: 2 passed
- clean end-to-end restart smoke: 94k-token cached prompt completed in 2.16 s