### PR TITLE
fix(client): retry minority misses in SG reads

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1410,51 +1410,72 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
 
   // Group by (node, total_cap): a group shares the Range length (= sum of caps)
   // so the existing RangeInto windowing/pipelining applies unchanged.
-  std::map<std::pair<std::string, size_t>, std::vector<size_t>> by;
-  for (size_t i = 0; i < N; ++i) {
-    if (over[i]) continue;
-    std::string node = Route(items[i].key);
-    if (node.empty()) continue;
-    by[{node, total_caps[i]}].push_back(i);
+  auto run_pass = [&](const std::vector<size_t>& todo) {
+    std::map<std::pair<std::string, size_t>, std::vector<size_t>> by;
+    for (size_t i : todo) {
+      if (over[i]) continue;
+      std::string node = Route(items[i].key);
+      if (node.empty()) continue;
+      by[{node, total_caps[i]}].push_back(i);
+    }
+    std::vector<std::pair<std::pair<std::string, size_t>,
+                          std::vector<size_t>>>
+        groups = ShardReadGroups(
+            std::vector<std::pair<std::pair<std::string, size_t>,
+                                  std::vector<size_t>>>(by.begin(), by.end()));
+    RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
+      const std::string& node = groups[g].first.first;
+      uint64_t now = NowMs();
+      if (!health_.Healthy(node, now)) return;
+      const std::vector<size_t>& idx = groups[g].second;
+      std::vector<BlockKey> keys;
+      std::vector<RangeDstMulti> dsts;
+      keys.reserve(idx.size());
+      dsts.reserve(idx.size());
+      for (size_t k : idx) {
+        keys.push_back(ToBlockKey(key_namespace_, items[k].key));
+        RangeDstMulti d;
+        d.payloads.reserve(items[k].dsts.size());
+        for (size_t j = 0; j < items[k].dsts.size(); ++j)
+          d.payloads.emplace_back(items[k].dsts[j], items[k].caps[j]);
+        dsts.push_back(std::move(d));
+      }
+      std::vector<size_t> value_lens;
+      std::vector<Status> sts =
+          t_->RangeIntoMulti(node, keys, dsts, &value_lens);
+      bool resp = false, ioerr = false;
+      // kInvalid (oversize/per-item guard) is neither: it must not clear the
+      // peer cooldown (resp) nor trip MarkBad (ioerr).
+      for (Status s : sts) {
+        if (s == Status::kIOError) ioerr = true;
+        else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+      }
+      if (resp) health_.MarkGood(node, NowMs());
+      else if (ioerr) health_.MarkBad(node, NowMs());
+      for (size_t m = 0; m < idx.size(); ++m) {
+        size_t cap = groups[g].first.second;
+        if (sts[m] != Status::kOk || m >= value_lens.size() ||
+            value_lens[m] > cap)
+          continue;
+        lens[idx[m]] = static_cast<size_t>(value_lens[m]);
+        hit[idx[m]] = 1;
+      }
+    });
+  };
+  std::vector<size_t> all(N);
+  for (size_t i = 0; i < N; ++i) all[i] = i;
+  run_pass(all);
+  // Match scalar BatchGet's bounded transient-miss recovery. Under concurrent
+  // RAM flush/reclaim or connection turnover a small subset can return absent
+  // for one pass even though the server serves it immediately on retry. Retry
+  // only a minority; a genuinely cold SG batch must remain a single probe.
+  for (int r = 0; r < get_miss_retries_; ++r) {
+    std::vector<size_t> missed;
+    for (size_t i = 0; i < N; ++i)
+      if (!over[i] && !hit[i]) missed.push_back(i);
+    if (missed.empty() || missed.size() > N / 2) break;
+    run_pass(missed);
   }
-  std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>> groups = ShardReadGroups(std::vector<std::pair<std::pair<std::string, size_t>, std::vector<size_t>>>(by.begin(), by.end()));
-  RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
-    const std::string& node = groups[g].first.first;
-    uint64_t now = NowMs();
-    if (!health_.Healthy(node, now)) return;
-    const std::vector<size_t>& idx = groups[g].second;
-    std::vector<BlockKey> keys;
-    std::vector<RangeDstMulti> dsts;
-    keys.reserve(idx.size());
-    dsts.reserve(idx.size());
-    for (size_t k : idx) {
-      keys.push_back(ToBlockKey(key_namespace_, items[k].key));
-      RangeDstMulti d;
-      d.payloads.reserve(items[k].dsts.size());
-      for (size_t j = 0; j < items[k].dsts.size(); ++j)
-        d.payloads.emplace_back(items[k].dsts[j], items[k].caps[j]);
-      dsts.push_back(std::move(d));
-    }
-    std::vector<size_t> value_lens;
-    std::vector<Status> sts =
-        t_->RangeIntoMulti(node, keys, dsts, &value_lens);
-    bool resp = false, ioerr = false;
-    // kInvalid (oversize/per-item guard) is neither: it must not clear the
-    // peer cooldown (resp) nor trip MarkBad (ioerr).
-    for (Status s : sts) {
-      if (s == Status::kIOError) ioerr = true;
-      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
-    }
-    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
-    for (size_t m = 0; m < idx.size(); ++m) {
-      size_t cap = groups[g].first.second;
-      if (sts[m] != Status::kOk || m >= value_lens.size() ||
-          value_lens[m] > cap)
-        continue;
-      lens[idx[m]] = static_cast<size_t>(value_lens[m]);
-      hit[idx[m]] = 1;
-    }
-  });
   if (out_lens) *out_lens = std::move(lens);
   return std::vector<bool>(hit.begin(), hit.end());
 }

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <array>
 
 #include <string>
 #include <chrono>
@@ -26,6 +27,8 @@ class MetricsTransport final : public Transport {
   std::vector<Status> exist_script;
   size_t exist_calls = 0;
   size_t range_calls = 0;
+  size_t range_multi_calls = 0;
+  size_t range_multi_misses = 0;
 
   Status Cache(const std::string&, const BlockKey& key, const void* data,
                size_t len) override {
@@ -73,6 +76,21 @@ class MetricsTransport final : public Transport {
     return Status::kOk;
   }
   bool pipelined() const override { return pipeline; }
+  std::vector<Status> RangeIntoMulti(
+      const std::string& node, const std::vector<BlockKey>& keys,
+      const std::vector<RangeDstMulti>& dsts,
+      std::vector<size_t>* out_lens) override {
+    ++range_multi_calls;
+    std::vector<Status> result =
+        Transport::RangeIntoMulti(node, keys, dsts, out_lens);
+    for (size_t i = 0; i < result.size() && range_multi_misses > 0; ++i) {
+      if (result[i] != Status::kOk) continue;
+      result[i] = Status::kNotFound;
+      if (out_lens && i < out_lens->size()) (*out_lens)[i] = 0;
+      --range_multi_misses;
+    }
+    return result;
+  }
 };
 
 uint64_t Metric(const std::string& snapshot, const std::string& family,
@@ -308,4 +326,32 @@ TEST(ClientRetries, InvalidOrOutOfRangeValueUsesBoundedDefault) {
     EXPECT_EQ(client.BatchGet(gets), std::vector<bool>({true, false}));
     EXPECT_EQ(transport.range_calls, 3u) << invalid;
   }
+}
+
+TEST(ClientRetries, SgGetRetriesTransientMinorityMisses) {
+  MetricsTransport transport;
+  transport.pipeline = true;
+  const std::string key_namespace = "retry/sg";
+  KVClient client({{"n", "test:1"}}, key_namespace, &transport);
+  const std::string value = "abcdef";
+  ASSERT_TRUE(client.Put("retry", value.data(), value.size()));
+  ASSERT_TRUE(client.Put("stable", value.data(), value.size()));
+  transport.range_multi_misses = 1;
+  std::array<char, 3> retry_first{}, retry_second{};
+  std::array<char, 3> stable_first{}, stable_second{};
+  KvGetItemSg retry{"retry",
+                    {retry_first.data(), retry_second.data()},
+                    {retry_first.size(), retry_second.size()}};
+  KvGetItemSg stable{"stable",
+                     {stable_first.data(), stable_second.data()},
+                     {stable_first.size(), stable_second.size()}};
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg({retry, stable}, &lengths),
+            std::vector<bool>({true, true}));
+  EXPECT_EQ(lengths,
+            std::vector<size_t>({value.size(), value.size()}));
+  EXPECT_EQ(std::string(retry_first.data(), retry_first.size()) +
+                std::string(retry_second.data(), retry_second.size()),
+            value);
+  EXPECT_EQ(transport.range_multi_calls, 2u);
 }


### PR DESCRIPTION
BatchGetAutoSg now applies the same bounded minority-miss retry policy as BatchGetDirect. This closes a correctness gap exposed by large vLLM GPU SG reads: a transient server handoff miss no longer turns an otherwise warm 5,872-key batch into partial_failure. Retries preserve the original node/capacity grouping and scatter destinations. Includes a deterministic regression test that injects one transient miss in a two-key SG batch. Verified on xb01-0064 with ClientRetries.* (3/3 passing) and deployed end-to-end: 94k-token restart retrieval completed with status=ok, 35.85 GB loaded, zero server cache misses, zero RDMA completion errors.