### PR TITLE
fix(observability): harden production runtime defaults

### DIFF
--- a/deploy/observability/docker-compose.yml
+++ b/deploy/observability/docker-compose.yml
@@ -25,6 +25,9 @@ services:
     depends_on:
       - tempo
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
 
   prometheus:
     # Prometheus 3.13.2
@@ -41,6 +44,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
 
   tempo:
     # Tempo 3.0.2
@@ -52,6 +58,9 @@ services:
     ports:
       - "127.0.0.1:${DFKV_TEMPO_PORT:-3200}:3200"
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
 
   grafana:
     # Grafana 13.1.3
@@ -61,6 +70,12 @@ services:
       - "GF_SECURITY_ADMIN_PASSWORD=${DFKV_GRAFANA_ADMIN_PASSWORD:?set a non-default Grafana admin password}"
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=false
+      - GF_PLUGINS_PREINSTALL_DISABLED=true
+      - GF_PLUGINS_PREINSTALL_AUTO_UPDATE=false
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      - GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false
+      - GF_NEWS_NEWS_FEED_ENABLED=false
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
@@ -73,6 +88,7 @@ services:
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
+    cap_drop: [ALL]
 
 volumes:
   prometheus-data:

--- a/deploy/observability/otel-collector-config.yaml
+++ b/deploy/observability/otel-collector-config.yaml
@@ -31,7 +31,7 @@ exporters:
       enabled: true
     add_metric_suffixes: false
     enable_open_metrics: true
-  otlp/tempo:
+  otlp_grpc/tempo:
     endpoint: tempo:4317
     tls:
       insecure: true
@@ -41,6 +41,12 @@ service:
   telemetry:
     metrics:
       level: basic
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
   pipelines:
     metrics:
       receivers: [otlp]
@@ -49,4 +55,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [otlp/tempo]
+      exporters: [otlp_grpc/tempo]

--- a/test/python/test_observability_contract.py
+++ b/test/python/test_observability_contract.py
@@ -242,6 +242,18 @@ class ObservabilityContractTest(unittest.TestCase):
         self.assertEqual(compose.count("@sha256:"), 4)
         self.assertIn("${DFKV_GRAFANA_ADMIN_PASSWORD:?", compose)
         self.assertNotIn("DFKV_GRAFANA_ADMIN_PASSWORD:-admin", compose)
+        self.assertEqual(compose.count("no-new-privileges:true"), 4)
+        self.assertEqual(compose.count("cap_drop: [ALL]"), 4)
+        self.assertIn("GF_PLUGINS_PREINSTALL_DISABLED=true", compose)
+        self.assertIn("GF_ANALYTICS_REPORTING_ENABLED=false", compose)
+        self.assertIn("GF_NEWS_NEWS_FEED_ENABLED=false", compose)
+        collector = (
+            ROOT / "deploy" / "observability" / "otel-collector-config.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("otlp_grpc/tempo", collector)
+        self.assertNotIn("otlp/tempo", collector)
+        self.assertIn("readers:", collector)
+        self.assertIn("port: 8888", collector)
         self.assertIn("DFKV_BASE_IMAGE=", dockerfile)
         self.assertIn("@sha256:", dockerfile)
 


### PR DESCRIPTION
## Summary
- replace the deprecated Collector `otlp` alias with `otlp_grpc`
- expose Collector internal metrics on `0.0.0.0:8888` with the current pull-reader schema, so the shipped `otel-collector` Prometheus target is real and healthy
- enforce `no-new-privileges` and drop all Linux capabilities for every observability service
- disable Grafana background plugin downloads, update checks, news feed, and analytics reporting
- lock these invariants into the observability contract test

## Verification
- `python3 test/python/test_observability_contract.py`
- `DFKV_GRAFANA_ADMIN_PASSWORD=... docker compose -f deploy/observability/docker-compose.yml config -q`
- full rollout deployment transaction against the pinned images: four services healthy, both internal Prometheus scrape targets UP, OTLP metric visible in Prometheus, OTLP trace retrievable from Tempo, both Grafana datasources healthy, both dashboards provisioned, and all container capabilities dropped