### PR TITLE
feat(cache): acknowledge write-back PUTs from RAM

### DIFF
--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -155,6 +155,16 @@ void KvNodeServer::InitRamTier() {
   // Background free-slot reclaimer cadence (ms; 0 disables). Default 10.
   if (const char* r = std::getenv("DFKV_RAM_RECLAIM_MS"))
     o.reclaim_interval_ms = static_cast<uint32_t>(std::strtoul(r, nullptr, 10));
+  const char* ack = std::getenv("DFKV_PUT_ACK_MODE");
+  ram_ack_enabled_ = ack != nullptr && std::string(ack) == "ram";
+  if (const char* p = std::getenv("DFKV_RAM_ACK_HIGH_WATERMARK_PCT")) {
+    const unsigned long n = std::strtoul(p, nullptr, 10);
+    if (n <= 100) o.ack_high_watermark_pct = static_cast<uint32_t>(n);
+  }
+  config_dump::RecordResolved("DFKV_PUT_ACK_MODE",
+                              ram_ack_enabled_ ? "ram" : "disk");
+  config_dump::RecordResolved("DFKV_RAM_ACK_HIGH_WATERMARK_PCT",
+                              std::to_string(o.ack_high_watermark_pct));
   config_dump::RecordResolved("DFKV_RAM_TIER_BYTES", std::to_string(o.bytes));
   config_dump::RecordResolved("DFKV_RAM_RECLAIM_MS", std::to_string(o.reclaim_interval_ms));
   // Flusher persists a RAM slot to the disk group. CacheDirect (not Cache): the
@@ -571,6 +581,22 @@ std::string KvNodeServer::MetricsText() const {
     metric("dfkv_ram_rebalanced_total", "counter", "RAM extents moved from cold classes to hot ones by the reclaimer", ram_->Rebalanced());
     metric("dfkv_ram_objects", "gauge", "Blocks currently resident in the RAM hot tier", ram_->Count());
     metric("dfkv_ram_flush_backlog", "gauge", "RAM slots queued or flushing (not yet durable)", ram_->FlushBacklog());
+    metric("dfkv_ram_dirty_objects", "gauge",
+           "RAM-resident objects not yet durable on disk", ram_->DirtyObjects());
+    metric("dfkv_ram_dirty_bytes", "gauge",
+           "Allocated bytes not yet durable on disk", ram_->DirtyBytes());
+    metric("dfkv_ram_oldest_dirty_age_seconds", "gauge",
+           "Age in seconds of the oldest non-durable RAM object",
+           ram_->OldestDirtyAgeSeconds());
+    metric("dfkv_ram_ack_total", "counter",
+           "PUTs acknowledged from flush-pinned RAM before disk commit",
+           ram_->RamAcks());
+    metric("dfkv_ram_ack_backpressure_total", "counter",
+           "RAM-ACK PUTs forced to wait for disk at the dirty watermark",
+           ram_->AckBackpressure());
+    metric("dfkv_ram_post_ack_flush_failures_total", "counter",
+           "Acknowledged RAM PUTs whose background disk flush later failed",
+           ram_->PostAckFlushFailures());
     metric("dfkv_ram_budget_bytes", "gauge",
            "Hard total RAM-tier budget across arena and dedicated values",
            ram_->budget_bytes());
@@ -677,13 +703,14 @@ Status KvNodeServer::ProcessRequestForKey(
       }
       bool samp = lat_sampler_.ShouldSample();
       double t0 = samp ? NowSec() : 0.0;
-      // A server PUT cannot acknowledge an arena admission: it waits for the
-      // actual disk commit. Only genuine RAM capacity backpressure falls through
-      // to a separate synchronous disk write; an in-flight duplicate shares its
-      // leader's final result.
+      // RAM-ACK mode publishes a flush-pinned copy and returns immediately;
+      // its dirty-byte watermark switches individual requests back to waiting
+      // for disk. Admission failure falls through to the normal disk path.
       bool needs_disk = true;
       if (ram_ && group_.TenantQuotaBytes(key.tenant_hash) == 0) {
-        st = ram_->PutCommitted(key, payload, payload_len);
+        st = ram_ack_enabled_
+                 ? ram_->PutWriteBack(key, payload, payload_len)
+                 : ram_->PutCommitted(key, payload, payload_len);
         needs_disk = st == Status::kCacheFull;
         if (st == Status::kOk) {
           cache_put_.fetch_add(1, std::memory_order_relaxed);
@@ -928,13 +955,12 @@ Status KvNodeServer::CacheDirectForKey(const BlockKey& key, char* data,
   Status st = Status::kCacheFull;
   const bool quota_ok = !ram_ || group_.TenantQuotaBytes(key.tenant_hash) == 0;
   bool needs_disk = true;
-  // Write-back: admit to the RAM arena first; the arena absorbs PUT bursts
-  // and serves zero-copy GET until the async flusher drains to disk. Only
-  // genuine arena backpressure (kCacheFull) falls through to direct disk
-  // write. Write-around (DFKV_RAM_WRITE_MODE=writearound) writes straight to
-  // disk and fills the arena lazily via GET read-promotion instead.
+  // Write-back admits to the RAM arena first. RAM-ACK returns after the
+  // flush-pinned value is visible; disk-ACK waits for the same flush result.
+  // Genuine arena backpressure falls through to direct disk write.
   if (ram_write_back_ && ram_ && quota_ok) {
-    st = ram_->PutCommitted(key, data, len);
+    st = ram_ack_enabled_ ? ram_->PutWriteBack(key, data, len)
+                          : ram_->PutCommitted(key, data, len);
     needs_disk = st == Status::kCacheFull;
     if (st == Status::kOk) {
       cache_put_.fetch_add(1, std::memory_order_relaxed);

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -224,6 +224,7 @@ class KvNodeServer {
   // mode, PUT lands in RAM (sync-visible) and flushes to group_; write-around
   // populates RAM through born-durable GET promotion. GET checks RAM first.
   std::unique_ptr<RamTier> ram_;
+  bool ram_ack_enabled_ = false;
   bool ram_required_failed_ = false;
   int listen_fd_ = -1;
   int port_ = 0;

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -451,7 +451,7 @@ Status RamTier::WaitPut(
 }
 
 RamTier::Admission RamTier::Admit(
-    const BlockKey& key, const void* data, size_t len,
+    const BlockKey& key, const void* data, size_t len, bool client_ack,
     std::shared_ptr<PutCompletion>* out_completion) {
   if (out_completion) out_completion->reset();
   if (!arena_ || len == 0 || data == nullptr) return Admission::kBypass;
@@ -572,8 +572,12 @@ RamTier::Admission RamTier::Admit(
       e.completion = completion;
       e.durable = false;
       e.flush_pin = true;
+      e.client_acked = client_ack;
+      e.dirty_since = std::chrono::steady_clock::now();
       s.index.emplace(key, std::move(e));
       s.flushq.push_back(QItem{key, 0});
+      dirty_bytes_.fetch_add(cap, std::memory_order_relaxed);
+      dirty_objects_.fetch_add(1, std::memory_order_relaxed);
     } else if (!large) {
       s.alloc->Unpin(key, slot_handle);
       s.alloc->Remove(key);
@@ -595,13 +599,12 @@ RamTier::Admission RamTier::Admit(
 
 bool RamTier::Put(const BlockKey& key, const void* data, size_t len) {
   std::shared_ptr<PutCompletion> completion;
-  return Admit(key, data, len, &completion) != Admission::kBypass;
+  return Admit(key, data, len, false, &completion) != Admission::kBypass;
 }
 
 Status RamTier::PutCommitted(const BlockKey& key, const void* data, size_t len) {
-  if (len == 0 || data == nullptr) return Status::kInvalid;
   std::shared_ptr<PutCompletion> completion;
-  const Admission admission = Admit(key, data, len, &completion);
+  const Admission admission = Admit(key, data, len, false, &completion);
   if (admission == Admission::kBypass) return Status::kCacheFull;
   return WaitPut(completion);
 }
@@ -745,6 +748,23 @@ void RamTier::AbortReservation(
   }
   ReleaseBudget(state->cap);
   CompletePut(state->completion, false);
+}
+
+Status RamTier::PutWriteBack(const BlockKey& key, const void* data, size_t len) {
+  const uint64_t high =
+      opt_.bytes * std::min<uint32_t>(opt_.ack_high_watermark_pct, 100) / 100;
+  const bool synchronous =
+      high == 0 || dirty_bytes_.load(std::memory_order_relaxed) >= high;
+  std::shared_ptr<PutCompletion> completion;
+  const Admission admission =
+      Admit(key, data, len, !synchronous, &completion);
+  if (admission == Admission::kBypass) return Status::kCacheFull;
+  if (synchronous) {
+    ack_backpressure_.fetch_add(1, std::memory_order_relaxed);
+    return WaitPut(completion);
+  }
+  ram_acks_.fetch_add(1, std::memory_order_relaxed);
+  return Status::kOk;
 }
 
 bool RamTier::PutDurable(const BlockKey& key, const void* data, size_t len) {
@@ -1009,6 +1029,10 @@ void RamTier::DropLocked(Shard& s, const BlockKey& key) {
   }
   const uint64_t cap = e.cap;
   const bool large = !e.in_arena();
+  if (!e.durable) {
+    dirty_bytes_.fetch_sub(cap, std::memory_order_relaxed);
+    dirty_objects_.fetch_sub(1, std::memory_order_relaxed);
+  }
   if (!large) s.alloc->Remove(e.key);
   s.index.erase(it);
   if (large)
@@ -1089,6 +1113,8 @@ void RamTier::FlushLoop(Shard& s) {
           if (entry.send_pins == 0) DropLocked(s, batch[i].key);
         } else if (ok[i]) {
           entry.durable = true;
+          dirty_bytes_.fetch_sub(entry.cap, std::memory_order_relaxed);
+          dirty_objects_.fetch_sub(1, std::memory_order_relaxed);
           if (entry.flush_pin) {
             if (entry.in_arena())
               s.alloc->Unpin(entry.key,
@@ -1107,6 +1133,8 @@ void RamTier::FlushLoop(Shard& s) {
             entry.flush_pin = false;
           }
           CompletePut(entry.completion, false);
+          if (entry.client_acked)
+            post_ack_flush_failures_.fetch_add(1, std::memory_order_relaxed);
           DropLocked(s, batch[i].key);
           healthy_.store(false, std::memory_order_release);
           flush_dropped_.fetch_add(1, std::memory_order_relaxed);
@@ -1144,6 +1172,21 @@ size_t RamTier::FlushBacklog() const {
     n += sh->flushq.size() + sh->flush_inflight;
   }
   return n;
+}
+
+uint64_t RamTier::OldestDirtyAgeSeconds() const {
+  const auto now = std::chrono::steady_clock::now();
+  std::chrono::steady_clock::duration oldest{};
+  for (const auto& sh : shards_) {
+    std::lock_guard<std::mutex> lk(sh->mu);
+    for (const auto& [_, entry] : sh->index) {
+      if (!entry.durable && !entry.remove_pending) {
+        oldest = std::max(oldest, now - entry.dirty_since);
+      }
+    }
+  }
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::seconds>(oldest).count());
 }
 
 }  // namespace dfkv

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -42,6 +42,7 @@
 #ifndef DFKV_RAM_TIER_H_
 #define DFKV_RAM_TIER_H_
 #include <cstdlib>
+#include <chrono>
 
 #include <atomic>
 #include <condition_variable>
@@ -85,6 +86,9 @@ class RamTier {
     // without it a full arena runs the CLOCK eviction sweep inline under the
     // shard lock on every admission.
     uint32_t reclaim_interval_ms = 10;
+    // Dirty-byte watermark for RAM-ACK mode. Once reached, new PUTs wait for
+    // their flush result instead of acknowledging asynchronously.
+    uint32_t ack_high_watermark_pct = 80;
   };
 
   // Persists a resident value to disk. `data` is 4 KiB aligned and `cap` is
@@ -167,10 +171,15 @@ class RamTier {
   // capacity backpressure.
   bool Put(const BlockKey& key, const void* data, size_t len);
 
-  // Server PUT contract: wait for the admitted key's actual flush result.
+  // Disk-ACK contract: wait for the admitted key's actual flush result.
   // kCacheFull is the only disk-fallback result; kIOError means an admitted
   // leader exhausted its flush retries (duplicates observe the same result).
   Status PutCommitted(const BlockKey& key, const void* data, size_t len);
+
+  // Cache RAM-ACK contract: acknowledge after the payload is copied into a
+  // visible, flush-pinned RAM entry. At the dirty-byte high watermark this
+  // request waits for disk commit, bounding acknowledged volatile data.
+  Status PutWriteBack(const BlockKey& key, const void* data, size_t len);
 
   // Read-promotion entry: install a value that is ALREADY durable on disk
   // (a coalesced cold read with fan-in evidence). Same allocation/index logic
@@ -222,6 +231,22 @@ class RamTier {
   uint64_t UsedBytes() const;   // arena slot + dedicated allocation bytes
   size_t Count() const;
   size_t FlushBacklog() const;  // queued or flushing, not-yet-durable items
+  uint64_t DirtyBytes() const {
+    return dirty_bytes_.load(std::memory_order_relaxed);
+  }
+  uint64_t DirtyObjects() const {
+    return dirty_objects_.load(std::memory_order_relaxed);
+  }
+  uint64_t OldestDirtyAgeSeconds() const;
+  uint64_t RamAcks() const {
+    return ram_acks_.load(std::memory_order_relaxed);
+  }
+  uint64_t AckBackpressure() const {
+    return ack_backpressure_.load(std::memory_order_relaxed);
+  }
+  uint64_t PostAckFlushFailures() const {
+    return post_ack_flush_failures_.load(std::memory_order_relaxed);
+  }
 
  private:
   struct FreeAligned {
@@ -247,6 +272,8 @@ class RamTier {
     bool durable = false;
     bool flushing = false;
     bool flush_pin = false;
+    bool client_acked = false;
+    std::chrono::steady_clock::time_point dirty_since;
     bool remove_pending = false;  // hidden immediately; physical free after pins
     bool in_arena() const { return !large; }
     char* data(char* arena) const { return large ? large.get() : arena + offset; }
@@ -293,6 +320,7 @@ class RamTier {
   void EraseEvictedLocked(Shard& s, const std::vector<BlockKey>& keys);
   enum class Admission { kAccepted, kDuplicate, kBypass };
   Admission Admit(const BlockKey& key, const void* data, size_t len,
+                  bool client_ack,
                   std::shared_ptr<PutCompletion>* completion);
   static void CompletePut(const std::shared_ptr<PutCompletion>& completion,
                           bool success);
@@ -348,6 +376,9 @@ class RamTier {
   std::atomic<uint64_t> large_evictions_{0};
   std::atomic<uint64_t> hits_{0}, misses_{0}, puts_{0}, put_bypass_{0}, promotes_{0};
   std::atomic<uint64_t> flushed_{0}, flush_dropped_{0}, reclaimed_{0}, rebalanced_{0};
+  std::atomic<uint64_t> dirty_bytes_{0}, dirty_objects_{0};
+  std::atomic<uint64_t> ram_acks_{0}, ack_backpressure_{0};
+  std::atomic<uint64_t> post_ack_flush_failures_{0};
 };
 
 inline RamTier::Hit::~Hit() { Reset(); }

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -113,6 +113,68 @@ TEST(RamTier, TenantIdentityIsPartOfResidentKey) {
   EXPECT_EQ(std::string(hit.ptr, hit.len), second_value);
 }
 
+TEST(RamTier, WriteBackAcknowledgesVisiblePinnedRamBeforeFlush) {
+  FlushSink sink;
+  sink.close();
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  const std::string value(4096, 'w');
+
+  EXPECT_EQ(rt.PutWriteBack(K(101), value.data(), value.size()), Status::kOk);
+  EXPECT_EQ(rt.RamAcks(), 1u);
+  EXPECT_EQ(rt.DirtyObjects(), 1u);
+  EXPECT_EQ(rt.DirtyBytes(), 4096u);
+  RamTier::Hit hit;
+  ASSERT_TRUE(rt.GetPrep(K(101), 0, 0, &hit));
+  EXPECT_EQ(std::string(hit.ptr, hit.len), value);
+  hit = RamTier::Hit{};
+
+  sink.open();
+  ASSERT_TRUE(WaitFor([&] { return rt.Flushed() == 1u; }));
+  EXPECT_EQ(rt.DirtyObjects(), 0u);
+  EXPECT_EQ(rt.DirtyBytes(), 0u);
+}
+
+TEST(RamTier, WriteBackWatermarkWaitsForDiskCommit) {
+  FlushSink sink;
+  sink.close();
+  RamTier::Options options = Opts(2 * 4096, 4096);
+  options.ack_high_watermark_pct = 50;
+  RamTier rt(options, sink.fn());
+  const std::string value(4096, 'b');
+
+  ASSERT_EQ(rt.PutWriteBack(K(102), value.data(), value.size()), Status::kOk);
+  std::atomic<bool> completed{false};
+  Status result = Status::kInvalid;
+  std::thread put([&] {
+    result = rt.PutWriteBack(K(103), value.data(), value.size());
+    completed.store(true, std::memory_order_release);
+  });
+  std::this_thread::sleep_for(10ms);
+  EXPECT_FALSE(completed.load(std::memory_order_acquire));
+  EXPECT_EQ(rt.AckBackpressure(), 1u);
+
+  sink.open();
+  put.join();
+  EXPECT_EQ(result, Status::kOk);
+  EXPECT_TRUE(WaitFor([&] { return rt.DirtyObjects() == 0u; }));
+}
+
+TEST(RamTier, WriteBackFlushFailureIsPostAckAndUnhealthy) {
+  FlushSink sink;
+  sink.fail = true;
+  RamTier::Options options = Opts(8 * 4096);
+  options.flush_retries = 1;
+  RamTier rt(options, sink.fn());
+  const std::string value(500, 'f');
+
+  EXPECT_EQ(rt.PutWriteBack(K(104), value.data(), value.size()), Status::kOk);
+  ASSERT_TRUE(WaitFor([&] { return rt.FlushDropped() == 1u; }));
+  EXPECT_EQ(rt.PostAckFlushFailures(), 1u);
+  EXPECT_EQ(rt.DirtyObjects(), 0u);
+  EXPECT_FALSE(rt.healthy());
+  EXPECT_FALSE(rt.Contains(K(104)));
+}
+
 TEST(RamTier, FlushMakesDurable) {
   FlushSink sink;
   RamTier rt(Opts(64 * 4096), sink.fn());


### PR DESCRIPTION
## Summary
- add explicit RAM-ACK mode for write-back PUTs
- switch to disk waiting at a configurable dirty-byte watermark
- expose dirty, ACK, backpressure, and post-ACK failure metrics
- preserve disk/direct defaults unless explicitly enabled

## Verification
- ram_tier_test: 35 passed
- metrics_test: 13 passed
- kv_node_server_listener_test: 9 passed
- local TCP smoke: 16/16 PUT+GET, dfkv_ram_ack_total=16, dirty_objects drained to 0