### PR TITLE
fix(release): align connector versions with 2.12.0

### DIFF
--- a/integration/common/pyproject.toml
+++ b/integration/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dfkv-common"
-version = "2.11.1"
+version = "2.12.0"
 description = "Canonical namespace and pool-key schema shared by dfkv connectors"
 requires-python = ">=3.9"
 

--- a/integration/lmcache/pyproject.toml
+++ b/integration/lmcache/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dfkv-connector"
-version = "2.11.1"
+version = "2.12.0"
 description = "LMCache RemoteConnector for the dfkv KV cache (ctypes over libdfkv.so)"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -14,7 +14,7 @@ authors = [{ name = "Wine93", email = "wine93.info@gmail.com" }]
 # runtime by path (DFKV_LIB / remote_storage_plugin.dfkv.lib). No bundled .so,
 # no CPython extension, so the wheel is platform-independent.
 dependencies = [
-  "dfkv-common==2.11.1",
+  "dfkv-common==2.12.0",
   "lmcache",
   "torch",
 ]

--- a/integration/vllm/pyproject.toml
+++ b/integration/vllm/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dfkv-vllm"
-version = "2.11.1"
+version = "2.12.0"
 description = "Direct vLLM KVConnectorBase_V1 connector for dfkv (GPUDirect RDMA, no LMCache)"
 requires-python = ">=3.12"
 # vllm + torch are provided by the runtime image; not pinned here. The connector
 # itself is pure Python (ctypes over libdfkv.so), so there is no native build.
-dependencies = ["dfkv-common==2.11.1"]
+dependencies = ["dfkv-common==2.12.0"]
 
 # Telemetry is opt-in: the OTel SDK is only needed when DFKV_METRICS_ENABLED /
 # DFKV_TRACE_ENABLED is set. Without this extra the connector stays dependency-


### PR DESCRIPTION
The 2.12.0 VERSION bump exposed the current multi-package release contract: connector pyproject versions and dfkv-common pins must match the root VERSION. Updates all three manifests. Verified with test/python/test_release_contract.py.