### PR TITLE
feat(cache): default writeback PUTs to RAM ACK

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -310,11 +310,14 @@ The RAM tier fronts the disk with a pre-registered RAM arena so a PD-warm GET is
 served straight from RAM over RDMA — no open, no pread, no disk. Enabled with
 `DFKV_RAM_TIER=1` (`DFKV_RAM_TIER_BYTES` sizes the arena; default off).
 
-**PUT policy with durable acknowledgement**: `writeback` (default) admits into
-a visible RAM slot and enqueues a disk flush; `writearound` writes straight to
-disk and populates RAM on a later whole-value GET. In either mode the server
-does not return PUT `kOk` before disk durability. Overlapping same-key
-write-back callers share the leader's exact success/failure.
+**PUT policy and acknowledgement**: `writeback` (default) admits into a visible,
+flush-pinned RAM slot and, by default, returns `kOk` before the asynchronous disk
+flush completes. At the dirty-byte high watermark (80% by default), new PUTs
+wait for disk so acknowledged volatile data stays bounded. Set
+`DFKV_PUT_ACK_MODE=disk` for durable acknowledgement. `writearound` writes
+straight to disk and populates RAM on a later whole-value GET, so its result
+always reflects the disk write. Overlapping same-key write-back callers share
+the leader's resident value and flush result when waiting is required.
 
 **State machine = allocator pin refcount.** The slot lifecycle maps directly onto
 the allocator's pin count — this is why the allocator was built media-agnostic:
@@ -391,8 +394,9 @@ data plane or the connection fails.
 | Feature | Enable with | Default | Notes |
 |---------|-------------|---------|-------|
 | disk storage engine | `--store-engine=slab|file` / `DFKV_STORE_ENGINE` | `slab` (all server/store construction paths) | option > env > default; v3 slab needs a clean cache directory; invalid capacity, format, or geometry fails closed without a file fallback |
-| RAM hot tier | `DFKV_RAM_TIER=1` (+ `DFKV_RAM_TIER_BYTES`) | off | durable-acknowledged write-back/write-around + direct cold-read promotion + RDMA zero-copy GET; requested allocation failure rejects startup |
+| RAM hot tier | `DFKV_RAM_TIER=1` (+ `DFKV_RAM_TIER_BYTES`) | off | write-back/write-around + direct cold-read promotion + RDMA zero-copy GET; requested allocation failure rejects startup |
 | RAM PUT policy | `--ram-write-mode=writeback|writearound` / `DFKV_RAM_WRITE_MODE` | `writeback` | write-back absorbs PUT bursts; write-around avoids the PUT arena copy and relies on direct GET promotion |
+| RAM PUT acknowledgement | `DFKV_PUT_ACK_MODE=ram|disk` | `ram` for write-back; disk otherwise | RAM-ACK returns after visible flush-pinned admission; `disk` explicitly restores durable ACK; dirty watermark forces bounded synchronous waiting |
 | RAM NUMA policy | `--ram-tier-numa=interleave|off` / `DFKV_RAM_TIER_NUMA` | `interleave` | numeric node IDs are not accepted |
 | RAM flush workers | `--ram-flush-threads` / `DFKV_RAM_FLUSH_THREADS` | 4× disk count, cap 16 | actual count is at least shard count and is reported after adjustment |
 | RAM dedicated-value reserve | `DFKV_RAM_TIER_LARGE_RESERVE_BYTES` | two extents | partitions the hard total budget; `0` disables oversized residency |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -253,7 +253,7 @@ WantedBy=multi-user.target
 > **存储/加速开关（见 [ARCHITECTURE.md](ARCHITECTURE.md) §5–7）。解析顺序为 flag > 环境变量 > `slab`；运行时真值经 `dfkvctl ring` INFO 列（`engine=`/`wr=`/`ram=`）和 `dfkv_build_info{engine,write_mode}` 审计。**
 > - `--store-engine slab|file`：不设置 flag/env 时所有 store/server 路径默认 `slab`。slab = extent 池 + sparse `slots.tbl` + dirty/clean epoch。**早期格式→v3 tenant-scoped slab 必须使用空缓存目录**；容量、格式或几何不符会拒绝启动而不会改写原数据，也绝不会静默改用 file。`file` 的 48 字符 tenant+object 文件名同样不读取旧 cache，仅作显式诊断/回滚。
 > - `--slab-write direct|buffered`（默认 `direct`）：slab 数据面使用 O_DIRECT；文件系统不支持时整店回退 bounded buffered，以 `wr=` 上报真值。
-> - `--ram-tier on`（默认关）：arena 内对象走 RDMA 零拷贝；配合 `--ram-write-mode writeback|writearound`（默认 `writeback`）选择 PUT 先入 RAM 再落盘，或 PUT 直写盘、后续整值 GET 直接从 NVMe 读入最终 arena slot。两种模式都等真实落盘结果后才返回 PUT `kOk`。超 extent 大对象走同预算的 dedicated allocation + bounded copy。`--ram-tier-bytes <bytes>` 定总预算；显式请求 RAM 时 allocation 或不支持的 NUMA mode 会拒绝启动，不能静默退成 disk-only。
+> - `--ram-tier on`（默认关）：arena 内对象走 RDMA 零拷贝；配合 `--ram-write-mode writeback|writearound`（默认 `writeback`）选择 PUT 先入 RAM 再落盘，或 PUT 直写盘、后续整值 GET 直接从 NVMe 读入最终 arena slot。`writeback` 默认在数据进入可读且 flush-pinned 的 RAM slot 后返回 PUT `kOk`；dirty bytes 达 `DFKV_RAM_ACK_HIGH_WATERMARK_PCT`（默认 80）后，新请求改为等待落盘。需要严格 durable ACK 时显式设置 `DFKV_PUT_ACK_MODE=disk`。`writearound` 仍以磁盘结果返回。超 extent 大对象走同预算的 dedicated allocation + bounded copy。`--ram-tier-bytes <bytes>` 定总预算；显式请求 RAM 时 allocation 或不支持的 NUMA mode 会拒绝启动，不能静默退成 disk-only。
 > - `--ram-tier-numa interleave|off`（默认 `interleave`）：这是当前完整 mode 集；不接受数字 node ID。arena 预触并绑策略，须核 `MemoryMax`。
 > - `--ram-flush-threads <n>` / `DFKV_RAM_FLUSH_THREADS`：请求值会提高到至少 shard 数；实际值由 `dfkv_ram_flush_threads` 报告（默认请求=4×盘数，上限 16）。
 > - 微调项（env only）：`DFKV_SLAB_TABLE_SYNC_MS` 控制 table sync 节奏（默认 100 ms，0=关；dirty epoch 重启仍无条件冷重置）。

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -155,8 +155,17 @@ void KvNodeServer::InitRamTier() {
   // Background free-slot reclaimer cadence (ms; 0 disables). Default 10.
   if (const char* r = std::getenv("DFKV_RAM_RECLAIM_MS"))
     o.reclaim_interval_ms = static_cast<uint32_t>(std::strtoul(r, nullptr, 10));
-  const char* ack = std::getenv("DFKV_PUT_ACK_MODE");
-  ram_ack_enabled_ = ack != nullptr && std::string(ack) == "ram";
+  const char* ack_env = std::getenv("DFKV_PUT_ACK_MODE");
+  const std::string ack = ack_env ? std::string(ack_env) : "";
+  if (ack.empty()) {
+    ram_ack_enabled_ = ram_write_back_;
+  } else if (ack == "ram" || ack == "disk") {
+    ram_ack_enabled_ = ack == "ram";
+  } else {
+    DFKV_LOG_WARN("DFKV_PUT_ACK_MODE='" + ack +
+                  "' not recognized; using RAM-ACK for writeback");
+    ram_ack_enabled_ = ram_write_back_;
+  }
   if (const char* p = std::getenv("DFKV_RAM_ACK_HIGH_WATERMARK_PCT")) {
     const unsigned long n = std::strtoul(p, nullptr, 10);
     if (n <= 100) o.ack_high_watermark_pct = static_cast<uint32_t>(n);

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -143,6 +143,7 @@ class KvNodeServer {
   const std::string& write_mode() const { return group_.WriteMode(); }
   char* ram_arena() const { return ram_ ? ram_->arena() : nullptr; }
   uint64_t ram_arena_bytes() const { return ram_ ? ram_->arena_bytes() : 0; }
+  bool ram_ack_enabled() const { return ram_ack_enabled_; }
 
  private:
   static void FinishDiskRead(void* owner, uint64_t flight, bool committed,

--- a/test/cache/kv_node_server_listener_test.cc
+++ b/test/cache/kv_node_server_listener_test.cc
@@ -68,6 +68,40 @@ int Dial(const KvNodeServer& server) {
 }
 }  // namespace
 
+TEST(KvNodeServerConfig, WriteBackDefaultsToRamAckAndDiskCanOverride) {
+  ScopedEnv engine("DFKV_STORE_ENGINE", "file");
+  ScopedEnv ram_tier("DFKV_RAM_TIER", "1");
+  ScopedEnv ram_bytes("DFKV_RAM_TIER_BYTES", "1048576");
+  ScopedEnv extent_bytes("DFKV_RAM_TIER_EXTENT_BYTES", "1048576");
+  ScopedEnv write_mode("DFKV_RAM_WRITE_MODE", "writeback");
+
+  {
+    ScopedEnv ack_mode("DFKV_PUT_ACK_MODE", "");
+    auto server = StartServer("ram_ack_default");
+    EXPECT_TRUE(server->ram_ack_enabled());
+    server->Stop();
+  }
+  {
+    ScopedEnv ack_mode("DFKV_PUT_ACK_MODE", "disk");
+    auto server = StartServer("disk_ack_override");
+    EXPECT_FALSE(server->ram_ack_enabled());
+    server->Stop();
+  }
+}
+
+TEST(KvNodeServerConfig, WriteAroundDoesNotDefaultToRamAck) {
+  ScopedEnv engine("DFKV_STORE_ENGINE", "file");
+  ScopedEnv ram_tier("DFKV_RAM_TIER", "1");
+  ScopedEnv ram_bytes("DFKV_RAM_TIER_BYTES", "1048576");
+  ScopedEnv extent_bytes("DFKV_RAM_TIER_EXTENT_BYTES", "1048576");
+  ScopedEnv write_mode("DFKV_RAM_WRITE_MODE", "writearound");
+  ScopedEnv ack_mode("DFKV_PUT_ACK_MODE", "");
+
+  auto server = StartServer("writearound_ack_default");
+  EXPECT_FALSE(server->ram_ack_enabled());
+  server->Stop();
+}
+
 TEST(KvNodeServerListener, SaturationRejectsBeyondHandlerLimit) {
   ScopedEnv engine("DFKV_STORE_ENGINE", "file");
   ScopedEnv max_connections("DFKV_TCP_MAX_CONNS", "2");


### PR DESCRIPTION
## Summary
- make write-back RAM tier default to RAM-ACK when DFKV_PUT_ACK_MODE is unset
- preserve explicit DFKV_PUT_ACK_MODE=disk for durable acknowledgement
- document and test write-back, disk override, and write-around resolution

## Verification
- kv_node_server_listener_test: 11 passed
- ram_tier_test: 35 passed
- metrics_test: 13 passed
- local TCP smoke: 16/16 PUT + GET, ram_ack_total=16, dirty_objects=0, post_ack_flush_failures=0