### PR TITLE
feat(rdma): enable 15s client keepalive by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ fabric selection and capacity explicit.
 |---|---|---|
 | `DFKV_RDMA_DEV` | leave unset for one local HCA; use the same fabric whitelist on both hosts for multi-rail | Unset lets each endpoint select its own first `ACTIVE` local HCA, so local names may differ. A comma list explicitly enables multi-rail and is sent to the peer; every listed name must exist and be on the intended interoperable fabric at both ends. |
 | `DFKV_RDMA_DEPTH` | `4` (default) | Keep client/server defaults aligned for connector batch correctness. Throughput scaling comes from multiple pooled connections, not raising one QP's depth; lowering depth reduces receive-segment consumption only after validating the real engine workload. |
-| `DFKV_RDMA_KEEPALIVE_MS` | `10000` when the server uses `DFKV_RDMA_IDLE_MS=30000`; otherwise `0` (default/off) | Sends lightweight membership probes over every idle pooled QP. Live clients keep their QPs and avoid first-GET reconnect tails; exited clients send no probes and remain reclaimable. Keep the interval strictly below the server reap interval. |
+| `DFKV_RDMA_KEEPALIVE_MS` | `15000` (default); `0` = off | Sends lightweight membership probes over every idle pooled QP. Live clients keep their QPs and avoid first-GET reconnect tails; exited clients send no probes and remain reclaimable. Keep the interval strictly below the server reap interval. |
 | `DFKV_FANOUT_THREADS` | unset (default 32) | Only wide single-process clients (benchmarks, many concurrent Batch* callers) need more. |
 
 **Read-side convoy collapse and direct promotion (opt-in)** — for MLA + TP-N

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -465,12 +465,11 @@ sglang serve /models/glm-5.2-nvfp4 --served-model-name glm-5.2 \
 - **`DFKV_RDMA_DEPTH` — 两侧无需强制相等。** 握手取最小值，按共享 segment
   容量和连接 fan-out 分别配置即可。
 - **HiCache 命中/吞吐/延迟与 client 注册指标**已内置，无需额外动作。
-- **短 server reaper 必须配 client keepalive。** server 使用
-  `DFKV_RDMA_IDLE_MS=30000` 回收已退出 Pod 的 receive-segment lease 时，live
-  connector 应设置 `DFKV_RDMA_KEEPALIVE_MS=10000`。后台线程只探测 idle pool
-  中的 QP；进程退出后探测自然停止，server 仍可在 30 秒后回收。keepalive
-  interval 必须严格小于 server idle interval；默认 `0`（关闭），因此使用
-  server 默认 10 分钟 reaper 的通用部署无需额外 QP 流量。
+- **client keepalive 默认开启。** `DFKV_RDMA_KEEPALIVE_MS` 默认 `15000`，每
+  15 秒探测 idle pool 中的 QP，低于频繁重建场景推荐的 server
+  `DFKV_RDMA_IDLE_MS=30000`。进程退出后探测自然停止，server 仍可在 30 秒后
+  回收 receive-segment lease。keepalive interval 必须严格小于 server idle
+  interval；不需要保活时显式设置 `DFKV_RDMA_KEEPALIVE_MS=0`。
 
 #### 0064 B200 + GLM-5.2-NVFP4 实测（2026-08-09）
 

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -337,15 +337,14 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
                               std::to_string(op_timeout_ms_));
   config_dump::RecordResolved("DFKV_RDMA_BATCH_OP_TIMEOUT_MS",
                               std::to_string(batch_op_timeout_ms_));
-  // Idle keepalives are opt-in: operators set an interval shorter than the
-  // server's DFKV_RDMA_IDLE_MS. They preserve live pooled QPs while still
-  // allowing the server reaper to reclaim clients whose process has exited.
+  // Keep live pooled QPs warm by default. The 15 s interval is below the
+  // recommended 30 s server dead-client reaper; set 0 explicitly to disable.
   if (const char* value = std::getenv("DFKV_RDMA_KEEPALIVE_MS");
       value && *value) {
     errno = 0;
     char* end = nullptr;
     const long parsed = std::strtol(value, &end, 10);
-    if (errno == 0 && end != value && *end == '\0' && parsed > 0) {
+    if (errno == 0 && end != value && *end == '\0' && parsed >= 0) {
       keepalive_ms_ = static_cast<int>(
           std::min<long>(parsed, std::numeric_limits<int>::max()));
     }

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -194,9 +194,9 @@ class RdmaTransport : public Transport {
     return batch_op_timeout_ms_ > 0 ? batch_op_timeout_ms_ : op_timeout_ms_;
   }
   size_t pool_max_ = 256;             // idle conns kept per node (DFKV_RDMA_POOL_MAX)
-  // Opt-in because the interval must be shorter than the server's
-  // DFKV_RDMA_IDLE_MS. Zero disables keepalives.
-  int keepalive_ms_ = 0;              // DFKV_RDMA_KEEPALIVE_MS
+  // Enabled by default below the recommended 30 s server reaper interval.
+  // Set DFKV_RDMA_KEEPALIVE_MS=0 to disable.
+  int keepalive_ms_ = 15000;
   std::atomic<bool> keepalive_stop_{false};
   std::condition_variable keepalive_cv_;
   std::mutex keepalive_mu_;

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -9,6 +9,7 @@
 #include "client/key_map.h"
 #include "cache/kv_node_server.h"
 #include "cache/rdma_server.h"
+#include "common/config_dump.h"
 #include "transport/rdma_transport.h"
 #include "transport/rdma_protocol.h"
 #include "transport/rdma_verbs.h"
@@ -816,6 +817,28 @@ TEST(RdmaLoopback, RegisterMemoryRoundtrip) {
     ASSERT_TRUE(c.Get(key, dst, sz)) << i;
     EXPECT_EQ(0, std::memcmp(src, dst, sz)) << i;
   }
+}
+
+TEST(RdmaLoopback, KeepaliveDefaultsToFifteenSecondsAndZeroDisables) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ::unsetenv("DFKV_RDMA_KEEPALIVE_MS");
+  config_dump::ResetForTest();
+  testing::internal::CaptureStderr();
+  { RdmaTransport rt(kMaxMsg); }
+  config_dump::Emit("keepalive-default-test");
+  std::string output = testing::internal::GetCapturedStderr();
+  EXPECT_NE(output.find("DFKV_RDMA_KEEPALIVE_MS"), std::string::npos);
+  EXPECT_NE(output.find(" = 15000  (default)"), std::string::npos);
+
+  ::setenv("DFKV_RDMA_KEEPALIVE_MS", "0", 1);
+  config_dump::ResetForTest();
+  testing::internal::CaptureStderr();
+  { RdmaTransport rt(kMaxMsg); }
+  config_dump::Emit("keepalive-disabled-test");
+  output = testing::internal::GetCapturedStderr();
+  EXPECT_NE(output.find("DFKV_RDMA_KEEPALIVE_MS"), std::string::npos);
+  EXPECT_NE(output.find(" = 0  (env)"), std::string::npos);
+  ::unsetenv("DFKV_RDMA_KEEPALIVE_MS");
 }
 
 // A live client must not inherit the server's short dead-client reap interval


### PR DESCRIPTION
## Summary
- default `DFKV_RDMA_KEEPALIVE_MS` to 15000 ms so live pooled QPs stay warm with the recommended 30 s server reaper
- preserve `DFKV_RDMA_KEEPALIVE_MS=0` as the explicit opt-out
- document the new default and cover both default and opt-out config resolution

## Verification
- 0064 real mlx5/IB: `KeepaliveDefaultsToFifteenSecondsAndZeroDisables` PASS
- 0064 real mlx5/IB: `KeepalivePreservesIdleDataConnection` PASS
- no environment outside authorized 0064 changed