### PR TITLE
feat(cache): harden RAM ACK production lifecycle

### DIFF
--- a/src/cache/disk_cache_group.cc
+++ b/src/cache/disk_cache_group.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <chrono>
 #include <charconv>
 #include <cstring>
 #include <fstream>
@@ -415,7 +416,8 @@ Status DiskCacheGroup::RangeDirectPrep(const BlockKey& key, uint64_t offset,
 }
 
 std::vector<Status> DiskCacheGroup::CacheDirectBatch(
-    const std::vector<StoreEngine::CacheBatchItem>& items) {
+    const std::vector<StoreEngine::CacheBatchItem>& items,
+    const DirectBatchObserver& observe) {
   std::vector<Status> out(items.size(), Status::kInvalid);
   if (items.empty()) return out;
 
@@ -493,8 +495,11 @@ std::vector<Status> DiskCacheGroup::CacheDirectBatch(
   }
 
   auto run_disk = [&](size_t disk) noexcept {
+    const auto started = std::chrono::steady_clock::now();
+    const auto& indexes = groups[disk];
+    uint64_t bytes = 0;
+    for (size_t index : indexes) bytes += items[index].len;
     try {
-      const auto& indexes = groups[disk];
       std::vector<StoreEngine::CacheBatchItem> sub;
       sub.reserve(indexes.size());
       for (size_t index : indexes) sub.push_back(items[index]);
@@ -504,6 +509,15 @@ std::vector<Status> DiskCacheGroup::CacheDirectBatch(
       for (size_t i = 0; i < count; ++i) out[indexes[i]] = statuses[i];
     } catch (...) {
       // Per-item defaults remain kIOError; other disks still complete.
+    }
+    if (observe) {
+      size_t failures = 0;
+      for (size_t index : indexes)
+        if (out[index] != Status::kOk) ++failures;
+      observe(disk, indexes.size(), bytes, failures,
+              std::chrono::duration<double>(
+                  std::chrono::steady_clock::now() - started)
+                  .count());
     }
   };
   if (participating.empty()) return out;

--- a/src/cache/disk_cache_group.h
+++ b/src/cache/disk_cache_group.h
@@ -47,7 +47,13 @@ class DiskCacheGroup {
   Status Cache(const BlockKey& key, const void* data, size_t len);
   Status CacheDirect(const BlockKey& key, char* data, size_t len, size_t cap);
   // Batched CacheDirect: split by disk route, one engine batch per disk.
-  std::vector<Status> CacheDirectBatch(const std::vector<StoreEngine::CacheBatchItem>& items);
+  // `observe` runs once per participating disk after its engine call.
+  using DirectBatchObserver = std::function<void(
+      size_t disk, size_t objects, uint64_t bytes, size_t failures,
+      double elapsed_seconds)>;
+  std::vector<Status> CacheDirectBatch(
+      const std::vector<StoreEngine::CacheBatchItem>& items,
+      const DirectBatchObserver& observe = {});
   Status Range(const BlockKey& key, uint64_t offset, uint64_t length,
                std::string* out, size_t* value_len = nullptr);
   Status RangeInto(const BlockKey& key, uint64_t offset, uint64_t length,

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -181,6 +181,9 @@ void KvNodeServer::InitRamTier() {
   // via O_DIRECT -- a buffered flush would route the RAM tier's entire write
   // volume back through the page cache, defeating the tier's purpose of keeping
   // memory use bounded and explicit on GPU nodes.
+  ram_flush_disks_.reserve(group_.DiskCount());
+  for (size_t i = 0; i < group_.DiskCount(); ++i)
+    ram_flush_disks_.push_back(std::make_unique<RamFlushDiskMetrics>());
   auto tier = std::make_unique<RamTier>(
       o, [this](const BlockKey& k, char* d, size_t l, size_t cap) {
         return group_.CacheDirect(k, d, l, cap) == Status::kOk;
@@ -192,7 +195,17 @@ void KvNodeServer::InitRamTier() {
     b.reserve(items.size());
     for (const auto& it : items)
       b.push_back(StoreEngine::CacheBatchItem{it.key, it.data, it.len, it.cap});
-    std::vector<Status> sts = group_.CacheDirectBatch(b);
+    std::vector<Status> sts = group_.CacheDirectBatch(
+        b, [this](size_t disk, size_t objects, uint64_t bytes,
+                  size_t failures, double seconds) {
+          if (disk >= ram_flush_disks_.size()) return;
+          auto& m = *ram_flush_disks_[disk];
+          m.batches.fetch_add(1, std::memory_order_relaxed);
+          m.objects.fetch_add(objects, std::memory_order_relaxed);
+          m.bytes.fetch_add(bytes, std::memory_order_relaxed);
+          m.failures.fetch_add(failures, std::memory_order_relaxed);
+          m.latency.Observe(seconds);
+        });
     std::vector<bool> ok(items.size(), false);
     for (size_t i = 0; i < sts.size(); ++i) ok[i] = (sts[i] == Status::kOk);
     return ok;
@@ -255,6 +268,22 @@ void KvNodeServer::Stop() {
   }
   for (int fd : fds) ::shutdown(fd, SHUT_RDWR);
   for (auto& c : conns) if (c.th.joinable()) c.th.join();
+  if (ram_) {
+    uint64_t timeout_seconds = 30;
+    if (const char* value =
+            std::getenv("DFKV_RAM_SHUTDOWN_DRAIN_TIMEOUT_S")) {
+      const unsigned long parsed = std::strtoul(value, nullptr, 10);
+      if (parsed <= 3600) timeout_seconds = parsed;
+    }
+    const bool drained = ram_->WaitForDrain(
+        std::chrono::seconds(timeout_seconds));
+    if (!drained) {
+      DFKV_LOG_WARN("RAM shutdown drain timed out after " +
+                    std::to_string(timeout_seconds) + "s with " +
+                    std::to_string(ram_->DirtyObjects()) +
+                    " dirty objects; destructor will continue safe draining");
+    }
+  }
 }
 
 void KvNodeServer::ReapDoneLocked() {
@@ -606,6 +635,7 @@ std::string KvNodeServer::MetricsText() const {
     metric("dfkv_ram_post_ack_flush_failures_total", "counter",
            "Acknowledged RAM PUTs whose background disk flush later failed",
            ram_->PostAckFlushFailures());
+    s += ram_->AckToDurableLatencyMetrics(idlabels);
     metric("dfkv_ram_budget_bytes", "gauge",
            "Hard total RAM-tier budget across arena and dedicated values",
            ram_->budget_bytes());
@@ -627,6 +657,37 @@ std::string KvNodeServer::MetricsText() const {
     metric("dfkv_ram_flush_threads", "gauge",
            "Actual RAM flusher count after the per-shard minimum adjustment",
            ram_->flusher_count());
+    metric("dfkv_ram_shutdown_drain_timeouts_total", "counter",
+           "Graceful shutdown drain attempts that exceeded their timeout",
+           ram_->ShutdownDrainTimeouts());
+    s += "# HELP dfkv_ram_flush_disk_batches_total RAM flush batches completed by disk\n";
+    s += "# TYPE dfkv_ram_flush_disk_batches_total counter\n";
+    s += "# HELP dfkv_ram_flush_disk_objects_total RAM flush objects submitted by disk\n";
+    s += "# TYPE dfkv_ram_flush_disk_objects_total counter\n";
+    s += "# HELP dfkv_ram_flush_disk_bytes_total RAM flush payload bytes submitted by disk\n";
+    s += "# TYPE dfkv_ram_flush_disk_bytes_total counter\n";
+    s += "# HELP dfkv_ram_flush_disk_failures_total RAM flush objects failed by disk\n";
+    s += "# TYPE dfkv_ram_flush_disk_failures_total counter\n";
+    s += "# HELP dfkv_ram_flush_disk_latency_seconds RAM flush engine batch latency seconds\n";
+    s += "# TYPE dfkv_ram_flush_disk_latency_seconds histogram\n";
+    for (size_t i = 0; i < ram_flush_disks_.size(); ++i) {
+      const auto& m = *ram_flush_disks_[i];
+      const std::string disk_labels =
+          "disk=\"" + PromLabelEscape(group_.DiskPath(i)) + "\",disk_index=\"" +
+          std::to_string(i) + "\"" +
+          (idlabels.empty() ? "" : "," + idlabels);
+      const std::string disk_braces = "{" + disk_labels + "}";
+      s += "dfkv_ram_flush_disk_batches_total" + disk_braces + " " +
+           std::to_string(m.batches.load(std::memory_order_relaxed)) + "\n";
+      s += "dfkv_ram_flush_disk_objects_total" + disk_braces + " " +
+           std::to_string(m.objects.load(std::memory_order_relaxed)) + "\n";
+      s += "dfkv_ram_flush_disk_bytes_total" + disk_braces + " " +
+           std::to_string(m.bytes.load(std::memory_order_relaxed)) + "\n";
+      s += "dfkv_ram_flush_disk_failures_total" + disk_braces + " " +
+           std::to_string(m.failures.load(std::memory_order_relaxed)) + "\n";
+      s += m.latency.RenderBody("dfkv_ram_flush_disk_latency_seconds",
+                                disk_labels);
+    }
   }
   return s;
 }

--- a/src/cache/kv_node_server.h
+++ b/src/cache/kv_node_server.h
@@ -217,6 +217,14 @@ class KvNodeServer {
   std::chrono::steady_clock::time_point start_time_ = std::chrono::steady_clock::now();
   mutable std::mutex metrics_extension_mu_;
   std::function<std::string()> metrics_extension_;
+  struct RamFlushDiskMetrics {
+    std::atomic<uint64_t> batches{0};
+    std::atomic<uint64_t> objects{0};
+    std::atomic<uint64_t> bytes{0};
+    std::atomic<uint64_t> failures{0};
+    LatencyHist latency;
+  };
+  std::vector<std::unique_ptr<RamFlushDiskMetrics>> ram_flush_disks_;
 
   DiskCacheGroup group_;
   // Optional RAM hot tier (P3). Declared AFTER group_ so it is destroyed FIRST:

--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -264,6 +264,18 @@ RamTier::~RamTier() {
   if (arena_) std::free(arena_);
 }
 
+bool RamTier::WaitForDrain(std::chrono::milliseconds timeout) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (DirtyObjects() != 0) {
+    if (std::chrono::steady_clock::now() >= deadline) {
+      shutdown_drain_timeouts_.fetch_add(1, std::memory_order_relaxed);
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return true;
+}
+
 // One reclaimer pass over one shard (mirror of DiskSlabStore::ReclaimTick,
 // arena flavor): for every class with new inserts since the last pass, top its
 // free slots up to a demand-driven watermark, in small batches per lock hold.
@@ -1113,6 +1125,13 @@ void RamTier::FlushLoop(Shard& s) {
           if (entry.send_pins == 0) DropLocked(s, batch[i].key);
         } else if (ok[i]) {
           entry.durable = true;
+          if (entry.client_acked) {
+            const double seconds =
+                std::chrono::duration<double>(
+                    std::chrono::steady_clock::now() - entry.dirty_since)
+                    .count();
+            ack_to_durable_latency_.Observe(seconds);
+          }
           dirty_bytes_.fetch_sub(entry.cap, std::memory_order_relaxed);
           dirty_objects_.fetch_sub(1, std::memory_order_relaxed);
           if (entry.flush_pin) {

--- a/src/cache/ram_tier.h
+++ b/src/cache/ram_tier.h
@@ -60,6 +60,7 @@
 #include "cache/slab_allocator.h"
 #include "common/kv_types.h"
 #include "common/status.h"
+#include "utils/latency_hist.h"
 
 namespace dfkv {
 class KvNodeServer;
@@ -247,6 +248,14 @@ class RamTier {
   uint64_t PostAckFlushFailures() const {
     return post_ack_flush_failures_.load(std::memory_order_relaxed);
   }
+  std::string AckToDurableLatencyMetrics(const std::string& labels) const {
+    return ack_to_durable_latency_.Render(
+        "dfkv_ram_ack_to_durable_latency_seconds", labels);
+  }
+  bool WaitForDrain(std::chrono::milliseconds timeout);
+  uint64_t ShutdownDrainTimeouts() const {
+    return shutdown_drain_timeouts_.load(std::memory_order_relaxed);
+  }
 
  private:
   struct FreeAligned {
@@ -379,6 +388,8 @@ class RamTier {
   std::atomic<uint64_t> dirty_bytes_{0}, dirty_objects_{0};
   std::atomic<uint64_t> ram_acks_{0}, ack_backpressure_{0};
   std::atomic<uint64_t> post_ack_flush_failures_{0};
+  std::atomic<uint64_t> shutdown_drain_timeouts_{0};
+  LatencyHist ack_to_durable_latency_;
 };
 
 inline RamTier::Hit::~Hit() { Reset(); }

--- a/test/cache/kv_node_server_listener_test.cc
+++ b/test/cache/kv_node_server_listener_test.cc
@@ -79,6 +79,12 @@ TEST(KvNodeServerConfig, WriteBackDefaultsToRamAckAndDiskCanOverride) {
     ScopedEnv ack_mode("DFKV_PUT_ACK_MODE", "");
     auto server = StartServer("ram_ack_default");
     EXPECT_TRUE(server->ram_ack_enabled());
+    const std::string metrics = server->MetricsText();
+    EXPECT_NE(metrics.find("dfkv_ram_ack_to_durable_latency_seconds_bucket"),
+              std::string::npos);
+    EXPECT_NE(metrics.find("dfkv_ram_flush_disk_batches_total"),
+              std::string::npos);
+    EXPECT_NE(metrics.find("disk_index=\"0\""), std::string::npos);
     server->Stop();
   }
   {

--- a/test/cache/ram_tier_test.cc
+++ b/test/cache/ram_tier_test.cc
@@ -85,6 +85,23 @@ TEST(RamTier, ReadAfterWriteBeforeFlush) {
   sink.open();
 }
 
+TEST(RamTier, ShutdownDrainTimeoutAndAckDurabilityLatencyAreObservable) {
+  FlushSink sink;
+  sink.close();
+  RamTier rt(Opts(64 * 4096), sink.fn());
+  const std::string value(4096, 'd');
+  ASSERT_EQ(rt.PutWriteBack(K(2), value.data(), value.size()), Status::kOk);
+
+  EXPECT_FALSE(rt.WaitForDrain(10ms));
+  EXPECT_EQ(rt.ShutdownDrainTimeouts(), 1u);
+  sink.open();
+  ASSERT_TRUE(rt.WaitForDrain(2s));
+  EXPECT_EQ(rt.DirtyObjects(), 0u);
+  EXPECT_NE(rt.AckToDurableLatencyMetrics("").find(
+                "dfkv_ram_ack_to_durable_latency_seconds_count 1"),
+            std::string::npos);
+}
+
 TEST(RamTier, TenantIdentityIsPartOfResidentKey) {
   FlushSink sink;
   RamTier rt(Opts(64 * 4096), sink.fn());


### PR DESCRIPTION
Adds the remaining production lifecycle and observability controls for default RAM-ACK write-back: bounded graceful shutdown drain, ACK-to-durable latency histogram, and per-disk RAM flush batches/objects/bytes/failures/latency metrics. Preserves the existing write path and storage routing. Verified locally: kv_node_server_listener_test 11 passed; ram_tier_test 36 passed; metrics_test 13 passed; rollout observability shell tests passed.