### PR TITLE
perf(rdma): reduce idle pool default to sixteen QPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ fabric selection and capacity explicit.
 | `DFKV_RDMA_DEV` | leave unset for one local HCA; use the same fabric whitelist on both hosts for multi-rail | Unset lets each endpoint select its own first `ACTIVE` local HCA, so local names may differ. A comma list explicitly enables multi-rail and is sent to the peer; every listed name must exist and be on the intended interoperable fabric at both ends. |
 | `DFKV_RDMA_DEPTH` | `4` (default) | Keep client/server defaults aligned for connector batch correctness. Throughput scaling comes from multiple pooled connections, not raising one QP's depth; lowering depth reduces receive-segment consumption only after validating the real engine workload. |
 | `DFKV_RDMA_KEEPALIVE_MS` | `15000` (default); `0` = off | Sends lightweight membership probes over every idle pooled QP. Live clients keep their QPs and avoid first-GET reconnect tails; exited clients send no probes and remain reclaimable. Keep the interval strictly below the server reap interval. |
+| `DFKV_RDMA_POOL_MAX` | `16` (default) | Maximum idle QPs retained per server and per lane, across all rails. It is not a process-wide connection cap. Raise only when connection-open metrics grow on repeated steady-state rounds; each retained QP leases `depth × align4K(4096 + declared_max_block)` from the server receive segment. |
 | `DFKV_FANOUT_THREADS` | unset (default 32) | Only wide single-process clients (benchmarks, many concurrent Batch* callers) need more. |
 
 **Read-side convoy collapse and direct promotion (opt-in)** — for MLA + TP-N

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -420,7 +420,7 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 | `DFKV_RDMA_CONNECT_MS` | — | IB QP 建连超时 |
 | `DFKV_RDMA_IO_MS` | — | 控制面帧读写超时 |
 | `DFKV_RDMA_BATCH_OP_TIMEOUT_MS` | 0=跟随 RDMA_OP | multi-item Cache/Range/Exist、SG 窗口总期限 |
-| `DFKV_RDMA_POOL_MAX` | — | client 侧 per-endpoint 连接池上限 |
+| `DFKV_RDMA_POOL_MAX` | `16` | client 侧每 server、每 lane、跨所有 rail 的 idle QP 保留上限，不是进程总连接上限；只在稳定负载仍反复建连时上调 |
 | `DFKV_RDMA_RAIL_CREDITS` | 默认 `64`, 硬上限 4096 | client 每 rail QP 信用数（inflight 上限），>server depth 会回退 |
 | `DFKV_RDMA_RAIL_BACKPRESSURE_MS` | `10` | Acquire 失败重试 backoff |
 | `DFKV_RDMA_RAIL_COOLDOWN_MS` | `5000` | rail quarantine 冷却期；期间只允许 1 个 recovery probe |

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -351,12 +351,14 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
   }
   config_dump::RecordResolved("DFKV_RDMA_KEEPALIVE_MS",
                               std::to_string(keepalive_ms_));
-  // Idle-connection pool cap. The pool naturally bounds at peak concurrency
-  // (each thread holds <=1 conn); this only guards against a thread-count spike
-  // leaving many idle conns. Must be >= peak concurrency or releases churn
-  // (destroy+recreate every op), which fails the bootstrap under load. Default
-  // 256 covers typical fan-out; raise via DFKV_RDMA_POOL_MAX for more threads.
-  pool_max_ = static_cast<size_t>(EnvInt("DFKV_RDMA_POOL_MAX", 256));
+  // Idle-connection pool cap per node and lane. The pool naturally bounds at
+  // peak concurrency; this guards against a transient thread spike retaining
+  // enough QPs to consume the server's shared receive segment. Sixteen covers
+  // the measured 0064 SGLang C32 fan-out with 2x per-lane headroom; raise it
+  // only for a workload that proves repeated connection churn.
+  pool_max_ = static_cast<size_t>(EnvInt("DFKV_RDMA_POOL_MAX", 16));
+  config_dump::RecordResolved("DFKV_RDMA_POOL_MAX",
+                              std::to_string(pool_max_));
   rail_conns_ = std::make_unique<std::atomic<uint64_t>[]>(devs_.size());
   if (keepalive_ms_ > 0)
     keepalive_thread_ = std::thread(&RdmaTransport::KeepaliveLoop, this);

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -193,7 +193,7 @@ class RdmaTransport : public Transport {
   int BatchTimeout() const {
     return batch_op_timeout_ms_ > 0 ? batch_op_timeout_ms_ : op_timeout_ms_;
   }
-  size_t pool_max_ = 256;             // idle conns kept per node (DFKV_RDMA_POOL_MAX)
+  size_t pool_max_ = 16;              // idle conns kept per node/lane
   // Enabled by default below the recommended 30 s server reaper interval.
   // Set DFKV_RDMA_KEEPALIVE_MS=0 to disable.
   int keepalive_ms_ = 15000;

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -268,8 +268,8 @@ TEST(RdmaLoopback, BatchExistReusesExpandedPool) {
     probe.push_back("e" + std::to_string(i) + "_x"); // absent
   }
 
-  // Warm one connection, then let the first large batch expand the bounded
-  // per-node pool according to the host's available fan-out.
+  // Warm one connection, then let two large batches settle the bounded
+  // per-node pool. Thread scheduling need not expose peak fan-out in one call.
   EXPECT_TRUE(c.Exist("e0"));
   const long before =
       CounterVal(rt.MetricsText(), "dfkv_rdma_client_conns_opened_total");
@@ -287,10 +287,18 @@ TEST(RdmaLoopback, BatchExistReusesExpandedPool) {
   ASSERT_EQ(again.size(), probe.size());
   for (size_t i = 0; i < probe.size(); ++i)
     EXPECT_EQ((bool)again[i], (i % 2 == 0)) << probe[i];
+  const long settled =
+      CounterVal(rt.MetricsText(), "dfkv_rdma_client_conns_opened_total");
+  EXPECT_LE(settled - before, 15);  // default pool cap 16, one already warm
+
+  auto steady = c.BatchExist(probe);
+  ASSERT_EQ(steady.size(), probe.size());
+  for (size_t i = 0; i < probe.size(); ++i)
+    EXPECT_EQ((bool)steady[i], (i % 2 == 0)) << probe[i];
   const long reused =
       CounterVal(rt.MetricsText(), "dfkv_rdma_client_conns_opened_total");
-  EXPECT_EQ(reused, expanded)
-      << "repeated BatchExist did not reuse its expanded connection pool";
+  EXPECT_EQ(reused, settled)
+      << "settled BatchExist did not reuse its bounded connection pool";
 }
 
 // Non-SG batch PUT: one oversized item must fail ONLY itself, not poison the
@@ -819,9 +827,10 @@ TEST(RdmaLoopback, RegisterMemoryRoundtrip) {
   }
 }
 
-TEST(RdmaLoopback, KeepaliveDefaultsToFifteenSecondsAndZeroDisables) {
+TEST(RdmaLoopback, ConnectionPoolAndKeepaliveDefaultsResolveAndDisable) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   ::unsetenv("DFKV_RDMA_KEEPALIVE_MS");
+  ::unsetenv("DFKV_RDMA_POOL_MAX");
   config_dump::ResetForTest();
   testing::internal::CaptureStderr();
   { RdmaTransport rt(kMaxMsg); }
@@ -829,8 +838,14 @@ TEST(RdmaLoopback, KeepaliveDefaultsToFifteenSecondsAndZeroDisables) {
   std::string output = testing::internal::GetCapturedStderr();
   EXPECT_NE(output.find("DFKV_RDMA_KEEPALIVE_MS"), std::string::npos);
   EXPECT_NE(output.find(" = 15000  (default)"), std::string::npos);
+  const size_t pool_name = output.find("DFKV_RDMA_POOL_MAX");
+  ASSERT_NE(pool_name, std::string::npos);
+  const std::string pool_line =
+      output.substr(pool_name, output.find('\n', pool_name) - pool_name);
+  EXPECT_NE(pool_line.find(" = 16  (default)"), std::string::npos);
 
   ::setenv("DFKV_RDMA_KEEPALIVE_MS", "0", 1);
+  ::setenv("DFKV_RDMA_POOL_MAX", "2", 1);
   config_dump::ResetForTest();
   testing::internal::CaptureStderr();
   { RdmaTransport rt(kMaxMsg); }
@@ -838,7 +853,14 @@ TEST(RdmaLoopback, KeepaliveDefaultsToFifteenSecondsAndZeroDisables) {
   output = testing::internal::GetCapturedStderr();
   EXPECT_NE(output.find("DFKV_RDMA_KEEPALIVE_MS"), std::string::npos);
   EXPECT_NE(output.find(" = 0  (env)"), std::string::npos);
+  const size_t pool_override_name = output.find("DFKV_RDMA_POOL_MAX");
+  ASSERT_NE(pool_override_name, std::string::npos);
+  const std::string pool_override_line =
+      output.substr(pool_override_name,
+                    output.find('\n', pool_override_name) - pool_override_name);
+  EXPECT_NE(pool_override_line.find(" = 2  (env)"), std::string::npos);
   ::unsetenv("DFKV_RDMA_KEEPALIVE_MS");
+  ::unsetenv("DFKV_RDMA_POOL_MAX");
 }
 
 // A live client must not inherit the server's short dead-client reap interval


### PR DESCRIPTION
## Summary
- reduce `DFKV_RDMA_POOL_MAX` from 256 to 16 idle QPs per server/lane
- expose the resolved pool cap in effective configuration
- document the exact scope and receive-segment budget implication
- make the pool reuse regression settle scheduler fan-out before asserting steady reuse

## 0064 evidence
- SGLang TP8, max-running-requests 32, 32 concurrent 125K-token requests, two rounds
- pool 256 baseline: 12.831 s elapsed
- pool 16: 11.615 / 11.821 s; second-round new connections 0; stale retries/timeouts 0
- pool 32: 11.668 / 11.745 s; second-round new connections 0
- pool 8: 12.090 / 12.274 s; second-round new connections 0
- chose 16 for 2x headroom over the observed per-lane requirement
- real mlx5/IB default-resolution and keepalive tests PASS; BatchExist pool reuse PASS 5/5

Only authorized 0064 was modified; it is healthy and currently runs with explicit `DFKV_RDMA_POOL_MAX=16`.