### PR TITLE
perf(rdma): make read completion ownership explicit

### DIFF
--- a/src/transport/rdma_operation.h
+++ b/src/transport/rdma_operation.h
@@ -1,0 +1,90 @@
+#ifndef DFKV_TRANSPORT_RDMA_OPERATION_H_
+#define DFKV_TRANSPORT_RDMA_OPERATION_H_
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+namespace dfkv::rdma {
+
+enum class OperationState : uint8_t {
+  kCreated,
+  kSubmitted,
+  kPolling,
+  kCompleted,
+  kCancelled,
+  kFailed,
+};
+
+// One shard-level RDMA operation context. The scheduler may run many contexts
+// concurrently, but one context admits exactly one CQ polling owner. Caller
+// buffers and transient MRs remain owned by the executing context until it
+// reaches a terminal state.
+class OperationContext {
+ public:
+  bool Submit() {
+    OperationState expected = OperationState::kCreated;
+    return state_.compare_exchange_strong(expected, OperationState::kSubmitted,
+                                          std::memory_order_release,
+                                          std::memory_order_relaxed);
+  }
+
+  bool ClaimPoller() {
+    OperationState expected = OperationState::kSubmitted;
+    if (!state_.compare_exchange_strong(expected, OperationState::kPolling,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire)) {
+      return false;
+    }
+    {
+      std::lock_guard<std::mutex> lock(owner_mu_);
+      poller_ = std::this_thread::get_id();
+    }
+    return true;
+  }
+
+  bool IsPoller() const {
+    std::lock_guard<std::mutex> lock(owner_mu_);
+    return poller_ == std::this_thread::get_id();
+  }
+
+  void RequestCancel() {
+    cancel_requested_.store(true, std::memory_order_release);
+  }
+  bool cancel_requested() const {
+    return cancel_requested_.load(std::memory_order_acquire);
+  }
+
+  bool Complete(bool success) {
+    if (!IsPoller()) return false;
+    OperationState expected = OperationState::kPolling;
+    const OperationState terminal =
+        cancel_requested() ? OperationState::kCancelled
+                           : (success ? OperationState::kCompleted
+                                      : OperationState::kFailed);
+    return state_.compare_exchange_strong(expected, terminal,
+                                          std::memory_order_acq_rel,
+                                          std::memory_order_acquire);
+  }
+
+  OperationState state() const {
+    return state_.load(std::memory_order_acquire);
+  }
+  bool terminal() const {
+    const OperationState current = state();
+    return current == OperationState::kCompleted ||
+           current == OperationState::kCancelled ||
+           current == OperationState::kFailed;
+  }
+
+ private:
+  std::atomic<OperationState> state_{OperationState::kCreated};
+  std::atomic<bool> cancel_requested_{false};
+  mutable std::mutex owner_mu_;
+  std::thread::id poller_;
+};
+
+}  // namespace dfkv::rdma
+
+#endif  // DFKV_TRANSPORT_RDMA_OPERATION_H_

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -18,6 +18,7 @@
 #include "transport/rail_select.h"
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
 #include "transport/rdma_protocol.h"
+#include "transport/rdma_operation.h"
 
 namespace dfkv {
 
@@ -1649,6 +1650,9 @@ std::vector<Status> RdmaTransport::RangeInto(
     }
   }
   if (valid_count == 0) return result;
+  rdma::OperationContext operation;
+  if (!operation.Submit() || !operation.ClaimPoller()) return result;
+  bool final_timeout = false;
 
   for (int attempt = 0; attempt < 2; ++attempt) {
     if (attempt != 0)
@@ -1660,7 +1664,10 @@ std::vector<Status> RdmaTransport::RangeInto(
     bool from_pool = false;
     Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0,
                          std::min(valid_count, depth_));
-    if (!conn) return result;
+    if (!conn) {
+      operation.Complete(false);
+      return result;
+    }
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
@@ -1714,6 +1721,7 @@ std::vector<Status> RdmaTransport::RangeInto(
       }
       if (timed_out)
         completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+      final_timeout = timed_out;
       if (!conn_ok) break;
       for (ibv_mr* mr : output_mrs) ep.ReleaseTransient(mr);
       for (size_t slot = 0; slot < width; ++slot) {
@@ -1735,12 +1743,17 @@ std::vector<Status> RdmaTransport::RangeInto(
     }
     if (conn_ok) {
       Release(node, Lane::kData, conn);
+      operation.Complete(true);
       return result;
     }
     Destroy(conn, completion);
     if (from_pool) continue;
+    if (final_timeout) operation.RequestCancel();
+    operation.Complete(false);
     return result;
   }
+  if (final_timeout) operation.RequestCancel();
+  operation.Complete(false);
   return result;
 }
 

--- a/test/transport/rdma_operation_test.cc
+++ b/test/transport/rdma_operation_test.cc
@@ -1,0 +1,54 @@
+#include "transport/rdma_operation.h"
+
+#include <atomic>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace dfkv::rdma {
+namespace {
+
+TEST(RdmaOperation, ExactlyOnePollerOwnsCompletion) {
+  OperationContext operation;
+  ASSERT_TRUE(operation.Submit());
+  ASSERT_TRUE(operation.ClaimPoller());
+
+  std::atomic<bool> foreign_completed{true};
+  std::thread foreign([&] {
+    EXPECT_FALSE(operation.ClaimPoller());
+    foreign_completed.store(operation.Complete(true),
+                            std::memory_order_release);
+  });
+  foreign.join();
+
+  EXPECT_FALSE(foreign_completed.load(std::memory_order_acquire));
+  EXPECT_TRUE(operation.Complete(true));
+  EXPECT_EQ(operation.state(), OperationState::kCompleted);
+  EXPECT_TRUE(operation.terminal());
+  EXPECT_FALSE(operation.Complete(true));
+}
+
+TEST(RdmaOperation, CancellationIsTerminalOnlyAfterOwnerDrains) {
+  OperationContext operation;
+  ASSERT_TRUE(operation.Submit());
+  ASSERT_TRUE(operation.ClaimPoller());
+  operation.RequestCancel();
+
+  EXPECT_FALSE(operation.terminal());
+  EXPECT_TRUE(operation.cancel_requested());
+  EXPECT_TRUE(operation.Complete(false));
+  EXPECT_EQ(operation.state(), OperationState::kCancelled);
+  EXPECT_TRUE(operation.terminal());
+}
+
+TEST(RdmaOperation, FailedOperationCompletesExactlyOnce) {
+  OperationContext operation;
+  ASSERT_TRUE(operation.Submit());
+  ASSERT_TRUE(operation.ClaimPoller());
+  ASSERT_TRUE(operation.Complete(false));
+  EXPECT_EQ(operation.state(), OperationState::kFailed);
+  EXPECT_FALSE(operation.Complete(false));
+}
+
+}  // namespace
+}  // namespace dfkv::rdma


### PR DESCRIPTION
## Change
- add a shard-level RDMA operation state machine
- scheduler workers submit and exclusively claim one operation poller
- prevent foreign/double completion
- cancellation becomes terminal only after the owner has returned from CQ reap and destroyed or released the endpoint
- preserve the synchronous external ABI and stale pooled-QP retry semantics

## Ownership invariant
Caller buffers and transient MRs remain owned by the executing operation until terminal completion. A timeout requests cancellation only after ReapPosted returns; the connection is destroyed before the context becomes terminal.

## Verification
- rdma_operation_test: exactly-one poller, deferred cancellation, exactly-once failure completion
- RdmaSafety filtered tests

No environment is changed by this PR.