### PR TITLE
fix(rdma): isolate idle endpoints before draining

### DIFF
--- a/src/transport/rdma_connection_lifecycle.h
+++ b/src/transport/rdma_connection_lifecycle.h
@@ -1,0 +1,61 @@
+#ifndef DFKV_TRANSPORT_RDMA_CONNECTION_LIFECYCLE_H_
+#define DFKV_TRANSPORT_RDMA_CONNECTION_LIFECYCLE_H_
+
+#include <atomic>
+#include <cstdint>
+
+namespace dfkv::rdma {
+
+enum class ConnectionState : uint8_t {
+  kActive,
+  kIdle,
+  kRetireRequested,
+  kDraining,
+};
+
+class ConnectionLifecycle {
+ public:
+  bool MakeIdle() {
+    ConnectionState expected = ConnectionState::kActive;
+    return state_.compare_exchange_strong(expected, ConnectionState::kIdle,
+                                          std::memory_order_acq_rel,
+                                          std::memory_order_acquire);
+  }
+
+  bool Activate() {
+    ConnectionState expected = ConnectionState::kIdle;
+    return state_.compare_exchange_strong(expected, ConnectionState::kActive,
+                                          std::memory_order_acq_rel,
+                                          std::memory_order_acquire);
+  }
+
+  bool RequestRetire() {
+    ConnectionState expected = ConnectionState::kIdle;
+    return state_.compare_exchange_strong(
+        expected, ConnectionState::kRetireRequested,
+        std::memory_order_acq_rel, std::memory_order_acquire);
+  }
+
+  bool BeginDrain() {
+    ConnectionState current = state_.load(std::memory_order_acquire);
+    while (current != ConnectionState::kDraining) {
+      if (state_.compare_exchange_weak(current, ConnectionState::kDraining,
+                                       std::memory_order_acq_rel,
+                                       std::memory_order_acquire)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  ConnectionState state() const {
+    return state_.load(std::memory_order_acquire);
+  }
+
+ private:
+  std::atomic<ConnectionState> state_{ConnectionState::kActive};
+};
+
+}  // namespace dfkv::rdma
+
+#endif  // DFKV_TRANSPORT_RDMA_CONNECTION_LIFECYCLE_H_

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -19,6 +19,7 @@
 #include "transport/rdma_verbs.h"   // RcEndpoint, QpInfo
 #include "transport/rdma_protocol.h"
 #include "transport/rdma_operation.h"
+#include "transport/rdma_connection_lifecycle.h"
 
 namespace dfkv {
 
@@ -214,6 +215,7 @@ struct RdmaTransport::Conn {
   bool budget_held = false;
   bool visited = true;  // guarded by RdmaTransport::mu_ while idle
 
+  rdma::ConnectionLifecycle lifecycle;
   void Encode(char* out, WireOp op, const BlockKey& key, uint64_t offset,
               uint64_t length, uint64_t payload_len) const {
     EncodeReqVersion(out, kNativeProtoRdmaV2, op, key, offset, length,
@@ -483,8 +485,10 @@ void RdmaTransport::KeepaliveLoop() {
       std::lock_guard<std::mutex> lock(mu_);
       const auto collect = [&](auto& pools, Lane lane) {
         for (auto& [node, connections] : pools) {
-          for (Conn* conn : connections)
-            idle.push_back(IdleConn{node, lane, conn});
+          for (Conn* conn : connections) {
+            if (conn->lifecycle.Activate())
+              idle.push_back(IdleConn{node, lane, conn});
+          }
           connections.clear();
         }
       };
@@ -506,6 +510,7 @@ void RdmaTransport::KeepaliveLoop() {
 
 void RdmaTransport::Destroy(Conn* c, rdma::RailCompletion completion) {
   if (!c) return;
+  c->lifecycle.BeginDrain();
   if (c->credit_held) {
     const uint64_t now = rdma::RailPolicy::NowMicros();
     rail_policy_->Complete(c->lease, now - c->lease_started_us, completion,
@@ -530,6 +535,7 @@ bool RdmaTransport::EvictOneIdle() {
             (*it)->visited = false;
             continue;
           }
+          if (!(*it)->lifecycle.RequestRetire()) continue;
           victim = *it;
           connections.erase(it);
           return true;
@@ -616,8 +622,8 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
       if (it != idle.end()) {
         auto& candidates = it->second;
         for (size_t i = candidates.size(); i > 0; --i) {
-          if (candidates[i - 1]->rail_index == ridx) {
-            pooled = candidates[i - 1];
+          if (candidates[i - 1]->rail_index == ridx &&
+              candidates[i - 1]->lifecycle.Activate()) {
             candidates.erase(candidates.begin() +
                              static_cast<std::ptrdiff_t>(i - 1));
             break;
@@ -1122,7 +1128,8 @@ void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
     // generation. Refresh it only after its WRs complete, before it becomes
     // idle; this is the endpoint lease that makes old-generation retirement
     // safe without interrupting the operation that used it.
-    if (v.size() < pool_max_ && c->ep.EnsurePoolMrs(pools_, true)) {
+    if (v.size() < pool_max_ && c->ep.EnsurePoolMrs(pools_, true) &&
+        c->lifecycle.MakeIdle()) {
       v.push_back(c);
       reusable = true;
     }

--- a/test/transport/rdma_connection_lifecycle_test.cc
+++ b/test/transport/rdma_connection_lifecycle_test.cc
@@ -1,0 +1,50 @@
+#include "transport/rdma_connection_lifecycle.h"
+
+#include <atomic>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace dfkv::rdma {
+namespace {
+
+TEST(RdmaConnectionLifecycle, IdleEndpointCanActivateOrRetireExactlyOnce) {
+  ConnectionLifecycle lifecycle;
+  ASSERT_TRUE(lifecycle.MakeIdle());
+
+  std::atomic<int> winners{0};
+  std::thread activate([&] {
+    if (lifecycle.Activate()) winners.fetch_add(1, std::memory_order_relaxed);
+  });
+  std::thread retire([&] {
+    if (lifecycle.RequestRetire())
+      winners.fetch_add(1, std::memory_order_relaxed);
+  });
+  activate.join();
+  retire.join();
+
+  EXPECT_EQ(winners.load(), 1);
+  EXPECT_TRUE(lifecycle.state() == ConnectionState::kActive ||
+              lifecycle.state() == ConnectionState::kRetireRequested);
+}
+
+TEST(RdmaConnectionLifecycle, RetiredEndpointCannotReactivate) {
+  ConnectionLifecycle lifecycle;
+  ASSERT_TRUE(lifecycle.MakeIdle());
+  ASSERT_TRUE(lifecycle.RequestRetire());
+  EXPECT_FALSE(lifecycle.Activate());
+  EXPECT_TRUE(lifecycle.BeginDrain());
+  EXPECT_EQ(lifecycle.state(), ConnectionState::kDraining);
+  EXPECT_FALSE(lifecycle.BeginDrain());
+}
+
+TEST(RdmaConnectionLifecycle, ActiveFailureTransitionsDirectlyToDrain) {
+  ConnectionLifecycle lifecycle;
+  ASSERT_TRUE(lifecycle.BeginDrain());
+  EXPECT_EQ(lifecycle.state(), ConnectionState::kDraining);
+  EXPECT_FALSE(lifecycle.MakeIdle());
+  EXPECT_FALSE(lifecycle.RequestRetire());
+}
+
+}  // namespace
+}  // namespace dfkv::rdma


### PR DESCRIPTION
## Change
- add explicit ACTIVE/IDLE/RETIRE_REQUESTED/DRAINING lifecycle
- pooled Acquire atomically claims IDLE before CQ use
- Release publishes IDLE only after WR completion and MR generation refresh
- SIEVE eviction atomically isolates IDLE before removing it from cache
- keepalive claims IDLE as ACTIVE before posting
- every failure/destructor path enters DRAINING before endpoint destruction and budget return

## Invariant
No endpoint accepts a new operation or keepalive after RETIRE_REQUESTED. Resource credit returns only after RcEndpoint destruction.

## Verification
- lifecycle activation-vs-retire race test
- retired endpoint cannot reactivate
- active failure drains directly
- RdmaSafety filtered tests

No environment is changed by this PR.