### PR TITLE
fix(rdma): retain activated pooled endpoint

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -624,6 +624,7 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
         for (size_t i = candidates.size(); i > 0; --i) {
           if (candidates[i - 1]->rail_index == ridx &&
               candidates[i - 1]->lifecycle.Activate()) {
+            pooled = candidates[i - 1];
             candidates.erase(candidates.begin() +
                              static_cast<std::ptrdiff_t>(i - 1));
             break;


### PR DESCRIPTION
## Problem
PR #309 activated an idle endpoint but erased it without assigning it to the caller. Every cache hit leaked the endpoint and its process-wide budget, forcing fresh QPs and eventually bounded waits.

## Fix
Assign the activated endpoint before removing it from the idle pool.

## Verification
- local lifecycle tests: 3/3 PASS
- local RDMA safety tests: 3 PASS, 1 hardware-dependent skip
- 0064 exact regression: broken PR #309 cold C32 makespan 36.13s; fixed commit 9.33s
- 0064 fixed warm C32: 5.00s vs pre-governance baseline 5.61s
- 0064 fixed cold C32: 9.33s vs pre-governance baseline 9.64s
- fixed candidate remained healthy with no fatal/error log matches