### PR TITLE
fix(hicache): accept no-layout logical pools on the v2 registration path

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -219,6 +219,22 @@ _MARKER_BUF = ctypes.create_string_buffer(1)
 _MARKER_PTR = ctypes.addressof(_MARKER_BUF)
 
 
+def _meta_has_no_layout(meta) -> bool:
+    """True when get_page_buffer_meta() explicitly declares "no physical layout".
+
+    Two wire forms exist for the logical-anchor pool of V4/DSA models:
+    - None                       (LogicalHostPool, SGLang <= v0.5.13)
+    - a 2-tuple containing None  (DeepSeekV4PagedHostPool, SGLang v0.5.17+)
+    Both mean "this pool holds no host buffer"; the real KV rides side pools.
+    Malformed shapes (wrong arity, empty/mismatched components) are NOT
+    treated as logical — they stay hard errors in the callers.
+    """
+    if meta is None:
+        return True
+    return (isinstance(meta, (tuple, list)) and len(meta) == 2
+            and (meta[0] is None or meta[1] is None))
+
+
 def _is_device_transfer(tr) -> bool:
     """A sidecar PoolTransfer is DEVICE-direct (task 4) when it carries device slot
     indices and NO host indices — the indexer RDMAs from/into its GPU buffer. A host
@@ -657,8 +673,27 @@ class DfkvHiCache(HiCacheStorage):
             except ImportError:
                 indices = list(range(page_size))
             meta = host_pool.get_page_buffer_meta(indices)
-            if (not isinstance(meta, (tuple, list)) or len(meta) != 2
-                    or meta[0] is None or meta[1] is None):
+            if _meta_has_no_layout(meta):
+                # The DSV4/DSA hybrid stack (SGLang v0.5.17+) registers the
+                # *logical anchor* "kv" pool through this v2 entry too. It holds
+                # no host buffer, so there is no layout to discover and nothing
+                # to physically register — but raising here crashes HiCache
+                # setup for the whole scheduler. Record it marker-only: v2
+                # writes ride the one-byte anchor markers, reads no-op (real
+                # data lives in the side pools). Malformed layouts (wrong
+                # arity, empty/mismatched components) still fail below.
+                if not hasattr(self, "_pool_logical"):
+                    self._pool_logical = {}
+                self._pool_logical[name] = True
+                self._pool_component_names[name] = ("all",)
+                self._pool_replicated[name] = True
+                self.registered_pools[name] = host_pool
+                self._note_logical_anchor_once()
+                with access_log("pool_components",
+                                lambda: f"{self._alog_tag} {name}") as result:
+                    result.result = "logical anchor (no host layout); marker-only"
+                return
+            if not isinstance(meta, (tuple, list)) or len(meta) != 2:
                 raise RuntimeError("pool component probe returned no layout")
             ptrs, sizes = meta
             count = len(ptrs)
@@ -691,12 +726,14 @@ class DfkvHiCache(HiCacheStorage):
             self.registered_pools.pop(name, None)
             self._pool_component_names.pop(name, None)
             self._pool_replicated.pop(name, None)
+            getattr(self, "_pool_logical", {}).pop(name, None)
             raise RuntimeError(
                 f"cannot discover physical layout for pool {name!r}") from exc
 
         self._pool_component_names[name] = tuple(names)
         self._pool_replicated[name] = replicated
         self.registered_pools[name] = host_pool
+        getattr(self, "_pool_logical", {}).pop(name, None)
         with access_log("pool_components",
                         lambda: f"{self._alog_tag} {name}") as result:
             result.result = (
@@ -1001,7 +1038,7 @@ class DfkvHiCache(HiCacheStorage):
                     _sp.attrs = {"dfkv.backup_skip": True}
                 return [True] * n
             meta = self.mem_pool_host.get_page_buffer_meta(host_indices)
-            if meta is None:
+            if _meta_has_no_layout(meta):
                 # Primary "kv" pool is a *logical anchor* holding no KV buffer
                 # (V4/DSA-compressed models, e.g. GLM-5.2: SGLang registers a
                 # LogicalHostPool whose get_page_buffer_meta() returns None). The
@@ -1267,7 +1304,7 @@ class DfkvHiCache(HiCacheStorage):
         with _tracing.span("batch_get_v1", n) as _sp, \
                 access_log("batch_get_v1", lambda: f"{self._alog_tag} {n} keys") as r:
             meta = self.mem_pool_host.get_page_buffer_meta(host_indices)
-            if meta is None:
+            if _meta_has_no_layout(meta):
                 # Logical anchor pool, no buffer to scatter into (V4/DSA models,
                 # e.g. GLM-5.2). The "kv" prefix was already confirmed present by
                 # batch_exists_v2 (via the one-byte markers written on backup);
@@ -1439,7 +1476,31 @@ class DfkvHiCache(HiCacheStorage):
                 results[name] = [True] * len(keys)
                 continue
             pool = self.registered_pools[name]
-            ptrs, sizes = pool.get_page_buffer_meta(tr.host_indices)
+            logical = getattr(self, "_pool_logical", {}).get(name, False)
+            if not logical:
+                meta = pool.get_page_buffer_meta(tr.host_indices)
+                if _meta_has_no_layout(meta):
+                    # Late no-layout declaration: the pool registered with a
+                    # physical-looking probe but now reports "no host buffer".
+                    # Same contract as registration time — flip to marker-only.
+                    if not hasattr(self, "_pool_logical"):
+                        self._pool_logical = {}
+                    self._pool_logical[name] = logical = True
+                    self._note_logical_anchor_once()
+            if logical:
+                if not putting:
+                    # A logical anchor holds no data to load; report complete so
+                    # the hybrid controller proceeds to the real side pools.
+                    results[name] = [True] * len(keys)
+                    continue
+                sub = self._pool_sub(name)
+                start = len(sks)
+                for k in keys:
+                    for sk in self._pool_keys(name, k):
+                        sks.append(sk); sp.append(_MARKER_PTR); ss.append(1)
+                segments.append((name, len(keys), sub, start, len(sks)))
+                continue
+            ptrs, sizes = meta
             sub = self._pool_sub(name)
             start = len(sks)
             for i, k in enumerate(keys):

--- a/test/python/test_dfkv_hicache.py
+++ b/test/python/test_dfkv_hicache.py
@@ -196,6 +196,18 @@ class FakeLogicalAnchorPool:
         return None
 
 
+class FakeTupleNoneAnchorPool:
+    """SGLang v0.5.17+ DeepSeekV4PagedHostPool contract: the logical anchor
+    declares "no host layout" as a tuple containing None instead of None
+    itself. Semantics are identical to FakeLogicalAnchorPool."""
+
+    def __init__(self, page_size=64):
+        self.page_size = page_size
+
+    def get_page_buffer_meta(self, host_indices):
+        return (None, None)
+
+
 def _spawn_node(tag):
     d = tempfile.mkdtemp(prefix=f"dfkv_py_{tag}_")
     p = subprocess.Popen(
@@ -869,6 +881,61 @@ class DingoFSHiCacheTest(unittest.TestCase):
         # anchor load is a no-op but reports all pages complete
         self.assertEqual(st.batch_get_v1(keys, hi), [True, True, True])
         self.assertTrue(st._anchor_noop_warned)
+
+    def test_v1_logical_anchor_tuple_none_contract(self):
+        # SGLang v0.5.17+ (DeepSeekV4PagedHostPool) declares the logical anchor
+        # as a tuple containing None instead of None itself. Same marker
+        # semantics as the None contract; must not crash or hard-miss.
+        members, _, ndir = self._node("anchor17")
+        st = self._plugin(self._cfg(members, model="glm-5.2"),
+                          FakeTupleNoneAnchorPool(self.PAGE_SIZE))
+        keys = ["t0", "t1"]
+        hi = list(range(2 * self.PAGE_SIZE))
+        self.assertEqual(st.batch_set_v1(keys, hi), [True, True])
+        self.assertEqual(_count_objects(ndir), 2)
+        self.assertEqual(st.batch_exists(keys), 2)
+        self.assertEqual(st.batch_get_v1(keys, hi), [True, True])
+        self.assertTrue(st._anchor_noop_warned)
+
+    def test_register_v2_logical_anchor_marker_only_no_raise(self):
+        # The v0.5.17 DSV4 hybrid stack registers the logical "kv" pool through
+        # register_mem_host_pool_v2 at attach time. Both no-layout wire forms
+        # must register marker-only instead of raising (was: RuntimeError
+        # "pool component probe returned no layout" crashing the scheduler).
+        from sglang.srt.mem_cache.hicache_storage import PoolTransfer
+        members, _, ndir = self._node("regv2anchor")
+        cfg = self._cfg(members, model="glm-5.2")
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        st.register_mem_host_pool_v2(FakeLogicalAnchorPool(self.PAGE_SIZE), "kv")
+        self.assertTrue(st._pool_logical["kv"])
+        st.register_mem_host_pool_v2(
+            FakeTupleNoneAnchorPool(self.PAGE_SIZE), "kv")
+        self.assertTrue(st._pool_logical["kv"])
+        # v2 writes on the logical pool land one-byte markers that gate the
+        # prefix; v2 reads no-op complete so side pools still get loaded.
+        keys = ["r0", "r1", "r2"]
+        hi = list(range(3 * self.PAGE_SIZE))
+        res = st.batch_set_v2(
+            [PoolTransfer(name="kv", host_indices=hi, keys=keys)])
+        self.assertEqual(res["kv"], [True, True, True])
+        self.assertEqual(_count_objects(ndir), 3)
+        self.assertEqual(st.batch_exists(keys), 3)
+        res = st.batch_get_v2(
+            [PoolTransfer(name="kv", host_indices=hi, keys=keys)])
+        self.assertEqual(res["kv"], [True, True, True])
+
+    def test_register_v2_physical_pool_clears_logical_flag(self):
+        # Re-registering the same name with a real layout must drop the
+        # marker-only state so the physical path takes over.
+        members, _, _ = self._node("regv2flip")
+        cfg = self._cfg(members, model="glm-5.2")
+        st = dfkv_hicache.DfkvHiCache(cfg, cfg.extra_config)
+        st.register_mem_host_pool_v2(
+            FakeTupleNoneAnchorPool(self.PAGE_SIZE), "side")
+        self.assertTrue(st._pool_logical["side"])
+        st.register_mem_host_pool_v2(
+            FakeMlaPool(2, self.PAGE_BYTES, self.PAGE_SIZE), "side")
+        self.assertNotIn("side", st._pool_logical)
 
     def test_v2_exists_with_logical_anchor_full_and_shrunk(self):
         # End-to-end multi-pool existence for a logical-anchor (DSA) model: the


### PR DESCRIPTION
SGLang v0.5.17's DSV4 hybrid stack (build_deepseek_v4_hicache_stack -> attach_storage_backend) registers the *logical anchor* "kv" pool through register_mem_host_pool_v2 at attach time, and its
DeepSeekV4PagedHostPool.get_page_buffer_meta() declares "no host layout" as a 2-tuple containing None (the older LogicalHostPool returned None). The v2 registration probe predates the logical-anchor fix (60c0522) and hard-raised "pool component probe returned no layout" on both wire forms; the RuntimeError propagated out of attach_storage_backend and killed the whole SGLang scheduler, forcing users to disable HiCache (observed with DFKV 2.1.1/2.10.0/2.15.1 + deepseek-v4-flash-0731).

- _meta_has_no_layout(): None or a 2-tuple with None members is an explicit no-layout declaration; malformed shapes (wrong arity, empty/mismatched components) still fail closed.
- register_mem_host_pool_v2: a no-layout pool registers marker-only (_pool_logical, replicated=True so MLA follower ranks skip writes) instead of raising; re-registering with a real layout clears the flag.
- _v2_io: logical pools write the one-byte anchor markers on put (the same "kv" sub-keys as the v1 anchor path, riding _put_flat's exist gate and retry) and no-op complete on get so the hybrid controller proceeds to load the real side pools; a late no-layout declaration at transfer time flips the pool to marker-only the same way.
- batch_set_v1/batch_get_v1: the logical-anchor branch now accepts the tuple-with-None wire form too.

Test: FakeTupleNoneAnchorPool + 3 new cases (v1 tuple-None contract writes markers, v2 registration accepts both wire forms with set/get keeping marker semantics, physical re-registration clears the logical flag); test_dfkv_hicache 76 passed, device-direct 23 passed/10 skipped.