### PR TITLE
perf(vllm): pipeline external KV cache transfers

### DIFF
--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -80,17 +80,68 @@ LMCache connector access logs, so one setting covers every integration. Format:
 | `lib` | env `DFKV_LIB` / `$DFKV_BUILD/libdfkv.so` | path to `libdfkv.so`. |
 | `batch_concurrency` | `0`=auto | client fan-out for batch ops; the real throughput lever (depth is flat). Auto = `min(max(nodes, 8), 32)`: 8-way parallel on single-node, one-per-node on multi-node. Set >0 to pin a fixed value. |
 | `load_async` | `True` | async KV load: the scheduler returns `WAITING_FOR_REMOTE_KVS` and the load runs off the critical path. Keep `True`. |
-| `transfer_queue_capacity` | `256` | Maximum queued requests **per direction and worker** (`1..65536`). Submission is non-blocking: a full queue rejects new saves as completed (releasing finish/free fences) and rejects new loads as load errors (forcing recompute), so overload cannot grow memory or pin blocks indefinitely. Invalid or out-of-range values abort connector construction. |
+| `transfer_queue_capacity` | `256` | Maximum queued requests in each direction (`1..65536`). All receive workers consume one shared receive queue of this capacity; capacity is not multiplied by `recv_workers`. Submission is non-blocking: a full queue rejects new saves as completed (releasing finish/free fences) and rejects new loads as load errors (forcing recompute), so overload cannot grow memory or pin blocks indefinitely. Invalid or out-of-range values abort connector construction. |
+| `recv_workers` | `1` | Receive/load worker count (`1..32`). Workers consume the shared bounded receive queue and may execute independent native GETs concurrently. Invalid, boolean, or out-of-range values abort connector construction. |
 | `enable_cross_layers_blocks` | `False` | opt-in for engines whose paged layout interleaves layers within a block. Leave `False` unless you know the layout needs it. |
 | `lookup_rpc_port` | (ipc auto) | port for the rank-0 scheduler-side prefix-lookup RPC; set only if the default IPC socket name collides. |
 
 Transfer threads are shut down through vLLM's connector `shutdown()` lifecycle
 hook. Shutdown stops admission, cancels queued transfers with the same visible
-save/load outcomes described above, waits for the one active native operation,
-joins both threads, and closes the native dfkv client exactly once. Accepted
-work can also be drained explicitly by the thread-level `stop(cancel_pending=False)`
-path; normal framework teardown uses cancellation to avoid extending engine
-shutdown behind an accumulated queue.
+save/load outcomes described above, waits for active native operations, joins
+the send thread and every receive worker, and closes native dfkv clients exactly
+once. Accepted work can also be drained explicitly by the thread-level
+`stop(cancel_pending=False)` path; normal framework teardown uses cancellation
+to avoid extending engine shutdown behind an accumulated queue.
+
+Start with `recv_workers=1`. Increase it only in controlled, byte-identical hot
+rounds when `vllm:dfkv_receive_queue_wait_time_seconds` and
+`vllm:dfkv_receive_queue_depth` show sustained receive-side queuing while native
+GET latency and the dfkv service still have headroom. Confirm actual parallelism
+with `vllm:dfkv_receive_active_workers`; all three are Prometheus histograms
+(with the standard `_bucket`, `_sum`, and `_count` series). Compare TTFT,
+queue-wait quantiles, active-worker samples, dfkv GET latency, and failed/recompute
+counts at each setting rather than assuming more workers are faster. Startup
+must contain the evidence line
+`dfkv transfer queues: capacity=<N> per direction, recv_workers=<N>, overload=reject-new, shutdown=cancel-pending`;
+capture it together with the before/after Prometheus snapshots.
+
+## Reproducible external-cache benchmark
+
+`test/python/vllm_external_cache_benchmark.py` never resets caches, deploys
+software, or runs local/remote version-discovery commands. Supply immutable
+deployment identity explicitly:
+
+| CLI option | summary/corpus key | default |
+|---|---|---|
+| `--vllm-version` | `vllm_version` | `null` |
+| `--vllm-commit` | `vllm_commit` | `null` |
+| `--dfkv-version` | `dfkv_version` | `null` |
+| `--dfkv-build-commit` | `dfkv_build_commit` | `null` |
+| `--connector-layout` | `connector_layout` | `null` |
+| `--connector-version` | `connector_version` | `null` |
+| `--model-revision` | `model_revision` | `null` |
+| `--deployment-manifest-hash` | `deployment_manifest_hash` | `null` |
+
+Values are stored verbatim in the fixed-schema `deployment_identity` object;
+the required `--model` is stored as its `model` member. Provide an immutable
+manifest digest, not a manifest path or manifest contents. Do not put
+credentials, URLs, or host paths in identity values. Summary files store
+endpoint hashes and artifact basenames rather than endpoint credentials or host
+paths.
+
+For a populate/restart/hot measurement, generate the corpus once, preserve the
+external cache, restart only the intended vLLM deployment, then reuse the corpus
+with `--corpus-file`. Keep model, model revision, prefix target, request count,
+seed, concurrency, and generation settings fixed. The corpus checksum proves
+byte-identical prompts; corpus reuse rejects a different model or model
+revision. Pass the populate summary as
+`--require-identity-summary FILE` when the compared rounds must use exactly the
+same model, vLLM, dfkv, connector, layout, and deployment-manifest identity.
+This check runs before metrics collection or inference requests, and the new
+summary records the reference summary's SHA-256. Capture vLLM and dfkv
+Prometheus endpoints with the respective repeatable
+`--vllm-metrics-endpoint` and `--dfkv-metrics-endpoint` options so every round
+contains before/after metric evidence.
 
 ## Identity and raw-value contract
 

--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -12,9 +12,10 @@ registered once via `dfkv_register_memory` (an `ibv_reg_mr` that, under
 nvidia-peermem, yields a GPUDirect MR). Only return code `0` is accepted;
 registration failure aborts startup rather than issuing I/O with an unregistered
 pointer. Transfers then run directly between RDMA and GPU memory with no host
-bounce. Per-chunk layer segments are coalesced into one dfkv
-key via the **scatter-gather** batch API (one multi-SGE RDMA per chunk instead of
-one per layer-segment), cutting key/disk-read count ~20x.
+bounce. Each logical chunk is one dfkv object whose complete ordered GPU
+segment vector is passed to the **scatter-gather** batch API. When the vector
+exceeds one HCA WR's SGE limit, libdfkv posts ordered bounded WR windows under
+that single object operation; it does not split the chunk into physical keys.
 
 > **Full deployment walkthrough + recommended settings: [`docs/CONNECTORS.md`](../../docs/CONNECTORS.md) §3.**
 > This README is the quick reference.
@@ -69,7 +70,7 @@ traffic if either requirement is missing.
 The access log shares the same env vars and line format as the dfkv HiCache /
 LMCache connector access logs, so one setting covers every integration. Format:
 `<op>(<args>) : <result> <duration_s>`, e.g.
-`batch_get_auto_sg(20 keys) : hits=20/20, 1310720 bytes <0.007234>`.
+`batch_get_auto_sg(20 keys, 1240 segments) : hits=20/20, 1310720 bytes <0.007234>`.
 
 ## `kv_connector_extra_config` keys
 
@@ -94,22 +95,33 @@ shutdown behind an accumulated queue.
 ## Identity and raw-value contract
 
 `model_name` is the exact vLLM `model_config.model`, not an extra-config key.
-The binary namespace always binds it to the source-controlled `vllm/raw-v1`
-layout ID; operator-supplied aliases are rejected.
+The binary namespace and every object key bind it to the source-controlled
+`vllm-multiwr-v2` storage-layout ID; operator-supplied aliases are rejected.
 
 Object keys are self-delimiting binary bytes: `DFKVPOOL\x02`, uint32-LE
 length-framed pool and full page hash, fixed `(uint32 size, int32 rank)` pairs
-for DP/TP/PCP/DCP/PP, uint32 group, and a length-framed component. Scatter
-groups append `DFKVSG\x02` plus uint32-LE width/group. Fields may contain NUL,
-delimiters, or non-UTF-8 bytes. Every native operation receives a pointer plus
-its exact uint64 length (parallel pointer/length arrays for batch and SG);
-no C-string, decode/re-encode, delimiter, Python-hash, or legacy ABI path exists.
-The namespace remains separate binary identity. dfkv stores only the raw GPU
-bytes and returns their length separately; it has no geometry/dtype envelope.
+for DP/TP/PCP/DCP/PP, uint32 KV-cache group, and the length-framed
+`vllm-multiwr-v2` component. There is exactly one key per logical chunk,
+independent of its GPU segment count or the negotiated HCA `max_sge`. Every
+native operation receives a pointer plus its exact uint64 length (parallel
+pointer/length arrays for batch and SG); no C-string, decode/re-encode,
+delimiter, Python-hash, or legacy ABI path exists. The KV-cache group field is
+the semantic vLLM hybrid `group_id`, never a WR-window or sibling index. dfkv
+stores only the raw GPU segments in canonical layer-name/run/physical-block
+order and returns their total length separately; it has no geometry/dtype
+envelope. A read is accepted only when the object hits and its returned length
+exactly equals the complete destination-vector capacity; otherwise that logical
+chunk is failed closed and recomputed.
+
+`multiwr-v2` is a clean cutover from the former `sg-v1` physical-key layout.
+Old objects are cold misses by namespace/key identity: readers do not probe,
+assemble, or clean up v1 scatter-group siblings. Roll producers and consumers
+together; expect a cold external cache after rollout. Do not mix connector
+versions in one deployment.
 
 Different namespace/key bytes are a cold miss. The same namespace+key with a
 different dtype, page/block size, shape, layer order, or KV memory layout is a
-type-safety violation, not a guarded miss. Such changes require a
+type-safety violation, not a guarded miss. Such changes require another
 source-controlled layout-ID bump and coordinated writer/reader deployment.
 Cross-runtime sharing requires both identical object keys and byte-compatible
 payload layouts.

--- a/integration/vllm/src/dfkv_vllm/_cabi.py
+++ b/integration/vllm/src/dfkv_vllm/_cabi.py
@@ -48,8 +48,8 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
     lib.dfkv_register_memory.restype = c_int
     lib.dfkv_register_memory.argtypes = [c_void_p, c_void_p, c_uint64]
 
-    # Live SG width (negotiated max_sge - 1). Older libs lack the symbol;
-    # callers must tolerate AttributeError and fall back to 29.
+    # Informational live width of one negotiated WR window (max_sge - 1).
+    # Logical SG calls accept wider vectors; libdfkv performs the windowing.
     try:
         lib.dfkv_max_sg_segs.restype = c_uint32
         lib.dfkv_max_sg_segs.argtypes = [c_void_p]
@@ -75,9 +75,10 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
         c_int, POINTER(c_int)]
 
     # Scatter-gather: one key gathers num_bufs[i] non-contiguous source buffers
-    # (ptrs[i][..], sizes[i][..]) on put / scatters into num_dsts[i] dst buffers
-    # (dsts[i][..], caps[i][..]) on get. Coalesces a chunk's per-layer segments
-    # into ONE key + one RDMA multi-SGE op (<=29 segs/key on max_sge=30 HCAs).
+    # (ptrs[i][..], sizes[i][..]) on put / scatters into num_dsts[i] destination
+    # buffers (dsts[i][..], caps[i][..]) on get. A logical object may have an
+    # arbitrary-width ordered descriptor vector; libdfkv posts bounded WR windows
+    # internally without splitting the object key or completion.
     lib.dfkv_batch_put_sg.restype = c_int
     lib.dfkv_batch_put_sg.argtypes = [
         c_void_p, POINTER(c_void_p), POINTER(c_uint64),
@@ -90,18 +91,6 @@ def load_lib(lib_path: Optional[str] = None) -> ctypes.CDLL:
         POINTER(POINTER(c_void_p)), POINTER(POINTER(c_uint64)),
         POINTER(c_int), c_int, POINTER(c_int), POINTER(c_uint64),
     ]
-
-
-    # Remove support remains capability-detected for deployments that omit the
-    # optional eviction RPC; partial-SG cleanup degrades to a no-op then.
-    if hasattr(lib, "dfkv_remove"):
-        lib.dfkv_remove.restype = c_int
-        lib.dfkv_remove.argtypes = [c_void_p, c_void_p, c_uint64]
-    if hasattr(lib, "dfkv_batch_remove"):
-        lib.dfkv_batch_remove.restype = c_int
-        lib.dfkv_batch_remove.argtypes = [
-            c_void_p, POINTER(c_void_p), POINTER(c_uint64),
-            c_int, POINTER(c_int)]
 
     lib.dfkv_transport_mode.restype = c_char_p
     lib.dfkv_transport_mode.argtypes = [c_void_p]

--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -161,7 +161,7 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self,
         request: Request,
         num_computed_tokens: int,
-    ) -> tuple[int, bool]:
+    ) -> tuple[int | None, bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
             request, num_computed_tokens

--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -43,7 +43,7 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
-from .data import DfkvStoreConnectorMetadata
+from .data import DfkvStoreConnectorMetadata, VLLM_MULTIWR_V2
 from .metrics import DfkvStoreConnectorStats, DfkvStorePromMetrics
 from .scheduler import DfkvStoreScheduler
 from .worker import DfkvStoreWorker
@@ -86,6 +86,9 @@ class DfkvStoreKVEvents(KVConnectorKVEvents):
 
 class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
     """KV connector using DfkvDistributedStore as shared KV pool."""
+
+    # Wire/storage schema, intentionally not operator-configurable.
+    storage_layout_id = VLLM_MULTIWR_V2
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:

--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -146,8 +146,10 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self._kv_cache_config = kv_cache_config
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self._kv_cache_events: DfkvStoreKVEvents | None = None
-        self._shutdown_lock = threading.Lock()
+        self._shutdown_condition = threading.Condition()
+        self._inflight_calls = 0
         self._shutdown = False
+        self._shutdown_complete = False
 
         self.connector_scheduler: DfkvStoreScheduler | None = None
         self.connector_worker: DfkvStoreWorker | None = None
@@ -168,10 +170,14 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         request: Request,
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
-        assert self.connector_scheduler is not None
-        return self.connector_scheduler.get_num_new_matched_tokens(
-            request, num_computed_tokens
-        )
+        self._begin_call()
+        try:
+            assert self.connector_scheduler is not None
+            return self.connector_scheduler.get_num_new_matched_tokens(
+                request, num_computed_tokens
+            )
+        finally:
+            self._finish_call()
 
     def update_state_after_alloc(
         self,
@@ -179,32 +185,49 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         blocks: KVCacheBlocks,
         num_external_tokens: int,
     ):
-        assert self.connector_scheduler is not None
-        return self.connector_scheduler.update_state_after_alloc(
-            request, blocks, num_external_tokens
-        )
+        self._begin_call()
+        try:
+            assert self.connector_scheduler is not None
+            return self.connector_scheduler.update_state_after_alloc(
+                request, blocks, num_external_tokens
+            )
+        finally:
+            self._finish_call()
 
     def build_connector_meta(
         self,
         scheduler_output: SchedulerOutput,
     ) -> KVConnectorMetadata:
-        assert self.connector_scheduler is not None
-        return self.connector_scheduler.build_connector_meta(scheduler_output)
+        self._begin_call()
+        try:
+            assert self.connector_scheduler is not None
+            return self.connector_scheduler.build_connector_meta(scheduler_output)
+        finally:
+            self._finish_call()
 
     def request_finished(
         self,
         request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
-        return self.request_finished_all_groups(request, (block_ids,))
+        self._begin_call()
+        try:
+            assert self.connector_scheduler is not None
+            return self.connector_scheduler.request_finished(request, (block_ids,))
+        finally:
+            self._finish_call()
 
     def request_finished_all_groups(
         self,
         request: Request,
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
-        assert self.connector_scheduler is not None
-        return self.connector_scheduler.request_finished(request, block_ids)
+        self._begin_call()
+        try:
+            assert self.connector_scheduler is not None
+            return self.connector_scheduler.request_finished(request, block_ids)
+        finally:
+            self._finish_call()
 
     def reset_cache(self) -> bool | None:
         """Reset the external Dfkv store on prefix-cache reset.
@@ -215,13 +238,17 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
 
         Returns True on ack, False on failure, None for the worker role.
         """
-        if self.role == KVConnectorRole.SCHEDULER:
-            assert self.connector_scheduler is not None
-            # Clear local references to keys we're about to wipe.
-            self.connector_scheduler.load_specs.clear()
-            self._kv_cache_events = None
-            return self.connector_scheduler.reset_store()
-        return None
+        self._begin_call()
+        try:
+            if self.role == KVConnectorRole.SCHEDULER:
+                assert self.connector_scheduler is not None
+                # Clear local references to keys we're about to wipe.
+                self.connector_scheduler.load_specs.clear()
+                self._kv_cache_events = None
+                return self.connector_scheduler.reset_store()
+            return None
+        finally:
+            self._finish_call()
 
     def update_connector_output(self, connector_output: KVConnectorOutput):
         kv_cache_events = connector_output.kv_cache_events
@@ -248,42 +275,62 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
     # ============================================================
     # Worker-side methods
     # ============================================================
-    def _reject_after_shutdown(self) -> None:
-        with self._shutdown_lock:
+    def _begin_call(self) -> None:
+        """Admit one API call while connector state is fully available."""
+        with self._shutdown_condition:
             if self._shutdown:
                 raise RuntimeError("dfkv connector is shut down")
+            self._inflight_calls += 1
 
+    def _finish_call(self) -> None:
+        with self._shutdown_condition:
+            self._inflight_calls -= 1
+            if self._inflight_calls == 0:
+                self._shutdown_condition.notify_all()
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        self._reject_after_shutdown()
-        assert self.connector_worker is not None
-        self.connector_worker.register_kv_caches(kv_caches)
+        self._begin_call()
+        try:
+            assert self.connector_worker is not None
+            self.connector_worker.register_kv_caches(kv_caches)
+        finally:
+            self._finish_call()
 
     def register_cross_layers_kv_cache(
         self, kv_cache: torch.Tensor, attn_backend: type
     ):
-        self._reject_after_shutdown()
-        assert self.connector_worker is not None
-        assert (
-            self._kv_cache_config is not None
-            and len(self._kv_cache_config.kv_cache_groups) == 1
-        ), "Cross-layer KV cache does not supported with hybrid models"
-        self.connector_worker.register_cross_layers_kv_caches(kv_cache)
+        self._begin_call()
+        try:
+            assert self.connector_worker is not None
+            assert (
+                self._kv_cache_config is not None
+                and len(self._kv_cache_config.kv_cache_groups) == 1
+            ), "Cross-layer KV cache does not supported with hybrid models"
+            self.connector_worker.register_cross_layers_kv_caches(kv_cache)
+        finally:
+            self._finish_call()
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
-        self._reject_after_shutdown()
-        # Loads are issued in get_finished() for compute overlap; this hook
-        # only runs the preemption fence, which must happen BEFORE this step's
-        # forward pass can overwrite a preempted request's freed (and possibly
-        # re-allocated) blocks while an in-flight save still reads them.
-        assert self.connector_worker is not None
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, DfkvStoreConnectorMetadata)
-        self.connector_worker.start_load_kv(metadata)
+        self._begin_call()
+        try:
+            # Loads are issued in get_finished() for compute overlap; this hook
+            # only runs the preemption fence, which must happen BEFORE this step's
+            # forward pass can overwrite a preempted request's freed (and possibly
+            # re-allocated) blocks while an in-flight save still reads them.
+            assert self.connector_worker is not None
+            metadata = self._get_connector_metadata()
+            assert isinstance(metadata, DfkvStoreConnectorMetadata)
+            self.connector_worker.start_load_kv(metadata)
+        finally:
+            self._finish_call()
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        # No layerwise support - no-op
-        return
+        self._begin_call()
+        try:
+            # No layerwise support - no-op
+            return
+        finally:
+            self._finish_call()
 
     def save_kv_layer(
         self,
@@ -292,62 +339,95 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         attn_metadata: AttentionMetadata,
         **kwargs: Any,
     ) -> None:
-        # No layerwise support - no-op
-        return
+        self._begin_call()
+        try:
+            # No layerwise support - no-op
+            return
+        finally:
+            self._finish_call()
 
     def wait_for_save(self):
-        # No-op: stores are issued in get_finished() for compute overlap.
-        pass
+        self._begin_call()
+        try:
+            # No-op: stores are issued in get_finished() for compute overlap.
+            return
+        finally:
+            self._finish_call()
 
     def get_finished(
         self, finished_req_ids: set[str]
     ) -> tuple[set[str] | None, set[str] | None]:
-        self._reject_after_shutdown()
-        assert self.connector_worker is not None
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, DfkvStoreConnectorMetadata)
-        return self.connector_worker.get_finished(finished_req_ids, metadata)
+        self._begin_call()
+        try:
+            assert self.connector_worker is not None
+            metadata = self._get_connector_metadata()
+            assert isinstance(metadata, DfkvStoreConnectorMetadata)
+            return self.connector_worker.get_finished(finished_req_ids, metadata)
+        finally:
+            self._finish_call()
 
     def get_block_ids_with_load_errors(self) -> set[int]:
-        assert self.connector_worker is not None
-        return self.connector_worker.get_block_ids_with_load_errors()
+        self._begin_call()
+        try:
+            assert self.connector_worker is not None
+            return self.connector_worker.get_block_ids_with_load_errors()
+        finally:
+            self._finish_call()
 
     def get_kv_connector_kv_cache_events(
         self,
     ) -> DfkvStoreKVEvents | None:
-        assert self.connector_worker is not None
-        events = self.connector_worker.get_kv_events()
-        if not events:
-            return None
+        self._begin_call()
+        try:
+            assert self.connector_worker is not None
+            events = self.connector_worker.get_kv_events()
+            if not events:
+                return None
 
-        kv_events = DfkvStoreKVEvents(num_workers=1)
-        kv_events.add_events(events)
-        return kv_events
+            kv_events = DfkvStoreKVEvents(num_workers=1)
+            kv_events.add_events(events)
+            return kv_events
+        finally:
+            self._finish_call()
 
     def get_kv_connector_stats(self) -> KVConnectorStats | None:
-        if self.connector_worker is None:
-            return None
-        return self.connector_worker.get_kv_connector_stats()
+        self._begin_call()
+        try:
+            if self.connector_worker is None:
+                return None
+            return self.connector_worker.get_kv_connector_stats()
+        finally:
+            self._finish_call()
 
     def shutdown(self) -> None:
-        """Join connector workers and release native state exactly once."""
-        errors: list[Exception] = []
-        with self._shutdown_lock:
+        """Drain admitted API calls, then release connector state exactly once."""
+        with self._shutdown_condition:
             if self._shutdown:
+                while not self._shutdown_complete:
+                    self._shutdown_condition.wait()
                 return
-            try:
-                if self.connector_worker is not None:
-                    try:
-                        self.connector_worker.close()
-                    except Exception as error:
-                        errors.append(error)
-                if self.connector_scheduler is not None:
-                    try:
-                        self.connector_scheduler.close()
-                    except Exception as error:
-                        errors.append(error)
-            finally:
-                self._shutdown = True
+            self._shutdown = True
+            self._shutdown_condition.notify_all()
+            while self._inflight_calls:
+                self._shutdown_condition.wait()
+
+        errors: list[Exception] = []
+        try:
+            if self.connector_worker is not None:
+                try:
+                    self.connector_worker.close()
+                except Exception as error:
+                    errors.append(error)
+            if self.connector_scheduler is not None:
+                try:
+                    self.connector_scheduler.close()
+                except Exception as error:
+                    errors.append(error)
+        finally:
+            with self._shutdown_condition:
+                self._shutdown_complete = True
+                self._shutdown_condition.notify_all()
+
         if errors:
             raise RuntimeError(
                 f"dfkv connector shutdown had {len(errors)} cleanup error(s)"

--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -12,6 +12,7 @@ enabling prefix caching via hash-based deduplication.
 """
 
 from collections.abc import Iterable
+import threading
 from typing import Any
 
 import torch
@@ -145,6 +146,8 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self._kv_cache_config = kv_cache_config
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self._kv_cache_events: DfkvStoreKVEvents | None = None
+        self._shutdown_lock = threading.Lock()
+        self._shutdown = False
 
         self.connector_scheduler: DfkvStoreScheduler | None = None
         self.connector_worker: DfkvStoreWorker | None = None
@@ -245,14 +248,21 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
     # ============================================================
     # Worker-side methods
     # ============================================================
+    def _reject_after_shutdown(self) -> None:
+        with self._shutdown_lock:
+            if self._shutdown:
+                raise RuntimeError("dfkv connector is shut down")
+
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        self._reject_after_shutdown()
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)
 
     def register_cross_layers_kv_cache(
         self, kv_cache: torch.Tensor, attn_backend: type
     ):
+        self._reject_after_shutdown()
         assert self.connector_worker is not None
         assert (
             self._kv_cache_config is not None
@@ -261,6 +271,7 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self.connector_worker.register_cross_layers_kv_caches(kv_cache)
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
+        self._reject_after_shutdown()
         # Loads are issued in get_finished() for compute overlap; this hook
         # only runs the preemption fence, which must happen BEFORE this step's
         # forward pass can overwrite a preempted request's freed (and possibly
@@ -291,6 +302,7 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def get_finished(
         self, finished_req_ids: set[str]
     ) -> tuple[set[str] | None, set[str] | None]:
+        self._reject_after_shutdown()
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, DfkvStoreConnectorMetadata)
@@ -318,11 +330,28 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         return self.connector_worker.get_kv_connector_stats()
 
     def shutdown(self) -> None:
-        """vLLM lifecycle hook: release connector resources deterministically."""
-        if self.connector_worker is not None:
-            self.connector_worker.close()
-        if self.connector_scheduler is not None:
-            self.connector_scheduler.close()
+        """Join connector workers and release native state exactly once."""
+        errors: list[Exception] = []
+        with self._shutdown_lock:
+            if self._shutdown:
+                return
+            try:
+                if self.connector_worker is not None:
+                    try:
+                        self.connector_worker.close()
+                    except Exception as error:
+                        errors.append(error)
+                if self.connector_scheduler is not None:
+                    try:
+                        self.connector_scheduler.close()
+                    except Exception as error:
+                        errors.append(error)
+            finally:
+                self._shutdown = True
+        if errors:
+            raise RuntimeError(
+                f"dfkv connector shutdown had {len(errors)} cleanup error(s)"
+            ) from errors[0]
 
     @classmethod
     def build_kv_connector_stats(

--- a/integration/vllm/src/dfkv_vllm/data.py
+++ b/integration/vllm/src/dfkv_vllm/data.py
@@ -7,7 +7,7 @@
 
 import hashlib
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, MutableSequence, Sequence
 from dfkv_common import pool_key
 from dataclasses import dataclass
 from itertools import product
@@ -96,6 +96,34 @@ def split_block_contiguous_runs(
             )
         previous_end = offset + size
     return block_stride, runs
+
+@dataclass(frozen=True, slots=True)
+class SgLayoutGeometry:
+    """Immutable pointer-arithmetic plan for one registered KV-cache group."""
+
+    segment_bases: tuple[int, ...]
+    block_strides: tuple[int, ...]
+    segment_sizes: tuple[int, ...]
+    segment_capacities: tuple[int, ...]
+    segments_per_block: int
+    logical_bytes_per_block: int
+
+    @classmethod
+    def from_layout(
+        cls, layout: Sequence[tuple[int, int, int]]
+    ) -> "SgLayoutGeometry":
+        bases = tuple(entry[0] for entry in layout)
+        strides = tuple(entry[1] for entry in layout)
+        sizes = tuple(entry[2] for entry in layout)
+        return cls(
+            segment_bases=bases,
+            block_strides=strides,
+            segment_sizes=sizes,
+            segment_capacities=sizes,
+            segments_per_block=len(layout),
+            logical_bytes_per_block=sum(sizes),
+        )
+
 
 
 
@@ -186,15 +214,20 @@ class ChunkedTokenDatabase:
         # strided layer. prepare_value emits them in canonical layer/run/block
         # order and always addresses the real physical block IDs.
         self._seg_layout: list[tuple[int, int, int]] | None = None
+        self._geometry: SgLayoutGeometry | None = None
 
     def _make_key_by_hash(self, chunk_hash: str | bytes) -> PoolKey:
         return PoolKey(self.metadata, chunk_hash)
 
     def set_kv_caches_base_addr(self, kv_caches_base_addr: list[int]):
-        self.kv_caches_base_addr = kv_caches_base_addr
+        self.kv_caches_base_addr = list(kv_caches_base_addr)
+        if self._seg_layout is None:
+            self._geometry = None
 
     def set_block_len(self, block_len: list[int]):
-        self.block_len = block_len
+        self.block_len = list(block_len)
+        if self._seg_layout is None:
+            self._geometry = None
 
     def set_seg_layout(self, seg_layout: list[tuple[int, int, int]]):
         """Install exact per-run ``(base, block_stride, block_content)``."""
@@ -205,11 +238,30 @@ class ChunkedTokenDatabase:
                     f"stride={stride} content={content}"
                 )
         self._seg_layout = list(seg_layout)
+        self._geometry = SgLayoutGeometry.from_layout(self._seg_layout)
 
-    def prepare_value(
-        self, start: int, end: int, block_ids: list[int]
-    ) -> tuple[list[int], list[int], int]:
-        """Return one logical chunk's complete, canonically ordered SG vector."""
+    @property
+    def geometry(self) -> SgLayoutGeometry:
+        """Return the immutable geometry shared by every request for this layout."""
+        geometry = self._geometry
+        if geometry is not None:
+            return geometry
+        if len(self.kv_caches_base_addr) != len(self.block_len):
+            raise ValueError("legacy KV base and block-length tables differ")
+        layout = tuple(
+            (base, length, length)
+            for base, length in zip(
+                self.kv_caches_base_addr, self.block_len, strict=True
+            )
+        )
+        geometry = SgLayoutGeometry.from_layout(layout)
+        self._geometry = geometry
+        return geometry
+
+    def descriptor_shape(
+        self, start: int, end: int, block_ids: Sequence[int]
+    ) -> tuple[int, int, int]:
+        """Return ``(segment_count, logical_bytes, first_block_id)``."""
         if (
             start < 0
             or end <= start
@@ -220,35 +272,63 @@ class ChunkedTokenDatabase:
                 f"token range [{start}, {end}) must align to "
                 f"block_size={self.block_size}"
             )
-
         start_block = start // self.block_size
         nblocks = (end - start) // self.block_size
-        chunk_block_ids = block_ids[start_block:start_block + nblocks]
-        if len(chunk_block_ids) != nblocks:
+        available = max(0, min(nblocks, len(block_ids) - start_block))
+        if available != nblocks:
             raise ValueError(
-                f"block table has {len(chunk_block_ids)} ids for "
+                f"block table has {available} ids for "
                 f"{nblocks} requested blocks at index {start_block}"
             )
+        geometry = self.geometry
+        return (
+            geometry.segments_per_block * nblocks,
+            geometry.logical_bytes_per_block * nblocks,
+            int(block_ids[start_block]),
+        )
 
-        if self._seg_layout is None:
-            if len(self.kv_caches_base_addr) != len(self.block_len):
-                raise ValueError("legacy KV base and block-length tables differ")
-            layout = [
-                (base, length, length)
-                for base, length in zip(
-                    self.kv_caches_base_addr, self.block_len, strict=True
-                )
-            ]
-        else:
-            layout = self._seg_layout
+    def fill_descriptors(
+        self,
+        start: int,
+        end: int,
+        block_ids: Sequence[int],
+        pointers: MutableSequence[int],
+        sizes: MutableSequence[int],
+        offset: int = 0,
+    ) -> int:
+        """Fill flat descriptor arrays and return the first unused index."""
+        segment_count, _, _ = self.descriptor_shape(start, end, block_ids)
+        if offset < 0 or len(pointers) - offset < segment_count:
+            raise ValueError("pointer descriptor array is too small")
+        if len(sizes) - offset < segment_count:
+            raise ValueError("size descriptor array is too small")
+        geometry = self.geometry
+        start_block = start // self.block_size
+        end_block = end // self.block_size
+        cursor = offset
+        for base, stride, content in zip(
+            geometry.segment_bases,
+            geometry.block_strides,
+            geometry.segment_sizes,
+            strict=True,
+        ):
+            for block_index in range(start_block, end_block):
+                pointers[cursor] = base + int(block_ids[block_index]) * stride
+                sizes[cursor] = content
+                cursor += 1
+        return cursor
 
-        addr_list: list[int] = []
-        size_list: list[int] = []
-        for base, stride, content in layout:
-            for block_id in chunk_block_ids:
-                addr_list.append(base + block_id * stride)
-                size_list.append(content)
-        return addr_list, size_list, chunk_block_ids[0]
+    def prepare_value(
+        self, start: int, end: int, block_ids: list[int]
+    ) -> tuple[list[int], list[int], int]:
+        """Return one logical chunk's complete, canonically ordered SG vector."""
+        segment_count, _, first_block_id = self.descriptor_shape(
+            start, end, block_ids
+        )
+        addr_list = [0] * segment_count
+        size_list = [0] * segment_count
+        self.fill_descriptors(start, end, block_ids, addr_list, size_list)
+        return addr_list, size_list, first_block_id
 
     def process_tokens(
         self,

--- a/integration/vllm/src/dfkv_vllm/data.py
+++ b/integration/vllm/src/dfkv_vllm/data.py
@@ -5,6 +5,8 @@
 # (vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/).
 """Data classes for DfkvStoreConnector."""
 
+import hashlib
+
 from collections.abc import Iterable, Sequence
 from dfkv_common import pool_key
 from dataclasses import dataclass
@@ -23,6 +25,20 @@ from vllm.v1.core.kv_cache_utils import (
 )
 
 logger = init_logger(__name__)
+
+# Source-controlled object-layout discriminator. It is framed into every pool
+# key and also binds the native namespace, so sg-v1 and multiwr-v2 objects can
+# never collide or be read through a compatibility fallback.
+VLLM_MULTIWR_V2 = b"vllm-multiwr-v2"
+
+def key_diagnostic_label(key: bytes) -> str:
+    """Return the standard non-reversible diagnostic label for a store key."""
+    try:
+        return f"len={len(key)} sha256={hashlib.sha256(key).hexdigest()[:16]}"
+    except Exception:
+        # Diagnostics must never turn a successfully transferred key into an
+        # application-visible failure.
+        return "<key unavailable>"
 
 
 def split_block_contiguous_runs(
@@ -142,7 +158,7 @@ class PoolKey:
             pp_size=self.key_metadata.pp_size,
             pp_rank=self.key_metadata.pp_rank,
             group_id=self.key_metadata.group_id,
-            component="all",
+            component=VLLM_MULTIWR_V2.decode("ascii"),
         )
 
 
@@ -193,7 +209,7 @@ class ChunkedTokenDatabase:
     def prepare_value(
         self, start: int, end: int, block_ids: list[int]
     ) -> tuple[list[int], list[int], int]:
-        """Compute memory addresses and sizes for an aligned token range."""
+        """Return one logical chunk's complete, canonically ordered SG vector."""
         if (
             start < 0
             or end <= start

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -23,6 +23,170 @@ c_void_p = ctypes.c_void_p
 c_uint64 = ctypes.c_uint64
 c_int = ctypes.c_int
 
+class _FlatSgVectorView(Sequence[int]):
+    """Read-only view of one key's slice in a flat ctypes descriptor array."""
+
+    __slots__ = ("_values", "_start", "_length")
+
+    def __init__(self, values: ctypes.Array, start: int, length: int):
+        self._values = values
+        self._start = start
+        self._length = length
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            start, stop, step = index.indices(self._length)
+            return [
+                0 if self._values[self._start + i] is None
+                else int(self._values[self._start + i])
+                for i in range(start, stop, step)
+            ]
+        if index < 0:
+            index += self._length
+        if index < 0 or index >= self._length:
+            raise IndexError(index)
+        value = self._values[self._start + index]
+        return 0 if value is None else int(value)
+
+
+class _FlatSgVectors(Sequence[Sequence[int]]):
+    """Public-API-compatible nested view backed by one flat allocation."""
+
+    __slots__ = ("_batch", "_kind")
+
+    def __init__(self, batch: "SgDescriptorBatch", kind: str):
+        self._batch = batch
+        self._kind = kind
+
+    def __len__(self) -> int:
+        return len(self._batch.counts)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            return [self[i] for i in range(start, stop, step)]
+        if index < 0:
+            index += len(self)
+        if index < 0 or index >= len(self):
+            raise IndexError(index)
+        values = (
+            self._batch._pointers
+            if self._kind == "pointers"
+            else self._batch._sizes
+        )
+        return _FlatSgVectorView(
+            values, self._batch.offsets[index], self._batch.counts[index]
+        )
+
+
+class SgDescriptorBatch:
+    """Request-owned, flat ctypes SG descriptors for one native batch call."""
+
+    __slots__ = (
+        "counts",
+        "offsets",
+        "logical_lengths",
+        "num_segments",
+        "total_bytes",
+        "_pointers",
+        "_sizes",
+        "_pointer_vectors",
+        "_size_vectors",
+        "_count_array",
+        "ptrs",
+        "sizes",
+        "caps",
+    )
+
+    def __init__(
+        self,
+        counts: Sequence[int],
+        logical_lengths: Sequence[int],
+    ):
+        if len(counts) != len(logical_lengths):
+            raise ValueError("descriptor counts and logical lengths differ")
+        if any(count <= 0 for count in counts):
+            raise ValueError("every SG key must have at least one descriptor")
+        self.counts = tuple(int(count) for count in counts)
+        self.logical_lengths = tuple(int(length) for length in logical_lengths)
+        offsets: list[int] = []
+        cursor = 0
+        for count in self.counts:
+            offsets.append(cursor)
+            cursor += count
+        self.offsets = tuple(offsets)
+        self.num_segments = cursor
+        self.total_bytes = sum(self.logical_lengths)
+        self._pointers = (c_void_p * self.num_segments)()
+        self._sizes = (c_uint64 * self.num_segments)()
+        nkeys = len(self.counts)
+        self._pointer_vectors = (ctypes.POINTER(c_void_p) * nkeys)()
+        self._size_vectors = (ctypes.POINTER(c_uint64) * nkeys)()
+        for i, offset in enumerate(self.offsets):
+            self._pointer_vectors[i] = ctypes.cast(
+                ctypes.byref(
+                    self._pointers, offset * ctypes.sizeof(c_void_p)
+                ),
+                ctypes.POINTER(c_void_p),
+            )
+            self._size_vectors[i] = ctypes.cast(
+                ctypes.byref(
+                    self._sizes, offset * ctypes.sizeof(c_uint64)
+                ),
+                ctypes.POINTER(c_uint64),
+            )
+        self._count_array = (c_int * nkeys)(*self.counts)
+        self.ptrs = _FlatSgVectors(self, "pointers")
+        self.sizes = _FlatSgVectors(self, "sizes")
+        self.caps = self.sizes
+
+    @classmethod
+    def from_chunks(cls, chunks: Sequence[tuple[object, int, int, Sequence[int]]]):
+        """Build one flat batch from ``(database, start, end, block_ids)``."""
+        shapes = [
+            db.descriptor_shape(start, end, block_ids)  # type: ignore[attr-defined]
+            for db, start, end, block_ids in chunks
+        ]
+        batch = cls(
+            [shape[0] for shape in shapes],
+            [shape[1] for shape in shapes],
+        )
+        cursor = 0
+        for db, start, end, block_ids in chunks:
+            cursor = db.fill_descriptors(  # type: ignore[attr-defined]
+                start,
+                end,
+                block_ids,
+                batch._pointers,
+                batch._sizes,
+                cursor,
+            )
+        if cursor != batch.num_segments:
+            raise RuntimeError(
+                f"descriptor fill mismatch: expected={batch.num_segments} "
+                f"actual={cursor}"
+            )
+        return batch
+
+
+def _prebuilt_sg_batch(
+    seg_ptrs: Sequence[Sequence[int]],
+    seg_lengths: Sequence[Sequence[int]],
+) -> SgDescriptorBatch | None:
+    if not isinstance(seg_ptrs, _FlatSgVectors):
+        return None
+    if not isinstance(seg_lengths, _FlatSgVectors):
+        return None
+    if seg_ptrs._kind != "pointers" or seg_lengths._kind != "sizes":
+        return None
+    if seg_ptrs._batch is not seg_lengths._batch:
+        return None
+    return seg_ptrs._batch
+
+
 
 
 def _env_rank() -> int:
@@ -51,6 +215,13 @@ def _validate_sg_vectors(
             f"keys={len(keys)} ptr_vectors={len(seg_ptrs)} "
             f"length_vectors={len(seg_lengths)}"
         )
+    prebuilt = _prebuilt_sg_batch(seg_ptrs, seg_lengths)
+    if prebuilt is not None:
+        if len(prebuilt.counts) != len(keys):
+            raise ValueError(
+                f"{operation} prebuilt descriptor count differs from keys"
+            )
+        return
     for i, (ptrs, lengths) in enumerate(
         zip(seg_ptrs, seg_lengths, strict=True)
     ):
@@ -288,8 +459,13 @@ class DfkvDeviceClient:
         reports one status per key (``0`` = ok, ``1`` = failed)."""
         _validate_sg_vectors(keys, seg_ptrs, seg_sizes, "batch_put_sg")
         n = len(keys)
-        num_segments = sum(len(p) for p in seg_ptrs)
-        num_bytes = sum(sum(s) for s in seg_sizes)
+        prebuilt = _prebuilt_sg_batch(seg_ptrs, seg_sizes)
+        if prebuilt is None:
+            num_segments = sum(len(p) for p in seg_ptrs)
+            num_bytes = sum(sum(s) for s in seg_sizes)
+        else:
+            num_segments = prebuilt.num_segments
+            num_bytes = prebuilt.total_bytes
         with _push_metrics.op("put", num_keys=n) as _m, \
                 _push_tracing.span("batch_put_sg", n) as _sp, \
                 access_log(
@@ -302,16 +478,30 @@ class DfkvDeviceClient:
                 _sp.bytes = num_bytes
                 _sp.attrs = {"dfkv.sg_segments": num_segments}
             karr, klens, key_owners = make_key_array(keys)
-            # Keep the per-key inner arrays alive for the duration of the call.
-            inner_p = [(c_void_p * len(p))(*[c_void_p(x) for x in p]) for p in seg_ptrs]
-            inner_s = [(c_uint64 * len(s))(*s) for s in seg_sizes]
-            parr = (ctypes.POINTER(c_void_p) * n)(
-                *[ctypes.cast(a, ctypes.POINTER(c_void_p)) for a in inner_p]
-            )
-            sarr = (ctypes.POINTER(c_uint64) * n)(
-                *[ctypes.cast(a, ctypes.POINTER(c_uint64)) for a in inner_s]
-            )
-            narr = (c_int * n)(*[len(p) for p in seg_ptrs])
+            if prebuilt is None:
+                # Legacy callers keep their existing nested-Sequence API.
+                inner_p = [
+                    (c_void_p * len(p))(*[c_void_p(x) for x in p])
+                    for p in seg_ptrs
+                ]
+                inner_s = [(c_uint64 * len(s))(*s) for s in seg_sizes]
+                parr = (ctypes.POINTER(c_void_p) * n)(
+                    *[
+                        ctypes.cast(a, ctypes.POINTER(c_void_p))
+                        for a in inner_p
+                    ]
+                )
+                sarr = (ctypes.POINTER(c_uint64) * n)(
+                    *[
+                        ctypes.cast(a, ctypes.POINTER(c_uint64))
+                        for a in inner_s
+                    ]
+                )
+                narr = (c_int * n)(*[len(p) for p in seg_ptrs])
+            else:
+                parr = prebuilt._pointer_vectors
+                sarr = prebuilt._size_vectors
+                narr = prebuilt._count_array
             out = (c_int * n)()
             rc = self._lib.dfkv_batch_put_sg(
                 self._h, karr, klens, parr, sarr, narr, n, out)
@@ -338,7 +528,12 @@ class DfkvDeviceClient:
         ``(hits, lengths)`` result."""
         _validate_sg_vectors(keys, seg_ptrs, seg_caps, "batch_get_auto_sg")
         n = len(keys)
-        num_segments = sum(len(p) for p in seg_ptrs)
+        prebuilt = _prebuilt_sg_batch(seg_ptrs, seg_caps)
+        num_segments = (
+            prebuilt.num_segments
+            if prebuilt is not None
+            else sum(len(p) for p in seg_ptrs)
+        )
         with _push_metrics.op("get", num_keys=n) as _m, \
                 _push_tracing.span("batch_get_auto_sg", n) as _sp, \
                 access_log(
@@ -348,15 +543,29 @@ class DfkvDeviceClient:
             if _sp:
                 _sp.attrs = {"dfkv.sg_segments": num_segments}
             karr, klens, key_owners = make_key_array(keys)
-            inner_p = [(c_void_p * len(p))(*[c_void_p(x) for x in p]) for p in seg_ptrs]
-            inner_c = [(c_uint64 * len(c))(*c) for c in seg_caps]
-            parr = (ctypes.POINTER(c_void_p) * n)(
-                *[ctypes.cast(a, ctypes.POINTER(c_void_p)) for a in inner_p]
-            )
-            carr = (ctypes.POINTER(c_uint64) * n)(
-                *[ctypes.cast(a, ctypes.POINTER(c_uint64)) for a in inner_c]
-            )
-            narr = (c_int * n)(*[len(p) for p in seg_ptrs])
+            if prebuilt is None:
+                inner_p = [
+                    (c_void_p * len(p))(*[c_void_p(x) for x in p])
+                    for p in seg_ptrs
+                ]
+                inner_c = [(c_uint64 * len(c))(*c) for c in seg_caps]
+                parr = (ctypes.POINTER(c_void_p) * n)(
+                    *[
+                        ctypes.cast(a, ctypes.POINTER(c_void_p))
+                        for a in inner_p
+                    ]
+                )
+                carr = (ctypes.POINTER(c_uint64) * n)(
+                    *[
+                        ctypes.cast(a, ctypes.POINTER(c_uint64))
+                        for a in inner_c
+                    ]
+                )
+                narr = (c_int * n)(*[len(p) for p in seg_ptrs])
+            else:
+                parr = prebuilt._pointer_vectors
+                carr = prebuilt._size_vectors
+                narr = prebuilt._count_array
             out_hit = (c_int * n)()
             out_len = (c_uint64 * n)()
             rc = self._lib.dfkv_batch_get_auto_sg(

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -38,6 +38,31 @@ def _env_rank() -> int:
     return 0
 
 
+def _validate_sg_vectors(
+    keys: Sequence[bytes],
+    seg_ptrs: Sequence[Sequence[int]],
+    seg_lengths: Sequence[Sequence[int]],
+    operation: str,
+) -> None:
+    """Reject malformed parallel SG vectors before entering the native ABI."""
+    if len(seg_ptrs) != len(keys) or len(seg_lengths) != len(keys):
+        raise ValueError(
+            f"{operation} requires one descriptor vector per key: "
+            f"keys={len(keys)} ptr_vectors={len(seg_ptrs)} "
+            f"length_vectors={len(seg_lengths)}"
+        )
+    for i, (ptrs, lengths) in enumerate(
+        zip(seg_ptrs, seg_lengths, strict=True)
+    ):
+        if not ptrs:
+            raise ValueError(f"{operation} key {i} has no descriptors")
+        if len(ptrs) != len(lengths):
+            raise ValueError(
+                f"{operation} key {i} descriptor arrays differ: "
+                f"ptrs={len(ptrs)} lengths={len(lengths)}"
+            )
+
+
 class DfkvDeviceClient:
     """Thin device-pointer wrapper over libdfkv.so for the vLLM connector."""
 
@@ -170,10 +195,10 @@ class DfkvDeviceClient:
         return self._lib.dfkv_transport_mode(self._h).decode()
 
     def max_sg_segs(self) -> int:
-        """Return the negotiated RDMA payload-SGE width for one key.
+        """Return the negotiated payload-SGE width of one native WR window.
 
-        Older native libraries may lack this export; the caller retains its
-        historical width fallback for key-geometry stability."""
+        Logical SG object operations may contain more segments; libdfkv splits
+        them into ordered windows of at most this width."""
         return int(self._lib.dfkv_max_sg_segs(self._h))
 
     def register_memory(self, base: int, size: int) -> None:
@@ -256,22 +281,26 @@ class DfkvDeviceClient:
         seg_ptrs: Sequence[Sequence[int]],
         seg_sizes: Sequence[Sequence[int]],
     ) -> list:
-        """Scatter-gather put: ``keys[i]`` stores the in-order concatenation of
-        the buffers ``seg_ptrs[i][..]`` (device pointers) of ``seg_sizes[i][..]``
-        bytes, as ONE dfkv key + one RDMA multi-SGE op. Each key takes <=29 segs
-        (max_sge-1); the C ABI reports a >29 key failed. Returns per-key status
-        (``0`` = ok, ``1`` = failed), same "0=ok" normalization as ``batch_put``."""
+        """Store each key as the in-order concatenation of its GPU segments.
+
+        Segment vectors may exceed one HCA WR's negotiated SGE limit: libdfkv
+        executes ordered bounded WR windows as one logical object operation and
+        reports one status per key (``0`` = ok, ``1`` = failed)."""
+        _validate_sg_vectors(keys, seg_ptrs, seg_sizes, "batch_put_sg")
         n = len(keys)
+        num_segments = sum(len(p) for p in seg_ptrs)
+        num_bytes = sum(sum(s) for s in seg_sizes)
         with _push_metrics.op("put", num_keys=n) as _m, \
                 _push_tracing.span("batch_put_sg", n) as _sp, \
                 access_log(
                     "batch_put_sg",
-                    lambda: f"{n} keys, {sum(sum(s) for s in seg_sizes)} bytes",
+                    lambda: f"{n} keys, {num_segments} segments, {num_bytes} bytes",
                 ) as r:
-            if _m or _sp:
-                _nb = sum(sum(s) for s in seg_sizes)
-                _m.bytes = _nb
-                _sp.bytes = _nb
+            if _m:
+                _m.bytes = num_bytes
+            if _sp:
+                _sp.bytes = num_bytes
+                _sp.attrs = {"dfkv.sg_segments": num_segments}
             karr, klens, key_owners = make_key_array(keys)
             # Keep the per-key inner arrays alive for the duration of the call.
             inner_p = [(c_void_p * len(p))(*[c_void_p(x) for x in p]) for p in seg_ptrs]
@@ -302,14 +331,22 @@ class DfkvDeviceClient:
         seg_ptrs: Sequence[Sequence[int]],
         seg_caps: Sequence[Sequence[int]],
     ):
-        """Scatter-gather get: ``keys[i]``'s stored blob is scattered in order
-        across destination buffers ``seg_ptrs[i][..]`` of capacity
-        ``seg_caps[i][..]`` (the segment sizes define the split). Returns
-        ``(hits, lengths)`` where ``lengths[i]`` is the total stored bytes."""
+        """Scatter each stored object in order across its destination segments.
+
+        Segment vectors may exceed one HCA WR's negotiated SGE limit; libdfkv
+        completes all bounded WR windows before returning the per-object
+        ``(hits, lengths)`` result."""
+        _validate_sg_vectors(keys, seg_ptrs, seg_caps, "batch_get_auto_sg")
         n = len(keys)
+        num_segments = sum(len(p) for p in seg_ptrs)
         with _push_metrics.op("get", num_keys=n) as _m, \
                 _push_tracing.span("batch_get_auto_sg", n) as _sp, \
-                access_log("batch_get_auto_sg", lambda: f"{n} keys") as r:
+                access_log(
+                    "batch_get_auto_sg",
+                    lambda: f"{n} keys, {num_segments} segments",
+                ) as r:
+            if _sp:
+                _sp.attrs = {"dfkv.sg_segments": num_segments}
             karr, klens, key_owners = make_key_array(keys)
             inner_p = [(c_void_p * len(p))(*[c_void_p(x) for x in p]) for p in seg_ptrs]
             inner_c = [(c_uint64 * len(c))(*c) for c in seg_caps]
@@ -357,37 +394,6 @@ class DfkvDeviceClient:
             del key_owners
             return res
 
-    def supports_remove(self) -> bool:
-        """True iff the loaded libdfkv.so exposes the remove RPC (additive)."""
-        return hasattr(self._lib, "dfkv_batch_remove")
-
-    def batch_remove(self, keys: Sequence[bytes]) -> list:
-        """Drop ``keys`` from the ring. Returns ``[1|0]`` per key: 1 iff the
-        owning node confirmed the op (removed or already absent). Used for
-        best-effort cleanup of partially-stored scatter groups. Raises if the
-        lib has no remove RPC."""
-        n = len(keys)
-        if not self.supports_remove():
-            raise RuntimeError(
-                "libdfkv.so has no dfkv_batch_remove (rebuild dfkv with the "
-                "remove RPC to enable partial-SG cleanup)"
-            )
-        with _push_metrics.op("remove", num_keys=n), \
-                _push_tracing.span("batch_remove", n) as _sp, \
-                access_log("batch_remove", lambda: f"{n} keys") as r:
-            karr, klens, key_owners = make_key_array(keys)
-            out = (c_int * n)()
-            rc = self._lib.dfkv_batch_remove(
-                self._h, karr, klens, n, out)
-            if rc != 0:
-                raise RuntimeError(f"dfkv_batch_remove rc={rc}")
-            res = list(out)
-            ok = res.count(1)
-            r.result = f"ok={ok}/{n}"
-            if _sp:
-                _sp.hits = ok
-            del key_owners
-            return res
 
     def close(self) -> None:
         try:

--- a/integration/vllm/src/dfkv_vllm/metrics.py
+++ b/integration/vllm/src/dfkv_vllm/metrics.py
@@ -41,6 +41,14 @@ DFKV_OBSERVATION_NAMES = frozenset(
         "geometry_preparation",
     }
 )
+
+DFKV_POOL_SAMPLE_NAMES = frozenset(
+    {
+        "receive_queue_depth",
+        "receive_active_workers",
+    }
+)
+_POOL_SAMPLES_KEY = "_pool_samples"
 _OBSERVATIONS_KEY = "_observations"
 
 
@@ -99,6 +107,18 @@ class DfkvStoreConnectorStats(KVConnectorStats):
                     ]
                     if durations:
                         _reduce_durations(reduced, observation, durations)
+                continue
+            if operation == _POOL_SAMPLES_KEY:
+                for sample_name in sorted(DFKV_POOL_SAMPLE_NAMES):
+                    values = [
+                        float(record["value"])
+                        for record in records
+                        if record["name"] == sample_name
+                    ]
+                    if values:
+                        reduced[f"{sample_name}_count"] = len(values)
+                        reduced[f"{sample_name}_avg"] = round(fmean(values), 3)
+                        reduced[f"{sample_name}_max"] = max(values)
                 continue
             if not records:
                 continue
@@ -160,6 +180,16 @@ class DfkvStoreConnectorStats(KVConnectorStats):
             }
         )
 
+    def record_pool_sample(self, name: str, value: int) -> None:
+        if name not in DFKV_POOL_SAMPLE_NAMES:
+            raise ValueError(f"Unknown Dfkv connector pool sample: {name!r}")
+        self.data.setdefault(_POOL_SAMPLES_KEY, []).append(
+            {
+                "name": name,
+                "value": value,
+            }
+        )
+
 
 class DfkvStorePromMetrics(KVConnectorPromMetrics):
     """Prometheus metrics for Dfkv store communication."""
@@ -175,6 +205,7 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
         metric_labelnames = labelnames + ["operation", "status"]
         self._metric_cache: dict[tuple[int, str, str], dict[str, PromMetric]] = {}
         self._observation_cache: dict[tuple[int, str], PromMetric] = {}
+        self._pool_sample_cache: dict[tuple[int, str], PromMetric] = {}
 
         self._histogram_operation_time = self._histogram_cls(
             name="vllm:dfkv_store_operation_time_seconds",
@@ -255,6 +286,21 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
             )
             for name, metric_name in observation_metric_names.items()
         }
+        pool_sample_metric_names = {
+            "receive_queue_depth": "vllm:dfkv_receive_queue_depth",
+            "receive_active_workers": "vllm:dfkv_receive_active_workers",
+        }
+        self._histogram_pool_samples = {
+            name: self._histogram_cls(
+                name=metric_name,
+                documentation=f"Histogram of Dfkv {name.replace('_', ' ')}.",
+                buckets=list(range(0, 33))
+                if name == "receive_active_workers"
+                else [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
+                labelnames=labelnames,
+            )
+            for name, metric_name in pool_sample_metric_names.items()
+        }
 
     def _get_metrics(
         self,
@@ -291,6 +337,16 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
             ].labels(*self.per_engine_labelvalues[engine_idx])
         return self._observation_cache[cache_key]
 
+    def _get_pool_sample_metric(self, engine_idx: int, name: str) -> PromMetric:
+        if name not in DFKV_POOL_SAMPLE_NAMES:
+            raise ValueError(f"Unknown Dfkv connector pool sample: {name!r}")
+        cache_key = (engine_idx, name)
+        if cache_key not in self._pool_sample_cache:
+            self._pool_sample_cache[cache_key] = self._histogram_pool_samples[
+                name
+            ].labels(*self.per_engine_labelvalues[engine_idx])
+        return self._pool_sample_cache[cache_key]
+
     def observe(self, transfer_stats_data: dict[str, Any] | None, engine_idx: int = 0):
         if not transfer_stats_data:
             return
@@ -300,8 +356,14 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
             self._get_observation_metric(engine_idx, name).observe(
                 float(record["duration_seconds"])
             )
+        for record in transfer_stats_data.get(_POOL_SAMPLES_KEY, ()):
+            assert isinstance(record, dict)
+            name = str(record["name"])
+            self._get_pool_sample_metric(engine_idx, name).observe(
+                float(record["value"])
+            )
         for operation, records in transfer_stats_data.items():
-            if operation == _OBSERVATIONS_KEY:
+            if operation in {_OBSERVATIONS_KEY, _POOL_SAMPLES_KEY}:
                 continue
             assert isinstance(records, list)
             for record in records:

--- a/integration/vllm/src/dfkv_vllm/metrics.py
+++ b/integration/vllm/src/dfkv_vllm/metrics.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Per-operation telemetry for DfkvStoreConnector.
+"""Fixed-cardinality telemetry for DfkvStoreConnector.
 
-Records one row per Dfkv RPC (``save_exists``, ``save_put``, ``load_get``,
-``lookup_exists``) with duration, key/byte counts, status, and failed-key
-count. Exposed to the logger via ``KVConnectorLogging`` and to Prometheus
-via ``DfkvStorePromMetrics``.
+RPC records retain physical key, logical chunk, byte, status, and wall-time
+totals. Queue, geometry, and lookup IPC phases use a validated observation set
+with dedicated Prometheus histograms, so request- or key-derived labels can
+never create unbounded series.
 """
 
 from dataclasses import dataclass
@@ -20,6 +20,29 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     PromMetricT,
 )
 
+DFKV_OPERATION_NAMES = frozenset(
+    {
+        "save_exists",
+        "save_put",
+        "save_remove_partial",
+        "load_get",
+        "lookup_exists",
+    }
+)
+DFKV_OPERATION_STATUSES = frozenset(
+    {"ok", "error", "partial_failure", "unsupported"}
+)
+
+DFKV_OBSERVATION_NAMES = frozenset(
+    {
+        "lookup_ipc",
+        "lookup_queue_wait",
+        "receive_queue_wait",
+        "geometry_preparation",
+    }
+)
+_OBSERVATIONS_KEY = "_observations"
+
 
 def _nearest_rank_percentile(values: list[float], percentile: float) -> float:
     if not values:
@@ -29,6 +52,18 @@ def _nearest_rank_percentile(values: list[float], percentile: float) -> float:
         0, min(len(sorted_values) - 1, int(percentile * len(sorted_values) - 1e-12))
     )
     return sorted_values[rank]
+
+
+def _reduce_durations(
+    reduced: dict[str, int | float],
+    name: str,
+    durations: list[float],
+) -> None:
+    reduced[f"{name}_count"] = len(durations)
+    reduced[f"{name}_avg_ms"] = round(fmean(durations) * 1e3, 3)
+    reduced[f"{name}_p90_ms"] = round(
+        _nearest_rank_percentile(durations, 0.9) * 1e3, 3
+    )
 
 
 @dataclass
@@ -55,16 +90,26 @@ class DfkvStoreConnectorStats(KVConnectorStats):
     def reduce(self) -> dict[str, int | float]:
         reduced: dict[str, int | float] = {}
         for operation, records in sorted(self.data.items()):
+            if operation == _OBSERVATIONS_KEY:
+                for observation in sorted(DFKV_OBSERVATION_NAMES):
+                    durations = [
+                        float(record["duration_seconds"])
+                        for record in records
+                        if record["name"] == observation
+                    ]
+                    if durations:
+                        _reduce_durations(reduced, observation, durations)
+                continue
             if not records:
                 continue
             durations = [float(record["duration_seconds"]) for record in records]
-            reduced[f"{operation}_count"] = len(records)
-            reduced[f"{operation}_avg_ms"] = round(fmean(durations) * 1e3, 3)
-            reduced[f"{operation}_p90_ms"] = round(
-                _nearest_rank_percentile(durations, 0.9) * 1e3, 3
-            )
+            _reduce_durations(reduced, operation, durations)
             reduced[f"{operation}_total_keys"] = sum(
                 int(record["num_keys"]) for record in records
+            )
+            reduced[f"{operation}_total_logical_keys"] = sum(
+                int(record.get("num_logical_keys", record["num_keys"]))
+                for record in records
             )
             reduced[f"{operation}_total_bytes"] = sum(
                 int(record["num_bytes"]) for record in records
@@ -83,17 +128,35 @@ class DfkvStoreConnectorStats(KVConnectorStats):
         duration_seconds: float,
         num_keys: int,
         *,
+        num_logical_keys: int | None = None,
         num_bytes: int = 0,
         status: str = "ok",
         num_failed_keys: int = 0,
     ) -> None:
+        if operation not in DFKV_OPERATION_NAMES:
+            raise ValueError(f"Unknown Dfkv connector operation: {operation!r}")
+        if status not in DFKV_OPERATION_STATUSES:
+            raise ValueError(f"Unknown Dfkv connector status: {status!r}")
+        if num_logical_keys is None:
+            num_logical_keys = num_keys
         self.data.setdefault(operation, []).append(
             {
                 "duration_seconds": duration_seconds,
                 "num_keys": num_keys,
+                "num_logical_keys": num_logical_keys,
                 "num_bytes": num_bytes,
                 "status": status,
                 "num_failed_keys": num_failed_keys,
+            }
+        )
+
+    def record_observation(self, name: str, duration_seconds: float) -> None:
+        if name not in DFKV_OBSERVATION_NAMES:
+            raise ValueError(f"Unknown Dfkv connector observation: {name!r}")
+        self.data.setdefault(_OBSERVATIONS_KEY, []).append(
+            {
+                "name": name,
+                "duration_seconds": duration_seconds,
             }
         )
 
@@ -111,6 +174,7 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
         super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
         metric_labelnames = labelnames + ["operation", "status"]
         self._metric_cache: dict[tuple[int, str, str], dict[str, PromMetric]] = {}
+        self._observation_cache: dict[tuple[int, str], PromMetric] = {}
 
         self._histogram_operation_time = self._histogram_cls(
             name="vllm:dfkv_store_operation_time_seconds",
@@ -144,6 +208,11 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
             documentation="Number of Dfkv store keys touched by operations.",
             labelnames=metric_labelnames,
         )
+        self._counter_operation_logical_keys = self._counter_cls(
+            name="vllm:dfkv_store_operation_logical_keys_total",
+            documentation="Number of logical Dfkv chunks touched by operations.",
+            labelnames=metric_labelnames,
+        )
         self._counter_operation_bytes = self._counter_cls(
             name="vllm:dfkv_store_operation_bytes_total",
             documentation="Number of bytes transferred by Dfkv store operations.",
@@ -154,6 +223,38 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
             documentation="Number of Dfkv store keys that failed in operations.",
             labelnames=metric_labelnames,
         )
+        observation_metric_names = {
+            "lookup_ipc": "vllm:dfkv_lookup_ipc_time_seconds",
+            "lookup_queue_wait": "vllm:dfkv_lookup_queue_wait_time_seconds",
+            "receive_queue_wait": "vllm:dfkv_receive_queue_wait_time_seconds",
+            "geometry_preparation": (
+                "vllm:dfkv_geometry_preparation_time_seconds"
+            ),
+        }
+        self._histogram_observations = {
+            name: self._histogram_cls(
+                name=metric_name,
+                documentation=f"Histogram of Dfkv {name.replace('_', ' ')} time.",
+                buckets=[
+                    1e-6,
+                    5e-6,
+                    1e-5,
+                    5e-5,
+                    1e-4,
+                    5e-4,
+                    1e-3,
+                    5e-3,
+                    1e-2,
+                    5e-2,
+                    1e-1,
+                    5e-1,
+                    1.0,
+                    5.0,
+                ],
+                labelnames=labelnames,
+            )
+            for name, metric_name in observation_metric_names.items()
+        }
 
     def _get_metrics(
         self,
@@ -161,6 +262,10 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
         operation: str,
         status: str,
     ) -> dict[str, PromMetric]:
+        if operation not in DFKV_OPERATION_NAMES:
+            raise ValueError(f"Unknown Dfkv connector operation: {operation!r}")
+        if status not in DFKV_OPERATION_STATUSES:
+            raise ValueError(f"Unknown Dfkv connector status: {status!r}")
         cache_key = (engine_idx, operation, status)
         if cache_key not in self._metric_cache:
             label_values = self.per_engine_labelvalues[engine_idx] + [operation, status]
@@ -168,15 +273,36 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
                 "time": self._histogram_operation_time.labels(*label_values),
                 "calls": self._counter_operation_calls.labels(*label_values),
                 "keys": self._counter_operation_keys.labels(*label_values),
+                "logical_keys": self._counter_operation_logical_keys.labels(
+                    *label_values
+                ),
                 "bytes": self._counter_operation_bytes.labels(*label_values),
                 "failed_keys": self._counter_failed_keys.labels(*label_values),
             }
         return self._metric_cache[cache_key]
 
+    def _get_observation_metric(self, engine_idx: int, name: str) -> PromMetric:
+        if name not in DFKV_OBSERVATION_NAMES:
+            raise ValueError(f"Unknown Dfkv connector observation: {name!r}")
+        cache_key = (engine_idx, name)
+        if cache_key not in self._observation_cache:
+            self._observation_cache[cache_key] = self._histogram_observations[
+                name
+            ].labels(*self.per_engine_labelvalues[engine_idx])
+        return self._observation_cache[cache_key]
+
     def observe(self, transfer_stats_data: dict[str, Any] | None, engine_idx: int = 0):
         if not transfer_stats_data:
             return
+        for record in transfer_stats_data.get(_OBSERVATIONS_KEY, ()):
+            assert isinstance(record, dict)
+            name = str(record["name"])
+            self._get_observation_metric(engine_idx, name).observe(
+                float(record["duration_seconds"])
+            )
         for operation, records in transfer_stats_data.items():
+            if operation == _OBSERVATIONS_KEY:
+                continue
             assert isinstance(records, list)
             for record in records:
                 assert isinstance(record, dict)
@@ -185,5 +311,8 @@ class DfkvStorePromMetrics(KVConnectorPromMetrics):
                 metrics["time"].observe(float(record["duration_seconds"]))
                 metrics["calls"].inc()
                 metrics["keys"].inc(int(record["num_keys"]))
+                metrics["logical_keys"].inc(
+                    int(record.get("num_logical_keys", record["num_keys"]))
+                )
                 metrics["bytes"].inc(int(record["num_bytes"]))
                 metrics["failed_keys"].inc(int(record["num_failed_keys"]))

--- a/integration/vllm/src/dfkv_vllm/protocol.py
+++ b/integration/vllm/src/dfkv_vllm/protocol.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Wire-format constants for the LookupKey ZMQ admin channel.
+"""Wire contract for the LookupKey ZMQ admin channel.
 
 This is the single source of truth shared by ``LookupKeyClient`` and
 ``LookupKeyServer`` on the scheduler<->worker rank-0 admin channel.
@@ -11,7 +11,8 @@ Wire format (REQ/REP over IPC):
 
       msg_type == LOOKUP_MSG:
           frame 1: token_len (u32 big-endian, 4 bytes)
-          frame 2..n: msgpack-encoded list[str] of block-hash hex digests
+          frame 2: hash_len (u16 big-endian, 2 bytes)
+          frame 3: the block hashes concatenated without separators
         Response: [hit_count: u32 big-endian, 4 bytes]
 
       msg_type == RESET_MSG:
@@ -20,17 +21,93 @@ Wire format (REQ/REP over IPC):
 
 The first frame of every request is a named bytes tag (not a numeric
 sentinel that aliases the data field) so the protocol stays
-self-describing and extensible: adding new admin commands requires
-only a new tag and a new dispatch branch.
-
-Mirrors the named-tag convention used by the NIXL connector (see
-``vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py``).
+self-describing and extensible. Lookup frames deliberately carry hashes as
+one binary blob: the receiver derives the count from ``len(blob) / hash_len``.
 """
+
+from collections.abc import Sequence
+
 
 # Request message-type tags. Frame 0 of every request.
 LOOKUP_MSG: bytes = b"lookup"
 RESET_MSG: bytes = b"reset"
 
+# Fixed field widths in the lookup request and response.
+TOKEN_LEN_BYTES = 4
+HASH_LEN_BYTES = 2
+LOOKUP_RESPONSE_BYTES = 4
+
 # Single-byte response status codes for admin commands.
 RESP_OK: bytes = b"\x01"
 RESP_ERR: bytes = b"\x00"
+
+
+def _encode_lookup_request(
+    token_len: int,
+    block_hashes: Sequence[bytes],
+) -> tuple[bytes, bytes, bytes, bytes]:
+    """Encode a lookup request as four ZMQ frames.
+
+    Empty hash lists use ``hash_len == 0`` and an empty blob. Non-empty hashes
+    must have one homogeneous, non-zero width so the receiver can split the
+    blob without per-hash framing.
+    """
+    if not 0 <= token_len < 1 << (8 * TOKEN_LEN_BYTES):
+        raise ValueError(f"token_len is outside uint32: {token_len}")
+
+    hash_len = len(block_hashes[0]) if block_hashes else 0
+    if hash_len >= 1 << (8 * HASH_LEN_BYTES):
+        raise ValueError(f"block hash is too long for uint16: {hash_len}")
+    if block_hashes and hash_len == 0:
+        raise ValueError("non-empty block hash list contains an empty hash")
+    if any(len(block_hash) != hash_len for block_hash in block_hashes):
+        raise ValueError("block hashes must all have the same length")
+
+    return (
+        LOOKUP_MSG,
+        token_len.to_bytes(TOKEN_LEN_BYTES, byteorder="big"),
+        hash_len.to_bytes(HASH_LEN_BYTES, byteorder="big"),
+        b"".join(block_hashes),
+    )
+
+
+def _decode_lookup_request(
+    frames: Sequence[bytes | bytearray | memoryview],
+) -> tuple[int, list[bytes]]:
+    """Decode and strictly validate a four-frame lookup request."""
+    if len(frames) != 4:
+        raise ValueError(f"lookup request has {len(frames)} frames, expected 4")
+    if bytes(frames[0]) != LOOKUP_MSG:
+        raise ValueError("lookup request has an invalid message type")
+
+    token_frame = frames[1]
+    hash_len_frame = frames[2]
+    if len(token_frame) != TOKEN_LEN_BYTES:
+        raise ValueError(
+            f"token_len frame has {len(token_frame)} bytes, "
+            f"expected {TOKEN_LEN_BYTES}"
+        )
+    if len(hash_len_frame) != HASH_LEN_BYTES:
+        raise ValueError(
+            f"hash_len frame has {len(hash_len_frame)} bytes, "
+            f"expected {HASH_LEN_BYTES}"
+        )
+
+    token_len = int.from_bytes(token_frame, byteorder="big")
+    hash_len = int.from_bytes(hash_len_frame, byteorder="big")
+    blob = memoryview(frames[3])
+    if not blob:
+        if hash_len != 0:
+            raise ValueError("empty hash blob has a non-zero hash_len")
+        return token_len, []
+    if hash_len == 0:
+        raise ValueError("non-empty hash blob has zero hash_len")
+    if len(blob) % hash_len:
+        raise ValueError(
+            f"hash blob length {len(blob)} is not divisible by hash_len {hash_len}"
+        )
+
+    return token_len, [
+        bytes(blob[offset : offset + hash_len])
+        for offset in range(0, len(blob), hash_len)
+    ]

--- a/integration/vllm/src/dfkv_vllm/scheduler.py
+++ b/integration/vllm/src/dfkv_vllm/scheduler.py
@@ -60,9 +60,11 @@ class DfkvStoreScheduler:
         # hashing (silent 0% cross-instance/cross-restart hit rate otherwise).
         ensure_deterministic_block_hashing(vllm_config.cache_config)
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-            "load_async", True
+        extra_config = (
+            vllm_config.kv_transfer_config.kv_connector_extra_config
         )
+        self.load_async = extra_config.get("load_async", True)
+        self.lookup_async = extra_config.get("lookup_async", False)
         self.client = LookupKeyClient(vllm_config)
         self._closed = False
 
@@ -82,21 +84,31 @@ class DfkvStoreScheduler:
         self,
         request: Request,
         num_computed_tokens: int,
-    ) -> tuple[int, bool]:
-        """Check for external KV cache hit."""
+    ) -> tuple[int | None, bool]:
+        """Check for an external KV cache hit.
+
+        Returns ``(None, False)`` while an asynchronous lookup is pending so
+        vLLM retries the request on a later scheduler step.
+        """
         # Look up against the full prefill range, not just the prompt.
         token_len = request.num_tokens // self._block_size * self._block_size
         if token_len < self._block_size:
             return 0, False
 
         _lk0 = time.perf_counter()
-        num_external_hit_tokens = self.client.lookup(token_len, request.block_hashes)
+        num_external_hit_tokens = self.client.lookup(
+            request.request_id,
+            token_len,
+            request.block_hashes,
+            non_block=self.lookup_async,
+        )
+        if num_external_hit_tokens is None:
+            return None, False
         logger.debug(
             "dfkv matched: req=%s tokens=%d computed=%d lookup_ms=%.1f hit_tokens=%d",
             request.request_id, request.num_tokens, num_computed_tokens,
             (time.perf_counter() - _lk0) * 1000.0, num_external_hit_tokens,
         )
-
         if num_external_hit_tokens == request.num_tokens:
             # Leave a sub-block tail uncomputed for sampling, on a block
             # boundary so the recv-side load mask covers every yielded chunk.
@@ -171,6 +183,7 @@ class DfkvStoreScheduler:
         force_skip_save = self.kv_role == "kv_consumer"
 
         for finished_req_id in scheduler_output.finished_req_ids:
+            self.client.discard(finished_req_id)
             self.load_specs.pop(finished_req_id, None)
             self._request_trackers.pop(finished_req_id, None)
             self._unfinished_requests.pop(finished_req_id, None)
@@ -180,6 +193,7 @@ class DfkvStoreScheduler:
         preempted_ids = scheduler_output.preempted_req_ids or set()
         self._preempted_req_ids.update(preempted_ids)
         for req_id in preempted_ids:
+            self.client.discard(req_id)
             self.load_specs.pop(req_id, None)
             if request_tracker := self._request_trackers.get(req_id):
                 request_tracker.reset()
@@ -360,6 +374,7 @@ class DfkvStoreScheduler:
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         """Determine whether to delay freeing blocks for async save."""
+        self.client.discard(request.request_id)
         if self.kv_role == "kv_consumer":
             return False, None
         tracker = self._request_trackers.get(request.request_id)

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -20,8 +20,9 @@ import queue
 import socket
 import threading
 import time
+import zlib
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, TypeVar
 
@@ -70,7 +71,7 @@ from .data import (
     key_diagnostic_label,
     split_block_contiguous_runs,
 )
-from .dfkv_client import DfkvDeviceClient
+from .dfkv_client import DfkvDeviceClient, SgDescriptorBatch
 from .dfkv_utils import get_dp_engine_index
 from .metrics import DfkvStoreConnectorStats
 from ._telemetry import config as _tcfg  # connector identity + client_register switch
@@ -91,6 +92,20 @@ _T = TypeVar("_T")
 
 def _rotate_list(values: list[_T], offset: int) -> list[_T]:
     return values[offset:] + values[:offset]
+
+def _batch_rotation_offset(
+    req_id: str,
+    block_hashes: list[BlockHash],
+    tp_rank: int,
+    batch_size: int,
+) -> int:
+    """Choose a stable, rank-staggered first object for one request batch."""
+    if batch_size <= 1:
+        return 0
+    seed = zlib.crc32(req_id.encode("utf-8"))
+    if block_hashes:
+        seed = zlib.crc32(bytes(block_hashes[0]), seed)
+    return (seed + tp_rank) % batch_size
 
 
 # dfkv: Removed Mooncake-store-only helpers:
@@ -123,6 +138,8 @@ def _put_failed_indices(rcs: list[int]) -> list[int]:
 # capacity would prevent vLLM from observing completions and freeing blocks.
 DEFAULT_TRANSFER_QUEUE_CAPACITY = 256
 MAX_TRANSFER_QUEUE_CAPACITY = 65536
+DEFAULT_RECV_WORKERS = 1
+MAX_RECV_WORKERS = 32
 _TRANSFER_STOP = object()
 
 
@@ -142,6 +159,31 @@ def _parse_transfer_queue_capacity(value: Any) -> int:
         )
     return capacity
 
+def _parse_recv_workers(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("recv_workers must be an integer")
+    if isinstance(value, int):
+        workers = value
+    elif isinstance(value, str) and value.strip().isdigit():
+        workers = int(value.strip())
+    else:
+        raise ValueError("recv_workers must be an integer")
+    if not 1 <= workers <= MAX_RECV_WORKERS:
+        raise ValueError(
+            f"recv_workers must be in [1, {MAX_RECV_WORKERS}], got {workers}"
+        )
+    return workers
+
+
+@dataclasses.dataclass
+class _ReceiveRequestState:
+    request: ReqMeta | None
+    block_ids: tuple[int, ...]
+    phase: str = "queued"
+    cancel_requested: bool = False
+    fail_closed_on_cancel: bool = False
+    completion: threading.Event = dataclasses.field(default_factory=threading.Event)
+
 
 
 
@@ -159,6 +201,7 @@ class KVTransferThread(threading.Thread):
         record_operation: Callable[..., None] | None = None,
         record_observation: Callable[[str, float], None] | None = None,
         queue_capacity: int = DEFAULT_TRANSFER_QUEUE_CAPACITY,
+        record_pool_sample: Callable[[str, int], None] | None = None,
     ):
         super().__init__(daemon=False, name=name)
         self.client = client
@@ -168,6 +211,7 @@ class KVTransferThread(threading.Thread):
         self.token_databases = token_databases
         self._record_operation_cb = record_operation
         self._record_observation_cb = record_observation
+        self._record_pool_sample_cb = record_pool_sample
         self.done_task_lock = threading.Lock()
         self.request_queue: queue.Queue[Any] = queue.Queue(maxsize=queue_capacity)
         self.finished_requests: set[str] = set()
@@ -303,6 +347,10 @@ class KVTransferThread(threading.Thread):
     def _record_observation(self, name: str, start_time: float) -> None:
         if self._record_observation_cb is not None:
             self._record_observation_cb(name, time.perf_counter() - start_time)
+
+    def _record_pool_sample(self, name: str, value: int) -> None:
+        if self._record_pool_sample_cb is not None:
+            self._record_pool_sample_cb(name, value)
 
     def update_kv_event(self, events: list[BlockStored]):
         with self.kv_event_lock:
@@ -505,8 +553,18 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 req_id,
             )
 
-            addrs: list[list[int]] = []
-            sizes: list[list[int]] = []
+            descriptor_chunks = [
+                (
+                    self.token_databases[g_idx],
+                    start,
+                    end,
+                    block_ids_per_group[g_idx],
+                )
+                for start, end, g_idx in zip(
+                    starts, ends, group_indices, strict=True
+                )
+            ]
+            descriptor_batch = SgDescriptorBatch.from_chunks(descriptor_chunks)
             stored_events: list[BlockStored] = []
             # parent_block_hash chains live within a group, not across.
             prev_key_per_group: dict[int, Any] = {}
@@ -516,9 +574,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 zip(starts, ends, group_indices, strict=True)
             ):
                 db = self.token_databases[g_idx]
-                addr, size, _ = db.prepare_value(s, e, block_ids_per_group[g_idx])
-                addrs.append(addr)
-                sizes.append(size)
 
                 if self.enable_kv_event:
                     token_ids = (
@@ -545,12 +600,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
             # One key and one complete segment vector represent each logical
             # chunk. libdfkv splits vectors wider than the negotiated HCA SGE
             # limit into ordered WR windows under one object completion.
-            batch_bytes = sum(sum(s) for s in sizes)
-            num_segments = sum(len(s) for s in sizes)
+            batch_bytes = descriptor_batch.total_bytes
+            num_segments = descriptor_batch.num_segments
             put_start = time.perf_counter()
             successful_events: list[BlockStored] = []
             try:
-                res = self.client.batch_put_sg(keys, addrs, sizes)
+                res = self.client.batch_put_sg(
+                    keys, descriptor_batch.ptrs, descriptor_batch.sizes
+                )
                 if len(res) != len(keys):
                     raise RuntimeError(
                         "batch_put_sg returned incomplete per-key results: "
@@ -624,7 +681,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
 
 class KVCacheStoreRecvingThread(KVTransferThread):
-    """Background thread for loading KV cache blocks from the store."""
+    """Bounded worker pool for loading KV cache blocks from the store.
+
+    The object remains a ``Thread`` for connector/API compatibility; that
+    thread is worker zero and ``recv_workers - 1`` bounded peer threads share
+    its request queue.  A request has one queue entry and one lifecycle state.
+    The state retains its GPU block fence until that request alone completes or
+    is cancelled, independent of other requests' completion order.
+    """
 
     def __init__(
         self,
@@ -638,6 +702,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         record_observation: Callable[[str, float], None] | None = None,
         client_provider: Callable[[], Any] | None = None,
         queue_capacity: int = DEFAULT_TRANSFER_QUEUE_CAPACITY,
+        recv_workers: int = DEFAULT_RECV_WORKERS,
+        record_pool_sample: Callable[[str, int], None] | None = None,
     ):
         super().__init__(
             client,
@@ -648,20 +714,263 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             name="KVCacheStoreRecvingThread",
             record_operation=record_operation,
             record_observation=record_observation,
+            record_pool_sample=record_pool_sample,
             queue_capacity=queue_capacity,
         )
-        # Elided ranks start with client=None; a real load arriving there calls
-        # this back into the worker to lazily un-elide (create + register the
-        # client) instead of failing the span into a recompute.
+        self.recv_workers = _parse_recv_workers(recv_workers)
         self.client_provider = client_provider
-        # _invalid_block_ids can be accessed by both the Worker and RecvingThread.
         self._invalid_block_ids_lock = threading.Lock()
         self._invalid_block_ids: set[int] = set()
         self.coord = coord
+        self._request_states_lock = threading.Lock()
+        self._request_states: dict[str, _ReceiveRequestState] = {}
+        self._active_workers = 0
+        self._pool_stop_lock = threading.Lock()
+        self._pool_stop_started = False
+        self._pool_stop_done = threading.Event()
+        self._peer_threads = [
+            threading.Thread(
+                target=self._run_receive_worker,
+                daemon=False,
+                name=f"KVCacheStoreRecvingThread-{worker_idx}",
+            )
+            for worker_idx in range(1, self.recv_workers)
+        ]
+
+    @property
+    def worker_threads(self) -> tuple[threading.Thread, ...]:
+        return (self, *self._peer_threads)
+
+    def start(self) -> None:
+        with self._pool_stop_lock:
+            if self._pool_stop_started:
+                raise RuntimeError("receive pool is closed")
+            super().start()
+            for worker in self._peer_threads:
+                worker.start()
+
+    def run(self) -> None:
+        self.ready_event.set()
+        self._run_receive_worker()
 
     def add_request(self, request: ReqMeta) -> bool:
         request._dfkv_receive_enqueued_at = time.perf_counter()  # type: ignore[attr-defined]
-        return super().add_request(request)
+        block_ids = tuple(
+            block_id for group_ids in request.block_ids for block_id in group_ids
+        )
+        reason = "closed"
+        with self._stop_lock:
+            if self._accepting:
+                with self._request_states_lock:
+                    if request.req_id in self._request_states:
+                        logger.warning(
+                            "%s ignored duplicate request %s",
+                            self.name,
+                            request.req_id,
+                        )
+                        return False
+                    state = _ReceiveRequestState(request=request, block_ids=block_ids)
+                    self._request_states[request.req_id] = state
+                    try:
+                        self.request_queue.put_nowait(request)
+                    except queue.Full:
+                        reason = "saturated"
+                        self._terminalize_locked(state, failed=True)
+                    else:
+                        self._record_pool_sample(
+                            "receive_queue_depth", self.request_queue.qsize()
+                        )
+                        return True
+            else:
+                state = _ReceiveRequestState(request=request, block_ids=block_ids)
+                with self._request_states_lock:
+                    existing = self._request_states.get(request.req_id)
+                    if existing is not None:
+                        return False
+                    self._request_states[request.req_id] = state
+                    self._terminalize_locked(state, failed=True)
+                    self._request_states.pop(request.req_id, None)
+        logger.warning(
+            "%s rejected request %s: transfer queue %s (capacity=%d)",
+            self.name,
+            request.req_id,
+            reason,
+            self.request_queue.maxsize,
+        )
+        return False
+
+    def get_and_clear_finished_requests(self) -> set[str]:
+        with self._request_states_lock:
+            with self.done_task_lock:
+                finished = self.finished_requests.copy()
+                self.finished_requests.clear()
+            for req_id in finished:
+                state = self._request_states.get(req_id)
+                if state is not None and state.phase == "terminal":
+                    self._request_states.pop(req_id, None)
+        return finished
+
+    def cancel_requests(
+        self,
+        req_ids: set[str] | list[str] | tuple[str, ...],
+        *,
+        wait: bool = True,
+        fail_closed: bool = True,
+    ) -> None:
+        """Cancel loads and fence active native calls through completion."""
+        wait_events: list[threading.Event] = []
+        with self._request_states_lock:
+            for req_id in req_ids:
+                state = self._request_states.get(req_id)
+                if state is None or state.phase == "terminal":
+                    continue
+                if state.phase == "queued":
+                    self._terminalize_locked(state, failed=fail_closed)
+                else:
+                    state.cancel_requested = True
+                    state.fail_closed_on_cancel = (
+                        state.fail_closed_on_cancel or fail_closed
+                    )
+                    wait_events.append(state.completion)
+        if wait:
+            for completion in wait_events:
+                completion.wait()
+
+    def _terminalize_locked(
+        self,
+        state: _ReceiveRequestState,
+        *,
+        failed: bool,
+    ) -> bool:
+        if state.phase == "terminal":
+            return False
+        req = state.request
+        req_id = req.req_id if req is not None else None
+        state.phase = "terminal"
+        state.request = None
+        if failed and state.block_ids:
+            with self._invalid_block_ids_lock:
+                self._invalid_block_ids.update(state.block_ids)
+        state.block_ids = ()
+        if req_id is not None:
+            with self.done_task_lock:
+                self.finished_requests.add(req_id)
+        state.completion.set()
+        return True
+
+    def _run_receive_worker(self) -> None:
+        while True:
+            request = self.request_queue.get()
+            try:
+                self._record_pool_sample(
+                    "receive_queue_depth", self.request_queue.qsize()
+                )
+                if request is _TRANSFER_STOP:
+                    return
+                with self._request_states_lock:
+                    state = self._request_states.get(request.req_id)
+                    if (
+                        state is None
+                        or state.phase != "queued"
+                        or state.request is not request
+                    ):
+                        continue
+                    state.phase = "active"
+                    self._active_workers += 1
+                    self._record_pool_sample(
+                        "receive_active_workers", self._active_workers
+                    )
+                failed = False
+                try:
+                    self._handle_request(request)
+                except Exception:
+                    failed = True
+                    logger.exception(
+                        "Error in %s for request %s", self.name, request.req_id
+                    )
+                finally:
+                    with self._request_states_lock:
+                        state = self._request_states.get(request.req_id)
+                        if state is not None and state.phase == "active":
+                            self._active_workers -= 1
+                            failed = (
+                                failed
+                                or (
+                                    state.cancel_requested
+                                    and state.fail_closed_on_cancel
+                                )
+                            )
+                            self._terminalize_locked(state, failed=failed)
+                            self._record_pool_sample(
+                                "receive_active_workers", self._active_workers
+                            )
+            finally:
+                self.request_queue.task_done()
+
+    def stop(self, *, cancel_pending: bool = True) -> None:
+        with self._pool_stop_lock:
+            first_stop = not self._pool_stop_started
+            if first_stop:
+                self._pool_stop_started = True
+        if not first_stop:
+            self._pool_stop_done.wait()
+            return
+
+        try:
+            with self._stop_lock:
+                self._accepting = False
+            if cancel_pending:
+                while True:
+                    try:
+                        pending = self.request_queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    try:
+                        if pending is not _TRANSFER_STOP:
+                            self.cancel_requests(
+                                (pending.req_id,),
+                                wait=False,
+                                fail_closed=False,
+                            )
+                    finally:
+                        self.request_queue.task_done()
+                with self._request_states_lock:
+                    for state in self._request_states.values():
+                        if state.phase == "active":
+                            state.cancel_requested = True
+            if self.ident is None:
+                while True:
+                    try:
+                        self.request_queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    else:
+                        self.request_queue.task_done()
+                with self._request_states_lock:
+                    for state in self._request_states.values():
+                        if state.phase != "terminal":
+                            self._terminalize_locked(state, failed=False)
+                    self._request_states.clear()
+                self._record_pool_sample("receive_queue_depth", 0)
+                self._record_pool_sample("receive_active_workers", 0)
+                return
+            for _ in self.worker_threads:
+                self.request_queue.put(_TRANSFER_STOP)
+            self.request_queue.join()
+            for worker in self.worker_threads:
+                if threading.current_thread() is not worker:
+                    worker.join()
+            with self._request_states_lock:
+                if any(state.phase != "terminal" for state in self._request_states.values()):
+                    raise RuntimeError("receive pool stopped with non-terminal requests")
+                self._request_states.clear()
+            self._record_pool_sample("receive_queue_depth", 0)
+            self._record_pool_sample("receive_active_workers", 0)
+        finally:
+            self._pool_stop_done.set()
+
+    close = stop
+
 
     def _add_load_error_block_ids(self, block_ids: list[int]) -> None:
         with self._invalid_block_ids_lock:
@@ -691,8 +1000,9 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             # locally (e.g. SWA pre-window) even if the producer stored them.
             load_mask_per_group = self.coord.load_mask(req_meta.block_hashes, token_len)
 
-            addr_list: list[list[int]] = []
-            size_list: list[list[int]] = []
+            descriptor_chunks: list[
+                tuple[object, int, int, Sequence[int]]
+            ] = []
             key_list: list[bytes] = []
             block_id_list: list[int] = []
             for g_idx, db in enumerate(self.token_databases):
@@ -703,27 +1013,33 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     chunk_idx = start // db.block_size
                     if chunk_idx >= len(mask) or not mask[chunk_idx]:
                         continue
-                    addr, size, block_id = db.prepare_value(
-                        start, end, req_meta.block_ids[g_idx]
+                    block_id = int(
+                        req_meta.block_ids[g_idx][start // db.block_size]
                     )
                     key_list.append(key.to_bytes())
-                    addr_list.append(addr)
-                    size_list.append(size)
+                    descriptor_chunks.append(
+                        (db, start, end, req_meta.block_ids[g_idx])
+                    )
                     block_id_list.append(block_id)
 
-            # Nothing to load (e.g. every chunk masked out for this group) -> finish
-            # the request now, else `tp_rank % 0` below would raise and the req would
-            # never be reported done, hanging vLLM's WAITING_FOR_REMOTE_KVS wait.
+            # An empty descriptor batch finishes immediately; in particular,
+            # avoid taking a modulo by zero while choosing the first object.
             if not key_list:
                 self._record_observation("geometry_preparation", geometry_start)
                 return
 
-            # Rotate aligned lists by tp_rank for load balancing.
-            rotation = self.tp_rank % len(key_list)
+            # Rotate submission order only. The request and its first chunk
+            # choose a stable base shard, while adjacent TP ranks start at
+            # adjacent objects instead of repeating one fixed burst pattern.
+            # All aligned metadata follows the same permutation, so keys,
+            # object-internal segment order, and failure attribution are intact.
+            rotation = _batch_rotation_offset(
+                req_id, req_meta.block_hashes, self.tp_rank, len(key_list)
+            )
             rotated_keys = _rotate_list(key_list, rotation)
-            rotated_addrs = _rotate_list(addr_list, rotation)
-            rotated_sizes = _rotate_list(size_list, rotation)
+            rotated_chunks = _rotate_list(descriptor_chunks, rotation)
             rotated_block_ids = _rotate_list(block_id_list, rotation)
+            descriptor_batch = SgDescriptorBatch.from_chunks(rotated_chunks)
 
             # dfkv: one logical chunk is one batch key with its complete
             # destination segment vector. libdfkv performs any HCA-width
@@ -734,9 +1050,9 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 if client is not None:
                     self.client = client
             self._record_observation("geometry_preparation", geometry_start)
-            chunk_totals = [sum(chunk_sizes) for chunk_sizes in rotated_sizes]
-            batch_bytes = sum(chunk_totals)
-            num_segments = sum(len(chunk_sizes) for chunk_sizes in rotated_sizes)
+            chunk_totals = descriptor_batch.logical_lengths
+            batch_bytes = descriptor_batch.total_bytes
+            num_segments = descriptor_batch.num_segments
 
             load_get_start = time.perf_counter()
             try:
@@ -748,7 +1064,9 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     hits, lens = [False] * len(rotated_keys), [0] * len(rotated_keys)
                 else:
                     hits, lens = client.batch_get_auto_sg(
-                        rotated_keys, rotated_addrs, rotated_sizes
+                        rotated_keys,
+                        descriptor_batch.ptrs,
+                        descriptor_batch.caps,
                     )
                 if len(hits) != len(rotated_keys) or len(lens) != len(rotated_keys):
                     raise RuntimeError(
@@ -830,24 +1148,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 )
             except Exception:
                 pass
-        finally:
-            self.set_finished_request(req_id)
-
     def _cancel_request(self, req_meta: Any) -> None:
-        # A queued/rejected load must finish as a visible recompute, never leave
-        # the request stuck in WAITING_FOR_REMOTE_KVS.
-        try:
-            self._add_load_error_block_ids(
-                [block_id for ids in req_meta.block_ids for block_id in ids]
-            )
-        except Exception:
-            logger.exception(
-                "%s could not enumerate cancelled load blocks for request %s",
-                self.name,
-                getattr(req_meta, "req_id", "<unknown>"),
-            )
-        finally:
-            self.set_finished_request(req_meta.req_id)
+        self.cancel_requests(
+            (req_meta.req_id,), wait=False, fail_closed=True
+        )
 
 
 
@@ -888,10 +1192,14 @@ class DfkvStoreWorker:
                 DEFAULT_TRANSFER_QUEUE_CAPACITY,
             )
         )
+        self.recv_workers = _parse_recv_workers(
+            extra.get("recv_workers", DEFAULT_RECV_WORKERS)
+        )
         logger.info(
-            "dfkv transfer queues: capacity=%d per direction, "
+            "dfkv transfer queues: capacity=%d per direction, recv_workers=%d, "
             "overload=reject-new, shutdown=cancel-pending",
             self.transfer_queue_capacity,
+            self.recv_workers,
         )
         self._close_lock = threading.Lock()
         self._closed = False
@@ -1401,6 +1709,8 @@ class DfkvStoreWorker:
             queue_capacity=getattr(
                 self, "transfer_queue_capacity", DEFAULT_TRANSFER_QUEUE_CAPACITY
             ),
+            recv_workers=getattr(self, "recv_workers", DEFAULT_RECV_WORKERS),
+            record_pool_sample=self._record_kv_connector_pool_sample,
         )
         self.kv_recv_thread.start()
         ready_event_recving.wait()
@@ -1409,24 +1719,22 @@ class DfkvStoreWorker:
         self,
         metadata: DfkvStoreConnectorMetadata,
     ):
-        """Pre-forward hook: fence preempted requests' in-flight saves.
+        """Fence every preempted request's active GPU transfer.
 
-        Loads/stores are issued in get_finished() for overlap; the ONLY work
-        here is the preemption fence, and it must be here. The scheduler
-        frees a preempted request's GPU blocks with no connector hook
-        (request_finished()'s delay-free covers only the normal finish path)
-        and can hand them to another request scheduled in this very step.
-        This hook runs before this step's forward pass writes into those
-        blocks, so it is the last point where the race can still be closed:
-        drop the queued-not-started saves, then wait out the one save the
-        send thread may currently be executing (an uncancellable RDMA read
-        of the request's old blocks). Without the fence that read races the
-        new request's prefill writes and stores mixed bytes under a
-        content-addressed key -- and the save path's exists-dedup then
-        prevents the correct bytes from ever replacing them (persistent
-        cache poison, spread across instances by PD reuse).
+        A queued receive is cancelled without a native call.  An active receive
+        cannot be interrupted safely, so this waits for only that request's
+        GPUDirect write before its blocks may be reused.  The send-side fence
+        likewise waits for its request's active RDMA read.
         """
-        if self.kv_send_thread is None or not metadata.preempted_req_ids:
+        if not metadata.preempted_req_ids:
+            return
+        if self.kv_recv_thread is not None:
+            self.kv_recv_thread.cancel_requests(
+                metadata.preempted_req_ids,
+                wait=True,
+                fail_closed=False,
+            )
+        if self.kv_send_thread is None:
             return
         # Drop queued entries first (the dequeue gate re-checks per entry),
         # then join whichever entry is already executing.
@@ -1461,6 +1769,14 @@ class DfkvStoreWorker:
         compute is launched on the compute stream) for better
         compute-I/O overlap.
         """
+        # Aborted/finished requests may have an outstanding remote load.  Their
+        # blocks cannot be freed until that request's own GPUDirect write exits.
+        if finished_req_ids and self.kv_recv_thread is not None:
+            self.kv_recv_thread.cancel_requests(
+                finished_req_ids,
+                wait=True,
+                fail_closed=False,
+            )
         # Issue async loads
         for request in meta.requests:
             load_spec = request.load_spec
@@ -1547,6 +1863,14 @@ class DfkvStoreWorker:
         with self._kv_connector_stats_lock:
             self.kv_connector_stats.record_observation(name, duration_seconds)
 
+    def _record_kv_connector_pool_sample(
+        self,
+        name: str,
+        value: int,
+    ) -> None:
+        with self._kv_connector_stats_lock:
+            self.kv_connector_stats.record_pool_sample(name, value)
+
     def get_kv_connector_stats(self) -> DfkvStoreConnectorStats | None:
         with self._kv_connector_stats_lock:
             if self.kv_connector_stats.is_empty():
@@ -1593,11 +1917,12 @@ class DfkvStoreWorker:
         if not block_hashes or token_len <= 0:
             return 0
 
-        # Build one physical object candidate per logical (group, hash, TP, PP)
-        # coordinate. candidate_meta maps each object back to the logical chunk.
+        # Build every physical object required by each logical LCM chunk.
+        # Object metadata retains the logical chunk index so repeated hashes
+        # cannot collapse accounting across distinct prefix positions.
         candidate_keys: list[bytes] = []
-        candidate_meta: list[tuple[int, bytes]] = []
-        expected_per_chunk: dict[tuple[int, bytes], int] = {}
+        candidate_meta: list[tuple[int, int, int, bytes]] = []
+        expected_per_object: dict[tuple[int, int, int, bytes], int] = {}
         tp_count = min(self.tp_size, self.num_kv_head)
         # dfkv: gate candidates by store_mask -- the SAME per-(group,chunk) set
         # the SAVE path stores (worker.py save gate) and the LOAD path reads
@@ -1610,6 +1935,11 @@ class DfkvStoreWorker:
             token_len // self.coord.lcm_block_size * self.coord.lcm_block_size
         )
         store_masks = self.coord.store_mask(aligned_token_len)
+        if aligned_token_len == 0:
+            return 0
+        num_prefix_chunks = aligned_token_len // self.coord.lcm_block_size
+        required_objects_per_chunk = [0] * num_prefix_chunks
+        missing_required_per_chunk = [False] * num_prefix_chunks
         for g_idx, db in enumerate(self.token_dbs):
             spec_block_size = db.block_size
             mask = store_masks[g_idx]
@@ -1625,18 +1955,35 @@ class DfkvStoreWorker:
                 [db.metadata.tp_rank] if db.metadata.tp_rank < 0 else range(tp_count)
             )
             rank_probes = max(1, len(tp_candidates) * self.pp_size)
+            processed_chunks = 0
             for chunk_id, h in enumerate(group_hashes):
                 start_idx = chunk_id * spec_block_size
-                if start_idx >= token_len:
+                if start_idx >= aligned_token_len:
                     break
+                processed_chunks = chunk_id + 1
                 if chunk_id >= len(mask) or not mask[chunk_id]:
                     continue
-                expected_per_chunk[(g_idx, bytes(h))] = rank_probes
+                logical_chunk_idx = start_idx // self.coord.lcm_block_size
+                object_meta = (logical_chunk_idx, g_idx, chunk_id, bytes(h))
+                expected_per_object[object_meta] = rank_probes
+                required_objects_per_chunk[logical_chunk_idx] += 1
                 for tp in tp_candidates:
                     for pp in range(self.pp_size):
                         md = dataclasses.replace(db.metadata, tp_rank=tp, pp_rank=pp)
                         candidate_keys.append(PoolKey(md, h.hex()).to_bytes())
-                        candidate_meta.append((g_idx, bytes(h)))
+                        candidate_meta.append(object_meta)
+            # A truncated hash vector is malformed metadata. Mark only its
+            # ungenerated required suffix chunks incomplete; the normal path
+            # has no second full mask scan.
+            for chunk_id in range(
+                processed_chunks,
+                min(len(mask), aligned_token_len // spec_block_size),
+            ):
+                if mask[chunk_id]:
+                    logical_chunk_idx = (
+                        chunk_id * spec_block_size // self.coord.lcm_block_size
+                    )
+                    missing_required_per_chunk[logical_chunk_idx] = True
 
         if not candidate_keys:
             return 0
@@ -1644,41 +1991,77 @@ class DfkvStoreWorker:
         lookup_start = time.perf_counter()
         try:
             res = self.client.batch_exist(candidate_keys)
-            self._record_kv_connector_operation(
-                "lookup_exists",
-                time.perf_counter() - lookup_start,
-                len(candidate_keys),
-                num_logical_keys=len(expected_per_chunk),
-            )
+            if len(res) != len(candidate_keys):
+                raise RuntimeError(
+                    "batch_exist returned incomplete per-key results: "
+                    f"keys={len(candidate_keys)} statuses={len(res)}"
+                )
         except Exception as e:
             self._record_kv_connector_operation(
                 "lookup_exists",
                 time.perf_counter() - lookup_start,
                 len(candidate_keys),
-                num_logical_keys=len(expected_per_chunk),
+                num_logical_keys=len(expected_per_object),
                 status="error",
                 num_failed_keys=len(candidate_keys),
             )
             logger.error("Remote connection failed in lookup: %s", e)
             return 0
 
-        # A (group, hash) is present only when every required TP*PP object
-        # exists. A partial request therefore fails closed at the first missing
-        # chunk without any sibling-key interpretation.
-        present_count: dict[tuple[int, bytes], int] = {}
-        for gh, exists in zip(candidate_meta, res, strict=True):
-            if exists == 1:
-                present_count[gh] = present_count.get(gh, 0) + 1
-        exists_set = {
-            gh for gh, c in present_count.items() if c >= expected_per_chunk[gh]
-        }
-
-        _masks, hit_length = self.coord.find_longest_cache_hit(
-            block_hashes, token_len, ExternalCachedBlockPool(exists_set)
+        self._record_kv_connector_operation(
+            "lookup_exists",
+            time.perf_counter() - lookup_start,
+            len(candidate_keys),
+            num_logical_keys=len(expected_per_object),
         )
+
+        # A semantic object exists only if every TP*PP coordinate exists. A
+        # logical LCM chunk is complete only if all of its semantic objects do.
+        # Scan logical chunks in order and cap the semantic coordinator at the
+        # first incomplete one, so an isolated later hit can never be loaded.
+        present_per_object: dict[tuple[int, int, int, bytes], int] = {}
+        for object_meta, exists in zip(candidate_meta, res, strict=True):
+            if exists == 1:
+                present_per_object[object_meta] = (
+                    present_per_object.get(object_meta, 0) + 1
+                )
+
+        complete_chunks = [
+            required > 0 and not missing_required_per_chunk[idx]
+            for idx, required in enumerate(required_objects_per_chunk)
+        ]
+        exists_set: set[tuple[int, bytes]] = set()
+        for object_meta, expected in expected_per_object.items():
+            logical_chunk_idx, g_idx, _chunk_id, chunk_hash = object_meta
+            if present_per_object.get(object_meta, 0) != expected:
+                complete_chunks[logical_chunk_idx] = False
+            else:
+                exists_set.add((g_idx, chunk_hash))
+
+        prefix_chunks = 0
+        for chunk_idx, complete in enumerate(complete_chunks):
+            if required_objects_per_chunk[chunk_idx] == 0 or not complete:
+                break
+            prefix_chunks += 1
+        complete_prefix_tokens = prefix_chunks * self.coord.lcm_block_size
+
+        if complete_prefix_tokens == 0:
+            hit_length = 0
+        else:
+            _masks, semantic_hit_length = self.coord.find_longest_cache_hit(
+                block_hashes,
+                complete_prefix_tokens,
+                ExternalCachedBlockPool(exists_set),
+            )
+            hit_length = min(complete_prefix_tokens, semantic_hit_length)
         logger.debug(
-            "dfkv lookup: token_len=%d candidates=%d present=%d -> hit_length=%d",
-            token_len, len(candidate_keys), len(exists_set), hit_length,
+            "dfkv lookup: token_len=%d candidates=%d complete_chunks=%d/%d "
+            "-> hit_length=%d",
+            token_len,
+            len(candidate_keys),
+            prefix_chunks,
+            num_prefix_chunks,
+            hit_length,
         )
         return hit_length
 

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -14,7 +14,7 @@ offload staging, ReplicateConfig/preferred_segment) are dropped.
 """
 
 import dataclasses
-import hashlib
+import logging
 import os
 import queue
 import socket
@@ -27,10 +27,8 @@ from typing import Any, TypeVar
 
 import torch
 from dfkv_common import (
-    VLLM_RAW_V1,
     canonical_namespace,
     reject_namespace_override,
-    sg_key,
 )
 import zmq
 
@@ -63,11 +61,13 @@ from .coordinator import (
     DfkvStoreCoordinator,
 )
 from .data import (
+    VLLM_MULTIWR_V2,
     ChunkedTokenDatabase,
     DfkvStoreConnectorMetadata,
     KeyMetadata,
     PoolKey,
     ReqMeta,
+    key_diagnostic_label,
     split_block_contiguous_runs,
 )
 from .dfkv_client import DfkvDeviceClient
@@ -93,10 +93,6 @@ def _rotate_list(values: list[_T], offset: int) -> list[_T]:
     return values[offset:] + values[:offset]
 
 
-def _sum_batch_bytes(sizes: list[list[int]]) -> int:
-    return sum(sum(size) for size in sizes)
-
-
 # dfkv: Removed Mooncake-store-only helpers:
 #   * disk-offload staging budget math (_align_up,
 #     _estimate_disk_offload_staging_bytes, _get_usable_disk_offload_buffer
@@ -110,10 +106,8 @@ def _sum_batch_bytes(sizes: list[list[int]]) -> int:
 #     _HANDLE pressure code -- dfkv is configured via kv_connector_extra_config
 #     and has no embedded/standalone-store topology or offload pressure signal.
 
-
-# dfkv: batch_put returns a per-key rc (0 == ok, non-zero == failure); a GET
-# returns (hits, lens) with hit in {0, 1}. These helpers normalize the two
-# dfkv return shapes into the (failed-index list) shape the threads expect.
+# dfkv: batch_put returns a per-key rc (0 == ok, non-zero == failure).
+# Normalize that result into the failed-index list the send thread expects.
 def _put_failed_indices(rcs: list[int]) -> list[int]:
     return [i for i, rc in enumerate(rcs) if rc != 0]
 
@@ -464,50 +458,35 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if not keys:
                 return
 
-            # Stored values use explicit scatter-group coordinates (see
-            # _group_segments_sg). A chunk is "stored" only when EVERY group
-            # of it is present: group 0 alone is a partial write (a sibling
-            # group failed or was evicted) whose load would fail wholesale,
-            # so it must be rewritten, not skipped in place. Lookup probes
-            # the same full set so both paths agree on "present". Probing
-            # the bare pool key would miss every stored group and defeat
-            # deduplication.
-            max_sg_segs = _sg_segs_of(self.client)
-            probe_keys: list[bytes] = []
-            probe_owner: list[int] = []
-            for i, (k, s, e) in enumerate(zip(keys, starts, ends, strict=True)):
-                for grp in range(
-                    _num_sg_groups(
-                        self.token_databases[group_indices[i]], e - s, max_sg_segs
-                    )
-                ):
-                    probe_keys.append(_sg_group_key(k, grp, max_sg_segs))
-                    probe_owner.append(i)
+            # A multiwr-v2 chunk is exactly one dfkv object. The native client
+            # owns any HCA-width windowing, so dedup probes the logical keys
+            # directly and a missing object is rewritten as a whole.
             save_exists_start = time.perf_counter()
             try:
-                exists_states = self.client.batch_exist(probe_keys)
+                exists_states = self.client.batch_exist(keys)
+                if len(exists_states) != len(keys):
+                    raise RuntimeError(
+                        "batch_exist returned incomplete per-key results: "
+                        f"keys={len(keys)} statuses={len(exists_states)}"
+                    )
             except Exception:
                 self._record_operation(
                     "save_exists",
                     save_exists_start,
-                    len(probe_keys),
+                    len(keys),
                     num_logical_keys=len(keys),
                     status="error",
-                    num_failed_keys=len(probe_keys),
+                    num_failed_keys=len(keys),
                 )
                 raise
             self._record_operation(
                 "save_exists",
                 save_exists_start,
-                len(probe_keys),
+                len(keys),
                 num_logical_keys=len(keys),
             )
-            chunk_missing = [False] * len(keys)
-            for owner, exists in zip(probe_owner, exists_states, strict=True):
-                if exists != 1:
-                    chunk_missing[owner] = True
             missing_indices = [
-                i for i, missing in enumerate(chunk_missing) if missing
+                i for i, exists in enumerate(exists_states) if exists != 1
             ]
 
             if not missing_indices:
@@ -563,104 +542,75 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if current_event is not None:
                 current_event.synchronize()
 
-            # Coalesce each chunk's per-layer segments into one raw dfkv value
-            # per explicit scatter group. This cuts the key count ~20x
-            # (25392 -> ~1242), making loads bandwidth-bound rather than
-            # per-key-bound.
-            sg_keys, sg_ptrs, sg_sizes, sg_owner = _group_segments_sg(
-                keys, addrs, sizes, _sg_segs_of(self.client)
-            )
-            batch_bytes = sum(sum(s) for s in sg_sizes)
+            # One key and one complete segment vector represent each logical
+            # chunk. libdfkv splits vectors wider than the negotiated HCA SGE
+            # limit into ordered WR windows under one object completion.
+            batch_bytes = sum(sum(s) for s in sizes)
+            num_segments = sum(len(s) for s in sizes)
             put_start = time.perf_counter()
+            successful_events: list[BlockStored] = []
             try:
-                res = self.client.batch_put_sg(sg_keys, sg_ptrs, sg_sizes)
+                res = self.client.batch_put_sg(keys, addrs, sizes)
+                if len(res) != len(keys):
+                    raise RuntimeError(
+                        "batch_put_sg returned incomplete per-key results: "
+                        f"keys={len(keys)} statuses={len(res)}"
+                    )
                 failed = _put_failed_indices(res)
+                if stored_events:
+                    successful_events = [
+                        event
+                        for event, rc in zip(stored_events, res, strict=True)
+                        if rc == 0
+                    ]
                 self._record_operation(
                     "save_put",
                     put_start,
-                    len(sg_keys),
+                    len(keys),
                     num_logical_keys=len(keys),
                     num_bytes=batch_bytes,
                     status="partial_failure" if failed else "ok",
                     num_failed_keys=len(failed),
                 )
                 logger.debug(
-                    "dfkv save_put: keys=%d bytes=%d ms=%.1f failed=%d",
-                    len(sg_keys), batch_bytes,
+                    "dfkv save_put: keys=%d segments=%d bytes=%d ms=%.1f "
+                    "failed=%d",
+                    len(keys), num_segments, batch_bytes,
                     (time.perf_counter() - put_start) * 1000.0, len(failed),
                 )
-                if failed:
+                if failed and logger.isEnabledFor(logging.WARNING):
                     failed_codes = set(res[i] for i in failed)
-                    # dfkv: write failure is non-fatal -- count + drop this
-                    # request's save; dfkv's peer-health marks the bad peer and
-                    # short-circuits. Never block inference.
+                    # A native multi-WR failure fails the object atomically.
+                    # Dropping this save is non-fatal to inference; no sibling
+                    # physical keys exist to probe or scrub.
                     logger.warning(
                         "batch_put_sg failed: %d/%d keys failed "
                         "(codes=%s, batch_bytes=%d), first_key=%s",
                         len(failed),
-                        len(sg_keys),
+                        len(keys),
                         failed_codes,
                         batch_bytes,
-                        _key_label(sg_keys[0]) if sg_keys else "N/A",
+                        key_diagnostic_label(keys[0]) if keys else "N/A",
                     )
-                    # Scrub every sibling group key of each failed chunk so no
-                    # half-stored chunk (group 0 in, siblings out) burns ring
-                    # capacity until eviction; the dedup probe above already
-                    # refuses to call such a chunk stored. Best-effort: never
-                    # raises, skipped entirely without a remove RPC.
-                    rm_start = time.perf_counter()
-                    rm_supported, rm_attempted, rm_confirmed = (
-                        _remove_partial_sg_groups(
-                            self.client, sg_keys, sg_owner, failed
-                        )
-                    )
-                    if rm_attempted:
-                        self._record_operation(
-                            "save_remove_partial",
-                            rm_start,
-                            rm_attempted,
-                            num_logical_keys=len({sg_owner[i] for i in failed}),
-                            status="ok" if rm_confirmed == rm_attempted
-                            else "partial_failure",
-                            num_failed_keys=rm_attempted - rm_confirmed,
-                        )
-                        logger.debug(
-                            "dfkv save partial-group cleanup: removed %d/%d "
-                            "sibling keys of %d failed chunk(s)",
-                            rm_confirmed,
-                            rm_attempted,
-                            len({sg_owner[i] for i in failed}),
-                        )
-                    elif not rm_supported:
-                        self._record_operation(
-                            "save_remove_partial",
-                            rm_start,
-                            0,
-                            status="unsupported",
-                        )
-                        logger.debug(
-                            "dfkv client has no remove RPC; %d failed chunk(s) "
-                            "keep partial-group residue until eviction",
-                            len({sg_owner[i] for i in failed}),
-                        )
             except Exception as e:
                 self._record_operation(
                     "save_put",
                     put_start,
-                    len(sg_keys),
+                    len(keys),
                     num_logical_keys=len(keys),
                     num_bytes=batch_bytes,
                     status="error",
-                    num_failed_keys=len(sg_keys),
+                    num_failed_keys=len(keys),
                 )
-                logger.error(
-                    "Failed to put keys %s, error: %s",
-                    [_key_label(key) for key in sg_keys[:3]],
-                    e,
-                )
+                if logger.isEnabledFor(logging.ERROR):
+                    logger.error(
+                        "Failed to put keys %s, error: %s",
+                        [key_diagnostic_label(key) for key in keys[:3]],
+                        e,
+                    )
 
-            if self.enable_kv_event and stored_events:
-                self.update_kv_event(stored_events)
+            if self.enable_kv_event and successful_events:
+                self.update_kv_event(successful_events)
         finally:
             with self._active_cv:
                 self._active_req_id = None
@@ -770,87 +720,105 @@ class KVCacheStoreRecvingThread(KVTransferThread):
 
             # Rotate aligned lists by tp_rank for load balancing.
             rotation = self.tp_rank % len(key_list)
-            key_list_c = _rotate_list(key_list, rotation)
-            addr_list_c = _rotate_list(addr_list, rotation)
-            size_list_c = _rotate_list(size_list, rotation)
-            block_id_list_c = _rotate_list(block_id_list, rotation)
+            rotated_keys = _rotate_list(key_list, rotation)
+            rotated_addrs = _rotate_list(addr_list, rotation)
+            rotated_sizes = _rotate_list(size_list, rotation)
+            rotated_block_ids = _rotate_list(block_id_list, rotation)
 
-            # dfkv: A GET is one batch -- dfkv has no owner-side DirectIO staging
-            # budget, so the Mooncake disk-offload sub-batch split is dropped.
-            # Flatten per-key scatter-gather to one (ptr, cap) per dfkv key, then
-            # map each flattened result back to its originating block id for error
-            # reporting (see _group_segments_sg / seg_owner).
-            # Resolve the client BEFORE grouping: the SG width (and with it the
-            # on-wire key names) comes from the live transport.
+            # dfkv: one logical chunk is one batch key with its complete
+            # destination segment vector. libdfkv performs any HCA-width
+            # multi-WR windowing without changing object identity.
             client = self.client
             if client is None and self.client_provider is not None:
                 client = self.client_provider()  # lazy un-elide
                 if client is not None:
                     self.client = client
-            sg_keys, sg_ptrs, sg_caps, sg_owner = _group_segments_sg(
-                key_list_c, addr_list_c, size_list_c, _sg_segs_of(client)
-            )
             self._record_observation("geometry_preparation", geometry_start)
-            sg_totals = [sum(c) for c in sg_caps]
-            batch_bytes = sum(sg_totals)
+            chunk_totals = [sum(chunk_sizes) for chunk_sizes in rotated_sizes]
+            batch_bytes = sum(chunk_totals)
+            num_segments = sum(len(chunk_sizes) for chunk_sizes in rotated_sizes)
 
             load_get_start = time.perf_counter()
             try:
-                # dfkv: one scatter-gather GET per coalesced key -> (hits, lens). The
-                # server returns one blob; the RDMA recv SGE list scatters it back
-                # into this chunk's per-layer segments. hit == 1 + len == sum(caps)
-                # means the chunk loaded; a miss or short read marks the originating
-                # block as a load error so vLLM recomputes that span (never fatal).
+                # The native logical operation publishes a hit only after every
+                # ordered WR window completes. Require the exact stored length;
+                # misses and either short or oversized objects fail the chunk
+                # closed and force vLLM to recompute it.
                 if client is None:  # no client (un-elide failed): miss -> recompute
-                    hits, lens = [False] * len(sg_keys), [0] * len(sg_keys)
+                    hits, lens = [False] * len(rotated_keys), [0] * len(rotated_keys)
                 else:
-                    hits, lens = client.batch_get_auto_sg(sg_keys, sg_ptrs, sg_caps)
-                failed_block_ids: list[int] = []
-                failed_detail: list[tuple[str, int]] = []
-                for i, (hit, got_len) in enumerate(zip(hits, lens, strict=True)):
-                    if hit != 1 or got_len < sg_totals[i]:
-                        failed_block_ids.append(block_id_list_c[sg_owner[i]])
-                        failed_detail.append((_key_label(sg_keys[i]), hit))
-                self._record_operation(
-                    "load_get",
-                    load_get_start,
-                    len(sg_keys),
-                    num_logical_keys=len(key_list_c),
-                    num_bytes=batch_bytes,
-                    status="partial_failure" if failed_block_ids else "ok",
-                    num_failed_keys=len(failed_block_ids),
-                )
-                logger.debug(
-                    "dfkv load_get: req=%s keys=%d bytes=%d ms=%.1f failed=%d",
-                    req_id, len(sg_keys), batch_bytes,
-                    (time.perf_counter() - load_get_start) * 1000.0,
-                    len(failed_block_ids),
-                )
-                if failed_block_ids:
-                    self._add_load_error_block_ids(failed_block_ids)
-                    logger.warning(
-                        "Failed to get %d dfkv keys from batch "
-                        "(batch_keys=%d, first_failures=%s)",
-                        len(failed_block_ids),
-                        len(sg_keys),
-                        failed_detail[:3],
+                    hits, lens = client.batch_get_auto_sg(
+                        rotated_keys, rotated_addrs, rotated_sizes
+                    )
+                if len(hits) != len(rotated_keys) or len(lens) != len(rotated_keys):
+                    raise RuntimeError(
+                        "batch_get_auto_sg returned incomplete per-key results: "
+                        f"keys={len(rotated_keys)} hits={len(hits)} lens={len(lens)}"
                     )
             except Exception as e:
-                self._add_load_error_block_ids(block_id_list_c)
+                self._add_load_error_block_ids(rotated_block_ids)
                 self._record_operation(
                     "load_get",
                     load_get_start,
-                    len(sg_keys),
-                    num_logical_keys=len(key_list_c),
+                    len(rotated_keys),
+                    num_logical_keys=len(rotated_keys),
                     num_bytes=batch_bytes,
                     status="error",
-                    num_failed_keys=len(sg_keys),
+                    num_failed_keys=len(rotated_keys),
                 )
-                logger.warning(
-                    "Failed to get dfkv batch %s, error: %s",
-                    [_key_label(key) for key in sg_keys[:3]],
-                    e,
-                )
+                if logger.isEnabledFor(logging.WARNING):
+                    logger.warning(
+                        "Failed to get dfkv batch %s, error: %s",
+                        [
+                            key_diagnostic_label(key)
+                            for key in rotated_keys[:3]
+                        ],
+                        e,
+                    )
+                return
+
+            failed_indices = [
+                i
+                for i, (hit, got_len) in enumerate(zip(hits, lens, strict=True))
+                if hit != 1 or got_len != chunk_totals[i]
+            ]
+            failed_block_ids = [rotated_block_ids[i] for i in failed_indices]
+            self._record_operation(
+                "load_get",
+                load_get_start,
+                len(rotated_keys),
+                num_logical_keys=len(rotated_keys),
+                num_bytes=batch_bytes,
+                status="partial_failure" if failed_block_ids else "ok",
+                num_failed_keys=len(failed_block_ids),
+            )
+            logger.debug(
+                "dfkv load_get: req=%s keys=%d segments=%d bytes=%d "
+                "ms=%.1f failed=%d",
+                req_id, len(rotated_keys), num_segments, batch_bytes,
+                (time.perf_counter() - load_get_start) * 1000.0,
+                len(failed_block_ids),
+            )
+            if failed_block_ids:
+                self._add_load_error_block_ids(failed_block_ids)
+                if logger.isEnabledFor(logging.WARNING):
+                    failed_detail = [
+                        (
+                            key_diagnostic_label(rotated_keys[i]),
+                            hits[i],
+                            lens[i],
+                            chunk_totals[i],
+                        )
+                        for i in failed_indices[:3]
+                    ]
+                    logger.warning(
+                        "Failed to get %d dfkv keys from batch "
+                        "(batch_keys=%d, first_failures="
+                        "[(key, hit, got, expected)]=%s)",
+                        len(failed_block_ids),
+                        len(rotated_keys),
+                        failed_detail,
+                    )
 
         except Exception as e:
             # Any unexpected failure in the load path -> recompute this
@@ -882,115 +850,6 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             self.set_finished_request(req_meta.req_id)
 
 
-# Maximum raw-payload segments gathered into one scatter-group object.
-# The ConnectX-era default is max_sge=30 minus one request-prefix SGE. The
-# negotiated value comes from ``dfkv_max_sg_segs``; the fallback is encoded in
-# the binary SG object-key coordinate (see ``_sg_group_key``).
-SG_MAX_SEGS = 29
-
-
-# Live SG width of a client's transport, cached on the client object (device
-# caps don't change under a running process). None / old libs => the default.
-def _sg_segs_of(client: Any) -> int:
-    if client is None:
-        return SG_MAX_SEGS
-    v = getattr(client, "_sg_segs_cache", None)
-    if v is None:
-        try:
-            v = int(client.max_sg_segs()) or SG_MAX_SEGS
-        except Exception:  # older libdfkv without dfkv_max_sg_segs
-            v = SG_MAX_SEGS
-        client._sg_segs_cache = v
-    return v
-
-def _key_label(key: bytes) -> str:
-    """Return a deterministic JSON/text-safe representation of a binary key."""
-    return f"len={len(key)} sha256={hashlib.sha256(key).hexdigest()[:16]}"
-
-
-# Scatter geometry is always explicit in the physical key.
-def _sg_group_key(key: bytes, grp: int, max_segs: int) -> bytes:
-    return sg_key(key, max_segs, grp)
-
-
-# Coalesce each chunk's per-layer segments into explicit scatter-group keys.
-# Each group is one raw dfkv value written through one RDMA multi-SGE operation.
-# owner[i] maps each physical key back to its source chunk for error attribution.
-def _group_segments_sg(
-    keys: list[bytes],
-    addrs: list[list[int]],
-    sizes: list[list[int]],
-    max_segs: int = SG_MAX_SEGS,
-) -> tuple[list[bytes], list[list[int]], list[list[int]], list[int]]:
-    sg_keys: list[bytes] = []
-    sg_ptrs: list[list[int]] = []
-    sg_sizes: list[list[int]] = []
-    sg_owner: list[int] = []
-    for key_idx, (key, addr, size) in enumerate(zip(keys, addrs, sizes, strict=True)):
-        grp = 0
-        for off in range(0, len(addr), max_segs):
-            sg_keys.append(_sg_group_key(key, grp, max_segs))
-            sg_ptrs.append(list(addr[off:off + max_segs]))
-            sg_sizes.append(list(size[off:off + max_segs]))
-            sg_owner.append(key_idx)
-            grp += 1
-    return sg_keys, sg_ptrs, sg_sizes, sg_owner
-
-
-# How many explicit scatter-group values _group_segments_sg emits for one
-# chunk. Probing only group 0 would treat a partially-written chunk (group 0
-# present, a sibling group lost to a failed put or eviction) as stored, so
-# dedup/lookup must enumerate this exact set to agree with SAVE/LOAD on what
-# "present" means. Layout selection mirrors data.py prepare_value: the exact
-# per-run seg layout when installed, else the legacy flat base/len tables
-# (one segment per layer per block). An unknown layout (unit-test doubles)
-# degrades to a single group -- the pre-fix probe geometry.
-def _num_sg_groups(db: Any, token_span: int, max_segs: int) -> int:
-    layout = getattr(db, "_seg_layout", None)
-    if layout is not None:
-        segs_per_block = len(layout)
-    else:
-        segs_per_block = max(
-            len(getattr(db, "kv_caches_base_addr", None) or ()),
-            len(getattr(db, "block_len", None) or ()),
-        )
-    num_segments = segs_per_block * (token_span // db.block_size)
-    return max(1, (num_segments + max_segs - 1) // max_segs)
-
-
-# Best-effort remove of every group key of each failed chunk after a partial
-# batch_put_sg: a chunk whose group 0 landed while a sibling failed is
-# half-stored -- probing alone now refuses to call it present, but the
-# orphan still burns ring capacity until eviction. Removing the whole chunk
-# makes the next save a clean full rewrite. Returns (supported, attempted,
-# confirmed); never raises and never blocks the save path. Clients without a
-# remove RPC (older libdfkv) report supported=False and are skipped.
-def _remove_partial_sg_groups(
-    client: Any,
-    sg_keys: list[bytes],
-    sg_owner: list[int],
-    failed: list[int],
-) -> tuple[bool, int, int]:
-    if not failed:
-        return False, 0, 0
-    remove = getattr(client, "batch_remove", None)
-    if remove is None:
-        return False, 0, 0
-    try:
-        supports = getattr(client, "supports_remove", None)
-        if callable(supports) and not supports():
-            return False, 0, 0
-    except Exception:
-        return False, 0, 0
-    bad_chunks = {sg_owner[i] for i in failed}
-    siblings = [k for j, k in enumerate(sg_keys) if sg_owner[j] in bad_chunks]
-    if not siblings:
-        return False, 0, 0
-    try:
-        per_key = remove(siblings)
-    except Exception:
-        return True, len(siblings), 0
-    return True, len(siblings), sum(1 for ok in per_key if ok)
 
 
 # ============================================================
@@ -1171,7 +1030,7 @@ class DfkvStoreWorker:
         )
         key_namespace = canonical_namespace(
             model_identity,
-            VLLM_RAW_V1,
+            VLLM_MULTIWR_V2.decode("ascii"),
             tenant_id=str(extra.get("tenant_id", "default")),
             model_revision=str(_model_revision),
             dtype=_cache_dtype,
@@ -1181,6 +1040,7 @@ class DfkvStoreWorker:
             dp_size=self.dp_size,
             pp_size=self.pp_size,
             layout_fields={
+                "storage_layout": VLLM_MULTIWR_V2.decode("ascii"),
                 "cache_dtype": _cache_dtype,
                 "model_dtype": str(getattr(model_config, "dtype", "unknown")),
                 "block_size": self.block_size,
@@ -1427,8 +1287,11 @@ class DfkvStoreWorker:
             [] for _ in self.token_dbs
         ]
 
-        for layer_name, value in kv_caches.items():
-            cache = _repr_tensor(value)
+        # Dict insertion order is not a storage-layout contract. Canonicalize by
+        # semantic layer name so independently constructed producer/consumer
+        # mappings gather and scatter the same ordered byte stream.
+        for layer_name in sorted(kv_caches):
+            cache = _repr_tensor(kv_caches[layer_name])
             cache_storage = cache.untyped_storage()
             base_addr = cache_storage.data_ptr()
             region_len = cache_storage.nbytes()
@@ -1730,12 +1593,10 @@ class DfkvStoreWorker:
         if not block_hashes or token_len <= 0:
             return 0
 
-        # Build per-(group, hash) candidate keys expanded across TP/PP.
-        # candidate_meta[i] is the (group_id, hash_bytes) for candidate_keys[i].
+        # Build one physical object candidate per logical (group, hash, TP, PP)
+        # coordinate. candidate_meta maps each object back to the logical chunk.
         candidate_keys: list[bytes] = []
         candidate_meta: list[tuple[int, bytes]] = []
-        # Per-(group_id, hash) hit count required to call the chunk present:
-        # TP*PP rank replicas x the chunk's number of scatter groups.
         expected_per_chunk: dict[tuple[int, bytes], int] = {}
         tp_count = min(self.tp_size, self.num_kv_head)
         # dfkv: gate candidates by store_mask -- the SAME per-(group,chunk) set
@@ -1749,8 +1610,6 @@ class DfkvStoreWorker:
             token_len // self.coord.lcm_block_size * self.coord.lcm_block_size
         )
         store_masks = self.coord.store_mask(aligned_token_len)
-        # SG width is fixed per client/transport; resolve once (cached).
-        max_sg_segs = _sg_segs_of(self.client)
         for g_idx, db in enumerate(self.token_dbs):
             spec_block_size = db.block_size
             mask = store_masks[g_idx]
@@ -1765,30 +1624,19 @@ class DfkvStoreWorker:
             tp_candidates = (
                 [db.metadata.tp_rank] if db.metadata.tp_rank < 0 else range(tp_count)
             )
-            rank_probes = max(1, len(list(tp_candidates)) * self.pp_size)
+            rank_probes = max(1, len(tp_candidates) * self.pp_size)
             for chunk_id, h in enumerate(group_hashes):
                 start_idx = chunk_id * spec_block_size
                 if start_idx >= token_len:
                     break
                 if chunk_id >= len(mask) or not mask[chunk_id]:
                     continue
-                # Probe EVERY explicit scatter group of the chunk, not just
-                # group 0: a partial write (group 0 present, a sibling group
-                # missing) must count as uncached -- the save dedup gate
-                # rewrites it and the load path needs every group to succeed.
-                n_groups = _num_sg_groups(
-                    db, min(spec_block_size, token_len - start_idx), max_sg_segs
-                )
-                expected_per_chunk[(g_idx, bytes(h))] = rank_probes * n_groups
+                expected_per_chunk[(g_idx, bytes(h))] = rank_probes
                 for tp in tp_candidates:
                     for pp in range(self.pp_size):
                         md = dataclasses.replace(db.metadata, tp_rank=tp, pp_rank=pp)
-                        base_key = PoolKey(md, h.hex()).to_bytes()
-                        for grp in range(n_groups):
-                            candidate_keys.append(
-                                _sg_group_key(base_key, grp, max_sg_segs)
-                            )
-                            candidate_meta.append((g_idx, bytes(h)))
+                        candidate_keys.append(PoolKey(md, h.hex()).to_bytes())
+                        candidate_meta.append((g_idx, bytes(h)))
 
         if not candidate_keys:
             return 0
@@ -1814,8 +1662,9 @@ class DfkvStoreWorker:
             logger.error("Remote connection failed in lookup: %s", e)
             return 0
 
-        # A (group, hash) is "present" only when every TP*PP rank has every
-        # scatter group of it.
+        # A (group, hash) is present only when every required TP*PP object
+        # exists. A partial request therefore fails closed at the first missing
+        # chunk without any sibling-key interpretation.
         present_count: dict[tuple[int, bytes], int] = {}
         for gh, exists in zip(candidate_meta, res, strict=True):
             if exists == 1:

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -22,6 +22,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, TypeVar
 
 import torch
@@ -50,7 +51,6 @@ from vllm.v1.core.kv_cache_utils import (
     resolve_kv_cache_block_sizes,
 )
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec
-from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 
 # dfkv: get_dp_engine_index replaces mooncake_utils.get_mooncake_dp_engine_index;
 # dfkv handles its own RDMA bootstrap so the transfer-engine helpers are dropped.
@@ -76,9 +76,12 @@ from .metrics import DfkvStoreConnectorStats
 from ._telemetry import config as _tcfg  # connector identity + client_register switch
 from .protocol import (
     LOOKUP_MSG,
+    LOOKUP_RESPONSE_BYTES,
     RESET_MSG,
     RESP_ERR,
     RESP_OK,
+    _decode_lookup_request,
+    _encode_lookup_request,
 )
 
 logger = init_logger(__name__)
@@ -160,6 +163,7 @@ class KVTransferThread(threading.Thread):
         ready_event: threading.Event,
         name: str,
         record_operation: Callable[..., None] | None = None,
+        record_observation: Callable[[str, float], None] | None = None,
         queue_capacity: int = DEFAULT_TRANSFER_QUEUE_CAPACITY,
     ):
         super().__init__(daemon=False, name=name)
@@ -169,6 +173,7 @@ class KVTransferThread(threading.Thread):
         self.tp_rank = tp_rank
         self.token_databases = token_databases
         self._record_operation_cb = record_operation
+        self._record_observation_cb = record_observation
         self.done_task_lock = threading.Lock()
         self.request_queue: queue.Queue[Any] = queue.Queue(maxsize=queue_capacity)
         self.finished_requests: set[str] = set()
@@ -284,6 +289,7 @@ class KVTransferThread(threading.Thread):
         start_time: float,
         num_keys: int,
         *,
+        num_logical_keys: int | None = None,
         num_bytes: int = 0,
         status: str = "ok",
         num_failed_keys: int = 0,
@@ -294,10 +300,15 @@ class KVTransferThread(threading.Thread):
             operation=operation,
             duration_seconds=time.perf_counter() - start_time,
             num_keys=num_keys,
+            num_logical_keys=num_logical_keys,
             num_bytes=num_bytes,
             status=status,
             num_failed_keys=num_failed_keys,
         )
+
+    def _record_observation(self, name: str, start_time: float) -> None:
+        if self._record_observation_cb is not None:
+            self._record_observation_cb(name, time.perf_counter() - start_time)
 
     def update_kv_event(self, events: list[BlockStored]):
         with self.kv_event_lock:
@@ -480,6 +491,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     "save_exists",
                     save_exists_start,
                     len(probe_keys),
+                    num_logical_keys=len(keys),
                     status="error",
                     num_failed_keys=len(probe_keys),
                 )
@@ -488,6 +500,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 "save_exists",
                 save_exists_start,
                 len(probe_keys),
+                num_logical_keys=len(keys),
             )
             chunk_missing = [False] * len(keys)
             for owner, exists in zip(probe_owner, exists_states, strict=True):
@@ -566,6 +579,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     "save_put",
                     put_start,
                     len(sg_keys),
+                    num_logical_keys=len(keys),
                     num_bytes=batch_bytes,
                     status="partial_failure" if failed else "ok",
                     num_failed_keys=len(failed),
@@ -605,6 +619,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                             "save_remove_partial",
                             rm_start,
                             rm_attempted,
+                            num_logical_keys=len({sg_owner[i] for i in failed}),
                             status="ok" if rm_confirmed == rm_attempted
                             else "partial_failure",
                             num_failed_keys=rm_attempted - rm_confirmed,
@@ -633,6 +648,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     "save_put",
                     put_start,
                     len(sg_keys),
+                    num_logical_keys=len(keys),
                     num_bytes=batch_bytes,
                     status="error",
                     num_failed_keys=len(sg_keys),
@@ -669,6 +685,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         tp_rank: int,
         ready_event: threading.Event,
         record_operation: Callable[..., None] | None = None,
+        record_observation: Callable[[str, float], None] | None = None,
         client_provider: Callable[[], Any] | None = None,
         queue_capacity: int = DEFAULT_TRANSFER_QUEUE_CAPACITY,
     ):
@@ -680,16 +697,21 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             ready_event,
             name="KVCacheStoreRecvingThread",
             record_operation=record_operation,
+            record_observation=record_observation,
             queue_capacity=queue_capacity,
         )
         # Elided ranks start with client=None; a real load arriving there calls
         # this back into the worker to lazily un-elide (create + register the
         # client) instead of failing the span into a recompute.
         self.client_provider = client_provider
-        # _invalid_block_ids can be access by both the Worker and RecvingThread
+        # _invalid_block_ids can be accessed by both the Worker and RecvingThread.
         self._invalid_block_ids_lock = threading.Lock()
         self._invalid_block_ids: set[int] = set()
         self.coord = coord
+
+    def add_request(self, request: ReqMeta) -> bool:
+        request._dfkv_receive_enqueued_at = time.perf_counter()  # type: ignore[attr-defined]
+        return super().add_request(request)
 
     def _add_load_error_block_ids(self, block_ids: list[int]) -> None:
         with self._invalid_block_ids_lock:
@@ -703,6 +725,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
 
     def _handle_request(self, req_meta: ReqMeta):
         req_id = req_meta.req_id
+        enqueued_at = getattr(req_meta, "_dfkv_receive_enqueued_at", None)
+        if enqueued_at is not None:
+            self._record_observation("receive_queue_wait", enqueued_at)
+        geometry_start = time.perf_counter()
         try:
             token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
             mask_num = (
@@ -739,6 +765,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             # the request now, else `tp_rank % 0` below would raise and the req would
             # never be reported done, hanging vLLM's WAITING_FOR_REMOTE_KVS wait.
             if not key_list:
+                self._record_observation("geometry_preparation", geometry_start)
                 return
 
             # Rotate aligned lists by tp_rank for load balancing.
@@ -763,6 +790,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             sg_keys, sg_ptrs, sg_caps, sg_owner = _group_segments_sg(
                 key_list_c, addr_list_c, size_list_c, _sg_segs_of(client)
             )
+            self._record_observation("geometry_preparation", geometry_start)
             sg_totals = [sum(c) for c in sg_caps]
             batch_bytes = sum(sg_totals)
 
@@ -787,6 +815,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     "load_get",
                     load_get_start,
                     len(sg_keys),
+                    num_logical_keys=len(key_list_c),
                     num_bytes=batch_bytes,
                     status="partial_failure" if failed_block_ids else "ok",
                     num_failed_keys=len(failed_block_ids),
@@ -812,6 +841,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     "load_get",
                     load_get_start,
                     len(sg_keys),
+                    num_logical_keys=len(key_list_c),
                     num_bytes=batch_bytes,
                     status="error",
                     num_failed_keys=len(sg_keys),
@@ -1503,6 +1533,7 @@ class DfkvStoreWorker:
             self.tp_rank,
             ready_event_recving,
             record_operation=self._record_kv_connector_operation,
+            record_observation=self._record_kv_connector_observation,
             client_provider=self._ensure_client_for_load,
             queue_capacity=getattr(
                 self, "transfer_queue_capacity", DEFAULT_TRANSFER_QUEUE_CAPACITY
@@ -1629,6 +1660,7 @@ class DfkvStoreWorker:
         duration_seconds: float,
         num_keys: int,
         *,
+        num_logical_keys: int | None = None,
         num_bytes: int = 0,
         status: str = "ok",
         num_failed_keys: int = 0,
@@ -1638,10 +1670,19 @@ class DfkvStoreWorker:
                 operation=operation,
                 duration_seconds=duration_seconds,
                 num_keys=num_keys,
+                num_logical_keys=num_logical_keys,
                 num_bytes=num_bytes,
                 status=status,
                 num_failed_keys=num_failed_keys,
             )
+
+    def _record_kv_connector_observation(
+        self,
+        name: str,
+        duration_seconds: float,
+    ) -> None:
+        with self._kv_connector_stats_lock:
+            self.kv_connector_stats.record_observation(name, duration_seconds)
 
     def get_kv_connector_stats(self) -> DfkvStoreConnectorStats | None:
         with self._kv_connector_stats_lock:
@@ -1759,12 +1800,14 @@ class DfkvStoreWorker:
                 "lookup_exists",
                 time.perf_counter() - lookup_start,
                 len(candidate_keys),
+                num_logical_keys=len(expected_per_chunk),
             )
         except Exception as e:
             self._record_kv_connector_operation(
                 "lookup_exists",
                 time.perf_counter() - lookup_start,
                 len(candidate_keys),
+                num_logical_keys=len(expected_per_chunk),
                 status="error",
                 num_failed_keys=len(candidate_keys),
             )
@@ -1886,7 +1929,6 @@ class LookupKeyServer:
         store_worker: DfkvStoreWorker,
         vllm_config: VllmConfig,
     ):
-        self.decoder = MsgpackDecoder()
         self.ctx = zmq.Context()  # type: ignore[attr-defined]
         socket_path = get_zmq_rpc_path_lookup(vllm_config)
         self._ipc_path = socket_path.removeprefix("ipc://")
@@ -1915,17 +1957,47 @@ class LookupKeyServer:
                     if not self.running:
                         return
                     raise
-                msg_type = bytes(all_frames[0])
 
+                if not all_frames:
+                    logger.warning("LookupKeyServer received an empty request")
+                    self.socket.send(RESP_ERR)
+                    continue
+
+                msg_type = bytes(all_frames[0])
                 if msg_type == LOOKUP_MSG:
-                    token_len = int.from_bytes(all_frames[1], byteorder="big")
-                    hash_frames = all_frames[2:]
-                    hashes_str = self.decoder.decode(hash_frames)
-                    block_hashes = [BlockHash(bytes.fromhex(s)) for s in hashes_str]
-                    result = self.store_worker.lookup(token_len, block_hashes)
-                    self.socket.send(result.to_bytes(4, "big"))
+                    # A malformed request is an external-cache miss, never a
+                    # reason to terminate the rank-0 admin server.
+                    lookup_ipc_start = time.perf_counter()
+                    try:
+                        token_len, hash_bytes = _decode_lookup_request(
+                            [frame.buffer for frame in all_frames]
+                        )
+                        block_hashes = [BlockHash(value) for value in hash_bytes]
+                        result = self.store_worker.lookup(token_len, block_hashes)
+                        if not 0 <= result < 1 << (8 * LOOKUP_RESPONSE_BYTES):
+                            raise ValueError(
+                                f"lookup result is outside uint32: {result}"
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            "LookupKeyServer rejected lookup request: %s", e
+                        )
+                        result = 0
+                    self.socket.send(
+                        result.to_bytes(LOOKUP_RESPONSE_BYTES, byteorder="big")
+                    )
+                    self.store_worker._record_kv_connector_observation(
+                        "lookup_ipc", time.perf_counter() - lookup_ipc_start
+                    )
 
                 elif msg_type == RESET_MSG:
+                    if len(all_frames) != 1:
+                        logger.warning(
+                            "LookupKeyServer rejected reset with %d frames",
+                            len(all_frames),
+                        )
+                        self.socket.send(RESP_ERR)
+                        continue
                     # dfkv: DfkvDeviceClient exposes no remove_all / global wipe
                     # primitive. Entries expire by the server's own policy. We
                     # still drain in-flight puts to honor the ordering contract,
@@ -1972,13 +2044,11 @@ class LookupKeyServer:
 class LookupKeyClient:
     """ZMQ client for the LookupKey admin channel.
 
-    Routes both prefix-cache lookups and admin commands (currently:
-    ``reset``) to ``LookupKeyServer`` on worker rank 0. The first frame
-    of every request is a named tag from ``protocol.py``.
+    The single-worker executor is also the sole owner of socket I/O. Async
+    scheduler calls retain one future per request and poll it on later steps.
     """
 
     def __init__(self, vllm_config: VllmConfig):
-        self.encoder = MsgpackEncoder()
         self.ctx = zmq.Context()  # type: ignore[attr-defined]
         self._close_lock = threading.Lock()
         self._closed = False
@@ -1989,37 +2059,86 @@ class LookupKeyClient:
             zmq.REQ,  # type: ignore[attr-defined]
             bind=False,
         )
+        self.executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="DfkvLookupClient",
+        )
+        self.futures: dict[str, Future[int]] = {}
 
-    def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
-        hash_strs = [h.hex() for h in block_hashes]
-        hash_frames = self.encoder.encode(hash_strs)
-        token_len_bytes = token_len.to_bytes(4, byteorder="big")
-        all_frames = [LOOKUP_MSG, token_len_bytes] + list(hash_frames)
+    def _lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
+        all_frames = _encode_lookup_request(token_len, block_hashes)
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
-        result = int.from_bytes(resp, "big")
-        return result
+        if len(resp) != LOOKUP_RESPONSE_BYTES:
+            raise ValueError(
+                f"lookup response has {len(resp)} bytes, "
+                f"expected {LOOKUP_RESPONSE_BYTES}"
+            )
+        return int.from_bytes(resp, byteorder="big")
 
-    def reset(self) -> bool:
-        """Trigger a global store wipe on worker rank 0.
+    def lookup(
+        self,
+        req_id: str,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        non_block: bool = False,
+    ) -> int | None:
+        """Return a hit count, or ``None`` while a non-blocking lookup runs."""
+        with self._close_lock:
+            if self._closed:
+                return 0
+            future = self.futures.get(req_id)
+            if future is None:
+                future = self.executor.submit(
+                    self._lookup,
+                    token_len,
+                    list(block_hashes),
+                )
+                self.futures[req_id] = future
 
-        Ordering assumption: caller MUST ensure no in-flight Dfkv
-        lookups or transfers when invoking reset. In RL workflows this
-        holds naturally at the step boundary after weight updates and
-        rollout drain. Returns True on ACK, False on NACK.
+        if non_block and not future.done():
+            return None
+        try:
+            return future.result()
+        except Exception as e:
+            logger.error("Dfkv lookup failed for %s: %s", req_id, e)
+            return 0
+        finally:
+            with self._close_lock:
+                if self.futures.get(req_id) is future:
+                    self.futures.pop(req_id)
 
-        dfkv: dfkv has no remove_all primitive, so the worker drains the
-        send queue and NACKs; this returns False.
-        """
+    def discard(self, req_id: str) -> None:
+        """Drop any cached or queued lookup for an aborted request."""
+        with self._close_lock:
+            future = self.futures.pop(req_id, None)
+        if future is not None:
+            future.cancel()
+
+    def _reset(self) -> bool:
+        """Send the reset admin request from the socket-owner thread."""
         self.socket.send(RESET_MSG)
         resp = self.socket.recv()
         return bytes(resp) == RESP_OK
+
+    def reset(self) -> bool:
+        """Trigger the worker's best-effort global store reset."""
+        with self._close_lock:
+            if self._closed:
+                return False
+            future = self.executor.submit(self._reset)
+        return future.result()
 
     def close(self):
         with self._close_lock:
             if self._closed:
                 return
             self._closed = True
+            futures = tuple(self.futures.values())
+            self.futures.clear()
+        for future in futures:
+            future.cancel()
+        self.executor.shutdown(wait=True, cancel_futures=True)
         self.socket.close(linger=0)
         self.ctx.term()
 

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -431,8 +431,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         executing cannot be cancelled -- it holds an RDMA read against the
         request's GPU blocks -- so the preemption path must wait it out
         before those blocks can be handed to another request. Returns False
-        on timeout (put ops are client-side bounded, so this only happens if
-        the store path is badly wedged).
+        when the diagnostic interval expires; callers that protect GPU block
+        ownership must keep waiting until this returns True.
         """
         with self._active_cv:
             return self._active_cv.wait_for(
@@ -1734,19 +1734,22 @@ class DfkvStoreWorker:
                 wait=True,
                 fail_closed=False,
             )
-        if self.kv_send_thread is None:
+        send_thread = self.kv_send_thread
+        if send_thread is None:
             return
         # Drop queued entries first (the dequeue gate re-checks per entry),
-        # then join whichever entry is already executing.
+        # then join whichever entry is already executing. The timeout is only
+        # a diagnostic interval: returning from this hook while native PUT can
+        # still read the blocks would let the scheduler reuse them.
         for req_id in metadata.preempted_req_ids:
-            self.kv_send_thread.delete_finished_stored_request(req_id)
+            send_thread.delete_finished_stored_request(req_id)
         for req_id in metadata.preempted_req_ids:
             wait_start = time.perf_counter()
-            if not self.kv_send_thread.wait_for_inflight_put(req_id):
+            while not send_thread.wait_for_inflight_put(req_id):
                 logger.error(
-                    "preemption fence timed out waiting for in-flight save "
-                    "of request %s (%.1fs); its old GPU blocks may be read "
-                    "while reused -- possible poisoned store keys",
+                    "preemption fence still waiting for in-flight save "
+                    "of request %s after %.1fs; GPU block reuse remains fenced "
+                    "until the native save exits",
                     req_id,
                     time.perf_counter() - wait_start,
                 )

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -577,6 +577,31 @@ void RdmaServer::Serve(int boot_fd) {
   const size_t direct_buffer_cap = slot_size - rdma::kV2DataOffset;
   const size_t logical_data_cap = conn_max;
 
+  struct MultiPutState {
+    bool active = false;
+    BlockKey key;
+    uint64_t total_len = 0;
+    uint64_t received = 0;
+    uint32_t next_window = 0;
+    uint32_t window_count = 0;
+  };
+  struct MultiGetState {
+    bool active = false;
+    BlockKey key;
+    uint64_t total_capacity = 0;
+    uint64_t next_offset = 0;
+    uint64_t payload_len = 0;
+    uint64_t value_len = 0;
+    uint32_t next_window = 0;
+    uint32_t window_count = 0;
+    const char* payload = nullptr;
+    ibv_mr* payload_mr = nullptr;
+    bool source_uses_slot = false;
+    PreparedRead completion;
+  };
+  std::vector<MultiPutState> multi_put(K);
+  std::vector<MultiGetState> multi_get(K);
+
   struct Request {
     ReqFields fields{};
     uint32_t recv_bytes = 0;
@@ -584,6 +609,8 @@ void RdmaServer::Serve(int boot_fd) {
     size_t data_slot = 0;  // shared receive-segment slot
     const char* contiguous_payload = nullptr;
     RdmaGetFields get;
+    bool multi_put_window = false;
+    bool multi_put_final = false;
   };
 
   auto decode_request = [&](const ibv_wc& completion,
@@ -603,23 +630,75 @@ void RdmaServer::Serve(int boot_fd) {
     request->recv_bytes = completion.byte_len;
     if (write_imm_recv) {
       const size_t data_slot = static_cast<size_t>(ntohl(completion.imm_data));
-      if (data_slot >= K || completion.byte_len < kReqPrefix) return false;
+      if (data_slot >= K || multi_get[data_slot].active) return false;
       const char* frame = recv_lease.data() + data_slot * slot_size +
                           rdma::kV2PutPrefixOffset;
-      if (!DecodeReqVersion(
-              frame, kNativeProtoRdmaV2, &request->fields,
-              static_cast<uint64_t>(logical_data_cap)) ||
-          request->fields.op != static_cast<uint8_t>(WireOp::kCache) ||
-          !rdma::V2PutCompletionIsValid(
-              write_imm_recv, has_immediate, completion.byte_len,
-              request->fields.payload_len, logical_data_cap, slot_size)) {
-        return false;
+      MultiPutState& state = multi_put[data_slot];
+      uint64_t window_bytes = completion.byte_len;
+      if (state.active) {
+        if (completion.byte_len == 0 || state.next_window >= state.window_count ||
+            window_bytes > state.total_len - state.received) {
+          return false;
+        }
+        request->fields.op = static_cast<uint8_t>(WireOp::kCache);
+        request->fields.tenant_hash = state.key.tenant_hash;
+        request->fields.digest_hi = state.key.digest_hi;
+        request->fields.digest_lo = state.key.digest_lo;
+        request->fields.offset = rdma::kV2MultiWrPutMagic;
+        request->fields.length = state.window_count;
+        request->fields.payload_len = state.total_len;
+        state.received += window_bytes;
+        ++state.next_window;
+        request->multi_put_window = true;
+        request->multi_put_final =
+            state.next_window == state.window_count;
+        if (request->multi_put_final !=
+            (state.received == state.total_len)) {
+          return false;
+        }
+        if (request->multi_put_final) state = MultiPutState{};
+      } else {
+        if (completion.byte_len < kReqPrefix ||
+            !DecodeReqVersion(
+                frame, kNativeProtoRdmaV2, &request->fields,
+                static_cast<uint64_t>(logical_data_cap)) ||
+            request->fields.op != static_cast<uint8_t>(WireOp::kCache)) {
+          return false;
+        }
+        if (request->fields.offset == rdma::kV2MultiWrPutMagic) {
+          if (request->fields.length <= 1 ||
+              request->fields.length >
+                  std::numeric_limits<uint32_t>::max() ||
+              request->fields.payload_len == 0) {
+            return false;
+          }
+          window_bytes -= kReqPrefix;
+          if (window_bytes == 0 ||
+              window_bytes >= request->fields.payload_len) {
+            return false;
+          }
+          state.active = true;
+          state.key = request->fields.Key();
+          state.total_len = request->fields.payload_len;
+          state.received = window_bytes;
+          state.next_window = 1;
+          state.window_count =
+              static_cast<uint32_t>(request->fields.length);
+          request->multi_put_window = true;
+        } else if (!rdma::V2PutCompletionIsValid(
+                       write_imm_recv, has_immediate,
+                       completion.byte_len, request->fields.payload_len,
+                       logical_data_cap, slot_size)) {
+          return false;
+        } else {
+          window_bytes = request->fields.payload_len;
+        }
       }
       request->data_slot = data_slot;
       request->contiguous_payload = frame + kReqPrefix;
       v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
       rail_stats.put_writes.fetch_add(1, std::memory_order_relaxed);
-      rail_stats.put_bytes.fetch_add(request->fields.payload_len,
+      rail_stats.put_bytes.fetch_add(window_bytes,
                                      std::memory_order_relaxed);
       return true;
     }
@@ -636,9 +715,16 @@ void RdmaServer::Serve(int boot_fd) {
                             static_cast<uint64_t>(conn_max))) {
         return false;
       }
+      if (multi_put[recv_slot].active ||
+          (request->get.window_index == 0 && multi_get[recv_slot].active)) {
+        return false;
+      }
       return request->get.targets.size() <= rdma::kV2MaxGetTargets;
     }
 
+
+    if (multi_put[recv_slot].active || multi_get[recv_slot].active)
+      return false;
 
     // Other control ops (Exist/Remove/Members/Lookup) with inline payload
     if (completion.byte_len <
@@ -677,6 +763,49 @@ void RdmaServer::Serve(int boot_fd) {
       reply->first_len = response_prefix;
       return true;
     };
+    if (fields.op == static_cast<uint8_t>(WireOp::kRange) &&
+        request.get.window_index != 0) {
+      MultiGetState& state = multi_get[request.data_slot];
+      uint64_t window_capacity = 0;
+      if (!request.get.Capacity(&window_capacity) || !state.active ||
+          multi_put[request.data_slot].active || !(state.key == key) ||
+          request.get.window_count != state.window_count ||
+          request.get.window_index != state.next_window ||
+          request.get.total_capacity != state.total_capacity ||
+          request.get.logical_offset != state.next_offset ||
+          window_capacity == 0 ||
+          window_capacity > state.total_capacity - state.next_offset ||
+          ((state.next_window + 1 == state.window_count) !=
+           (window_capacity == state.total_capacity - state.next_offset))) {
+        state = MultiGetState{};
+        return false;
+      }
+      encode_status(Status::kOk, state.payload_len, state.value_len);
+      reply->first_len = response_prefix;
+      const uint64_t remaining =
+          state.payload_len > state.next_offset
+              ? state.payload_len - state.next_offset
+              : 0;
+      const size_t bytes = static_cast<size_t>(
+          std::min<uint64_t>(remaining, window_capacity));
+      reply->defer_recv_rearm = state.source_uses_slot;
+      reply->recv_slot = request.recv_slot;
+      if (bytes != 0) {
+        reply->remote_write = true;
+        reply->payload = state.payload + state.next_offset;
+        reply->payload_len = bytes;
+        reply->payload_mr = state.payload_mr;
+        reply->targets = request.get.targets;
+      }
+      state.next_offset += window_capacity;
+      ++state.next_window;
+      if (state.next_window == state.window_count) {
+        reply->completion = std::move(state.completion);
+        state = MultiGetState{};
+      }
+      return true;
+    }
+
     auto data_reply = [&](Status status, const char* data, size_t data_len,
                           size_t value_len, ibv_mr* data_mr,
                           bool source_uses_slot,
@@ -687,24 +816,63 @@ void RdmaServer::Serve(int boot_fd) {
         reply->first_len = response_prefix;
         return true;
       }
-      if (successful_len > request.get.Capacity() ||
-          (successful_len != 0 && !data)) {
+      if (successful_len > request.get.total_capacity ||
+          value_len > request.get.total_capacity ||
+          (request.get.window_count > 1 && successful_len != value_len) ||
+          (successful_len != 0 && (!data || !data_mr))) {
         return invalid_reply();
       }
       encode_status(Status::kOk, successful_len, value_len);
       reply->first_len = response_prefix;
-      if (successful_len != 0) {
-        if (!data_mr) return false;
+      if (request.get.window_count == 1) {
+        if (successful_len != 0) {
+          reply->remote_write = true;
+          reply->defer_recv_rearm = source_uses_slot;
+          reply->recv_slot = request.recv_slot;
+          reply->payload = data;
+          reply->payload_len = successful_len;
+          reply->payload_mr = data_mr;
+          reply->targets = request.get.targets;
+          reply->completion = std::move(completion);
+        } else {
+          completion.Commit(Status::kOk, 0, 0.0);
+        }
+        return true;
+      }
+
+      MultiGetState& state = multi_get[request.data_slot];
+      uint64_t window_capacity = 0;
+      if (request.get.window_index != 0 ||
+          request.get.logical_offset != 0 || state.active ||
+          multi_put[request.data_slot].active ||
+          !request.get.Capacity(&window_capacity) ||
+          window_capacity == 0 ||
+          window_capacity >= request.get.total_capacity) {
+        return invalid_reply();
+      }
+      state.active = true;
+      state.key = key;
+      state.total_capacity = request.get.total_capacity;
+      state.next_offset = window_capacity;
+      state.payload_len = successful_len;
+      state.value_len = value_len;
+      state.next_window = 1;
+      state.window_count = request.get.window_count;
+      state.payload = data;
+      state.payload_mr = data_mr;
+      state.source_uses_slot = source_uses_slot;
+      state.completion = std::move(completion);
+      reply->defer_recv_rearm = source_uses_slot;
+      reply->recv_slot = request.recv_slot;
+      const size_t bytes =
+          std::min<size_t>(successful_len,
+                           static_cast<size_t>(window_capacity));
+      if (bytes != 0) {
         reply->remote_write = true;
-        reply->defer_recv_rearm = source_uses_slot;
-        reply->recv_slot = request.recv_slot;
         reply->payload = data;
-        reply->payload_len = successful_len;
+        reply->payload_len = bytes;
         reply->payload_mr = data_mr;
         reply->targets = request.get.targets;
-        reply->completion = std::move(completion);
-      } else {
-        completion.Commit(Status::kOk, 0, 0.0);
       }
       return true;
     };
@@ -782,6 +950,13 @@ void RdmaServer::Serve(int boot_fd) {
       return data_reply(status, output, output_len, value_len,
                         direct_mr(request.data_slot),
                         /*source_uses_slot=*/true, PreparedRead{});
+    }
+
+    if (fields.op == static_cast<uint8_t>(WireOp::kCache) &&
+        request.multi_put_window && !request.multi_put_final) {
+      encode_status(Status::kOk, 0);
+      reply->first_len = response_prefix;
+      return true;
     }
 
     if (fields.op == static_cast<uint8_t>(WireOp::kCache) &&
@@ -985,6 +1160,7 @@ void RdmaServer::Serve(int boot_fd) {
           bool deferred = false;
           bool handled = false;
           if (rq.op == static_cast<uint8_t>(WireOp::kRange) &&
+              request.get.window_count == 1 &&
               direct_buffer(request.data_slot) &&
               direct_mr(request.data_slot) &&
               rq.length <= static_cast<uint64_t>(conn_max)) {
@@ -1011,7 +1187,8 @@ void RdmaServer::Serve(int boot_fd) {
                        !prepared.needs_io()) {
               char* sb = ep.sbuf(qd.send_slot);
               const size_t payload_len = prepared.payload_len();
-              if (payload_len > qd.get.Capacity() ||
+              if (payload_len > qd.get.total_capacity ||
+                  prepared.value_len() > qd.get.total_capacity ||
                   (payload_len != 0 && prepared.data() == nullptr)) {
                 EncodeRespVersion(sb, wire_epoch, Status::kInvalid, 0);
                 qd.reply.first_len = response_prefix;
@@ -1155,7 +1332,8 @@ void RdmaServer::Serve(int boot_fd) {
             }
             continue;
           }
-          if (payload_len > qd.get.Capacity()) {
+          if (payload_len > qd.get.total_capacity ||
+              value_len > qd.get.total_capacity) {
             EncodeRespVersion(sb, wire_epoch, Status::kInvalid, 0);
             if (!post_request_recv(qd.recv_slot) ||
                 !ep.PostSend(qd.send_slot, response_prefix)) {

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -594,6 +594,8 @@ void RdmaServer::Serve(int boot_fd) {
     uint64_t value_len = 0;
     uint32_t next_window = 0;
     uint32_t window_count = 0;
+    size_t source_slot = 0;
+    size_t last_recv_slot = 0;
     const char* payload = nullptr;
     ibv_mr* payload_mr = nullptr;
     bool source_uses_slot = false;
@@ -601,6 +603,17 @@ void RdmaServer::Serve(int boot_fd) {
   };
   std::vector<MultiPutState> multi_put(K);
   std::vector<MultiGetState> multi_get(K);
+  std::vector<int32_t> multi_get_source_owner(K, -1);
+  auto clear_multi_get = [&](size_t operation_id) {
+    MultiGetState& state = multi_get[operation_id];
+    if (state.active && state.source_uses_slot &&
+        state.source_slot < multi_get_source_owner.size() &&
+        multi_get_source_owner[state.source_slot] ==
+            static_cast<int32_t>(operation_id)) {
+      multi_get_source_owner[state.source_slot] = -1;
+    }
+    state = MultiGetState{};
+  };
 
   struct Request {
     ReqFields fields{};
@@ -630,7 +643,8 @@ void RdmaServer::Serve(int boot_fd) {
     request->recv_bytes = completion.byte_len;
     if (write_imm_recv) {
       const size_t data_slot = static_cast<size_t>(ntohl(completion.imm_data));
-      if (data_slot >= K || multi_get[data_slot].active) return false;
+      if (data_slot >= K || multi_get_source_owner[data_slot] >= 0)
+        return false;
       const char* frame = recv_lease.data() + data_slot * slot_size +
                           rdma::kV2PutPrefixOffset;
       MultiPutState& state = multi_put[data_slot];
@@ -712,19 +726,21 @@ void RdmaServer::Serve(int boot_fd) {
     if (request->fields.op == static_cast<uint8_t>(WireOp::kRange)) {
       if (!DecodeRdmaGetReq(frame, completion.byte_len, &request->fields,
                             &request->get,
-                            static_cast<uint64_t>(conn_max))) {
+                            static_cast<uint64_t>(conn_max)) ||
+          !rdma::V2GetOperationIdValid(request->get.operation_id, K)) {
         return false;
       }
-      if (multi_put[recv_slot].active ||
-          (request->get.window_index == 0 && multi_get[recv_slot].active)) {
+      MultiGetState& state = multi_get[request->get.operation_id];
+      if (request->get.window_index == 0 &&
+          (multi_put[recv_slot].active ||
+           multi_get_source_owner[recv_slot] >= 0 || state.active)) {
         return false;
       }
       return request->get.targets.size() <= rdma::kV2MaxGetTargets;
     }
 
 
-    if (multi_put[recv_slot].active || multi_get[recv_slot].active)
-      return false;
+    if (multi_put[recv_slot].active) return false;
 
     // Other control ops (Exist/Remove/Members/Lookup) with inline payload
     if (completion.byte_len <
@@ -739,7 +755,9 @@ void RdmaServer::Serve(int boot_fd) {
   struct Reply {
     bool remote_write = false;
     bool defer_recv_rearm = false;
+    bool release_source_on_send = false;
     size_t recv_slot = 0;
+    size_t source_recv_slot = 0;
     size_t first_len = 0;
     const char* payload = nullptr;
     size_t payload_len = 0;
@@ -765,10 +783,11 @@ void RdmaServer::Serve(int boot_fd) {
     };
     if (fields.op == static_cast<uint8_t>(WireOp::kRange) &&
         request.get.window_index != 0) {
-      MultiGetState& state = multi_get[request.data_slot];
+      const size_t operation_id = request.get.operation_id;
+      MultiGetState& state = multi_get[operation_id];
       uint64_t window_capacity = 0;
       if (!request.get.Capacity(&window_capacity) || !state.active ||
-          multi_put[request.data_slot].active || !(state.key == key) ||
+          !(state.key == key) ||
           request.get.window_count != state.window_count ||
           request.get.window_index != state.next_window ||
           request.get.total_capacity != state.total_capacity ||
@@ -777,9 +796,14 @@ void RdmaServer::Serve(int boot_fd) {
           window_capacity > state.total_capacity - state.next_offset ||
           ((state.next_window + 1 == state.window_count) !=
            (window_capacity == state.total_capacity - state.next_offset))) {
-        state = MultiGetState{};
+        clear_multi_get(operation_id);
         return false;
       }
+      if (request.recv_slot != state.last_recv_slot) {
+        v2_get_continuation_slot_changes_.fetch_add(
+            1, std::memory_order_relaxed);
+      }
+      state.last_recv_slot = request.recv_slot;
       encode_status(Status::kOk, state.payload_len, state.value_len);
       reply->first_len = response_prefix;
       const uint64_t remaining =
@@ -788,8 +812,6 @@ void RdmaServer::Serve(int boot_fd) {
               : 0;
       const size_t bytes = static_cast<size_t>(
           std::min<uint64_t>(remaining, window_capacity));
-      reply->defer_recv_rearm = state.source_uses_slot;
-      reply->recv_slot = request.recv_slot;
       if (bytes != 0) {
         reply->remote_write = true;
         reply->payload = state.payload + state.next_offset;
@@ -801,7 +823,17 @@ void RdmaServer::Serve(int boot_fd) {
       ++state.next_window;
       if (state.next_window == state.window_count) {
         reply->completion = std::move(state.completion);
-        state = MultiGetState{};
+        reply->release_source_on_send = state.source_uses_slot;
+        reply->source_recv_slot = state.source_slot;
+        if (state.source_uses_slot &&
+            request.recv_slot == state.source_slot) {
+          reply->defer_recv_rearm = true;
+          reply->recv_slot = request.recv_slot;
+        }
+        // The source remains protected until this final RDMA WRITE's SEND
+        // completion. clear_multi_get must not release its owner early.
+        state.source_uses_slot = false;
+        clear_multi_get(operation_id);
       }
       return true;
     }
@@ -840,11 +872,13 @@ void RdmaServer::Serve(int boot_fd) {
         return true;
       }
 
-      MultiGetState& state = multi_get[request.data_slot];
+      const size_t operation_id = request.get.operation_id;
+      MultiGetState& state = multi_get[operation_id];
       uint64_t window_capacity = 0;
       if (request.get.window_index != 0 ||
           request.get.logical_offset != 0 || state.active ||
           multi_put[request.data_slot].active ||
+          multi_get_source_owner[request.data_slot] >= 0 ||
           !request.get.Capacity(&window_capacity) ||
           window_capacity == 0 ||
           window_capacity >= request.get.total_capacity) {
@@ -855,14 +889,22 @@ void RdmaServer::Serve(int boot_fd) {
       state.total_capacity = request.get.total_capacity;
       state.next_offset = window_capacity;
       state.payload_len = successful_len;
+      state.last_recv_slot = request.recv_slot;
       state.value_len = value_len;
       state.next_window = 1;
       state.window_count = request.get.window_count;
+      state.source_slot = request.data_slot;
       state.payload = data;
       state.payload_mr = data_mr;
       state.source_uses_slot = source_uses_slot;
       state.completion = std::move(completion);
-      reply->defer_recv_rearm = source_uses_slot;
+      if (source_uses_slot) {
+        multi_get_source_owner[request.data_slot] =
+            static_cast<int32_t>(operation_id);
+        // Repost this WQE only after the first write finishes, but keep the
+        // source owner until the logical GET's final SEND completion.
+        reply->defer_recv_rearm = true;
+      }
       reply->recv_slot = request.recv_slot;
       const size_t bytes =
           std::min<size_t>(successful_len,
@@ -1044,6 +1086,10 @@ void RdmaServer::Serve(int boot_fd) {
   std::vector<ibv_wc> wcs(K);
   constexpr size_t kNoSlot = static_cast<size_t>(-1);
   std::vector<size_t> rearm_on_send(K, kNoSlot);
+  std::vector<size_t> release_source_on_send(K, kNoSlot);
+  auto rearm_request_recv = [&](size_t slot) {
+    return post_request_recv(slot);
+  };
   // A prepared RAM read remains pinned in its move-only transaction until the
   // signaled SEND completion. Uncompleted slots destructor-abort on teardown.
   std::vector<PreparedRead> complete_on_send(K);
@@ -1131,8 +1177,16 @@ void RdmaServer::Serve(int boot_fd) {
           }
           if (wc.opcode == IBV_WC_SEND) {
             size_t sid = static_cast<size_t>(wc.wr_id);
+            if (sid < release_source_on_send.size() &&
+                release_source_on_send[sid] != kNoSlot) {
+              multi_get_source_owner[release_source_on_send[sid]] = -1;
+              release_source_on_send[sid] = kNoSlot;
+            }
             if (sid < rearm_on_send.size() && rearm_on_send[sid] != kNoSlot) {
-              if (!post_request_recv(rearm_on_send[sid])) { fail = true; break; }
+              if (!rearm_request_recv(rearm_on_send[sid])) {
+                fail = true;
+                break;
+              }
               rearm_on_send[sid] = kNoSlot;
             }
             complete_send(sid);
@@ -1278,8 +1332,17 @@ void RdmaServer::Serve(int boot_fd) {
             Reply& reply = qd.reply;
             if (reply.defer_recv_rearm) {
               rearm_on_send[qd.send_slot] = reply.recv_slot;
-            } else if (!post_request_recv(qd.recv_slot)) {
-              fail = true; break;
+            } else if (!rearm_request_recv(qd.recv_slot)) {
+              fail = true;
+              break;
+            }
+            if (reply.release_source_on_send) {
+              if (release_source_on_send[qd.send_slot] != kNoSlot) {
+                fail = true;
+                break;
+              }
+              release_source_on_send[qd.send_slot] =
+                  reply.source_recv_slot;
             }
             complete_on_send[qd.send_slot] = std::move(reply.completion);
             if (!post_reply(qd.send_slot, reply)) {
@@ -1400,8 +1463,16 @@ sync_serve_loop:;
       }
       if (wc.opcode == IBV_WC_SEND) {
         size_t sid = static_cast<size_t>(wc.wr_id);
+        if (sid < release_source_on_send.size() &&
+            release_source_on_send[sid] != kNoSlot) {
+          multi_get_source_owner[release_source_on_send[sid]] = -1;
+          release_source_on_send[sid] = kNoSlot;
+        }
         if (sid < rearm_on_send.size() && rearm_on_send[sid] != kNoSlot) {
-          if (!post_request_recv(rearm_on_send[sid])) { fail = true; break; }
+          if (!rearm_request_recv(rearm_on_send[sid])) {
+            fail = true;
+            break;
+          }
           rearm_on_send[sid] = kNoSlot;
         }
         complete_send(sid);
@@ -1420,8 +1491,16 @@ sync_serve_loop:;
       if (!built) { fail = true; break; }
       if (reply.defer_recv_rearm) {
         rearm_on_send[s] = reply.recv_slot;
-      } else if (!post_request_recv(r)) {
-        fail = true; break;  // re-arm (request consumed)
+      } else if (!rearm_request_recv(r)) {
+        fail = true;
+        break;  // re-arm (request consumed)
+      }
+      if (reply.release_source_on_send) {
+        if (release_source_on_send[s] != kNoSlot) {
+          fail = true;
+          break;
+        }
+        release_source_on_send[s] = reply.source_recv_slot;
       }
       complete_on_send[s] = std::move(reply.completion);
       bool sent = post_reply(s, reply);
@@ -1455,6 +1534,9 @@ std::string RdmaServer::MetricsText() const {
     "PUT requests received by RDMA WRITE_WITH_IMM", V2PutWrites());
   m(s, "dfkv_rdma_v2_get_writes_total", "counter",
     "GET payloads sent by RDMA WRITE", V2GetWrites());
+  m(s, "dfkv_rdma_v2_get_continuation_slot_changes_total", "counter",
+    "Multi-window GET continuations received on a different WQE slot",
+    V2GetContinuationSlotChanges());
   m(s, "dfkv_rdma_recv_segment_bytes", "gauge",
     "Process-wide registered receive-segment bytes", recv_segment_.size());
   m(s, "dfkv_rdma_recv_segment_free_bytes", "gauge",

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -105,6 +105,9 @@ class RdmaServer {
   uint64_t V2GetWrites() const {
     return v2_get_writes_.load(std::memory_order_relaxed);
   }
+  uint64_t V2GetContinuationSlotChanges() const {
+    return v2_get_continuation_slot_changes_.load(std::memory_order_relaxed);
+  }
   // The server-side pipeline depth (env DFKV_RDMA_DEPTH, default 4) -- surfaced
   // in ring INFO because the CLIENT's depth must not exceed it: excess in-flight
   // requests hit receiver-not-ready retries and degrade SILENTLY (measured 3-4x
@@ -179,6 +182,7 @@ class RdmaServer {
   std::vector<std::unique_ptr<RailStats>> rail_stats_;  // indexed with anchor_devs_
   std::atomic<uint64_t> uring_reads_{0}, uring_init_fallbacks_{0};
   std::atomic<uint64_t> v2_conns_{0}, v2_put_writes_{0}, v2_get_writes_{0};
+  std::atomic<uint64_t> v2_get_continuation_slot_changes_{0};
   std::atomic<uint64_t> completions_{0}, completion_errors_{0}, active_conns_{0},
       idle_reclaims_{0};
 };

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -49,11 +49,9 @@ std::string MembershipDelta(const std::map<std::string, std::string>& old_m,
   return s;
 }
 
-// Max payload segments per scatter-gather key: the guards below use the active
-// transport's runtime capability, and the connector reads that same value
-// through dfkv_max_sg_segs. A key exceeding the reported limit, or whose
-// aggregate byte count cannot be represented by size_t, fails independently
-// before routing; valid siblings in the same batch still run.
+// Aggregate SG byte counts are checked once before routing. Descriptor count is
+// intentionally unbounded at this layer: RDMA windows it to the negotiated HCA
+// width, while framed transports preserve their existing logical SG fallback.
 
 bool CheckedSizeSum(const std::vector<size_t>& values, size_t* total) {
   size_t sum = 0;
@@ -1170,7 +1168,6 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     }
     if (items[i].key.empty() ||
         items[i].ptrs.size() != items[i].sizes.size() ||
-        items[i].ptrs.size() > t_->MaxSgPayloadSegs() ||
         !CheckedSizeSum(items[i].sizes, &total_bytes[i]) ||
         total_bytes[i] == 0 || invalid_buffer)
       over[i] = 1;
@@ -1288,7 +1285,6 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
     // rendezvous entirely — an unclaimed fetch has no publish obligation.
     const bool eligible = !items[i].key.empty() && !items[i].dsts.empty() &&
                           items[i].dsts.size() == items[i].caps.size() &&
-                          items[i].dsts.size() <= t_->MaxSgPayloadSegs() &&
                           totals_valid[i] && cu->IsDevicePtr(items[i].dsts[0]);
     if (!eligible) {
       fetch_map.push_back(i);
@@ -1402,14 +1398,13 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
   std::vector<char> hit(N, 0);
   std::vector<size_t> lens(N, 0);  // distinct indices => thread-safe writes
 
-  // Guard (same as put): an item exceeding the active transport's runtime
-  // destination-segment capability is reported a miss up front.
+  // Validate shape and aggregate capacity; the transport windows arbitrary
+  // descriptor counts internally.
   std::vector<char> over(N, 0);
   std::vector<size_t> total_caps(N, 0);
   for (size_t i = 0; i < N; ++i) {
     if (items[i].key.empty() ||  // null/empty key: skip (no wasted GET issued)
         items[i].dsts.size() != items[i].caps.size() ||
-        items[i].dsts.size() > t_->MaxSgPayloadSegs() ||
         !CheckedSizeSum(items[i].caps, &total_caps[i]))
       over[i] = 1;
   }

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -54,7 +54,7 @@ struct KvGetItem { std::string key; void* out; size_t n; };
 // is the in-order concatenation of the segments; segment boundaries are purely
 // client-side (the server stores one opaque blob). ptrs.size() == sizes.size();
 // dsts.size() == caps.size(). Used by the additive C ABI dfkv_batch_put_sg /
-// dfkv_batch_get_auto_sg to coalesce many tiny KV chunks into one key/RDMA op.
+// dfkv_batch_get_auto_sg; N may exceed one transport WR's SGE width.
 struct KvPutItemSg {
   std::string key;
   std::vector<const void*> ptrs;
@@ -109,16 +109,15 @@ class KVClient {
   std::vector<bool> BatchRemove(const std::vector<std::string>& keys);
 
   // Scatter-gather batch put: each key gathers its N source segments into one
-  // stored blob (sum of sizes). Mirrors BatchPut (consistent-hash routing per key,
-  // group by node, zero-copy multi-SGE gather where supported). Per-item result.
-  // A key exceeding the active transport's runtime segment limit, whose total
-  // value size is zero, or whose byte sum overflows size_t is reported failed
-  // rather than routed.
+  // stored blob (sum of sizes). Mirrors BatchPut (consistent-hash routing per
+  // key, group by node, zero-copy bounded multi-WR gather where required).
+  // Descriptor count is arbitrary; zero total size or a byte-sum overflow fails
+  // the item before routing.
   std::vector<bool> BatchPutSg(const std::vector<KvPutItemSg>& items);
   // Scatter-gather variable-size batch get: each key's stored blob is scattered
-  // across its N destination segments in order. Mirrors BatchGetAuto: accepts a
-  // stored size <= the checked sum(caps); overflow or a runtime segment-limit
-  // violation is a miss. out_lens receives the true length (0 on miss).
+  // across its N destination segments in order. Mirrors BatchGetAuto and accepts
+  // a stored size <= the checked sum(caps). Descriptor count is arbitrary;
+  // overflow is a miss. out_lens receives the true length (0 on miss).
   std::vector<bool> BatchGetAutoSg(const std::vector<KvGetItemSg>& items,
                                    std::vector<size_t>* out_lens);
 
@@ -139,9 +138,8 @@ class KVClient {
     return t_->RegisterMemory(base, size);
   }
 
-  // Runtime payload-segment limit reported by the active transport. Connectors
-  // query this through dfkv_max_sg_segs and must not assume a fixed HCA or
-  // transport capability.
+  // Runtime payload-segment width of one transport window. Logical SG calls may
+  // exceed it: the transport splits them into one ordered operation internally.
   size_t MaxSgPayloadSegs() const { return t_->MaxSgPayloadSegs(); }
 
   // Hot-swap the cluster membership (rebuilds the consistent-hash ring).

--- a/src/transport/rdma_protocol.h
+++ b/src/transport/rdma_protocol.h
@@ -37,7 +37,7 @@ constexpr size_t kV2MaxGetTargets = 29;
 constexpr uint64_t kV2MultiWrPutMagic = 0x325257495455504dull;  // "MPUTIWR2"
 
 constexpr const char* kV2ProbeDevice = "__dfkv_v2__";
-constexpr uint32_t kV2ProbeMagic = 0x32564644u;  // ASCII "DFV2" (LE)
+constexpr uint32_t kV2ProbeMagic = 0x33564644u;  // ASCII "DFV3" (LE)
 constexpr size_t kV2ProbeReplyBytes = 8;
 
 inline bool IsV2Probe(const char frame[kDevNameBytes]) {
@@ -58,6 +58,13 @@ inline bool ParseV2ProbeReply(const char in[kV2ProbeReplyBytes]) {
   std::memcpy(&magic, in, sizeof(magic));
   return magic == kV2ProbeMagic &&
          static_cast<uint8_t>(in[4]) == kDevProtoV2;
+}
+
+// Multi-window GET IDs name one of the negotiated per-connection logical
+// request slots. Keeping the namespace bounded by queue depth both caps server
+// state and makes duplicate ownership explicit.
+inline bool V2GetOperationIdValid(uint32_t operation_id, size_t depth) {
+  return depth != 0 && operation_id < depth;
 }
 
 inline size_t AlignUp(size_t value, size_t alignment) {

--- a/src/transport/rdma_protocol.h
+++ b/src/transport/rdma_protocol.h
@@ -29,6 +29,13 @@ constexpr size_t kV2PutPrefixOffset = kV2DataOffset - kReqPrefix;
 // Keep it equal to the public SG layout's maximum payload width.
 constexpr size_t kV2MaxGetTargets = 29;
 
+// A kCache request with offset=kV2MultiWrPutMagic and length>1 starts an
+// ordered multi-WR PUT. payload_len remains the logical object size; each
+// WRITE_WITH_IMM completion contributes one bounded payload window. The server
+// publishes the object only after exactly `length` windows and payload_len
+// bytes have arrived.
+constexpr uint64_t kV2MultiWrPutMagic = 0x325257495455504dull;  // "MPUTIWR2"
+
 constexpr const char* kV2ProbeDevice = "__dfkv_v2__";
 constexpr uint32_t kV2ProbeMagic = 0x32564644u;  // ASCII "DFV2" (LE)
 constexpr size_t kV2ProbeReplyBytes = 8;
@@ -133,7 +140,9 @@ inline bool DecodeRecvSegmentInfo(const char in[kRecvSegmentInfoBytes],
   info->slot_size = net::GetU64(in + 16);
   return info->rkey != 0 && info->base_addr != 0 &&
          info->slot_size >= kV2DataOffset &&
-         info->slot_size % kV2DataOffset == 0;
+         info->slot_size % kV2DataOffset == 0 &&
+         info->base_addr <=
+             std::numeric_limits<uint64_t>::max() - (info->slot_size - 1);
 }
 
 }  // namespace dfkv::rdma

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -77,6 +77,18 @@ bool AbortMultiWrWindow(size_t one_based_window, size_t window_count) {
          parsed == one_based_window;
 }
 
+bool CorruptGetOperationId(size_t one_based_window, size_t window_count) {
+  if (window_count <= 1) return false;
+  const char* value =
+      std::getenv("DFKV_RDMA_TEST_BAD_GET_OP_ID_WINDOW");
+  if (!value || !*value) return false;
+  errno = 0;
+  char* end = nullptr;
+  const unsigned long long parsed = std::strtoull(value, &end, 10);
+  return errno == 0 && end != value && *end == '\0' &&
+         parsed == one_based_window;
+}
+
 size_t ResolveMaxPayload(size_t configured) {
   size_t n = configured ? configured : (64u << 20);
   n = EnvBytes("DFKV_RDMA_MAX_PAYLOAD_BYTES", n);
@@ -658,7 +670,7 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
     return pooled;
   }
   endpoint_cache_misses_.fetch_add(1, std::memory_order_relaxed);
-  const size_t conn_depth = lane == Lane::kSgData ? 1 : depth_;
+  const size_t conn_depth = depth_;
   const uint64_t conn_declared =
       lane == Lane::kControl
           ? static_cast<uint64_t>(rdma::kV2ControlCap)
@@ -2040,123 +2052,212 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       }
     }
     bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kSgData, &from_pool, attempt > 0, 1);
+    Conn* conn = Acquire(
+        node, Lane::kSgData, &from_pool, attempt > 0,
+        std::min<size_t>(valid_count, depth_));
     if (!conn) return result;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t target_limit =
         std::max<size_t>(1, std::min(ep.max_sge() - 1,
                                     rdma::kV2MaxGetTargets));
-    bool conn_ok = true;
+    const size_t operation_limit = ep.window();
+    bool conn_ok = operation_limit != 0;
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
 
-    for (size_t item_index = 0; item_index < count && conn_ok; ++item_index) {
-      if (bad[item_index] || completed[item_index]) continue;
-      const RangeDstMulti& destination = destinations[item_index];
-      size_t nonempty = 0;
-      for (const auto& payload : destination.payloads)
-        if (payload.second != 0) ++nonempty;
-      const size_t window_count =
-          nonempty == 0 ? 1 : 1 + (nonempty - 1) / target_limit;
-      if (window_count > std::numeric_limits<uint32_t>::max()) {
-        result[item_index] = Status::kInvalid;
-        completed[item_index] = 1;
+    struct GetProgress {
+      size_t item = 0;
+      size_t segment_index = 0;
+      size_t logical_offset = 0;
+      size_t window_index = 0;
+      size_t window_count = 0;
+      uint32_t operation_id = 0;
+      uint64_t response_data_len = 0;
+      uint64_t response_value_len = 0;
+      bool finished = false;
+    };
+
+    size_t next_item = 0;
+    while (conn_ok) {
+      std::vector<GetProgress> active;
+      active.reserve(operation_limit);
+      while (next_item < count && active.size() < operation_limit) {
+        const size_t item = next_item++;
+        if (bad[item] || completed[item]) continue;
+        size_t nonempty = 0;
+        for (const auto& payload : destinations[item].payloads)
+          if (payload.second != 0) ++nonempty;
+        const size_t window_count =
+            nonempty == 0 ? 1 : 1 + (nonempty - 1) / target_limit;
+        if (window_count > std::numeric_limits<uint32_t>::max()) {
+          result[item] = Status::kInvalid;
+          completed[item] = 1;
+          continue;
+        }
+        GetProgress progress;
+        progress.item = item;
+        progress.window_count = window_count;
+        progress.operation_id = static_cast<uint32_t>(active.size());
+        active.push_back(progress);
+      }
+      if (active.empty()) {
+        if (next_item >= count) break;
         continue;
       }
 
-      size_t segment_index = 0;
-      size_t logical_offset = 0;
-      uint64_t value_len = 0;
-      uint64_t response_data_len = 0;
-      uint64_t response_value_len = 0;
-      for (size_t window_index = 0;
-           window_index < window_count && conn_ok; ++window_index) {
-        std::vector<RdmaWriteTarget> targets;
-        std::vector<ibv_mr*> mrs;
-        targets.reserve(target_limit);
-        mrs.reserve(target_limit);
-        size_t window_capacity = 0;
-        while (segment_index < destination.payloads.size() &&
-               targets.size() < target_limit) {
-          const auto& payload = destination.payloads[segment_index++];
-          if (payload.second == 0) continue;
-          ibv_mr* mr =
-              ep.RegisterTransient(payload.first, payload.second);
-          if (!mr) {
-            conn_ok = false;
+      size_t remaining = active.size();
+      while (conn_ok && remaining != 0) {
+        std::vector<size_t> frame_lengths;
+        std::vector<size_t> round_progress;
+        std::vector<size_t> round_capacity;
+        std::vector<std::vector<ibv_mr*>> round_mrs;
+        frame_lengths.reserve(remaining);
+        round_progress.reserve(remaining);
+        round_capacity.reserve(remaining);
+        round_mrs.reserve(remaining);
+
+        for (size_t progress_index = 0;
+             progress_index < active.size() && conn_ok; ++progress_index) {
+          GetProgress& progress = active[progress_index];
+          if (progress.finished) continue;
+          const RangeDstMulti& destination =
+              destinations[progress.item];
+          std::vector<RdmaWriteTarget> targets;
+          std::vector<ibv_mr*> mrs;
+          targets.reserve(target_limit);
+          mrs.reserve(target_limit);
+          size_t window_capacity = 0;
+          while (progress.segment_index < destination.payloads.size() &&
+                 targets.size() < target_limit) {
+            const auto& payload =
+                destination.payloads[progress.segment_index++];
+            if (payload.second == 0) continue;
+            ibv_mr* mr =
+                ep.RegisterTransient(payload.first, payload.second);
+            if (!mr) {
+              conn_ok = false;
+              break;
+            }
+            targets.push_back(
+                {reinterpret_cast<uint64_t>(payload.first), mr->rkey,
+                 static_cast<uint32_t>(payload.second)});
+            mrs.push_back(mr);
+            window_capacity += payload.second;
+          }
+          if (!conn_ok) {
+            for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
             break;
           }
-          targets.push_back(
-              {reinterpret_cast<uint64_t>(payload.first), mr->rkey,
-               static_cast<uint32_t>(payload.second)});
-          mrs.push_back(mr);
-          window_capacity += payload.second;
+          if (AbortMultiWrWindow(progress.window_index + 1,
+                                 progress.window_count)) {
+            for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
+            conn_ok = false;
+            completion = rdma::RailCompletion::kEndpointFailure;
+            break;
+          }
+          uint32_t operation_id = progress.operation_id;
+          if (CorruptGetOperationId(progress.window_index + 1,
+                                    progress.window_count)) {
+            operation_id =
+                operation_limit > 1
+                    ? static_cast<uint32_t>(
+                          (static_cast<size_t>(operation_id) + 1) %
+                          operation_limit)
+                    : 1;
+          }
+          const size_t slot = frame_lengths.size();
+          size_t frame_len = 0;
+          if (!EncodeRdmaGetReqWindow(
+                  ep.sbuf(slot), ep.cap(), keys[progress.item], 0,
+                  capacities[progress.item], targets, operation_id,
+                  static_cast<uint32_t>(progress.window_index),
+                  static_cast<uint32_t>(progress.window_count),
+                  progress.logical_offset, capacities[progress.item],
+                  &frame_len)) {
+            for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
+            conn_ok = false;
+            completion = rdma::RailCompletion::kEndpointFailure;
+            break;
+          }
+          frame_lengths.push_back(frame_len);
+          round_progress.push_back(progress_index);
+          round_capacity.push_back(window_capacity);
+          round_mrs.push_back(std::move(mrs));
         }
-        if (!conn_ok) break;
-        if (AbortMultiWrWindow(window_index + 1, window_count)) {
-          conn_ok = false;
+        if (!conn_ok) {
+          for (auto& mrs : round_mrs)
+            for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
           break;
         }
-        size_t frame_len = 0;
-        if (!EncodeRdmaGetReqWindow(
-                ep.sbuf(0), ep.cap(), keys[item_index], 0,
-                capacities[item_index], targets,
-                static_cast<uint32_t>(window_index),
-                static_cast<uint32_t>(window_count), logical_offset,
-                capacities[item_index], &frame_len) ||
-            !ep.PostRecv(0) || !ep.PostSend(0, frame_len)) {
-          conn_ok = false;
-          break;
-        }
-        v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
+
         std::vector<uint32_t> reply_bytes;
         bool timed_out = false;
         ibv_wc_status wc_status = IBV_WC_SUCCESS;
         bool had_wcs = false;
-        if (!ReapPosted(ep, 1, 1, &reply_bytes, BatchTimeout(), &timed_out,
-                        &wc_status, &had_wcs)) {
+        if (!RunWindow(ep, frame_lengths, &reply_bytes, BatchTimeout(),
+                       &timed_out, &wc_status, &had_wcs)) {
           conn_ok = false;
           completion = rdma::ClassifyCompletion(wc_status, had_wcs);
         }
         if (timed_out)
           completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
         if (!conn_ok) break;
-        for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
-        Status status;
-        uint64_t data_len = 0;
-        if (reply_bytes[0] < kRespPrefix ||
-            !conn->Decode(ep.rbuf(0), &status, &data_len,
-                          capacities[item_index], &value_len) ||
-            value_len > std::numeric_limits<size_t>::max() ||
-            value_len > capacities[item_index] ||
-            (status == Status::kOk && data_len != value_len) ||
-            (window_index != 0 &&
-             (status != Status::kOk ||
-              data_len != response_data_len ||
-              value_len != response_value_len))) {
-          conn_ok = false;
-          completion = rdma::RailCompletion::kEndpointFailure;
-          break;
+        for (auto& mrs : round_mrs)
+          for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
+        v2_get_writes_.fetch_add(frame_lengths.size(),
+                                 std::memory_order_relaxed);
+
+        for (size_t slot = 0;
+             slot < round_progress.size() && conn_ok; ++slot) {
+          GetProgress& progress = active[round_progress[slot]];
+          Status status;
+          uint64_t data_len = 0;
+          uint64_t value_len = 0;
+          if (reply_bytes[slot] < kRespPrefix ||
+              !conn->Decode(ep.rbuf(slot), &status, &data_len,
+                            capacities[progress.item], &value_len) ||
+              value_len > std::numeric_limits<size_t>::max() ||
+              value_len > capacities[progress.item] ||
+              (status == Status::kOk && data_len != value_len) ||
+              (progress.window_index != 0 &&
+               (status != Status::kOk ||
+                data_len != progress.response_data_len ||
+                value_len != progress.response_value_len))) {
+            conn_ok = false;
+            completion = rdma::RailCompletion::kEndpointFailure;
+            break;
+          }
+          if (progress.window_index == 0) {
+            progress.response_data_len = data_len;
+            progress.response_value_len = value_len;
+          }
+          result[progress.item] = status;
+          if (status != Status::kOk) {
+            progress.finished = true;
+            completed[progress.item] = 1;
+            --remaining;
+            continue;
+          }
+          progress.logical_offset += round_capacity[slot];
+          ++progress.window_index;
+          if (progress.window_index == progress.window_count) {
+            if (progress.logical_offset != capacities[progress.item]) {
+              conn_ok = false;
+              completion = rdma::RailCompletion::kEndpointFailure;
+              break;
+            }
+            progress.finished = true;
+            completed[progress.item] = 1;
+            if (out_lengths) {
+              (*out_lengths)[progress.item] =
+                  static_cast<size_t>(progress.response_value_len);
+            }
+            --remaining;
+          }
         }
-        if (window_index == 0) {
-          response_data_len = data_len;
-          response_value_len = value_len;
-        }
-        result[item_index] = status;
-        if (status != Status::kOk) break;
-        logical_offset += window_capacity;
       }
-      if (conn_ok && result[item_index] == Status::kOk) {
-        if (logical_offset != capacities[item_index]) {
-          conn_ok = false;
-          completion = rdma::RailCompletion::kEndpointFailure;
-          break;
-        }
-        if (out_lengths)
-          (*out_lengths)[item_index] =
-              static_cast<size_t>(response_value_len);
-      }
-      if (conn_ok) completed[item_index] = 1;
+      if (next_item >= count && conn_ok) break;
     }
+
     if (conn_ok) {
       Release(node, Lane::kSgData, conn);
       return result;

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -66,6 +66,17 @@ uint64_t EnvU64(const char* name, uint64_t dflt) {
 }
 
 
+bool AbortMultiWrWindow(size_t one_based_window, size_t window_count) {
+  if (window_count <= 1) return false;
+  const char* value = std::getenv("DFKV_RDMA_TEST_ABORT_MULTIWR_WINDOW");
+  if (!value || !*value) return false;
+  errno = 0;
+  char* end = nullptr;
+  const unsigned long long parsed = std::strtoull(value, &end, 10);
+  return errno == 0 && end != value && *end == '\0' &&
+         parsed == one_based_window;
+}
+
 size_t ResolveMaxPayload(size_t configured) {
   size_t n = configured ? configured : (64u << 20);
   n = EnvBytes("DFKV_RDMA_MAX_PAYLOAD_BYTES", n);
@@ -1782,10 +1793,11 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) return result;
   std::vector<char> bad(count, 0);
+  std::vector<char> completed(count, 0);
   std::vector<size_t> totals(count, 0);
   size_t valid_count = 0;
   for (size_t i = 0; i < count; ++i) {
-    bool invalid = sources[i].payloads.size() > sg_payload_segs_;
+    bool invalid = false;
     size_t total = 0;
     for (const auto& payload : sources[i].payloads) {
       size_t next = 0;
@@ -1811,99 +1823,132 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   for (int attempt = 0; attempt < 2; ++attempt) {
     if (attempt != 0)
       stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
-    std::fill(result.begin(), result.end(), Status::kIOError);
-    for (size_t i = 0; i < count; ++i)
-      if (bad[i]) result[i] = Status::kInvalid;
+    for (size_t i = 0; i < count; ++i) {
+      if (bad[i]) {
+        result[i] = Status::kInvalid;
+      } else if (!completed[i]) {
+        result[i] = Status::kIOError;
+      }
+    }
     bool from_pool = false;
-    // Multi-SGE GPU writes are fanned out across independent connections by
-    // KVClient. Keep each connection at one in-flight item: the B200 mlx5
-    // device-direct path reports protection/error WCs when one QP overlaps
-    // writes from distinct registered CUDA ranges. That reduced a 3,937-page
-    // backup to 34 successful writes at depth 4; depth 1 completed all pages.
-    // RDMA depth is not a throughput lever for this path.
     Conn* conn = Acquire(node, Lane::kSgData, &from_pool, attempt > 0, 1);
     if (!conn) return result;
     rdma::RcEndpoint& ep = conn->ep;
-    const size_t window = std::min(
-        ep.window(), static_cast<size_t>(conn->lease.credits));
+    const size_t seg_limit = std::max<size_t>(1, ep.max_sge() - 1);
     bool conn_ok = true;
-    // Failure attribution for Destroy: post/encode/register failures keep the
-    // local-rail default; a failed reap window is classified from its WC
-    // evidence; wire decode failures blame the peer.
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
-    for (size_t base = 0; base < count && conn_ok; base += window) {
-      const size_t width = std::min(window, count - base);
-      std::vector<std::vector<ibv_mr*>> mrs(width);
-      size_t posted = 0;
-      for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = base + slot;
-        if (bad[item_index]) continue;
-        const CacheSrcMulti& source = sources[item_index];
-        mrs[slot].assign(source.payloads.size(), nullptr);
-        for (size_t seg = 0; seg < source.payloads.size(); ++seg) {
-          if (source.payloads[seg].second == 0) continue;
-          mrs[slot][seg] = ep.RegisterTransient(
-              const_cast<void*>(source.payloads[seg].first),
-              source.payloads[seg].second, /*remote_write=*/false);
-          if (!mrs[slot][seg]) {
+    const size_t remote_capacity = conn->data_capacity();
+
+    for (size_t item_index = 0; item_index < count && conn_ok; ++item_index) {
+      if (bad[item_index] || completed[item_index]) continue;
+      if (totals[item_index] > remote_capacity) {
+        result[item_index] = Status::kInvalid;
+        completed[item_index] = 1;
+        continue;
+      }
+      const CacheSrcMulti& source = sources[item_index];
+      size_t nonempty = 0;
+      for (const auto& payload : source.payloads)
+        if (payload.second != 0) ++nonempty;
+      const size_t window_count = 1 + (nonempty - 1) / seg_limit;
+      if (window_count > std::numeric_limits<uint32_t>::max()) {
+        result[item_index] = Status::kInvalid;
+        completed[item_index] = 1;
+        continue;
+      }
+
+      conn->Encode(ep.sbuf(0), WireOp::kCache, source.key,
+                   window_count > 1 ? rdma::kV2MultiWrPutMagic : 0,
+                   window_count > 1 ? window_count : 0,
+                   totals[item_index]);
+      size_t segment_index = 0;
+      size_t logical_offset = 0;
+      for (size_t window_index = 0;
+           window_index < window_count && conn_ok; ++window_index) {
+        std::vector<std::pair<const void*, uint32_t>> segments;
+        std::vector<ibv_mr*> mrs;
+        segments.reserve(seg_limit);
+        mrs.reserve(seg_limit);
+        size_t window_bytes = 0;
+        while (segment_index < source.payloads.size() &&
+               segments.size() < seg_limit) {
+          const auto& payload = source.payloads[segment_index++];
+          if (payload.second == 0) continue;
+          ibv_mr* mr = ep.RegisterTransient(
+              const_cast<void*>(payload.first), payload.second,
+              /*remote_write=*/false);
+          if (!mr) {
             conn_ok = false;
             break;
           }
-        }
-        if (!conn_ok) break;
-        std::vector<std::pair<const void*, uint32_t>> segments;
-        segments.reserve(source.payloads.size());
-        for (const auto& payload : source.payloads) {
           segments.emplace_back(payload.first,
                                 static_cast<uint32_t>(payload.second));
+          mrs.push_back(mr);
+          window_bytes += payload.second;
         }
-        conn->Encode(ep.sbuf(slot), WireOp::kCache, source.key, 0, 0,
-                     totals[item_index]);
-        if (!ep.PostRecv(slot) ||
-            !ep.PostWriteImmScatterMulti(
-                slot, kReqPrefix, segments, mrs[slot],
-                conn->put_addr(slot), conn->recv_segment.rkey,
-                static_cast<uint32_t>(slot))) {
+        if (!conn_ok) break;
+        if (AbortMultiWrWindow(window_index + 1, window_count)) {
           conn_ok = false;
           break;
         }
-        ++posted;
+        const size_t header_len = window_index == 0 ? kReqPrefix : 0;
+        const uint64_t remote_addr =
+            conn->put_addr(0) +
+            (window_index == 0 ? 0 : kReqPrefix + logical_offset);
+        if (!ep.PostRecv(0) ||
+            !ep.PostWriteImmScatterMulti(
+                0, header_len, segments, mrs, remote_addr,
+                conn->recv_segment.rkey, 0)) {
+          conn_ok = false;
+          break;
+        }
         v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
-      }
-      std::vector<uint32_t> reply_bytes;
-      bool timed_out = false;
-      ibv_wc_status wc_status = IBV_WC_SUCCESS;
-      bool had_wcs = false;
-      if (conn_ok &&
-          !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out, &wc_status, &had_wcs)) {
-        conn_ok = false;
-        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
-      }
-      if (timed_out)
-        completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
-      if (!conn_ok) break;
-      for (auto& slot_mrs : mrs)
-        for (ibv_mr* mr : slot_mrs) ep.ReleaseTransient(mr);
-      for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = base + slot;
-        if (bad[item_index]) continue;
+        std::vector<uint32_t> reply_bytes;
+        bool timed_out = false;
+        ibv_wc_status wc_status = IBV_WC_SUCCESS;
+        bool had_wcs = false;
+        if (!ReapPosted(ep, 1, 1, &reply_bytes, BatchTimeout(), &timed_out,
+                        &wc_status, &had_wcs)) {
+          conn_ok = false;
+          completion = rdma::ClassifyCompletion(wc_status, had_wcs);
+        }
+        if (timed_out)
+          completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+        if (!conn_ok) break;
+        for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
         Status status;
         uint64_t data_len = 0;
-        if (reply_bytes[slot] < kRespPrefix ||
-            !conn->Decode(ep.rbuf(slot), &status, &data_len, 0)) {
+        if (reply_bytes[0] < kRespPrefix ||
+            !conn->Decode(ep.rbuf(0), &status, &data_len, 0)) {
           conn_ok = false;
           completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
         result[item_index] = status;
+        if (status != Status::kOk) {
+          if (window_index + 1 != window_count) {
+            conn_ok = false;
+            completion = rdma::RailCompletion::kEndpointFailure;
+          }
+          break;
+        }
+        logical_offset += window_bytes;
       }
+      if (conn_ok && result[item_index] == Status::kOk &&
+          logical_offset != totals[item_index]) {
+        conn_ok = false;
+        completion = rdma::RailCompletion::kEndpointFailure;
+      }
+      if (conn_ok) completed[item_index] = 1;
     }
     if (conn_ok) {
       Release(node, Lane::kSgData, conn);
       return result;
     }
     Destroy(conn, completion);
+    for (size_t i = 0; i < count; ++i) {
+      if (!bad[i] && !completed[i]) result[i] = Status::kIOError;
+    }
     if (from_pool) continue;
     return result;
   }
@@ -1956,11 +2001,11 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) return result;
   std::vector<char> bad(count, 0);
+  std::vector<char> completed(count, 0);
   std::vector<size_t> capacities(count, 0);
   size_t valid_count = 0;
   for (size_t i = 0; i < count; ++i) {
-    bool invalid =
-        destinations[i].payloads.size() > rdma::kV2MaxGetTargets;
+    bool invalid = false;
     size_t capacity = 0;
     for (const auto& destination : destinations[i].payloads) {
       size_t next = 0;
@@ -1986,101 +2031,143 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
   for (int attempt = 0; attempt < 2; ++attempt) {
     if (attempt != 0)
       stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
-    std::fill(result.begin(), result.end(), Status::kIOError);
-    for (size_t i = 0; i < count; ++i)
-      if (bad[i]) result[i] = Status::kInvalid;
-    if (out_lengths) out_lengths->assign(count, 0);
+    for (size_t i = 0; i < count; ++i) {
+      if (bad[i]) {
+        result[i] = Status::kInvalid;
+      } else if (!completed[i]) {
+        result[i] = Status::kIOError;
+        if (out_lengths) (*out_lengths)[i] = 0;
+      }
+    }
     bool from_pool = false;
-    // GPU multi-SGE reads need the same dedicated depth-one QP lane as writes:
-    // sharing kData reintroduces overlapping CUDA-range WRs and lets SG traffic
-    // consume the ordinary batch window.
     Conn* conn = Acquire(node, Lane::kSgData, &from_pool, attempt > 0, 1);
     if (!conn) return result;
     rdma::RcEndpoint& ep = conn->ep;
-    const size_t window = std::min(
-        ep.window(), static_cast<size_t>(conn->lease.credits));
+    const size_t target_limit =
+        std::max<size_t>(1, std::min(ep.max_sge() - 1,
+                                    rdma::kV2MaxGetTargets));
     bool conn_ok = true;
-    // Failure attribution for Destroy: post/encode/register failures keep the
-    // local-rail default; a failed reap window is classified from its WC
-    // evidence; wire decode failures blame the peer.
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
-    for (size_t base = 0; base < count && conn_ok; base += window) {
-      const size_t width = std::min(window, count - base);
-      std::vector<std::vector<ibv_mr*>> mrs(width);
-      size_t posted = 0;
-      for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = base + slot;
-        if (bad[item_index]) continue;
-        const RangeDstMulti& destination = destinations[item_index];
-        mrs[slot].assign(destination.payloads.size(), nullptr);
+
+    for (size_t item_index = 0; item_index < count && conn_ok; ++item_index) {
+      if (bad[item_index] || completed[item_index]) continue;
+      const RangeDstMulti& destination = destinations[item_index];
+      size_t nonempty = 0;
+      for (const auto& payload : destination.payloads)
+        if (payload.second != 0) ++nonempty;
+      const size_t window_count =
+          nonempty == 0 ? 1 : 1 + (nonempty - 1) / target_limit;
+      if (window_count > std::numeric_limits<uint32_t>::max()) {
+        result[item_index] = Status::kInvalid;
+        completed[item_index] = 1;
+        continue;
+      }
+
+      size_t segment_index = 0;
+      size_t logical_offset = 0;
+      uint64_t value_len = 0;
+      uint64_t response_data_len = 0;
+      uint64_t response_value_len = 0;
+      for (size_t window_index = 0;
+           window_index < window_count && conn_ok; ++window_index) {
         std::vector<RdmaWriteTarget> targets;
-        targets.reserve(destination.payloads.size());
-        for (size_t seg = 0; seg < destination.payloads.size(); ++seg) {
-          const auto& payload = destination.payloads[seg];
+        std::vector<ibv_mr*> mrs;
+        targets.reserve(target_limit);
+        mrs.reserve(target_limit);
+        size_t window_capacity = 0;
+        while (segment_index < destination.payloads.size() &&
+               targets.size() < target_limit) {
+          const auto& payload = destination.payloads[segment_index++];
           if (payload.second == 0) continue;
-          mrs[slot][seg] =
+          ibv_mr* mr =
               ep.RegisterTransient(payload.first, payload.second);
-          if (!mrs[slot][seg]) {
+          if (!mr) {
             conn_ok = false;
             break;
           }
           targets.push_back(
-              {reinterpret_cast<uint64_t>(payload.first),
-               mrs[slot][seg]->rkey,
+              {reinterpret_cast<uint64_t>(payload.first), mr->rkey,
                static_cast<uint32_t>(payload.second)});
+          mrs.push_back(mr);
+          window_capacity += payload.second;
         }
         if (!conn_ok) break;
-        size_t frame_len = 0;
-        if (!EncodeRdmaGetReq(ep.sbuf(slot), ep.cap(), keys[item_index],
-                              0, capacities[item_index], targets,
-                              &frame_len) ||
-            !ep.PostRecv(slot) || !ep.PostSend(slot, frame_len)) {
+        if (AbortMultiWrWindow(window_index + 1, window_count)) {
           conn_ok = false;
           break;
         }
-        ++posted;
+        size_t frame_len = 0;
+        if (!EncodeRdmaGetReqWindow(
+                ep.sbuf(0), ep.cap(), keys[item_index], 0,
+                capacities[item_index], targets,
+                static_cast<uint32_t>(window_index),
+                static_cast<uint32_t>(window_count), logical_offset,
+                capacities[item_index], &frame_len) ||
+            !ep.PostRecv(0) || !ep.PostSend(0, frame_len)) {
+          conn_ok = false;
+          break;
+        }
         v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
-      }
-      std::vector<uint32_t> reply_bytes;
-      bool timed_out = false;
-      ibv_wc_status wc_status = IBV_WC_SUCCESS;
-      bool had_wcs = false;
-      if (conn_ok &&
-          !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out, &wc_status, &had_wcs)) {
-        conn_ok = false;
-        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
-      }
-      if (timed_out)
-        completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
-      if (!conn_ok) break;
-      for (auto& slot_mrs : mrs)
-        for (ibv_mr* mr : slot_mrs) ep.ReleaseTransient(mr);
-      for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = base + slot;
-        if (bad[item_index]) continue;
+        std::vector<uint32_t> reply_bytes;
+        bool timed_out = false;
+        ibv_wc_status wc_status = IBV_WC_SUCCESS;
+        bool had_wcs = false;
+        if (!ReapPosted(ep, 1, 1, &reply_bytes, BatchTimeout(), &timed_out,
+                        &wc_status, &had_wcs)) {
+          conn_ok = false;
+          completion = rdma::ClassifyCompletion(wc_status, had_wcs);
+        }
+        if (timed_out)
+          completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+        if (!conn_ok) break;
+        for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
         Status status;
         uint64_t data_len = 0;
-        uint64_t value_len = 0;
-        if (reply_bytes[slot] < kRespPrefix ||
-            !conn->Decode(ep.rbuf(slot), &status, &data_len,
+        if (reply_bytes[0] < kRespPrefix ||
+            !conn->Decode(ep.rbuf(0), &status, &data_len,
                           capacities[item_index], &value_len) ||
-            value_len > std::numeric_limits<size_t>::max()) {
+            value_len > std::numeric_limits<size_t>::max() ||
+            value_len > capacities[item_index] ||
+            (status == Status::kOk && data_len != value_len) ||
+            (window_index != 0 &&
+             (status != Status::kOk ||
+              data_len != response_data_len ||
+              value_len != response_value_len))) {
           conn_ok = false;
           completion = rdma::RailCompletion::kEndpointFailure;
           break;
         }
-        result[item_index] = status;
-        if (status == Status::kOk && out_lengths) {
-          (*out_lengths)[item_index] = static_cast<size_t>(value_len);
+        if (window_index == 0) {
+          response_data_len = data_len;
+          response_value_len = value_len;
         }
+        result[item_index] = status;
+        if (status != Status::kOk) break;
+        logical_offset += window_capacity;
       }
+      if (conn_ok && result[item_index] == Status::kOk) {
+        if (logical_offset != capacities[item_index]) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kEndpointFailure;
+          break;
+        }
+        if (out_lengths)
+          (*out_lengths)[item_index] =
+              static_cast<size_t>(response_value_len);
+      }
+      if (conn_ok) completed[item_index] = 1;
     }
     if (conn_ok) {
       Release(node, Lane::kSgData, conn);
       return result;
     }
     Destroy(conn, completion);
+    for (size_t i = 0; i < count; ++i) {
+      if (!bad[i] && !completed[i]) {
+        result[i] = Status::kIOError;
+        if (out_lengths) (*out_lengths)[i] = 0;
+      }
+    }
     if (from_pool) continue;
     return result;
   }

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -120,8 +120,8 @@ class RdmaTransport : public Transport {
  private:
   struct Conn;
   // force_new skips the idle pool after a stale connection. Lanes separate
-  // payload, device-direct SG, and key-sized control traffic. SG uses a
-  // depth-one QP because overlapping multi-SGE CUDA writes fail on mlx5.
+  // payload, device-direct SG, and key-sized control traffic; each lane keeps
+  // the negotiated depth while owning an independent endpoint pool.
   enum class Lane { kData, kSgData, kControl };
   Conn* Acquire(const std::string& node, Lane lane, bool* from_pool,
                 bool force_new = false, size_t requested_credits = 1);

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -314,14 +314,17 @@ class Transport {
          valid_i < indices.size() && valid_i < valid_result.size(); ++valid_i) {
       const size_t i = indices[valid_i];
       result[i] = valid_result[valid_i];
-      if (result[i] != Status::kOk || valid_i >= stored.size()) continue;
-      if (stored[valid_i] > std::numeric_limits<size_t>::max()) {
+      if (result[i] != Status::kOk) continue;
+      if (valid_i >= stored.size()) {
         result[i] = Status::kInvalid;
         continue;
       }
-      size_t remaining =
-          std::min<size_t>(static_cast<size_t>(stored[valid_i]),
-                           scratch[i].size());
+      if (stored[valid_i] > std::numeric_limits<size_t>::max() ||
+          static_cast<size_t>(stored[valid_i]) > scratch[i].size()) {
+        result[i] = Status::kInvalid;
+        continue;
+      }
+      size_t remaining = static_cast<size_t>(stored[valid_i]);
       size_t off = 0;
       for (const auto& p : dsts[i].payloads) {
         const size_t copy = std::min(p.second, remaining);

--- a/src/transport/wire.h
+++ b/src/transport/wire.h
@@ -146,9 +146,10 @@ inline bool DecodeResp(const char* p, Status* st, uint64_t* data_len,
                            value_len);
 }
 
-// RDMA v2 GET carries one or more client destinations after the request prefix.
-// The server returns metadata in the response prefix and RDMA-WRITEs raw value
-// bytes into these regions in order.
+// RDMA v2 GET carries one bounded window of client destinations after the
+// request prefix. window_index/window_count bind multiple ordered requests to
+// one logical lookup; logical_offset selects the slice of the already-read
+// value written by this window.
 struct RdmaWriteTarget {
   uint64_t addr = 0;
   uint32_t rkey = 0;
@@ -157,6 +158,10 @@ struct RdmaWriteTarget {
 
 struct RdmaGetFields {
   std::vector<RdmaWriteTarget> targets;
+  uint32_t window_index = 0;
+  uint32_t window_count = 1;
+  uint64_t logical_offset = 0;
+  uint64_t total_capacity = 0;
 
   bool Capacity(uint64_t* capacity) const {
     if (capacity == nullptr) return false;
@@ -176,8 +181,9 @@ struct RdmaGetFields {
   }
 };
 
-constexpr size_t kRdmaGetFixed = 4;   // target_count(4)
-constexpr size_t kRdmaGetTarget = 16; // addr(8), rkey(4), length(4)
+constexpr uint32_t kRdmaGetWindowMagic = 0x3257474du;  // "MGW2" (LE)
+constexpr size_t kRdmaGetFixed = 32;
+constexpr size_t kRdmaGetTarget = 16;  // addr(8), rkey(4), length(4)
 
 inline size_t RdmaGetFrameSize(size_t target_count) {
   if (target_count >
@@ -188,28 +194,42 @@ inline size_t RdmaGetFrameSize(size_t target_count) {
   return kReqPrefix + kRdmaGetFixed + target_count * kRdmaGetTarget;
 }
 
-inline bool EncodeRdmaGetReq(char* p, size_t cap, const BlockKey& key,
-                             uint64_t offset, uint64_t length,
-                             const std::vector<RdmaWriteTarget>& targets,
-                             size_t* encoded_len) {
+inline bool EncodeRdmaGetReqWindow(
+    char* p, size_t cap, const BlockKey& key, uint64_t offset,
+    uint64_t length, const std::vector<RdmaWriteTarget>& targets,
+    uint32_t window_index, uint32_t window_count, uint64_t logical_offset,
+    uint64_t total_capacity, size_t* encoded_len) {
   const size_t frame_len = RdmaGetFrameSize(targets.size());
   if (p == nullptr || encoded_len == nullptr || frame_len == 0 ||
       frame_len > cap ||
-      targets.size() > std::numeric_limits<uint32_t>::max()) {
+      targets.size() > std::numeric_limits<uint32_t>::max() ||
+      window_count == 0 || window_index >= window_count ||
+      logical_offset > total_capacity || length > total_capacity) {
     return false;
   }
-  uint64_t capacity = 0;
+  uint64_t window_capacity = 0;
   for (const auto& target : targets) {
-    if ((target.length != 0 && (target.addr == 0 || target.rkey == 0)) ||
-        target.length > std::numeric_limits<uint64_t>::max() - capacity) {
+    if ((target.length != 0 &&
+         (target.addr == 0 || target.rkey == 0 ||
+          target.addr >
+              std::numeric_limits<uint64_t>::max() -
+                  (static_cast<uint64_t>(target.length) - 1))) ||
+        target.length >
+            std::numeric_limits<uint64_t>::max() - window_capacity) {
       return false;
     }
-    capacity += target.length;
+    window_capacity += target.length;
   }
-  if (capacity < length) return false;
+  if (window_capacity > total_capacity - logical_offset) return false;
+  if (window_count > 1 && window_capacity == 0) return false;
   EncodeReqVersion(p, kNativeProtoRdmaV2, WireOp::kRange, key, offset, length,
                    0);
   net::PutU32(p + kReqPrefix, static_cast<uint32_t>(targets.size()));
+  net::PutU32(p + kReqPrefix + 4, kRdmaGetWindowMagic);
+  net::PutU32(p + kReqPrefix + 8, window_index);
+  net::PutU32(p + kReqPrefix + 12, window_count);
+  net::PutU64(p + kReqPrefix + 16, logical_offset);
+  net::PutU64(p + kReqPrefix + 24, total_capacity);
   char* out = p + kReqPrefix + kRdmaGetFixed;
   for (const auto& target : targets) {
     net::PutU64(out, target.addr);
@@ -221,39 +241,71 @@ inline bool EncodeRdmaGetReq(char* p, size_t cap, const BlockKey& key,
   return true;
 }
 
+inline bool EncodeRdmaGetReq(char* p, size_t cap, const BlockKey& key,
+                             uint64_t offset, uint64_t length,
+                             const std::vector<RdmaWriteTarget>& targets,
+                             size_t* encoded_len) {
+  uint64_t capacity = 0;
+  for (const auto& target : targets) {
+    if (target.length > std::numeric_limits<uint64_t>::max() - capacity)
+      return false;
+    capacity += target.length;
+  }
+  return EncodeRdmaGetReqWindow(p, cap, key, offset, length, targets, 0, 1, 0,
+                                capacity, encoded_len);
+}
+
 inline bool DecodeRdmaGetReq(const char* p, size_t frame_len, ReqFields* req,
                              RdmaGetFields* get,
                              uint64_t max_payload = kMaxFrameLen) {
   if (frame_len < kReqPrefix + kRdmaGetFixed ||
       !DecodeReqVersion(p, kNativeProtoRdmaV2, req, max_payload) ||
       req->op != static_cast<uint8_t>(WireOp::kRange) ||
-      req->payload_len != 0) {
+      req->payload_len != 0 ||
+      net::GetU32(p + kReqPrefix + 4) != kRdmaGetWindowMagic) {
     return false;
   }
   const uint32_t count = net::GetU32(p + kReqPrefix);
   const size_t expected = RdmaGetFrameSize(count);
   if (expected == 0 || expected != frame_len) return false;
+  get->window_index = net::GetU32(p + kReqPrefix + 8);
+  get->window_count = net::GetU32(p + kReqPrefix + 12);
+  get->logical_offset = net::GetU64(p + kReqPrefix + 16);
+  get->total_capacity = net::GetU64(p + kReqPrefix + 24);
+  if (get->window_count == 0 ||
+      get->window_index >= get->window_count ||
+      get->logical_offset > get->total_capacity ||
+      get->total_capacity > max_payload ||
+      req->length > get->total_capacity ||
+      req->offset > std::numeric_limits<uint64_t>::max() - req->length) {
+    return false;
+  }
   get->targets.clear();
   get->targets.reserve(count);
   const char* in = p + kReqPrefix + kRdmaGetFixed;
-  uint64_t capacity = 0;
+  uint64_t window_capacity = 0;
   for (uint32_t i = 0; i < count; ++i) {
     RdmaWriteTarget target;
     target.addr = net::GetU64(in);
     target.rkey = net::GetU32(in + 8);
     target.length = net::GetU32(in + 12);
-    if (target.length != 0 && (target.addr == 0 || target.rkey == 0)) {
+    if (target.length != 0 &&
+        (target.addr == 0 || target.rkey == 0 ||
+         target.addr >
+             std::numeric_limits<uint64_t>::max() -
+                 (static_cast<uint64_t>(target.length) - 1))) {
       return false;
     }
-    if (capacity > std::numeric_limits<uint64_t>::max() - target.length) {
+    if (target.length >
+        std::numeric_limits<uint64_t>::max() - window_capacity) {
       return false;
     }
-    capacity += target.length;
+    window_capacity += target.length;
     get->targets.push_back(target);
     in += kRdmaGetTarget;
   }
-  if (capacity < req->length) return false;
-  return true;
+  return (get->window_count == 1 || window_capacity != 0) &&
+         window_capacity <= get->total_capacity - get->logical_offset;
 }
 
 }  // namespace dfkv

--- a/src/transport/wire.h
+++ b/src/transport/wire.h
@@ -1,5 +1,5 @@
 /* Versioned native dfkv wire.
- * TCP epoch 6 and RDMA epoch 7 carry a tenant hash plus the full 128-bit
+ * TCP epoch 6 and RDMA epoch 8 carry a tenant hash plus the full 128-bit
  * object identity and authoritative stored-value length. Other epochs are
  * rejected before field decoding.
  */
@@ -34,7 +34,7 @@ enum class WireOp : uint8_t {
 };
 
 constexpr uint8_t kNativeProtoTcp = 6;
-constexpr uint8_t kNativeProtoRdmaV2 = 7;
+constexpr uint8_t kNativeProtoRdmaV2 = 8;
 constexpr uint8_t kProtoVersion = kNativeProtoTcp;
 
 // Hard ceiling on a single wire frame's variable payload. Decode rejects any
@@ -147,9 +147,10 @@ inline bool DecodeResp(const char* p, Status* st, uint64_t* data_len,
 }
 
 // RDMA v2 GET carries one bounded window of client destinations after the
-// request prefix. window_index/window_count bind multiple ordered requests to
-// one logical lookup; logical_offset selects the slice of the already-read
-// value written by this window.
+// request prefix. operation_id is a connection-local logical-request slot;
+// window_index/window_count bind ordered requests to that slot and
+// logical_offset selects the slice of the already-read value written by this
+// window.
 struct RdmaWriteTarget {
   uint64_t addr = 0;
   uint32_t rkey = 0;
@@ -158,6 +159,7 @@ struct RdmaWriteTarget {
 
 struct RdmaGetFields {
   std::vector<RdmaWriteTarget> targets;
+  uint32_t operation_id = 0;
   uint32_t window_index = 0;
   uint32_t window_count = 1;
   uint64_t logical_offset = 0;
@@ -181,8 +183,8 @@ struct RdmaGetFields {
   }
 };
 
-constexpr uint32_t kRdmaGetWindowMagic = 0x3257474du;  // "MGW2" (LE)
-constexpr size_t kRdmaGetFixed = 32;
+constexpr uint32_t kRdmaGetWindowMagic = 0x3357474du;  // "MGW3" (LE)
+constexpr size_t kRdmaGetFixed = 40;
 constexpr size_t kRdmaGetTarget = 16;  // addr(8), rkey(4), length(4)
 
 inline size_t RdmaGetFrameSize(size_t target_count) {
@@ -197,8 +199,8 @@ inline size_t RdmaGetFrameSize(size_t target_count) {
 inline bool EncodeRdmaGetReqWindow(
     char* p, size_t cap, const BlockKey& key, uint64_t offset,
     uint64_t length, const std::vector<RdmaWriteTarget>& targets,
-    uint32_t window_index, uint32_t window_count, uint64_t logical_offset,
-    uint64_t total_capacity, size_t* encoded_len) {
+    uint32_t operation_id, uint32_t window_index, uint32_t window_count,
+    uint64_t logical_offset, uint64_t total_capacity, size_t* encoded_len) {
   const size_t frame_len = RdmaGetFrameSize(targets.size());
   if (p == nullptr || encoded_len == nullptr || frame_len == 0 ||
       frame_len > cap ||
@@ -226,10 +228,12 @@ inline bool EncodeRdmaGetReqWindow(
                    0);
   net::PutU32(p + kReqPrefix, static_cast<uint32_t>(targets.size()));
   net::PutU32(p + kReqPrefix + 4, kRdmaGetWindowMagic);
-  net::PutU32(p + kReqPrefix + 8, window_index);
-  net::PutU32(p + kReqPrefix + 12, window_count);
-  net::PutU64(p + kReqPrefix + 16, logical_offset);
-  net::PutU64(p + kReqPrefix + 24, total_capacity);
+  net::PutU32(p + kReqPrefix + 8, operation_id);
+  net::PutU32(p + kReqPrefix + 12, window_index);
+  net::PutU32(p + kReqPrefix + 16, window_count);
+  net::PutU32(p + kReqPrefix + 20, 0);
+  net::PutU64(p + kReqPrefix + 24, logical_offset);
+  net::PutU64(p + kReqPrefix + 32, total_capacity);
   char* out = p + kReqPrefix + kRdmaGetFixed;
   for (const auto& target : targets) {
     net::PutU64(out, target.addr);
@@ -251,8 +255,8 @@ inline bool EncodeRdmaGetReq(char* p, size_t cap, const BlockKey& key,
       return false;
     capacity += target.length;
   }
-  return EncodeRdmaGetReqWindow(p, cap, key, offset, length, targets, 0, 1, 0,
-                                capacity, encoded_len);
+  return EncodeRdmaGetReqWindow(p, cap, key, offset, length, targets, 0, 0, 1,
+                                0, capacity, encoded_len);
 }
 
 inline bool DecodeRdmaGetReq(const char* p, size_t frame_len, ReqFields* req,
@@ -268,11 +272,13 @@ inline bool DecodeRdmaGetReq(const char* p, size_t frame_len, ReqFields* req,
   const uint32_t count = net::GetU32(p + kReqPrefix);
   const size_t expected = RdmaGetFrameSize(count);
   if (expected == 0 || expected != frame_len) return false;
-  get->window_index = net::GetU32(p + kReqPrefix + 8);
-  get->window_count = net::GetU32(p + kReqPrefix + 12);
-  get->logical_offset = net::GetU64(p + kReqPrefix + 16);
-  get->total_capacity = net::GetU64(p + kReqPrefix + 24);
-  if (get->window_count == 0 ||
+  get->operation_id = net::GetU32(p + kReqPrefix + 8);
+  get->window_index = net::GetU32(p + kReqPrefix + 12);
+  get->window_count = net::GetU32(p + kReqPrefix + 16);
+  get->logical_offset = net::GetU64(p + kReqPrefix + 24);
+  get->total_capacity = net::GetU64(p + kReqPrefix + 32);
+  if (net::GetU32(p + kReqPrefix + 20) != 0 ||
+      get->window_count == 0 ||
       get->window_index >= get->window_count ||
       get->logical_offset > get->total_capacity ||
       get->total_capacity > max_payload ||

--- a/test/client/c_api_test.cc
+++ b/test/client/c_api_test.cc
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
@@ -56,6 +57,16 @@ class CApiTransport final : public dfkv::Transport {
     Throw();
     return 29;
   }
+  std::vector<dfkv::Status> RangeIntoMulti(
+      const std::string&, const std::vector<dfkv::BlockKey>& keys,
+      const std::vector<dfkv::RangeDstMulti>&,
+      std::vector<size_t>* out_lens) override {
+    range_into_multi_called.store(true, std::memory_order_relaxed);
+    Throw();
+    if (out_lens) out_lens->assign(keys.size(), 0);
+    return std::vector<dfkv::Status>(keys.size(), dfkv::Status::kNotFound);
+  }
+  std::atomic<bool> range_into_multi_called{false};
   std::string MetricsText() const override {
     Throw();
     return {};
@@ -294,7 +305,7 @@ TEST(CApiRegistration, PropagatesNativeRegistrationFailure) {
   dfkv_close(c);
 }
 
-TEST(CApiNoThrow, EveryOperationFamilyTranslatesInjectedExceptions) {
+TEST(CApiNoThrow, EveryOperationFamilyContainsInjectedExceptions) {
   CApiTransport transport;
   dfkv_client_t c = Injected(&transport);
   transport.throwing = true;
@@ -350,11 +361,16 @@ TEST(CApiNoThrow, EveryOperationFamilyTranslatesInjectedExceptions) {
   void** sg_dsts[] = {sg_dst};
   out[0] = 9;
   lengths[0] = 9;
+  // SG reads run on the bounded read scheduler. It contains transport
+  // exceptions as per-item misses before control returns to the C ABI, whereas
+  // SG writes execute this single-item fake inline and reach the ABI guard.
   EXPECT_EQ(dfkv_batch_get_auto_sg(c, keys, key_lens, sg_dsts,
                                    sg_sizes_array, counts, 1, out, lengths),
-            -1);
+            0);
   EXPECT_EQ(out[0], 0);
   EXPECT_EQ(lengths[0], 0u);
+  EXPECT_TRUE(
+      transport.range_into_multi_called.load(std::memory_order_relaxed));
 
   char stats[16] = {'X'};
   EXPECT_EQ(dfkv_stats_snapshot(c, stats, sizeof(stats)), 0u);

--- a/test/client/kv_client_test.cc
+++ b/test/client/kv_client_test.cc
@@ -192,6 +192,55 @@ TEST_F(KVClientTest, RawPayloadCorruptionIsReturned) {
   EXPECT_EQ(out[100], '!');                           // the corrupted byte is returned
 }
 
+TEST_F(KVClientTest, ScatterGatherMultiWindowSemanticsMatchTcp) {
+  nodes_.push_back(StartNode("sg_multiwr_tcp"));
+  KVClient c({{"a", nodes_[0]->addr}}, SelfHdr());
+
+  constexpr size_t kSegments = 67;  // more than two 29-SGE WR windows
+  std::vector<std::string> src(kSegments);
+  std::vector<const void*> ptrs;
+  std::vector<size_t> sizes;
+  std::string expected;
+  for (size_t i = 0; i < kSegments; ++i) {
+    const size_t len = (i == 3 || i == 31) ? 0 : 5 + i % 17;
+    src[i].resize(len);
+    for (size_t j = 0; j < len; ++j)
+      src[i][j] = static_cast<char>((i * 37 + j * 11) & 0xff);
+    ptrs.push_back(src[i].data());
+    sizes.push_back(len);
+    expected.append(static_cast<const char*>(ptrs[i]), sizes[i]);
+  }
+
+  const auto put = c.BatchPutSg({{"tcp_multiwr", ptrs, sizes}});
+  ASSERT_EQ(put.size(), 1u);
+  ASSERT_TRUE(put[0]);
+  EXPECT_EQ(nodes_[0]->srv->Count(), 1u);
+
+  std::vector<std::string> dst(kSegments);
+  std::vector<void*> dptrs;
+  for (size_t i = 0; i < kSegments; ++i) {
+    dst[i].assign(sizes[i], '\0');
+    dptrs.push_back(dst[i].data());
+  }
+  std::vector<size_t> lens;
+  const auto get = c.BatchGetAutoSg(
+      {{"tcp_multiwr", dptrs, sizes}}, &lens);
+  ASSERT_EQ(get.size(), 1u);
+  ASSERT_TRUE(get[0]);
+  ASSERT_EQ(lens.size(), 1u);
+  EXPECT_EQ(lens[0], expected.size());
+  std::string scattered;
+  for (size_t i = 0; i < dst.size(); ++i) {
+    EXPECT_EQ(dst[i], src[i]) << "segment " << i;
+    scattered += dst[i];
+  }
+  EXPECT_EQ(scattered, expected);
+
+  std::string ordinary(expected.size(), '\0');
+  ASSERT_TRUE(c.Get("tcp_multiwr", ordinary.data(), ordinary.size()));
+  EXPECT_EQ(ordinary, expected);
+}
+
 TEST_F(KVClientTest, TwoNodeConsistentHashCrossNodeRead) {
   nodes_.push_back(StartNode("n1"));
   nodes_.push_back(StartNode("n2"));

--- a/test/client/kv_client_test.cc
+++ b/test/client/kv_client_test.cc
@@ -196,49 +196,74 @@ TEST_F(KVClientTest, ScatterGatherMultiWindowSemanticsMatchTcp) {
   nodes_.push_back(StartNode("sg_multiwr_tcp"));
   KVClient c({{"a", nodes_[0]->addr}}, SelfHdr());
 
-  constexpr size_t kSegments = 67;  // more than two 29-SGE WR windows
-  std::vector<std::string> src(kSegments);
-  std::vector<const void*> ptrs;
-  std::vector<size_t> sizes;
-  std::string expected;
-  for (size_t i = 0; i < kSegments; ++i) {
-    const size_t len = (i == 3 || i == 31) ? 0 : 5 + i % 17;
-    src[i].resize(len);
-    for (size_t j = 0; j < len; ++j)
-      src[i][j] = static_cast<char>((i * 37 + j * 11) & 0xff);
-    ptrs.push_back(src[i].data());
-    sizes.push_back(len);
-    expected.append(static_cast<const char*>(ptrs[i]), sizes[i]);
+  constexpr size_t kItems = 2;
+  constexpr size_t kSegments = 97;  // at least four 29-SGE RDMA windows
+  std::vector<std::vector<std::string>> src(
+      kItems, std::vector<std::string>(kSegments));
+  std::vector<std::vector<const void*>> ptrs(kItems);
+  std::vector<std::vector<size_t>> sizes(kItems);
+  std::vector<std::string> expected(kItems);
+  std::vector<KvPutItemSg> puts;
+  for (size_t item = 0; item < kItems; ++item) {
+    for (size_t segment = 0; segment < kSegments; ++segment) {
+      const size_t len =
+          (segment == 3 + item || segment == 31 + item) ? 0
+                                                        : 5 + segment % 17;
+      src[item][segment].resize(len);
+      for (size_t byte = 0; byte < len; ++byte) {
+        src[item][segment][byte] = static_cast<char>(
+            (item * 149 + segment * 37 + byte * 11) & 0xff);
+      }
+      ptrs[item].push_back(src[item][segment].data());
+      sizes[item].push_back(len);
+      expected[item].append(src[item][segment]);
+    }
+    puts.push_back({"tcp_multiwr_" + std::to_string(item), ptrs[item],
+                    sizes[item]});
   }
 
-  const auto put = c.BatchPutSg({{"tcp_multiwr", ptrs, sizes}});
-  ASSERT_EQ(put.size(), 1u);
-  ASSERT_TRUE(put[0]);
-  EXPECT_EQ(nodes_[0]->srv->Count(), 1u);
+  const auto put = c.BatchPutSg(puts);
+  ASSERT_EQ(put.size(), kItems);
+  for (size_t item = 0; item < kItems; ++item) ASSERT_TRUE(put[item]);
+  EXPECT_EQ(nodes_[0]->srv->Count(), kItems);
 
-  std::vector<std::string> dst(kSegments);
-  std::vector<void*> dptrs;
-  for (size_t i = 0; i < kSegments; ++i) {
-    dst[i].assign(sizes[i], '\0');
-    dptrs.push_back(dst[i].data());
+  std::vector<std::vector<std::string>> dst(
+      kItems, std::vector<std::string>(kSegments));
+  std::vector<KvGetItemSg> gets;
+  for (size_t item = 0; item < kItems; ++item) {
+    std::vector<void*> dptrs;
+    for (size_t segment = 0; segment < kSegments; ++segment) {
+      dst[item][segment].assign(sizes[item][segment], '\0');
+      dptrs.push_back(dst[item][segment].data());
+    }
+    gets.push_back({"tcp_multiwr_" + std::to_string(item), dptrs,
+                    sizes[item]});
   }
+
   std::vector<size_t> lens;
-  const auto get = c.BatchGetAutoSg(
-      {{"tcp_multiwr", dptrs, sizes}}, &lens);
-  ASSERT_EQ(get.size(), 1u);
-  ASSERT_TRUE(get[0]);
-  ASSERT_EQ(lens.size(), 1u);
-  EXPECT_EQ(lens[0], expected.size());
-  std::string scattered;
-  for (size_t i = 0; i < dst.size(); ++i) {
-    EXPECT_EQ(dst[i], src[i]) << "segment " << i;
-    scattered += dst[i];
+  const auto get = c.BatchGetAutoSg(gets, &lens);
+  ASSERT_EQ(get.size(), kItems);
+  ASSERT_EQ(lens.size(), kItems);
+  for (size_t item = 0; item < kItems; ++item) {
+    ASSERT_TRUE(get[item]) << "item " << item;
+    EXPECT_EQ(lens[item], expected[item].size()) << "item " << item;
+    std::string scattered;
+    for (size_t segment = 0; segment < kSegments; ++segment) {
+      EXPECT_EQ(dst[item][segment], src[item][segment])
+          << "item " << item << " segment " << segment;
+      scattered += dst[item][segment];
+    }
+    EXPECT_EQ(scattered, expected[item]) << "item " << item;
+    EXPECT_NE(scattered, expected[1 - item])
+        << "distinct logical GETs contaminated each other";
   }
-  EXPECT_EQ(scattered, expected);
 
-  std::string ordinary(expected.size(), '\0');
-  ASSERT_TRUE(c.Get("tcp_multiwr", ordinary.data(), ordinary.size()));
-  EXPECT_EQ(ordinary, expected);
+  for (size_t item = 0; item < kItems; ++item) {
+    std::string ordinary(expected[item].size(), '\0');
+    ASSERT_TRUE(c.Get("tcp_multiwr_" + std::to_string(item), ordinary.data(),
+                      ordinary.size()));
+    EXPECT_EQ(ordinary, expected[item]);
+  }
 }
 
 TEST_F(KVClientTest, TwoNodeConsistentHashCrossNodeRead) {

--- a/test/client/sg_test.cc
+++ b/test/client/sg_test.cc
@@ -1,9 +1,8 @@
 // Scatter-gather (multi-buffer-per-key) round-trip tests for the additive
 // dfkv_batch_put_sg / dfkv_batch_get_auto_sg path. One dfkv key gathers N
 // non-contiguous source buffers on put and scatters into N destination buffers
-// on get. Exercises N=1, N=2, N=29, the >29 guard, and a multi-key/multi-node
-// fan-out. Runs over the loopback TCP transport (default-fallback SG path), which
-// is what the build env provides when RDMA is unavailable.
+// on get. Exercises small widths, variable segment sizes, logical widths larger
+// than one transport window, and multi-key/multi-node fan-out over loopback TCP.
 #include "client/kv_client.h"
 #include "cache/kv_node_server.h"
 
@@ -92,7 +91,7 @@ TEST(Sg, RoundTripN2) {
 TEST(Sg, RoundTripN29) {
   auto a = Start("n29");
   KVClient c({{"a", a->addr}}, Hdr());
-  RoundTrip(c, "k_n29", 29, 128);  // max allowed (max_sge-1)
+  RoundTrip(c, "k_n29", 29, 128);
   a->srv->Stop();
 }
 
@@ -118,29 +117,45 @@ TEST(Sg, RoundTripVariableSizes) {
   a->srv->Stop();
 }
 
-// >29 buffers must be reported failed (put) and a miss (get), not corrupt.
-TEST(Sg, OverLimitGuard) {
-  auto a = Start("over");
+// Logical SG width is not capped by one transport window. Use enough uniquely
+// sized and populated segments to cross two boundaries, so both PUT gathering
+// and GET scattering must preserve every byte in order across multiple windows.
+TEST(Sg, UnlimitedLogicalWidthRoundTripsByteExact) {
+  auto a = Start("unlimited_width");
   KVClient c({{"a", a->addr}}, Hdr());
-  const size_t kBad = 30;  // 30 > max_sge-1 (=29)
-  std::vector<size_t> sizes(kBad, 16);
-  auto src = MakeChunks("over", sizes);
-  std::vector<const void*> ptrs;
-  for (auto& s : src) ptrs.push_back(s.data());
-  KvPutItemSg put{"k_over", ptrs, sizes};
-  auto pr = c.BatchPutSg({put});
-  ASSERT_EQ(pr.size(), 1u);
-  EXPECT_FALSE(pr[0]) << "30-segment put must be rejected by the guard";
+  const size_t window_segs = c.MaxSgPayloadSegs();
+  ASSERT_GT(window_segs, 0u);
+  const size_t nsegs = window_segs * 2 + 3;
 
-  // The key was never written, so a get is a miss too (and a 30-dst get is also
-  // guarded out independently).
-  std::vector<std::string> dst(kBad);
+  std::vector<size_t> sizes;
+  sizes.reserve(nsegs);
+  for (size_t i = 0; i < nsegs; ++i) sizes.push_back(1 + (i * 17) % 97);
+  auto src = MakeChunks("unlimited_width", sizes);
+  std::vector<const void*> ptrs;
+  ptrs.reserve(nsegs);
+  for (auto& segment : src) ptrs.push_back(segment.data());
+
+  const auto put = c.BatchPutSg({{"k_unlimited_width", ptrs, sizes}});
+  ASSERT_EQ(put.size(), 1u);
+  ASSERT_TRUE(put[0]);
+
+  std::vector<std::string> dst(nsegs);
   std::vector<void*> dptrs;
-  for (size_t i = 0; i < kBad; ++i) { dst[i].assign(16, '\0'); dptrs.push_back(&dst[i][0]); }
-  KvGetItemSg get{"k_over", dptrs, sizes};
-  std::vector<size_t> lens;
-  auto gr = c.BatchGetAutoSg({get}, &lens);
-  EXPECT_FALSE(gr[0]) << "30-segment get must be rejected by the guard";
+  dptrs.reserve(nsegs);
+  for (size_t i = 0; i < nsegs; ++i) {
+    dst[i].assign(sizes[i], '\0');
+    dptrs.push_back(dst[i].data());
+  }
+  std::vector<size_t> lengths;
+  const auto get = c.BatchGetAutoSg(
+      {{"k_unlimited_width", dptrs, sizes}}, &lengths);
+  ASSERT_EQ(get.size(), 1u);
+  ASSERT_EQ(lengths.size(), 1u);
+  ASSERT_TRUE(get[0]);
+  EXPECT_EQ(lengths[0],
+            std::accumulate(sizes.begin(), sizes.end(), size_t{0}));
+  for (size_t i = 0; i < nsegs; ++i)
+    EXPECT_EQ(dst[i], src[i]) << "segment " << i;
   a->srv->Stop();
 }
 

--- a/test/python/test_dfkv_vllm_connector.py
+++ b/test/python/test_dfkv_vllm_connector.py
@@ -179,6 +179,11 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "integration" / "common" / "src"))
 sys.path.insert(0, str(ROOT / "integration" / "vllm" / "src"))
 
+from dfkv_common import VLLM_RAW_V1, pool_key  # noqa: E402
+from dfkv_vllm.data import (  # noqa: E402
+    KeyMetadata,
+    PoolKey,
+)
 from dfkv_vllm.metrics import (  # noqa: E402
     DfkvStoreConnectorStats,
     DfkvStorePromMetrics,
@@ -311,6 +316,59 @@ class SchedulerLookupTest(unittest.TestCase):
 
         self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (0, False))
         self.assertEqual(client.calls[0][2], ())
+
+
+class LogicalChunkNamespaceTest(unittest.TestCase):
+    def test_multiwr_v2_component_isolated_from_legacy_layouts(self) -> None:
+        metadata = KeyMetadata(
+            model_name="model",
+            dp_size=2,
+            dp_rank=1,
+            tp_size=4,
+            tp_rank=3,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=2,
+            pp_rank=1,
+            group_id=5,
+        )
+        chunk_hash = bytes(range(32))
+        generated = PoolKey(metadata, chunk_hash).to_bytes()
+        coordinates = dict(
+            pool="kv",
+            dp_size=2,
+            dp_rank=1,
+            tp_size=4,
+            tp_rank=3,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=2,
+            pp_rank=1,
+            group_id=5,
+        )
+        expected_v2 = pool_key(
+            chunk_hash,
+            component="vllm-multiwr-v2",
+            **coordinates,
+        )
+        legacy_raw = pool_key(
+            chunk_hash,
+            component=VLLM_RAW_V1,
+            **coordinates,
+        )
+        legacy_sg = pool_key(
+            chunk_hash,
+            component="sg-v1",
+            **coordinates,
+        )
+
+        self.assertEqual(generated, expected_v2)
+        self.assertNotEqual(generated, legacy_raw)
+        self.assertNotEqual(generated, legacy_sg)
 
 
 class _PromMetric:

--- a/test/python/test_dfkv_vllm_connector.py
+++ b/test/python/test_dfkv_vllm_connector.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from importlib.util import find_spec
 import sys
+import threading
 import unittest
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -70,6 +71,22 @@ def _install_vllm_stubs() -> None:
     class BlockHash(bytes):
         pass
 
+    class KVConnectorBase_V1:
+        pass
+
+    class SupportsHMA:
+        pass
+
+    class KVConnectorRole:
+        SCHEDULER = "scheduler"
+        WORKER = "worker"
+
+    class KVConnectorKVEvents:
+        pass
+
+    class KVEventAggregator:
+        pass
+
     @dataclass
     class KVCacheBlock:
         block_id: int
@@ -106,13 +123,22 @@ def _install_vllm_stubs() -> None:
         get_tensor_model_parallel_rank=lambda: 0,
         get_tensor_model_parallel_world_size=lambda: 1,
     )
-    stub("vllm.distributed.kv_events", BlockStored=BlockStored)
+    stub(
+        "vllm.distributed.kv_events",
+        BlockStored=BlockStored,
+        KVCacheEvent=Placeholder,
+        KVConnectorKVEvents=KVConnectorKVEvents,
+        KVEventAggregator=KVEventAggregator,
+    )
     stub("vllm.distributed.kv_transfer")
     stub("vllm.distributed.kv_transfer.kv_connector")
     stub("vllm.distributed.kv_transfer.kv_connector.v1")
     stub(
         "vllm.distributed.kv_transfer.kv_connector.v1.base",
+        KVConnectorBase_V1=KVConnectorBase_V1,
         KVConnectorMetadata=Placeholder,
+        KVConnectorRole=KVConnectorRole,
+        SupportsHMA=SupportsHMA,
     )
     stub(
         "vllm.distributed.kv_transfer.kv_connector.v1.metrics",
@@ -122,6 +148,7 @@ def _install_vllm_stubs() -> None:
         PromMetricT=PromMetric,
     )
     stub("vllm.logger", init_logger=logging.getLogger)
+    stub("vllm.forward_context", ForwardContext=Placeholder)
     stub("vllm.utils")
     stub(
         "vllm.utils.math_utils",
@@ -135,6 +162,11 @@ def _install_vllm_stubs() -> None:
         make_zmq_socket=lambda *_args, **_kwargs: None,
     )
     stub("vllm.v1")
+    stub("vllm.v1.attention")
+    stub(
+        "vllm.v1.attention.backend",
+        AttentionMetadata=Placeholder,
+    )
     stub("vllm.v1.core")
     stub("vllm.v1.core.block_pool", BlockPool=Placeholder)
     stub("vllm.v1.core.kv_cache_manager", KVCacheBlocks=Placeholder)
@@ -165,6 +197,7 @@ def _install_vllm_stubs() -> None:
         KVCacheSpec=Placeholder,
         UniformTypeKVCacheSpecs=Placeholder,
     )
+    stub("vllm.v1.outputs", KVConnectorOutput=Placeholder)
     stub(
         "vllm.v1.kv_cache_spec_registry",
         KVCacheSpecRegistry=KVCacheSpecRegistry,
@@ -180,7 +213,9 @@ sys.path.insert(0, str(ROOT / "integration" / "common" / "src"))
 sys.path.insert(0, str(ROOT / "integration" / "vllm" / "src"))
 
 from dfkv_common import VLLM_RAW_V1, pool_key  # noqa: E402
+from dfkv_vllm.connector import DfkvStoreConnector  # noqa: E402
 from dfkv_vllm.data import (  # noqa: E402
+    DfkvStoreConnectorMetadata,
     KeyMetadata,
     PoolKey,
 )
@@ -316,6 +351,145 @@ class SchedulerLookupTest(unittest.TestCase):
 
         self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (0, False))
         self.assertEqual(client.calls[0][2], ())
+
+
+class _BlockingConnectorBackend:
+    def __init__(self) -> None:
+        self.call_entered = threading.Barrier(2)
+        self.call_release = threading.Barrier(2)
+        self.close_calls = 0
+
+    def _block_call(self) -> None:
+        self.call_entered.wait(timeout=5)
+        self.call_release.wait(timeout=5)
+
+    def get_finished(self, finished_req_ids, metadata):
+        self._block_call()
+        return set(finished_req_ids), set(metadata.unfinished_request_ids)
+
+    def request_finished(self, request, block_ids):
+        self._block_call()
+        return True, {"request_id": request.request_id, "block_ids": block_ids}
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class ConnectorShutdownGateTest(unittest.TestCase):
+    @staticmethod
+    def _connector(
+        *,
+        worker: _BlockingConnectorBackend | None = None,
+        scheduler: _BlockingConnectorBackend | None = None,
+    ) -> DfkvStoreConnector:
+        connector = DfkvStoreConnector.__new__(DfkvStoreConnector)
+        connector._shutdown_condition = threading.Condition()
+        connector._inflight_calls = 0
+        connector._shutdown = False
+        connector._shutdown_complete = False
+        connector.connector_worker = worker
+        connector.connector_scheduler = scheduler
+        return connector
+
+    def _assert_shutdown_waits_for_call(
+        self,
+        connector: DfkvStoreConnector,
+        backend: _BlockingConnectorBackend,
+        call,
+        rejected_call,
+    ):
+        call_results = []
+        thread_errors = []
+
+        def run_call() -> None:
+            try:
+                call_results.append(call())
+            except BaseException as error:
+                thread_errors.append(error)
+
+        def run_shutdown() -> None:
+            try:
+                connector.shutdown()
+            except BaseException as error:
+                thread_errors.append(error)
+
+        call_thread = threading.Thread(target=run_call)
+        call_thread.start()
+        backend.call_entered.wait(timeout=5)
+
+        shutdown_thread = threading.Thread(target=run_shutdown)
+        shutdown_thread.start()
+        with connector._shutdown_condition:
+            self.assertTrue(
+                connector._shutdown_condition.wait_for(
+                    lambda: connector._shutdown, timeout=5
+                )
+            )
+
+        self.assertTrue(shutdown_thread.is_alive())
+        self.assertEqual(backend.close_calls, 0)
+        with self.assertRaisesRegex(RuntimeError, "connector is shut down"):
+            rejected_call()
+
+        backend.call_release.wait(timeout=5)
+        call_thread.join(timeout=5)
+        shutdown_thread.join(timeout=5)
+        self.assertFalse(call_thread.is_alive())
+        self.assertFalse(shutdown_thread.is_alive())
+        self.assertEqual(thread_errors, [])
+        self.assertEqual(backend.close_calls, 1)
+
+        connector.shutdown()
+        self.assertEqual(backend.close_calls, 1)
+        with self.assertRaisesRegex(RuntimeError, "connector is shut down"):
+            rejected_call()
+        return call_results
+
+    def test_get_finished_admitted_before_shutdown_completes_before_close(
+        self,
+    ) -> None:
+        backend = _BlockingConnectorBackend()
+        connector = self._connector(worker=backend)
+        metadata = DfkvStoreConnectorMetadata({"unfinished"}, set())
+        connector._get_connector_metadata = lambda: metadata
+
+        results = self._assert_shutdown_waits_for_call(
+            connector,
+            backend,
+            lambda: connector.get_finished({"finished"}),
+            lambda: connector.get_finished({"too-late"}),
+        )
+
+        self.assertEqual(results, [({"finished"}, {"unfinished"})])
+
+    def test_request_lifecycle_calls_admitted_before_shutdown_finish_first(
+        self,
+    ) -> None:
+        request = SimpleNamespace(request_id="request")
+        calls = (
+            (
+                lambda connector: connector.request_finished(request, [1, 2]),
+                (True, {"request_id": "request", "block_ids": ([1, 2],)}),
+            ),
+            (
+                lambda connector: connector.request_finished_all_groups(
+                    request, ([1], [2])
+                ),
+                (True, {"request_id": "request", "block_ids": ([1], [2])}),
+            ),
+        )
+
+        for call, expected in calls:
+            with self.subTest(expected=expected):
+                backend = _BlockingConnectorBackend()
+                connector = self._connector(scheduler=backend)
+                results = self._assert_shutdown_waits_for_call(
+                    connector,
+                    backend,
+                    lambda: call(connector),
+                    lambda: call(connector),
+                )
+                self.assertEqual(results, [expected])
 
 
 class LogicalChunkNamespaceTest(unittest.TestCase):

--- a/test/python/test_dfkv_vllm_connector.py
+++ b/test/python/test_dfkv_vllm_connector.py
@@ -1,0 +1,442 @@
+"""Deterministic scheduler and connector-metrics contracts for vLLM."""
+
+from __future__ import annotations
+
+import logging
+from importlib.util import find_spec
+import sys
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+
+def _install_runtime_dependency_stubs() -> None:
+    """Keep imports CPU-only when torch and pyzmq are not installed."""
+    if "torch" not in sys.modules and find_spec("torch") is None:
+        class Tensor:
+            pass
+
+        class Event:
+            pass
+
+        torch_module = ModuleType("torch")
+        torch_cuda_module = ModuleType("torch.cuda")
+        torch_cuda_module.Event = Event
+        torch_module.Tensor = Tensor
+        torch_module.cuda = torch_cuda_module
+        sys.modules["torch"] = torch_module
+        sys.modules["torch.cuda"] = torch_cuda_module
+
+    if "zmq" not in sys.modules and find_spec("zmq") is None:
+        class Again(Exception):
+            pass
+
+        class ZMQError(Exception):
+            pass
+
+        class Context:
+            pass
+
+        zmq_module = ModuleType("zmq")
+        zmq_module.Again = Again
+        zmq_module.ZMQError = ZMQError
+        zmq_module.Context = Context
+        zmq_module.REQ = 1
+        zmq_module.REP = 2
+        zmq_module.RCVTIMEO = 3
+        sys.modules["zmq"] = zmq_module
+
+
+def _install_vllm_stubs() -> None:
+    """Install the import surface used by the connector under standalone Python."""
+    if "vllm" in sys.modules or find_spec("vllm") is not None:
+        return
+
+    def stub(name: str, **attributes):
+        module = ModuleType(name)
+        module.__path__ = []
+        module.__dict__.update(attributes)
+        sys.modules[name] = module
+        if "." in name:
+            parent_name, child_name = name.rsplit(".", 1)
+            setattr(sys.modules[parent_name], child_name, module)
+        return module
+
+    class Placeholder:
+        pass
+
+    class BlockHash(bytes):
+        pass
+
+    @dataclass
+    class KVCacheBlock:
+        block_id: int
+
+    @dataclass
+    class KVConnectorStats:
+        data: dict = field(default_factory=dict)
+
+        def is_empty(self) -> bool:
+            return not self.data
+
+    class KVConnectorPromMetrics:
+        pass
+
+    class PromMetric:
+        pass
+
+    class BlockStored:
+        def __init__(self, **values) -> None:
+            self.__dict__.update(values)
+
+    class KVCacheSpecRegistry:
+        @classmethod
+        def get_manager_class(cls, _spec):
+            return Placeholder
+
+    stub("vllm")
+    stub("vllm.envs", VLLM_RPC_BASE_PATH="/tmp")
+    stub("vllm.config", VllmConfig=Placeholder, ParallelConfig=Placeholder)
+    stub(
+        "vllm.distributed",
+        get_dcp_group=lambda: Placeholder(),
+        get_pcp_group=lambda: Placeholder(),
+        get_tensor_model_parallel_rank=lambda: 0,
+        get_tensor_model_parallel_world_size=lambda: 1,
+    )
+    stub("vllm.distributed.kv_events", BlockStored=BlockStored)
+    stub("vllm.distributed.kv_transfer")
+    stub("vllm.distributed.kv_transfer.kv_connector")
+    stub("vllm.distributed.kv_transfer.kv_connector.v1")
+    stub(
+        "vllm.distributed.kv_transfer.kv_connector.v1.base",
+        KVConnectorMetadata=Placeholder,
+    )
+    stub(
+        "vllm.distributed.kv_transfer.kv_connector.v1.metrics",
+        KVConnectorPromMetrics=KVConnectorPromMetrics,
+        KVConnectorStats=KVConnectorStats,
+        PromMetric=PromMetric,
+        PromMetricT=PromMetric,
+    )
+    stub("vllm.logger", init_logger=logging.getLogger)
+    stub("vllm.utils")
+    stub(
+        "vllm.utils.math_utils",
+        cdiv=lambda numerator, denominator: (
+            numerator + denominator - 1
+        )
+        // denominator,
+    )
+    stub(
+        "vllm.utils.network_utils",
+        make_zmq_socket=lambda *_args, **_kwargs: None,
+    )
+    stub("vllm.v1")
+    stub("vllm.v1.core")
+    stub("vllm.v1.core.block_pool", BlockPool=Placeholder)
+    stub("vllm.v1.core.kv_cache_manager", KVCacheBlocks=Placeholder)
+    stub(
+        "vllm.v1.core.kv_cache_utils",
+        BlockHash=BlockHash,
+        BlockHashList=list[BlockHash],
+        BlockHashListWithBlockSize=tuple[list[BlockHash], int],
+        KVCacheBlock=KVCacheBlock,
+        maybe_convert_block_hash=lambda value: value,
+        resolve_kv_cache_block_sizes=lambda *_args, **_kwargs: (64, 64),
+    )
+    stub(
+        "vllm.v1.core.single_type_kv_cache_manager",
+        SingleTypeKVCacheManager=Placeholder,
+    )
+    stub("vllm.v1.core.sched")
+    stub(
+        "vllm.v1.core.sched.output",
+        NewRequestData=Placeholder,
+        SchedulerOutput=Placeholder,
+    )
+    stub(
+        "vllm.v1.kv_cache_interface",
+        FullAttentionSpec=Placeholder,
+        KVCacheConfig=Placeholder,
+        KVCacheGroupSpec=Placeholder,
+        KVCacheSpec=Placeholder,
+        UniformTypeKVCacheSpecs=Placeholder,
+    )
+    stub(
+        "vllm.v1.kv_cache_spec_registry",
+        KVCacheSpecRegistry=KVCacheSpecRegistry,
+    )
+    stub("vllm.v1.request", Request=Placeholder)
+
+
+_install_runtime_dependency_stubs()
+_install_vllm_stubs()
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "integration" / "common" / "src"))
+sys.path.insert(0, str(ROOT / "integration" / "vllm" / "src"))
+
+from dfkv_vllm.metrics import (  # noqa: E402
+    DfkvStoreConnectorStats,
+    DfkvStorePromMetrics,
+)
+from dfkv_vllm.scheduler import DfkvStoreScheduler  # noqa: E402
+
+
+class _LookupClient:
+    def __init__(self, results: dict[str, list[int | None]]) -> None:
+        self.results = {request_id: list(values) for request_id, values in results.items()}
+        self.calls: list[tuple[str, int, tuple[bytes, ...], bool]] = []
+        self.discarded: list[str] = []
+        self.closed = False
+
+    def lookup(self, request_id, token_len, block_hashes, non_block=False):
+        self.calls.append(
+            (request_id, token_len, tuple(bytes(value) for value in block_hashes), non_block)
+        )
+        values = self.results[request_id]
+        if len(values) == 1:
+            return values[0]
+        return values.pop(0)
+
+    def discard(self, request_id: str) -> None:
+        self.discarded.append(request_id)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class SchedulerLookupTest(unittest.TestCase):
+    def _scheduler(
+        self,
+        client: _LookupClient,
+        *,
+        lookup_async: bool,
+        load_async: bool = True,
+    ) -> DfkvStoreScheduler:
+        transfer = SimpleNamespace(
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "lookup_async": lookup_async,
+                "load_async": load_async,
+            },
+        )
+        config = SimpleNamespace(
+            kv_transfer_config=transfer,
+            cache_config=SimpleNamespace(cache_salt="stable"),
+        )
+        with (
+            patch("dfkv_vllm.scheduler.ensure_deterministic_block_hashing"),
+            patch("dfkv_vllm.scheduler.resolve_kv_cache_block_sizes", return_value=(64, 64)),
+            patch("dfkv_vllm.scheduler.LookupKeyClient", return_value=client),
+        ):
+            return DfkvStoreScheduler(config, SimpleNamespace())
+
+    @staticmethod
+    def _request(request_id: str, blocks: int = 2):
+        return SimpleNamespace(
+            request_id=request_id,
+            num_tokens=blocks * 64,
+            block_hashes=[bytes([index + 1]) * 32 for index in range(blocks)],
+        )
+
+    def test_sync_lookup_remains_single_call_and_returns_existing_shape(self) -> None:
+        client = _LookupClient({"sync": [64]})
+        scheduler = self._scheduler(client, lookup_async=False)
+
+        self.assertEqual(
+            scheduler.get_num_new_matched_tokens(self._request("sync"), 0),
+            (64, True),
+        )
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(client.calls[0][0], "sync")
+        self.assertFalse(client.calls[0][3])
+
+    def test_async_first_call_is_pending_then_returns_completed_result(self) -> None:
+        client = _LookupClient({"async": [None, 64]})
+        scheduler = self._scheduler(client, lookup_async=True)
+        request = self._request("async")
+
+        self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (None, False))
+        self.assertNotIn("async", scheduler.load_specs)
+        self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (64, True))
+        self.assertTrue(all(call[3] for call in client.calls))
+
+    def test_concurrent_request_ids_do_not_share_lookup_state(self) -> None:
+        client = _LookupClient({"left": [None, 64], "right": [None, 128]})
+        scheduler = self._scheduler(client, lookup_async=True)
+        left = self._request("left")
+        right = self._request("right", blocks=3)
+
+        self.assertEqual(scheduler.get_num_new_matched_tokens(left, 0), (None, False))
+        self.assertEqual(scheduler.get_num_new_matched_tokens(right, 0), (None, False))
+        self.assertEqual(scheduler.get_num_new_matched_tokens(right, 0), (128, True))
+        self.assertEqual(scheduler.get_num_new_matched_tokens(left, 0), (64, True))
+        self.assertEqual([call[0] for call in client.calls], ["left", "right", "right", "left"])
+
+    def test_finish_preemption_abort_and_close_discard_pending_lookups(self) -> None:
+        client = _LookupClient(
+            {"finished": [None], "preempted": [None], "aborted": [None]}
+        )
+        scheduler = self._scheduler(client, lookup_async=True)
+        for request_id in ("finished", "preempted", "aborted"):
+            self.assertEqual(
+                scheduler.get_num_new_matched_tokens(self._request(request_id), 0),
+                (None, False),
+            )
+
+        scheduler.request_finished(self._request("aborted"), ())
+        output = SimpleNamespace(
+            finished_req_ids={"finished"},
+            preempted_req_ids={"preempted"},
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=SimpleNamespace(req_ids=[]),
+            num_scheduled_tokens={},
+        )
+        scheduler.build_connector_meta(output)
+        scheduler.close()
+        scheduler.close()
+
+        self.assertCountEqual(client.discarded, ["aborted", "finished", "preempted"])
+        self.assertTrue(client.closed)
+
+    def test_empty_hash_list_is_a_normal_miss(self) -> None:
+        client = _LookupClient({"empty": [0]})
+        scheduler = self._scheduler(client, lookup_async=False)
+        request = self._request("empty")
+        request.block_hashes = []
+
+        self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (0, False))
+        self.assertEqual(client.calls[0][2], ())
+
+
+class _PromMetric:
+    def __init__(self) -> None:
+        self.labels_seen: list[tuple[object, ...]] = []
+        self.observed: list[float] = []
+        self.increments: list[int] = []
+
+    def labels(self, *values):
+        self.labels_seen.append(values)
+        return self
+
+    def observe(self, value: float) -> None:
+        self.observed.append(value)
+
+    def inc(self, value: int = 1) -> None:
+        self.increments.append(value)
+
+
+class ConnectorStatsTest(unittest.TestCase):
+    def test_aggregate_preserves_physical_and_logical_key_accounting(self) -> None:
+        first = DfkvStoreConnectorStats()
+        first.record_operation(
+            "lookup_exists",
+            0.001,
+            12,
+            num_logical_keys=3,
+        )
+        second = DfkvStoreConnectorStats()
+        second.record_operation(
+            "lookup_exists",
+            0.003,
+            8,
+            num_logical_keys=2,
+            status="partial_failure",
+            num_failed_keys=1,
+        )
+
+        self.assertIs(first.aggregate(second), first)
+        reduced = first.reduce()
+        self.assertEqual(reduced["lookup_exists_count"], 2)
+        self.assertEqual(reduced["lookup_exists_total_keys"], 20)
+        self.assertEqual(reduced["lookup_exists_total_logical_keys"], 5)
+        self.assertEqual(reduced["lookup_exists_failed_keys"], 1)
+        self.assertEqual(reduced["lookup_exists_error_count"], 0)
+
+    def test_default_logical_count_keeps_existing_producers_compatible(self) -> None:
+        stats = DfkvStoreConnectorStats()
+        stats.record_operation("save_put", 0.001, 7)
+        self.assertEqual(stats.reduce()["save_put_total_logical_keys"], 7)
+
+    def test_phase_observations_aggregate_without_dynamic_labels(self) -> None:
+        first = DfkvStoreConnectorStats()
+        second = DfkvStoreConnectorStats()
+        for name in (
+            "lookup_ipc",
+            "lookup_queue_wait",
+            "receive_queue_wait",
+            "geometry_preparation",
+        ):
+            first.record_observation(name, 0.001)
+            second.record_observation(name, 0.003)
+        first.aggregate(second)
+
+        self.assertEqual(
+            set(first.data),
+            {"_observations"},
+        )
+        reduced = first.reduce()
+        for name in (
+            "lookup_ipc",
+            "lookup_queue_wait",
+            "receive_queue_wait",
+            "geometry_preparation",
+        ):
+            self.assertEqual(reduced[f"{name}_count"], 2)
+            self.assertEqual(reduced[f"{name}_avg_ms"], 2.0)
+            self.assertEqual(reduced[f"{name}_p90_ms"], 3.0)
+
+    def test_prometheus_observe_separates_bounded_phases_and_key_counters(
+        self,
+    ) -> None:
+        operation_metrics = {
+            name: _PromMetric()
+            for name in (
+                "time",
+                "calls",
+                "keys",
+                "logical_keys",
+                "bytes",
+                "failed_keys",
+            )
+        }
+        observation_metric = _PromMetric()
+        prometheus = DfkvStorePromMetrics.__new__(DfkvStorePromMetrics)
+        prometheus.per_engine_labelvalues = {0: ["engine-0"]}
+        prometheus._metric_cache = {
+            (0, "lookup_exists", "ok"): operation_metrics
+        }
+        prometheus._observation_cache = {}
+        prometheus._histogram_observations = {
+            "lookup_ipc": observation_metric
+        }
+
+        stats = DfkvStoreConnectorStats()
+        stats.record_operation(
+            "lookup_exists", 0.004, 12, num_logical_keys=3
+        )
+        stats.record_observation("lookup_ipc", 0.002)
+        prometheus.observe(stats.data)
+
+        self.assertEqual(operation_metrics["keys"].increments, [12])
+        self.assertEqual(operation_metrics["logical_keys"].increments, [3])
+        self.assertEqual(observation_metric.labels_seen, [("engine-0",)])
+        self.assertEqual(observation_metric.observed, [0.002])
+
+
+    def test_metric_dimensions_reject_unbounded_values(self) -> None:
+        stats = DfkvStoreConnectorStats()
+        with self.assertRaises(ValueError):
+            stats.record_operation("lookup_exists:request-123", 0.1, 1)
+        with self.assertRaises(ValueError):
+            stats.record_operation("lookup_exists", 0.1, 1, status="request-123")
+        with self.assertRaises(ValueError):
+            stats.record_observation("request-123", 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/test_dfkv_vllm_worker.py
+++ b/test/python/test_dfkv_vllm_worker.py
@@ -9,7 +9,7 @@ import queue
 import sys
 import threading
 import unittest
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
@@ -184,10 +184,17 @@ sys.path.insert(0, str(ROOT / "integration" / "vllm" / "src"))
 
 from vllm.v1.core.kv_cache_utils import BlockHash  # noqa: E402
 
-from dfkv_vllm.data import KeyMetadata  # noqa: E402
+from dfkv_vllm.data import (  # noqa: E402
+    KeyMetadata,
+    LoadSpec,
+    PoolKey,
+    ReqMeta,
+)
 from dfkv_vllm.protocol import LOOKUP_MSG  # noqa: E402
 from dfkv_vllm.worker import (  # noqa: E402
     DfkvStoreWorker,
+    KVCacheStoreRecvingThread,
+    KVCacheStoreSendingThread,
     LookupKeyClient,
     LookupKeyServer,
 )
@@ -451,12 +458,198 @@ class LookupFutureTest(unittest.TestCase):
 
 
 
+class LogicalChunkTransferTest(unittest.TestCase):
+    @staticmethod
+    def _metadata() -> KeyMetadata:
+        return KeyMetadata(
+            model_name="model",
+            dp_size=1,
+            dp_rank=-1,
+            tp_size=1,
+            tp_rank=-1,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=1,
+            pp_rank=0,
+            group_id=0,
+        )
+
+    @staticmethod
+    def _hash(seed: str) -> BlockHash:
+        return BlockHash(hashlib.sha256(seed.encode()).digest())
+
+    def test_save_uses_one_key_and_preserves_more_than_29_descriptors(self) -> None:
+        metadata = self._metadata()
+        logical_key = PoolKey(metadata, self._hash("save").hex())
+        addresses = [0x1000 + i * 0x100 for i in range(35)]
+        sizes = [i + 1 for i in range(35)]
+
+        class _Database:
+            block_size = 64
+            _seg_layout = [(0, 1, 1)] * len(addresses)
+
+            def process_tokens(self, *_args):
+                return [(0, 64, logical_key)]
+
+            def prepare_value(self, *_args):
+                return list(addresses), list(sizes), 7
+
+        class _Client:
+            def __init__(self) -> None:
+                self.exist_calls: list[list[bytes]] = []
+                self.put_calls: list[
+                    tuple[list[bytes], list[list[int]], list[list[int]]]
+                ] = []
+                self.remove_calls: list[list[bytes]] = []
+
+            def max_sg_segs(self) -> int:
+                return 29
+
+            def batch_exist(self, keys):
+                self.exist_calls.append(list(keys))
+                return [0] * len(keys)
+
+            def batch_put_sg(self, keys, ptrs, seg_sizes):
+                self.put_calls.append(
+                    (list(keys), [list(v) for v in ptrs],
+                     [list(v) for v in seg_sizes])
+                )
+                return [0] * len(keys)
+
+            def supports_remove(self) -> bool:
+                return True
+
+            def batch_remove(self, keys):
+                self.remove_calls.append(list(keys))
+                return [0] * len(keys)
+
+        client = _Client()
+        coord = SimpleNamespace(
+            lcm_block_size=64,
+            store_mask=lambda _token_len: [[True]],
+        )
+        sender = KVCacheStoreSendingThread(
+            client,
+            coord,
+            [_Database()],
+            block_size=64,
+            tp_rank=0,
+            put_step=1,
+            kv_role="kv_both",
+            ready_event=threading.Event(),
+        )
+        sender.add_stored_request("save")
+        sender._handle_request(
+            ReqMeta(
+                req_id="save",
+                token_len_chunk=64,
+                block_ids=([7],),
+                block_hashes=[self._hash("save")],
+            )
+        )
+
+        expected_key = logical_key.to_bytes()
+        self.assertEqual(client.exist_calls, [[expected_key]])
+        self.assertEqual(len(client.put_calls), 1)
+        put_keys, put_ptrs, put_sizes = client.put_calls[0]
+        self.assertEqual(put_keys, [expected_key])
+        self.assertEqual(put_ptrs, [addresses])
+        self.assertEqual(put_sizes, [sizes])
+        self.assertEqual(client.remove_calls, [])
+
+    def test_partial_chunk_load_preserves_descriptor_order(self) -> None:
+        metadata = self._metadata()
+        hashes = [self._hash("load-hit"), self._hash("load-miss")]
+        keys = [PoolKey(metadata, value.hex()) for value in hashes]
+        addresses = [
+            [0x2000 + i * 0x80 for i in range(35)],
+            [0x8000 + i * 0x40 for i in range(33)],
+        ]
+        sizes = [
+            [2 + i for i in range(35)],
+            [7 + (i % 5) for i in range(33)],
+        ]
+
+        class _Database:
+            block_size = 64
+            _seg_layout = [(0, 1, 1)] * 35
+
+            def process_tokens(self, *_args):
+                return [(0, 64, keys[0]), (64, 128, keys[1])]
+
+            def prepare_value(self, start, *_args):
+                index = start // 64
+                return list(addresses[index]), list(sizes[index]), (7, 9)[index]
+
+        class _Client:
+            def __init__(self) -> None:
+                self.get_call = None
+                self.result = ([1, 0], [sum(sizes[0]), 0])
+
+            def max_sg_segs(self) -> int:
+                return 29
+
+            def batch_get_auto_sg(self, get_keys, ptrs, caps):
+                self.get_call = (
+                    list(get_keys),
+                    [list(value) for value in ptrs],
+                    [list(value) for value in caps],
+                )
+                return self.result
+
+        client = _Client()
+        coord = SimpleNamespace(
+            load_mask=lambda _hashes, _token_len: [[True, True]],
+        )
+        receiver = KVCacheStoreRecvingThread(
+            client,
+            coord,
+            [_Database()],
+            block_size=64,
+            tp_rank=0,
+            ready_event=threading.Event(),
+        )
+        request = ReqMeta(
+            req_id="load",
+            token_len_chunk=128,
+            block_ids=([7, 9],),
+            block_hashes=hashes,
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=128,
+                can_load=True,
+                token_len=128,
+            ),
+        )
+        receiver._handle_request(request)
+
+        self.assertEqual(
+            client.get_call,
+            ([key.to_bytes() for key in keys], addresses, sizes),
+        )
+        load_errors = receiver.get_and_clear_block_ids_with_load_errors()
+        self.assertNotIn(7, load_errors)
+        self.assertIn(9, load_errors)
+        self.assertEqual(load_errors, {9})
+
+        # A truncated native result must be rejected before per-key indexing.
+        # Fail the whole batch closed rather than silently treating the omitted
+        # logical chunk as a hit.
+        client.result = ([1], [sum(sizes[0])])
+        receiver._handle_request(request)
+        self.assertEqual(
+            receiver.get_and_clear_block_ids_with_load_errors(), {7, 9}
+        )
+
+
 class LookupAccountingTest(unittest.TestCase):
     @staticmethod
     def _hash(seed: str) -> BlockHash:
         return BlockHash(hashlib.sha256(seed.encode()).digest())
 
-    def test_lookup_records_physical_and_logical_key_counts(self) -> None:
+    def test_lookup_probes_one_v2_key_per_rank_and_keeps_partial_prefix(self) -> None:
         hashes = [self._hash("one"), self._hash("two")]
         metadata = KeyMetadata(
             model_name="model",
@@ -481,19 +674,31 @@ class LookupAccountingTest(unittest.TestCase):
 
             def batch_exist(self, keys):
                 self.keys = list(keys)
-                return [1] * len(keys)
+                # Every rank replica of chunk 0 is present. Chunk 1 is only
+                # partially replicated and therefore cannot extend the prefix.
+                return [1, 1, 1, 1, 1, 1, 1, 0]
 
         client = _Client()
         records: list[dict[str, object]] = []
-        db = SimpleNamespace(block_size=64, metadata=metadata, _seg_layout=[1, 2, 3])
+        db = SimpleNamespace(
+            block_size=64,
+            metadata=metadata,
+            _seg_layout=[1, 2, 3],
+        )
+
+        def _find_longest(values, _token_len, pool):
+            hit = 0
+            for value in values:
+                if pool.get_cached_block(value, [0]) is None:
+                    break
+                hit += 64
+            return None, hit
+
         coord = SimpleNamespace(
             lcm_block_size=64,
             store_mask=lambda _token_len: [[True, True]],
             block_hashes_for_spec=lambda values, _spec: values,
-            find_longest_cache_hit=lambda _hashes, token_len, _pool: (
-                None,
-                token_len,
-            ),
+            find_longest_cache_hit=_find_longest,
         )
         worker = SimpleNamespace(
             coord=coord,
@@ -504,15 +709,30 @@ class LookupAccountingTest(unittest.TestCase):
             pp_size=2,
             _kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())],
             _record_kv_connector_operation=lambda operation, duration, num_keys, **kwargs: records.append(
-                {"operation": operation, "duration": duration, "num_keys": num_keys, **kwargs}
+                {
+                    "operation": operation,
+                    "duration": duration,
+                    "num_keys": num_keys,
+                    **kwargs,
+                }
             ),
         )
 
-        self.assertEqual(DfkvStoreWorker.lookup(worker, 128, hashes), 128)
-        self.assertEqual(len(client.keys), 16)
+        self.assertEqual(DfkvStoreWorker.lookup(worker, 128, hashes), 64)
+        expected_keys = [
+            PoolKey(
+                replace(metadata, tp_rank=tp, pp_rank=pp),
+                value.hex(),
+            ).to_bytes()
+            for value in hashes
+            for tp in range(2)
+            for pp in range(2)
+        ]
+        self.assertEqual(client.keys, expected_keys)
+        self.assertEqual(len(set(client.keys)), 8)
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["operation"], "lookup_exists")
-        self.assertEqual(records[0]["num_keys"], 16)
+        self.assertEqual(records[0]["num_keys"], 8)
         self.assertEqual(records[0]["num_logical_keys"], 2)
 
 

--- a/test/python/test_dfkv_vllm_worker.py
+++ b/test/python/test_dfkv_vllm_worker.py
@@ -185,6 +185,7 @@ sys.path.insert(0, str(ROOT / "integration" / "vllm" / "src"))
 from vllm.v1.core.kv_cache_utils import BlockHash  # noqa: E402
 
 from dfkv_vllm.data import (  # noqa: E402
+    ChunkedTokenDatabase,
     KeyMetadata,
     LoadSpec,
     PoolKey,
@@ -493,6 +494,19 @@ class LogicalChunkTransferTest(unittest.TestCase):
             def process_tokens(self, *_args):
                 return [(0, 64, logical_key)]
 
+            def descriptor_shape(self, _start, _end, block_ids):
+                return len(addresses), sum(sizes), block_ids[0]
+
+            def fill_descriptors(
+                self, _start, _end, _block_ids, pointers, out_sizes, offset=0
+            ):
+                for index, (address, size) in enumerate(
+                    zip(addresses, sizes, strict=True), start=offset
+                ):
+                    pointers[index] = address
+                    out_sizes[index] = size
+                return offset + len(addresses)
+
             def prepare_value(self, *_args):
                 return list(addresses), list(sizes), 7
 
@@ -579,6 +593,26 @@ class LogicalChunkTransferTest(unittest.TestCase):
             def process_tokens(self, *_args):
                 return [(0, 64, keys[0]), (64, 128, keys[1])]
 
+            def descriptor_shape(self, start, _end, block_ids):
+                index = start // 64
+                return (
+                    len(addresses[index]),
+                    sum(sizes[index]),
+                    block_ids[index],
+                )
+
+            def fill_descriptors(
+                self, start, _end, _block_ids, pointers, out_sizes, offset=0
+            ):
+                index = start // 64
+                for cursor, (address, size) in enumerate(
+                    zip(addresses[index], sizes[index], strict=True),
+                    start=offset,
+                ):
+                    pointers[cursor] = address
+                    out_sizes[cursor] = size
+                return offset + len(addresses[index])
+
             def prepare_value(self, start, *_args):
                 index = start // 64
                 return list(addresses[index]), list(sizes[index]), (7, 9)[index]
@@ -586,18 +620,26 @@ class LogicalChunkTransferTest(unittest.TestCase):
         class _Client:
             def __init__(self) -> None:
                 self.get_call = None
-                self.result = ([1, 0], [sum(sizes[0]), 0])
+                self.truncate = False
 
             def max_sg_segs(self) -> int:
                 return 29
 
             def batch_get_auto_sg(self, get_keys, ptrs, caps):
+                key_order = list(get_keys)
                 self.get_call = (
-                    list(get_keys),
+                    key_order,
                     [list(value) for value in ptrs],
                     [list(value) for value in caps],
                 )
-                return self.result
+                hits = [int(key == keys[0].to_bytes()) for key in key_order]
+                lengths = [
+                    sum(sizes[0]) if key == keys[0].to_bytes() else 0
+                    for key in key_order
+                ]
+                if self.truncate:
+                    return hits[:1], lengths[:1]
+                return hits, lengths
 
         client = _Client()
         coord = SimpleNamespace(
@@ -625,9 +667,19 @@ class LogicalChunkTransferTest(unittest.TestCase):
         )
         receiver._handle_request(request)
 
+        get_keys, get_addrs, get_sizes = client.get_call
+        observed = {
+            key: (chunk_addrs, chunk_sizes)
+            for key, chunk_addrs, chunk_sizes in zip(
+                get_keys, get_addrs, get_sizes, strict=True
+            )
+        }
         self.assertEqual(
-            client.get_call,
-            ([key.to_bytes() for key in keys], addresses, sizes),
+            observed,
+            {
+                keys[0].to_bytes(): (addresses[0], sizes[0]),
+                keys[1].to_bytes(): (addresses[1], sizes[1]),
+            },
         )
         load_errors = receiver.get_and_clear_block_ids_with_load_errors()
         self.assertNotIn(7, load_errors)
@@ -637,11 +689,895 @@ class LogicalChunkTransferTest(unittest.TestCase):
         # A truncated native result must be rejected before per-key indexing.
         # Fail the whole batch closed rather than silently treating the omitted
         # logical chunk as a hit.
-        client.result = ([1], [sum(sizes[0])])
+        client.truncate = True
         receiver._handle_request(request)
         self.assertEqual(
             receiver.get_and_clear_block_ids_with_load_errors(), {7, 9}
         )
+
+
+class GeometryReuseTest(unittest.TestCase):
+    @staticmethod
+    def _metadata() -> KeyMetadata:
+        return KeyMetadata(
+            model_name="geometry",
+            dp_size=1,
+            dp_rank=-1,
+            tp_size=1,
+            tp_rank=-1,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=1,
+            pp_rank=0,
+        )
+
+    def test_cached_layout_uses_current_arbitrary_ids_and_returns_owned_arrays(
+        self,
+    ) -> None:
+        database = ChunkedTokenDatabase(self._metadata(), block_size=64)
+        database.set_seg_layout(
+            [
+                (0x1000, 0x80, 0x60),
+                (0x8000, 0x100, 0xC0),
+            ]
+        )
+        geometry = database.geometry
+        with self.assertRaises(AttributeError):
+            geometry.segment_bases = ()  # type: ignore[misc]
+
+        first_ids = [17, 2, 999]
+        first_addrs, first_sizes, first_block_id = database.prepare_value(
+            0, 192, first_ids
+        )
+        expected_first_addrs = [
+            0x1000 + block_id * 0x80 for block_id in first_ids
+        ] + [
+            0x8000 + block_id * 0x100 for block_id in first_ids
+        ]
+        self.assertEqual(list(first_addrs), expected_first_addrs)
+        self.assertEqual(list(first_sizes), [0x60] * 3 + [0xC0] * 3)
+        self.assertEqual(first_block_id, 17)
+
+        first_snapshot = (list(first_addrs), list(first_sizes))
+        second_addrs, second_sizes, second_block_id = database.prepare_value(
+            0, 192, [4, 81, 6]
+        )
+        self.assertEqual(second_block_id, 4)
+        self.assertEqual(
+            list(second_addrs),
+            [
+                0x1000 + 4 * 0x80,
+                0x1000 + 81 * 0x80,
+                0x1000 + 6 * 0x80,
+                0x8000 + 4 * 0x100,
+                0x8000 + 81 * 0x100,
+                0x8000 + 6 * 0x100,
+            ],
+        )
+        self.assertEqual(list(second_sizes), [0x60] * 3 + [0xC0] * 3)
+        self.assertIsNot(first_addrs, second_addrs)
+        self.assertIsNot(first_sizes, second_sizes)
+        self.assertEqual((list(first_addrs), list(first_sizes)), first_snapshot)
+        self.assertIs(database.geometry, geometry)
+
+    def test_sequential_requests_do_not_share_mutable_native_vectors(self) -> None:
+        database = ChunkedTokenDatabase(self._metadata(), block_size=64)
+        database.set_seg_layout([(0x5000, 0x200, 0x180)])
+
+        class _Client:
+            def __init__(self) -> None:
+                self.calls = []
+
+            def batch_get_auto_sg(self, keys, pointers, capacities):
+                self.calls.append((keys, pointers, capacities))
+                return [1], [0x180]
+
+        client = _Client()
+        receiver = KVCacheStoreRecvingThread(
+            client,
+            SimpleNamespace(load_mask=lambda _hashes, _token_len: [[True]]),
+            [database],
+            block_size=64,
+            tp_rank=0,
+            ready_event=threading.Event(),
+        )
+
+        def request(request_id: str, block_id: int) -> ReqMeta:
+            block_hash = BlockHash(hashlib.sha256(request_id.encode()).digest())
+            return ReqMeta(
+                req_id=request_id,
+                token_len_chunk=64,
+                block_ids=([block_id],),
+                block_hashes=[block_hash],
+                load_spec=LoadSpec(
+                    vllm_cached_tokens=0,
+                    kvpool_cached_tokens=64,
+                    can_load=True,
+                    token_len=64,
+                ),
+            )
+
+        receiver._handle_request(request("first", 37))
+        first_pointers = client.calls[0][1]
+        first_capacities = client.calls[0][2]
+        first_snapshot = (
+            [list(chunk) for chunk in first_pointers],
+            [list(chunk) for chunk in first_capacities],
+        )
+        receiver._handle_request(request("second", 901))
+
+        self.assertIsNot(first_pointers, client.calls[1][1])
+        self.assertIsNot(first_capacities, client.calls[1][2])
+        self.assertEqual(
+            (
+                [list(chunk) for chunk in first_pointers],
+                [list(chunk) for chunk in first_capacities],
+            ),
+            first_snapshot,
+        )
+        self.assertEqual(first_snapshot, ([[0x5000 + 37 * 0x200]], [[0x180]]))
+        self.assertEqual(
+            [list(chunk) for chunk in client.calls[1][1]],
+            [[0x5000 + 901 * 0x200]],
+        )
+
+
+class ReceiveRotationTest(unittest.TestCase):
+    @staticmethod
+    def _hash(seed: str) -> BlockHash:
+        return BlockHash(hashlib.sha256(seed.encode()).digest())
+
+    @staticmethod
+    def _metadata() -> KeyMetadata:
+        return KeyMetadata(
+            model_name="rotation",
+            dp_size=1,
+            dp_rank=-1,
+            tp_size=8,
+            tp_rank=-1,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=1,
+            pp_rank=0,
+        )
+
+    def _exercise(
+        self, req_id: str, tp_rank: int
+    ) -> tuple[list[bytes], set[int]]:
+        hashes = [self._hash(f"chunk-{index}") for index in range(4)]
+        keys = [PoolKey(self._metadata(), value.hex()).to_bytes() for value in hashes]
+        block_ids = [101, 7, 4095, 23]
+        expected_by_key = {
+            key: (0x2000 + block_id * 0x100, 64, block_id)
+            for key, block_id in zip(keys, block_ids, strict=True)
+        }
+
+        class _Database:
+            block_size = 64
+            _seg_layout = [(0x2000, 0x100, 64)]
+
+            def process_tokens(self, *_args):
+                return [
+                    (index * 64, (index + 1) * 64, PoolKey(
+                        ReceiveRotationTest._metadata(), hashes[index].hex()
+                    ))
+                    for index in range(4)
+                ]
+
+            def descriptor_shape(self, start, _end, current_block_ids):
+                index = start // 64
+                return 1, 64, current_block_ids[index]
+
+            def fill_descriptors(
+                self, start, _end, current_block_ids, pointers, sizes, offset=0
+            ):
+                index = start // 64
+                pointers[offset] = 0x2000 + current_block_ids[index] * 0x100
+                sizes[offset] = 64
+                return offset + 1
+
+            def prepare_value(self, start, _end, current_block_ids):
+                index = start // 64
+                block_id = current_block_ids[index]
+                return [0x2000 + block_id * 0x100], [64], block_id
+
+        class _Client:
+            def __init__(self) -> None:
+                self.orders: list[list[bytes]] = []
+
+            def batch_get_auto_sg(self, get_keys, ptrs, caps):
+                key_order = list(get_keys)
+                self.orders.append(key_order)
+                hits: list[int] = []
+                lengths: list[int] = []
+                for key, addresses, sizes in zip(
+                    key_order, ptrs, caps, strict=True
+                ):
+                    expected_addr, expected_size, expected_block_id = expected_by_key[key]
+                    if list(addresses) != [expected_addr]:
+                        raise AssertionError(
+                            f"key {key!r} used stale block {expected_block_id}"
+                        )
+                    if list(sizes) != [expected_size]:
+                        raise AssertionError(f"key {key!r} used wrong geometry")
+                    hit = key != keys[2]
+                    hits.append(int(hit))
+                    lengths.append(expected_size if hit else 0)
+                return hits, lengths
+
+        client = _Client()
+        receiver = KVCacheStoreRecvingThread(
+            client,
+            SimpleNamespace(load_mask=lambda _hashes, _token_len: [[True] * 4]),
+            [_Database()],
+            block_size=64,
+            tp_rank=tp_rank,
+            ready_event=threading.Event(),
+        )
+        request = ReqMeta(
+            req_id=req_id,
+            token_len_chunk=256,
+            block_ids=(block_ids,),
+            block_hashes=hashes,
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=256,
+                can_load=True,
+                token_len=256,
+            ),
+        )
+        receiver._handle_request(request)
+        return client.orders[0], receiver.get_and_clear_block_ids_with_load_errors()
+
+    def test_request_seed_rotates_initial_chunk_stably_without_reordering_results(
+        self,
+    ) -> None:
+        canonical = [
+            PoolKey(self._metadata(), self._hash(f"chunk-{index}").hex()).to_bytes()
+            for index in range(4)
+        ]
+        orders: list[list[bytes]] = []
+        for index in range(12):
+            order, failed_blocks = self._exercise(f"request-{index}", tp_rank=0)
+            orders.append(order)
+            self.assertEqual(failed_blocks, {4095})
+            doubled = canonical + canonical
+            start = doubled.index(order[0])
+            self.assertEqual(order, doubled[start:start + len(canonical)])
+
+        self.assertGreater(
+            len({tuple(order) for order in orders}),
+            1,
+            "request identity must spread the first logical chunk at fixed TP rank",
+        )
+        repeated, failed_blocks = self._exercise("request-3", tp_rank=0)
+        self.assertEqual(repeated, orders[3])
+        self.assertEqual(failed_blocks, {4095})
+
+    def test_tp_ranks_rotate_only_the_native_issue_order(self) -> None:
+        orders = []
+        for tp_rank in range(4):
+            order, failed_blocks = self._exercise("same-request", tp_rank)
+            orders.append(tuple(order))
+            self.assertEqual(failed_blocks, {4095})
+        self.assertEqual(len(set(orders)), 4)
+
+
+class LongestCompletePrefixLookupTest(unittest.TestCase):
+    @staticmethod
+    def _hash(seed: str) -> BlockHash:
+        return BlockHash(hashlib.sha256(seed.encode()).digest())
+
+    @staticmethod
+    def _metadata(group_id: int) -> KeyMetadata:
+        return KeyMetadata(
+            model_name="lookup-prefix",
+            dp_size=1,
+            dp_rank=-1,
+            tp_size=1,
+            tp_rank=-1,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=1,
+            pp_rank=0,
+            group_id=group_id,
+        )
+
+    def _worker(self, response, *, repeated_hashes: bool = False):
+        if repeated_hashes:
+            wide_hashes = [self._hash("wide-repeat")] * 3
+            fine_hashes = [self._hash("fine-repeat")] * 6
+        else:
+            wide_hashes = [self._hash(f"wide-{index}") for index in range(3)]
+            fine_hashes = [self._hash(f"fine-{index}") for index in range(6)]
+        wide_spec, fine_spec = object(), object()
+
+        class _Coordinator:
+            lcm_block_size = 128
+
+            @staticmethod
+            def store_mask(_token_len):
+                return [[True] * 3, [True] * 6]
+
+            @staticmethod
+            def block_hashes_for_spec(_block_hashes, spec):
+                return wide_hashes if spec is wide_spec else fine_hashes
+
+            @staticmethod
+            def find_longest_cache_hit(_block_hashes, _token_len, pool):
+                hit = 0
+                for chunk in range(3):
+                    required = (
+                        (0, wide_hashes[chunk]),
+                        (1, fine_hashes[chunk * 2]),
+                        (1, fine_hashes[chunk * 2 + 1]),
+                    )
+                    if not all(
+                        pool.get_cached_block(block_hash, [group_id])
+                        for group_id, block_hash in required
+                    ):
+                        break
+                    hit += 128
+                return [[], []], hit
+
+        class _Client:
+            def __init__(self):
+                self.calls: list[list[bytes]] = []
+
+            def batch_exist(self, keys):
+                self.calls.append(list(keys))
+                if isinstance(response, Exception):
+                    raise response
+                return response
+
+        client = _Client()
+        worker = DfkvStoreWorker.__new__(DfkvStoreWorker)
+        worker.client = client
+        worker.coord = _Coordinator()
+        worker.token_dbs = [
+            SimpleNamespace(block_size=128, metadata=self._metadata(0)),
+            SimpleNamespace(block_size=64, metadata=self._metadata(1)),
+        ]
+        worker._kv_cache_groups = [
+            SimpleNamespace(kv_cache_spec=wide_spec),
+            SimpleNamespace(kv_cache_spec=fine_spec),
+        ]
+        worker.tp_size = 1
+        worker.num_kv_head = 1
+        worker.pp_size = 1
+        worker._record_kv_connector_operation = lambda *_args, **_kwargs: None
+        return worker, client
+
+    def test_stops_at_first_incomplete_cross_group_chunk_and_ignores_later_hits(
+        self,
+    ) -> None:
+        # Candidate order is three wide-group chunks followed by six fine-group
+        # subchunks. Logical chunk 1 is incomplete only in the fine group;
+        # logical chunk 2 is an isolated later hit and must not be loaded.
+        worker, client = self._worker(
+            [1, 1, 1, 1, 1, 1, 0, 1, 1]
+        )
+        block_hashes = [self._hash(f"scheduler-{index}") for index in range(6)]
+        self.assertEqual(worker.lookup(384, block_hashes), 128)
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(len(client.calls[0]), 9)
+
+        first_missing_worker, _ = self._worker(
+            [1, 1, 1, 1, 0, 1, 1, 1, 1]
+        )
+        self.assertEqual(first_missing_worker.lookup(384, block_hashes), 0)
+
+    def test_repeated_equal_hashes_do_not_mask_an_incomplete_occurrence(self) -> None:
+        worker, _client = self._worker(
+            # Fine-group occurrence 0 is absent; identical hashes in later
+            # chunks are present and must not inflate this occurrence's count.
+            [1, 1, 1, 0, 1, 1, 1, 1, 1],
+            repeated_hashes=True,
+        )
+        block_hashes = [self._hash("scheduler-repeat")] * 6
+        self.assertEqual(worker.lookup(384, block_hashes), 0)
+
+    def test_malformed_exist_result_lengths_fail_closed(self) -> None:
+        block_hashes = [self._hash(f"scheduler-{index}") for index in range(6)]
+        for malformed in (
+            [1] * 8,
+            [1] * 10,
+            None,
+        ):
+            with self.subTest(result=malformed):
+                worker, _client = self._worker(malformed)
+                self.assertEqual(worker.lookup(384, block_hashes), 0)
+
+
+class _BlockingReceiveClient:
+    def __init__(self, request_keys: dict[bytes, str]) -> None:
+        self.request_keys = request_keys
+        self.started = {
+            request_id: threading.Event() for request_id in request_keys.values()
+        }
+        self.release = {
+            request_id: threading.Event() for request_id in request_keys.values()
+        }
+        self.returned = {
+            request_id: threading.Event() for request_id in request_keys.values()
+        }
+        self.raise_for: set[str] = set()
+        self._lock = threading.Lock()
+        self.active = 0
+        self.max_active = 0
+
+    def batch_get_auto_sg(self, keys, addresses, sizes):
+        self.assert_one_aligned_object(keys, addresses, sizes)
+        request_id = self.request_keys[bytes(keys[0])]
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        self.started[request_id].set()
+        try:
+            if request_id in self.raise_for:
+                raise RuntimeError(f"injected receive failure for {request_id}")
+            if not self.release[request_id].wait(timeout=5):
+                raise TimeoutError(f"test did not release {request_id}")
+            return [1], [64]
+        finally:
+            with self._lock:
+                self.active -= 1
+            self.returned[request_id].set()
+
+    @staticmethod
+    def assert_one_aligned_object(keys, addresses, sizes) -> None:
+        if len(keys) != 1 or len(addresses) != 1 or len(sizes) != 1:
+            raise AssertionError("expected one logical object")
+        if len(addresses[0]) != 1 or list(sizes[0]) != [64]:
+            raise AssertionError("key/descriptor geometry was not aligned")
+
+
+class ReceiveConcurrencyTest(unittest.TestCase):
+    @staticmethod
+    def _metadata() -> KeyMetadata:
+        return KeyMetadata(
+            model_name="receive-concurrency",
+            dp_size=1,
+            dp_rank=-1,
+            tp_size=1,
+            tp_rank=-1,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=1,
+            pp_rank=0,
+        )
+
+    @staticmethod
+    def _hash(request_id: str) -> BlockHash:
+        return BlockHash(hashlib.sha256(request_id.encode()).digest())
+
+    def test_recv_worker_configuration_is_positive_and_bounded(self) -> None:
+        common = (
+            object(),
+            SimpleNamespace(),
+            [],
+            64,
+            0,
+            threading.Event(),
+        )
+        for invalid in (0, 33, True, "four"):
+            with self.subTest(value=invalid):
+                with self.assertRaises(ValueError):
+                    KVCacheStoreRecvingThread(
+                        *common, recv_workers=invalid  # type: ignore[arg-type]
+                    )
+
+        receiver = KVCacheStoreRecvingThread(
+            *common, recv_workers="4"  # type: ignore[arg-type]
+        )
+        self.assertEqual(receiver.recv_workers, 4)
+        self.assertEqual(len(receiver.worker_threads), 4)
+        receiver.stop()
+
+    def _requests(self, request_ids: tuple[str, ...]) -> tuple[
+        dict[str, ReqMeta], dict[bytes, str]
+    ]:
+        requests: dict[str, ReqMeta] = {}
+        request_keys: dict[bytes, str] = {}
+        metadata = self._metadata()
+        for index, request_id in enumerate(request_ids):
+            block_hash = self._hash(request_id)
+            request_keys[PoolKey(metadata, block_hash.hex()).to_bytes()] = request_id
+            requests[request_id] = ReqMeta(
+                req_id=request_id,
+                token_len_chunk=64,
+                block_ids=([1000 + index * 17],),
+                block_hashes=[block_hash],
+                load_spec=LoadSpec(
+                    vllm_cached_tokens=0,
+                    kvpool_cached_tokens=64,
+                    can_load=True,
+                    token_len=64,
+                ),
+            )
+        return requests, request_keys
+
+    def _receiver(
+        self,
+        request_ids: tuple[str, ...],
+        *,
+        recv_workers: int = 1,
+        queue_capacity: int = 8,
+    ) -> tuple[
+        KVCacheStoreRecvingThread,
+        _BlockingReceiveClient,
+        dict[str, ReqMeta],
+        dict[str, threading.Event],
+        dict[str, int],
+        list[str],
+    ]:
+        requests, request_keys = self._requests(request_ids)
+        metadata = self._metadata()
+
+        class _Database:
+            block_size = 64
+            _seg_layout = [(0x10000, 0x100, 64)]
+
+            @staticmethod
+            def process_tokens(_token_len, block_hashes, _mask_num):
+                return [(0, 64, PoolKey(metadata, block_hashes[0].hex()))]
+
+            @staticmethod
+            def descriptor_shape(_start, _end, block_ids):
+                return 1, 64, block_ids[0]
+
+            @staticmethod
+            def fill_descriptors(
+                _start, _end, block_ids, pointers, sizes, offset=0
+            ):
+                pointers[offset] = 0x10000 + block_ids[0] * 0x100
+                sizes[offset] = 64
+                return offset + 1
+
+            @staticmethod
+            def prepare_value(_start, _end, block_ids):
+                return [0x10000 + block_ids[0] * 0x100], [64], block_ids[0]
+
+        client = _BlockingReceiveClient(request_keys)
+        receiver = KVCacheStoreRecvingThread(
+            client,
+            SimpleNamespace(load_mask=lambda _hashes, _token_len: [[True]]),
+            [_Database()],
+            block_size=64,
+            tp_rank=0,
+            ready_event=threading.Event(),
+            queue_capacity=queue_capacity,
+            recv_workers=recv_workers,
+        )
+        done_events = {
+            request_id: threading.Event() for request_id in request_ids
+        }
+        transition_counts = {request_id: 0 for request_id in request_ids}
+        transition_order: list[str] = []
+        transition_lock = threading.Lock()
+        terminalize = receiver._terminalize_locked
+
+        def record_terminal(state, *, failed):
+            request = state.request
+            request_id = request.req_id if request is not None else None
+            transitioned = terminalize(state, failed=failed)
+            if transitioned and request_id is not None:
+                with transition_lock:
+                    transition_counts[request_id] += 1
+                    transition_order.append(request_id)
+                    done_events[request_id].set()
+            return transitioned
+
+        receiver._terminalize_locked = record_terminal
+        receiver.start()
+        self.assertTrue(receiver.ready_event.wait(timeout=1))
+        return (
+            receiver,
+            client,
+            requests,
+            done_events,
+            transition_counts,
+            transition_order,
+        )
+
+    @staticmethod
+    def _wait(event: threading.Event, label: str) -> None:
+        if not event.wait(timeout=2):
+            raise AssertionError(f"timed out waiting for {label}")
+
+    def test_recv_workers_overlap_complete_out_of_order_and_bound_active_calls(
+        self,
+    ) -> None:
+        request_ids = ("slow", "fast", "queued", "rejected")
+        (
+            receiver,
+            client,
+            requests,
+            done,
+            counts,
+            order,
+        ) = self._receiver(request_ids, recv_workers=2, queue_capacity=1)
+        try:
+            self.assertTrue(receiver.add_request(requests["slow"]))
+            self._wait(client.started["slow"], "slow native GET")
+            self.assertTrue(receiver.add_request(requests["fast"]))
+            self._wait(client.started["fast"], "fast native GET")
+
+            self.assertTrue(receiver.add_request(requests["queued"]))
+            self.assertFalse(receiver.add_request(requests["rejected"]))
+            self._wait(done["rejected"], "saturated request terminalization")
+            self.assertFalse(client.started["queued"].is_set())
+            self.assertLessEqual(client.max_active, 2)
+
+            client.release["fast"].set()
+            self._wait(done["fast"], "fast completion")
+            self._wait(client.started["queued"], "queued request start")
+            self.assertFalse(done["slow"].is_set())
+            client.release["queued"].set()
+            self._wait(done["queued"], "queued completion")
+            client.release["slow"].set()
+            self._wait(done["slow"], "slow completion")
+
+            self.assertLess(order.index("fast"), order.index("slow"))
+            self.assertEqual(counts, {request_id: 1 for request_id in request_ids})
+            self.assertEqual(
+                receiver.get_and_clear_block_ids_with_load_errors(),
+                {requests["rejected"].block_ids[0][0]},
+            )
+            self.assertEqual(
+                receiver.get_and_clear_finished_requests(), set(request_ids)
+            )
+            self.assertEqual(receiver.get_and_clear_finished_requests(), set())
+        finally:
+            for event in client.release.values():
+                event.set()
+            receiver.stop(cancel_pending=True)
+
+    def test_default_single_worker_preserves_compatibility_without_overlap(
+        self,
+    ) -> None:
+        receiver, client, requests, done, counts, _order = self._receiver(
+            ("first", "second")
+        )
+        try:
+            self.assertTrue(receiver.add_request(requests["first"]))
+            self._wait(client.started["first"], "first native GET")
+            self.assertTrue(receiver.add_request(requests["second"]))
+            self.assertFalse(client.started["second"].is_set())
+            self.assertEqual(client.max_active, 1)
+
+            client.release["first"].set()
+            self._wait(done["first"], "first completion")
+            self._wait(client.started["second"], "second native GET")
+            client.release["second"].set()
+            self._wait(done["second"], "second completion")
+            self.assertEqual(counts, {"first": 1, "second": 1})
+            self.assertEqual(client.max_active, 1)
+        finally:
+            for event in client.release.values():
+                event.set()
+            receiver.stop(cancel_pending=True)
+
+    def test_cancel_active_and_queued_requests_fences_each_block_once(self) -> None:
+        receiver, client, requests, done, counts, _order = self._receiver(
+            ("active", "queued"), recv_workers=1
+        )
+        try:
+            self.assertTrue(receiver.add_request(requests["active"]))
+            self._wait(client.started["active"], "active native GET")
+            self.assertTrue(receiver.add_request(requests["queued"]))
+
+            receiver.cancel_requests({"active", "queued"}, wait=False)
+            self._wait(done["queued"], "queued cancellation")
+            self.assertFalse(done["active"].is_set())
+            self.assertFalse(client.started["queued"].is_set())
+
+            client.release["active"].set()
+            self._wait(done["active"], "active cancellation fence")
+            self.assertEqual(counts, {"active": 1, "queued": 1})
+            self.assertEqual(
+                receiver.get_and_clear_block_ids_with_load_errors(),
+                {
+                    requests["active"].block_ids[0][0],
+                    requests["queued"].block_ids[0][0],
+                },
+            )
+            receiver.cancel_requests({"active", "queued"}, wait=True)
+            self.assertEqual(counts, {"active": 1, "queued": 1})
+        finally:
+            for event in client.release.values():
+                event.set()
+            receiver.stop(cancel_pending=True)
+
+    def test_preemption_hook_waits_for_only_its_inflight_receive(self) -> None:
+        receiver, client, requests, done, counts, _order = self._receiver(
+            ("preempted",), recv_workers=1
+        )
+        self.assertTrue(receiver.add_request(requests["preempted"]))
+        self._wait(client.started["preempted"], "preempted native GET")
+
+        cancel_entered = threading.Event()
+        original_cancel = receiver.cancel_requests
+
+        def observed_cancel(req_ids, *, wait=True, **kwargs):
+            cancel_entered.set()
+            return original_cancel(req_ids, wait=wait, **kwargs)
+
+        receiver.cancel_requests = observed_cancel
+        send_thread = SimpleNamespace(
+            delete_finished_stored_request=lambda _req_id: None,
+            wait_for_inflight_put=lambda _req_id: True,
+        )
+        worker = DfkvStoreWorker.__new__(DfkvStoreWorker)
+        worker.kv_send_thread = send_thread
+        worker.kv_recv_thread = receiver
+        returned = threading.Event()
+
+        def preempt() -> None:
+            worker.start_load_kv(SimpleNamespace(preempted_req_ids={"preempted"}))
+            returned.set()
+
+        thread = threading.Thread(target=preempt)
+        thread.start()
+        try:
+            self._wait(cancel_entered, "receive preemption hook")
+            self.assertFalse(returned.is_set())
+            self.assertFalse(done["preempted"].is_set())
+            client.release["preempted"].set()
+            self._wait(returned, "preemption fence return")
+            thread.join(timeout=1)
+            self._wait(done["preempted"], "preempted terminalization")
+            self.assertEqual(counts["preempted"], 1)
+            self.assertEqual(
+                receiver.get_and_clear_block_ids_with_load_errors(), set()
+            )
+        finally:
+            client.release["preempted"].set()
+            thread.join(timeout=1)
+            receiver.stop(cancel_pending=True)
+
+    def test_finished_abort_waits_for_inflight_receive_before_acknowledging(
+        self,
+    ) -> None:
+        receiver, client, requests, done, counts, _order = self._receiver(
+            ("aborted",), recv_workers=1
+        )
+        self.assertTrue(receiver.add_request(requests["aborted"]))
+        self._wait(client.started["aborted"], "aborted native GET")
+
+        cancel_entered = threading.Event()
+        original_cancel = receiver.cancel_requests
+
+        def observed_cancel(req_ids, *, wait=True, **kwargs):
+            cancel_entered.set()
+            return original_cancel(req_ids, wait=wait, **kwargs)
+
+        receiver.cancel_requests = observed_cancel
+        worker = DfkvStoreWorker.__new__(DfkvStoreWorker)
+        worker.kv_recv_thread = receiver
+        worker.kv_send_thread = None
+        worker.kv_role = "kv_consumer"
+        worker.load_async = True
+        worker.tp_rank = 0
+        returned = threading.Event()
+        result: list[tuple[set[str], set[str]]] = []
+
+        def finish_abort() -> None:
+            result.append(
+                worker.get_finished(
+                    {"aborted"},
+                    SimpleNamespace(requests=[], preempted_req_ids=set()),
+                )
+            )
+            returned.set()
+
+        thread = threading.Thread(target=finish_abort)
+        thread.start()
+        try:
+            self._wait(cancel_entered, "finished-request receive cancellation")
+            self.assertFalse(returned.is_set())
+            self.assertFalse(done["aborted"].is_set())
+            client.release["aborted"].set()
+            self._wait(returned, "finished-request receive fence")
+            thread.join(timeout=1)
+            self.assertEqual(result, [(set(), {"aborted"})])
+            self.assertEqual(counts["aborted"], 1)
+            self.assertEqual(
+                receiver.get_and_clear_block_ids_with_load_errors(), set()
+            )
+        finally:
+            client.release["aborted"].set()
+            thread.join(timeout=1)
+            receiver.stop(cancel_pending=True)
+
+    def test_stop_drains_when_requested_and_native_exception_is_fail_closed(
+        self,
+    ) -> None:
+        receiver, client, requests, done, counts, order = self._receiver(
+            ("failing", "drained"), recv_workers=1
+        )
+        thread: threading.Thread | None = None
+        try:
+            client.raise_for.add("failing")
+            self.assertTrue(receiver.add_request(requests["failing"]))
+            self._wait(done["failing"], "exception terminalization")
+            self.assertTrue(receiver.add_request(requests["drained"]))
+            self._wait(client.started["drained"], "drained native GET")
+
+            stopped = threading.Event()
+
+            def drain() -> None:
+                receiver.stop(cancel_pending=False)
+                stopped.set()
+
+            thread = threading.Thread(target=drain)
+            thread.start()
+            self.assertFalse(stopped.is_set())
+            client.release["drained"].set()
+            self._wait(stopped, "draining stop")
+            thread.join(timeout=1)
+            self._wait(done["drained"], "drained request completion")
+
+            self.assertEqual(counts, {"failing": 1, "drained": 1})
+            self.assertEqual(order, ["failing", "drained"])
+            self.assertEqual(
+                receiver.get_and_clear_block_ids_with_load_errors(),
+                {requests["failing"].block_ids[0][0]},
+            )
+        finally:
+            for event in client.release.values():
+                event.set()
+            if thread is not None:
+                thread.join(timeout=1)
+            receiver.stop(cancel_pending=True)
+
+    def test_close_cancels_queued_and_fences_active_before_returning(self) -> None:
+        receiver, client, requests, done, counts, _order = self._receiver(
+            ("active", "queued", "after-close"), recv_workers=1
+        )
+        thread: threading.Thread | None = None
+        try:
+            self.assertTrue(receiver.add_request(requests["active"]))
+            self._wait(client.started["active"], "active native GET")
+            self.assertTrue(receiver.add_request(requests["queued"]))
+            stopped = threading.Event()
+
+            def close() -> None:
+                receiver.close(cancel_pending=True)
+                stopped.set()
+
+            thread = threading.Thread(target=close)
+            thread.start()
+            self._wait(done["queued"], "queued close cancellation")
+            self.assertFalse(stopped.is_set())
+            self.assertFalse(done["active"].is_set())
+            client.release["active"].set()
+            self._wait(stopped, "close after active fence")
+            thread.join(timeout=1)
+            self._wait(done["active"], "active close cancellation")
+
+            self.assertFalse(receiver.add_request(requests["after-close"]))
+            self._wait(done["after-close"], "post-close rejection")
+            self.assertEqual(
+                counts, {"active": 1, "queued": 1, "after-close": 1}
+            )
+            self.assertEqual(
+                receiver.get_and_clear_block_ids_with_load_errors(),
+                {requests["after-close"].block_ids[0][0]},
+            )
+        finally:
+            client.release["active"].set()
+            if thread is not None:
+                thread.join(timeout=1)
+            receiver.stop(cancel_pending=True)
 
 
 class LookupAccountingTest(unittest.TestCase):

--- a/test/python/test_dfkv_vllm_worker.py
+++ b/test/python/test_dfkv_vllm_worker.py
@@ -1,0 +1,520 @@
+"""CPU-only contracts for the vLLM lookup IPC and lookup accounting."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from importlib.util import find_spec
+import queue
+import sys
+import threading
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+
+def _install_runtime_dependency_stubs() -> None:
+    """Keep imports CPU-only when torch and pyzmq are not installed."""
+    if "torch" not in sys.modules and find_spec("torch") is None:
+        class Tensor:
+            pass
+
+        class Event:
+            pass
+
+        torch_module = ModuleType("torch")
+        torch_cuda_module = ModuleType("torch.cuda")
+        torch_cuda_module.Event = Event
+        torch_module.Tensor = Tensor
+        torch_module.cuda = torch_cuda_module
+        sys.modules["torch"] = torch_module
+        sys.modules["torch.cuda"] = torch_cuda_module
+
+    if "zmq" not in sys.modules and find_spec("zmq") is None:
+        class Again(Exception):
+            pass
+
+        class ZMQError(Exception):
+            pass
+
+        class Context:
+            pass
+
+        zmq_module = ModuleType("zmq")
+        zmq_module.Again = Again
+        zmq_module.ZMQError = ZMQError
+        zmq_module.Context = Context
+        zmq_module.REQ = 1
+        zmq_module.REP = 2
+        zmq_module.RCVTIMEO = 3
+        sys.modules["zmq"] = zmq_module
+
+
+def _install_vllm_stubs() -> None:
+    """Install the import surface used by the connector under standalone Python."""
+    if "vllm" in sys.modules or find_spec("vllm") is not None:
+        return
+
+    def stub(name: str, **attributes):
+        module = ModuleType(name)
+        module.__path__ = []
+        module.__dict__.update(attributes)
+        sys.modules[name] = module
+        if "." in name:
+            parent_name, child_name = name.rsplit(".", 1)
+            setattr(sys.modules[parent_name], child_name, module)
+        return module
+
+    class Placeholder:
+        pass
+
+    class BlockHash(bytes):
+        pass
+
+    @dataclass
+    class KVCacheBlock:
+        block_id: int
+
+    @dataclass
+    class KVConnectorStats:
+        data: dict = field(default_factory=dict)
+
+        def is_empty(self) -> bool:
+            return not self.data
+
+    class KVConnectorPromMetrics:
+        pass
+
+    class PromMetric:
+        pass
+
+    class BlockStored:
+        def __init__(self, **values) -> None:
+            self.__dict__.update(values)
+
+    class KVCacheSpecRegistry:
+        @classmethod
+        def get_manager_class(cls, _spec):
+            return Placeholder
+
+    stub("vllm")
+    stub("vllm.envs", VLLM_RPC_BASE_PATH="/tmp")
+    stub("vllm.config", VllmConfig=Placeholder, ParallelConfig=Placeholder)
+    stub(
+        "vllm.distributed",
+        get_dcp_group=lambda: Placeholder(),
+        get_pcp_group=lambda: Placeholder(),
+        get_tensor_model_parallel_rank=lambda: 0,
+        get_tensor_model_parallel_world_size=lambda: 1,
+    )
+    stub("vllm.distributed.kv_events", BlockStored=BlockStored)
+    stub("vllm.distributed.kv_transfer")
+    stub("vllm.distributed.kv_transfer.kv_connector")
+    stub("vllm.distributed.kv_transfer.kv_connector.v1")
+    stub(
+        "vllm.distributed.kv_transfer.kv_connector.v1.base",
+        KVConnectorMetadata=Placeholder,
+    )
+    stub(
+        "vllm.distributed.kv_transfer.kv_connector.v1.metrics",
+        KVConnectorPromMetrics=KVConnectorPromMetrics,
+        KVConnectorStats=KVConnectorStats,
+        PromMetric=PromMetric,
+        PromMetricT=PromMetric,
+    )
+    stub("vllm.logger", init_logger=logging.getLogger)
+    stub("vllm.utils")
+    stub(
+        "vllm.utils.math_utils",
+        cdiv=lambda numerator, denominator: (
+            numerator + denominator - 1
+        )
+        // denominator,
+    )
+    stub(
+        "vllm.utils.network_utils",
+        make_zmq_socket=lambda *_args, **_kwargs: None,
+    )
+    stub("vllm.v1")
+    stub("vllm.v1.core")
+    stub("vllm.v1.core.block_pool", BlockPool=Placeholder)
+    stub("vllm.v1.core.kv_cache_manager", KVCacheBlocks=Placeholder)
+    stub(
+        "vllm.v1.core.kv_cache_utils",
+        BlockHash=BlockHash,
+        BlockHashList=list[BlockHash],
+        BlockHashListWithBlockSize=tuple[list[BlockHash], int],
+        KVCacheBlock=KVCacheBlock,
+        maybe_convert_block_hash=lambda value: value,
+        resolve_kv_cache_block_sizes=lambda *_args, **_kwargs: (64, 64),
+    )
+    stub(
+        "vllm.v1.core.single_type_kv_cache_manager",
+        SingleTypeKVCacheManager=Placeholder,
+    )
+    stub("vllm.v1.core.sched")
+    stub(
+        "vllm.v1.core.sched.output",
+        NewRequestData=Placeholder,
+        SchedulerOutput=Placeholder,
+    )
+    stub(
+        "vllm.v1.kv_cache_interface",
+        FullAttentionSpec=Placeholder,
+        KVCacheConfig=Placeholder,
+        KVCacheGroupSpec=Placeholder,
+        KVCacheSpec=Placeholder,
+        UniformTypeKVCacheSpecs=Placeholder,
+    )
+    stub(
+        "vllm.v1.kv_cache_spec_registry",
+        KVCacheSpecRegistry=KVCacheSpecRegistry,
+    )
+    stub("vllm.v1.request", Request=Placeholder)
+
+
+_install_runtime_dependency_stubs()
+_install_vllm_stubs()
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "integration" / "common" / "src"))
+sys.path.insert(0, str(ROOT / "integration" / "vllm" / "src"))
+
+from vllm.v1.core.kv_cache_utils import BlockHash  # noqa: E402
+
+from dfkv_vllm.data import KeyMetadata  # noqa: E402
+from dfkv_vllm.protocol import LOOKUP_MSG  # noqa: E402
+from dfkv_vllm.worker import (  # noqa: E402
+    DfkvStoreWorker,
+    LookupKeyClient,
+    LookupKeyServer,
+)
+
+
+class _Frame:
+    def __init__(self, value: bytes) -> None:
+        self.buffer = value
+
+    def __bytes__(self) -> bytes:
+        return self.buffer
+
+
+class _MemoryLookupSocket:
+    """In-memory REQ/REP endpoint with the subset used by the lookup classes."""
+
+    def __init__(self) -> None:
+        self.requests: queue.Queue[list[bytes]] = queue.Queue()
+        self.responses: queue.Queue[bytes] = queue.Queue()
+        self.last_request: list[bytes] | None = None
+        self.closed = False
+
+    def setsockopt(self, _option, _value) -> None:
+        pass
+
+    def send_multipart(self, frames, copy=False) -> None:
+        del copy
+        request = [bytes(frame) for frame in frames]
+        self.last_request = request
+        self.requests.put(request)
+
+    def recv_multipart(self, copy=False):
+        del copy
+        try:
+            return [_Frame(value) for value in self.requests.get(timeout=0.02)]
+        except queue.Empty as exc:
+            import zmq
+
+            raise zmq.Again() from exc
+
+    def send(self, response) -> None:
+        self.responses.put(bytes(response))
+
+    def recv(self) -> bytes:
+        return self.responses.get(timeout=1)
+
+    def close(self, linger=0) -> None:
+        del linger
+        self.closed = True
+
+
+class _ControlledLookupSocket:
+    """Thread-safe fake whose replies are released explicitly by token length."""
+
+    def __init__(self, token_lengths: tuple[int, ...]) -> None:
+        self.started = {value: threading.Event() for value in token_lengths}
+        self.release = {value: threading.Event() for value in token_lengths}
+        self.send_count = {value: 0 for value in token_lengths}
+        self._local = threading.local()
+        self.closed = False
+
+    def send_multipart(self, frames, copy=False) -> None:
+        del copy
+        token_len = int.from_bytes(bytes(frames[1]), "big")
+        self._local.token_len = token_len
+        self.send_count[token_len] += 1
+        self.started[token_len].set()
+
+    def recv(self) -> bytes:
+        token_len = self._local.token_len
+        if not self.release[token_len].wait(timeout=1):
+            raise TimeoutError(f"lookup {token_len} was not released")
+        return token_len.to_bytes(4, "big")
+
+    def send(self, _frame) -> None:
+        raise AssertionError("reset is not used by these tests")
+
+    def close(self, linger=0) -> None:
+        del linger
+        self.closed = True
+
+
+class _MemoryContext:
+    def __init__(self) -> None:
+        self.terminated = False
+
+    def term(self) -> None:
+        self.terminated = True
+
+
+class _StoreWorker:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, list[bytes]]] = []
+        self.kv_send_thread = None
+        self.observations: list[tuple[str, float]] = []
+
+    def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
+        self.calls.append((token_len, [bytes(value) for value in block_hashes]))
+        return min(token_len, len(block_hashes) * 64)
+    def _record_kv_connector_observation(
+        self, name: str, duration_seconds: float
+    ) -> None:
+        self.observations.append((name, duration_seconds))
+
+
+
+class LookupFrameTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.endpoint = _MemoryLookupSocket()
+        self.context = _MemoryContext()
+        self.store = _StoreWorker()
+        patches = (
+            patch("dfkv_vllm.worker.zmq.Context", return_value=self.context),
+            patch("dfkv_vllm.worker.get_zmq_rpc_path_lookup", return_value="ipc:///tmp/dfkv-test-lookup"),
+            patch("dfkv_vllm.worker.make_zmq_socket", return_value=self.endpoint),
+            patch("dfkv_vllm.worker.os.path.exists", return_value=False),
+        )
+        self._patches = patches
+        for active_patch in patches:
+            active_patch.start()
+        self.server = LookupKeyServer(self.store, SimpleNamespace())
+        self.client = LookupKeyClient(SimpleNamespace())
+
+    def tearDown(self) -> None:
+        self.client.close()
+        self.server.close()
+        for active_patch in reversed(self._patches):
+            active_patch.stop()
+
+    @staticmethod
+    def _hash(seed: str) -> BlockHash:
+        return BlockHash(hashlib.sha256(seed.encode()).digest())
+
+    def test_binary_lookup_frame_round_trip(self) -> None:
+        hashes = [self._hash("alpha"), self._hash("beta")]
+
+        self.assertEqual(self.client.lookup("round-trip", 160, hashes), 128)
+
+        frames = self.endpoint.last_request
+        self.assertIsNotNone(frames)
+        assert frames is not None
+        self.assertEqual(frames[0], LOOKUP_MSG)
+        self.assertEqual(frames[1], (160).to_bytes(4, "big"))
+        self.assertEqual(frames[2], (32).to_bytes(2, "big"))
+        self.assertEqual(frames[3], b"".join(bytes(value) for value in hashes))
+        self.assertEqual(self.store.calls, [(160, [bytes(value) for value in hashes])])
+
+    def test_empty_hash_list_has_canonical_binary_frame(self) -> None:
+        self.assertEqual(self.client.lookup("empty", 64, []), 0)
+        self.assertEqual(
+            self.endpoint.last_request,
+            [LOOKUP_MSG, (64).to_bytes(4, "big"), (0).to_bytes(2, "big"), b""],
+        )
+        self.assertEqual(self.store.calls, [(64, [])])
+
+    def test_malformed_lookup_frames_are_rejected_and_server_survives(self) -> None:
+        malformed = (
+            [LOOKUP_MSG],
+            [LOOKUP_MSG, b"\x00", (32).to_bytes(2, "big"), b"x" * 32],
+            [LOOKUP_MSG, (64).to_bytes(4, "big"), b"\x00", b"x" * 32],
+            [LOOKUP_MSG, (64).to_bytes(4, "big"), (0).to_bytes(2, "big"), b"x"],
+            [LOOKUP_MSG, (64).to_bytes(4, "big"), (32).to_bytes(2, "big"), b"x" * 33],
+        )
+        for frames in malformed:
+            with self.subTest(frames=frames):
+                self.endpoint.send_multipart(frames)
+                self.assertEqual(self.endpoint.recv(), (0).to_bytes(4, "big"))
+                self.assertEqual(self.store.calls, [])
+
+        valid_hash = self._hash("still-alive")
+        self.assertEqual(self.client.lookup("valid-after-errors", 64, [valid_hash]), 64)
+
+class LookupFutureTest(unittest.TestCase):
+    @staticmethod
+    def _hash(seed: str) -> BlockHash:
+        return BlockHash(hashlib.sha256(seed.encode()).digest())
+
+    def _client(self, socket: _ControlledLookupSocket) -> LookupKeyClient:
+        context = _MemoryContext()
+        with (
+            patch("dfkv_vllm.worker.zmq.Context", return_value=context),
+            patch(
+                "dfkv_vllm.worker.get_zmq_rpc_path_lookup",
+                return_value="ipc:///tmp/dfkv-test-futures",
+            ),
+            patch("dfkv_vllm.worker.make_zmq_socket", return_value=socket),
+        ):
+            return LookupKeyClient(SimpleNamespace())
+
+    def test_only_one_future_is_created_per_request(self) -> None:
+        socket = _ControlledLookupSocket((64,))
+        client = self._client(socket)
+        hashes = [self._hash("same")]
+        try:
+            self.assertIsNone(client.lookup("same", 64, hashes, non_block=True))
+            self.assertTrue(socket.started[64].wait(timeout=1))
+            pending = client.futures["same"]
+
+            self.assertIsNone(client.lookup("same", 64, hashes, non_block=True))
+            self.assertIs(client.futures["same"], pending)
+            self.assertEqual(socket.send_count[64], 1)
+
+            socket.release[64].set()
+            self.assertEqual(pending.result(timeout=1), 64)
+            self.assertEqual(client.lookup("same", 64, hashes, non_block=True), 64)
+            self.assertNotIn("same", client.futures)
+        finally:
+            socket.release[64].set()
+            client.close()
+
+    def test_concurrent_request_ids_have_distinct_futures(self) -> None:
+        socket = _ControlledLookupSocket((64, 128))
+        client = self._client(socket)
+        hashes = [self._hash("concurrent")]
+        try:
+            self.assertIsNone(client.lookup("left", 64, hashes, non_block=True))
+            self.assertIsNone(client.lookup("right", 128, hashes, non_block=True))
+            self.assertEqual(set(client.futures), {"left", "right"})
+            self.assertIsNot(client.futures["left"], client.futures["right"])
+
+            socket.release[64].set()
+            socket.release[128].set()
+            self.assertEqual(client.futures["left"].result(timeout=1), 64)
+            self.assertEqual(client.futures["right"].result(timeout=1), 128)
+            self.assertEqual(client.lookup("left", 64, hashes, non_block=True), 64)
+            self.assertEqual(client.lookup("right", 128, hashes, non_block=True), 128)
+        finally:
+            socket.release[64].set()
+            socket.release[128].set()
+            client.close()
+
+    def test_discard_and_close_remove_and_cancel_pending_futures(self) -> None:
+        socket = _ControlledLookupSocket((32, 64, 128))
+        client = self._client(socket)
+        hashes = [self._hash("cancel")]
+        try:
+            self.assertIsNone(client.lookup("discarded", 32, hashes, non_block=True))
+            self.assertTrue(socket.started[32].wait(timeout=1))
+            client.discard("discarded")
+            self.assertNotIn("discarded", client.futures)
+            socket.release[32].set()
+
+            self.assertIsNone(
+                client.lookup("running-at-close", 64, hashes, non_block=True)
+            )
+            self.assertTrue(socket.started[64].wait(timeout=1))
+            self.assertIsNone(
+                client.lookup("queued-at-close", 128, hashes, non_block=True)
+            )
+            queued = client.futures["queued-at-close"]
+            client.close()
+
+            self.assertEqual(client.futures, {})
+            self.assertTrue(queued.cancelled())
+            self.assertTrue(socket.closed)
+        finally:
+            socket.release[32].set()
+            socket.release[64].set()
+            socket.release[128].set()
+            client.close()
+
+
+
+class LookupAccountingTest(unittest.TestCase):
+    @staticmethod
+    def _hash(seed: str) -> BlockHash:
+        return BlockHash(hashlib.sha256(seed.encode()).digest())
+
+    def test_lookup_records_physical_and_logical_key_counts(self) -> None:
+        hashes = [self._hash("one"), self._hash("two")]
+        metadata = KeyMetadata(
+            model_name="model",
+            dp_size=1,
+            dp_rank=-1,
+            tp_size=2,
+            tp_rank=0,
+            pcp_size=1,
+            pcp_rank=0,
+            dcp_size=1,
+            dcp_rank=0,
+            pp_size=2,
+            pp_rank=0,
+            group_id=0,
+        )
+
+        class _Client:
+            _sg_segs_cache = 2
+
+            def __init__(self) -> None:
+                self.keys: list[bytes] = []
+
+            def batch_exist(self, keys):
+                self.keys = list(keys)
+                return [1] * len(keys)
+
+        client = _Client()
+        records: list[dict[str, object]] = []
+        db = SimpleNamespace(block_size=64, metadata=metadata, _seg_layout=[1, 2, 3])
+        coord = SimpleNamespace(
+            lcm_block_size=64,
+            store_mask=lambda _token_len: [[True, True]],
+            block_hashes_for_spec=lambda values, _spec: values,
+            find_longest_cache_hit=lambda _hashes, token_len, _pool: (
+                None,
+                token_len,
+            ),
+        )
+        worker = SimpleNamespace(
+            coord=coord,
+            token_dbs=[db],
+            client=client,
+            tp_size=2,
+            num_kv_head=2,
+            pp_size=2,
+            _kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())],
+            _record_kv_connector_operation=lambda operation, duration, num_keys, **kwargs: records.append(
+                {"operation": operation, "duration": duration, "num_keys": num_keys, **kwargs}
+            ),
+        )
+
+        self.assertEqual(DfkvStoreWorker.lookup(worker, 128, hashes), 128)
+        self.assertEqual(len(client.keys), 16)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["operation"], "lookup_exists")
+        self.assertEqual(records[0]["num_keys"], 16)
+        self.assertEqual(records[0]["num_logical_keys"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/test_dfkv_vllm_worker.py
+++ b/test/python/test_dfkv_vllm_worker.py
@@ -573,6 +573,158 @@ class LogicalChunkTransferTest(unittest.TestCase):
         self.assertEqual(put_sizes, [sizes])
         self.assertEqual(client.remove_calls, [])
 
+    def test_put_timeout_stays_fenced_until_exception_and_close_complete(
+        self,
+    ) -> None:
+        metadata = self._metadata()
+        logical_key = PoolKey(metadata, self._hash("blocked-save").hex())
+        native_started = threading.Event()
+        native_release = threading.Event()
+
+        class _Database:
+            block_size = 64
+            _seg_layout = [(0, 1, 1)]
+
+            @staticmethod
+            def process_tokens(*_args):
+                return [(0, 64, logical_key)]
+
+            @staticmethod
+            def descriptor_shape(_start, _end, block_ids):
+                return 1, 64, block_ids[0]
+
+            @staticmethod
+            def fill_descriptors(
+                _start, _end, block_ids, pointers, sizes, offset=0
+            ):
+                pointers[offset] = 0x10000 + block_ids[0] * 0x100
+                sizes[offset] = 64
+                return offset + 1
+
+        client_closed = threading.Event()
+        class _Client:
+            @staticmethod
+            def batch_exist(keys):
+                return [0] * len(keys)
+
+            @staticmethod
+            def batch_put_sg(_keys, _ptrs, _sizes):
+                native_started.set()
+                if not native_release.wait(timeout=2):
+                    raise AssertionError("native PUT release was not signalled")
+                raise RuntimeError("controlled native PUT failure")
+
+            @staticmethod
+            def close():
+                client_closed.set()
+
+        client = _Client()
+        sender = KVCacheStoreSendingThread(
+            client,
+            SimpleNamespace(
+                lcm_block_size=64,
+                store_mask=lambda _token_len: [[True]],
+            ),
+            [_Database()],
+            block_size=64,
+            tp_rank=0,
+            put_step=1,
+            kv_role="kv_both",
+            ready_event=threading.Event(),
+        )
+        request = ReqMeta(
+            req_id="blocked-save",
+            token_len_chunk=64,
+            block_ids=([7],),
+            block_hashes=[self._hash("blocked-save")],
+        )
+        sender.add_stored_request(request.req_id)
+        sender.start()
+        self.assertTrue(sender.ready_event.wait(timeout=1))
+        self.assertTrue(sender.add_request(request))
+        self.assertTrue(native_started.wait(timeout=1))
+
+        diagnostic_expired = threading.Event()
+        wait_outcomes: list[bool] = []
+        original_wait = sender.wait_for_inflight_put
+
+        def short_diagnostic_wait(req_id: str) -> bool:
+            result = original_wait(req_id, timeout_s=0.01)
+            wait_outcomes.append(result)
+            if not result:
+                diagnostic_expired.set()
+            return result
+
+        sender.wait_for_inflight_put = short_diagnostic_wait
+        worker = DfkvStoreWorker.__new__(DfkvStoreWorker)
+        worker.kv_recv_thread = None
+        worker.kv_send_thread = sender
+        worker.lookup_server = None
+        worker._close_lock = threading.Lock()
+        worker._closed = False
+        worker._close_done = threading.Event()
+        worker._lazy_client_lock = threading.Lock()
+        worker._lazy_client_kwargs = None
+        worker.client = client
+        preemption_returned = threading.Event()
+        preemption_errors: list[BaseException] = []
+
+        def preempt() -> None:
+            try:
+                worker.start_load_kv(
+                    SimpleNamespace(preempted_req_ids={request.req_id})
+                )
+            except BaseException as exc:
+                preemption_errors.append(exc)
+            finally:
+                preemption_returned.set()
+
+        close_entered = threading.Event()
+        close_returned = threading.Event()
+        close_errors: list[BaseException] = []
+
+        def close() -> None:
+            close_entered.set()
+            try:
+                worker.close()
+            except BaseException as exc:
+                close_errors.append(exc)
+            finally:
+                close_returned.set()
+
+        preemption_thread = threading.Thread(target=preempt)
+        close_thread = threading.Thread(target=close)
+        preemption_thread.start()
+        try:
+            self.assertTrue(diagnostic_expired.wait(timeout=1))
+            self.assertFalse(preemption_returned.is_set())
+
+            close_thread.start()
+            self.assertTrue(close_entered.wait(timeout=1))
+            self.assertFalse(close_returned.is_set())
+
+            native_release.set()
+            self.assertTrue(preemption_returned.wait(timeout=1))
+            self.assertTrue(close_returned.wait(timeout=1))
+            preemption_thread.join(timeout=1)
+            close_thread.join(timeout=1)
+
+            self.assertEqual(preemption_errors, [])
+            self.assertEqual(close_errors, [])
+            self.assertGreaterEqual(wait_outcomes.count(False), 1)
+            self.assertEqual(wait_outcomes.count(True), 1)
+            self.assertIsNone(sender._active_req_id)
+            self.assertFalse(sender.is_alive())
+            self.assertTrue(client_closed.is_set())
+            self.assertIsNone(worker.kv_send_thread)
+            self.assertIsNone(worker.client)
+        finally:
+            native_release.set()
+            preemption_thread.join(timeout=1)
+            if close_thread.ident is not None:
+                close_thread.join(timeout=1)
+            sender.stop(cancel_pending=True)
+
     def test_partial_chunk_load_preserves_descriptor_order(self) -> None:
         metadata = self._metadata()
         hashes = [self._hash("load-hit"), self._hash("load-miss")]

--- a/test/python/vllm_external_cache_benchmark.py
+++ b/test/python/vllm_external_cache_benchmark.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""Deterministic streaming benchmark for vLLM external KV-cache rounds.
+
+Rounds are labels only: this program never clears, resets, or otherwise manages
+vLLM's local prefix cache or the configured external cache. Reuse the generated
+corpus (automatically from the same output directory, or via --corpus-file) to
+compare populate and post-restart hot rounds with byte-identical prompts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import random
+import statistics
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+CORPUS_FORMAT_VERSION = 1
+GENERATOR_VERSION = "dfkv-vllm-long-prefix-v1"
+WORDS = (
+    "amber", "aperture", "archive", "balance", "beacon", "binary", "canvas",
+    "cascade", "circuit", "context", "delta", "deterministic", "engine",
+    "fabric", "gradient", "harbor", "index", "kernel", "lattice", "matrix",
+    "memory", "metric", "model", "network", "observe", "parallel", "prefix",
+    "protocol", "quartz", "request", "scheduler", "segment", "signal",
+    "storage", "stream", "tensor", "token", "vector", "window", "zenith",
+)
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def atomic_write(path: str, data: bytes) -> None:
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=".tmp-vllm-cache-bench-", dir=directory)
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def completion_url(endpoint: str) -> str:
+    parsed = urllib.parse.urlsplit(endpoint)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("--endpoint must be an absolute http(s) URL")
+    path = parsed.path.rstrip("/")
+    if path.endswith("/chat/completions"):
+        result_path = path
+    elif path.endswith("/v1"):
+        result_path = path + "/chat/completions"
+    elif not path:
+        result_path = "/v1/chat/completions"
+    else:
+        result_path = path + "/v1/chat/completions"
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, result_path, parsed.query, ""))
+
+
+def tokenizer_url(endpoint: str, operation: str) -> str:
+    parsed = urllib.parse.urlsplit(endpoint)
+    path = parsed.path.rstrip("/")
+    marker = path.find("/v1/")
+    if marker >= 0:
+        path = path[:marker]
+    elif path.endswith("/v1"):
+        path = path[:-3]
+    elif path.endswith("/chat/completions"):
+        path = path[: -len("/chat/completions")]
+    result_path = path.rstrip("/") + "/" + operation
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, result_path, parsed.query, ""))
+
+
+def metrics_url(endpoint: str) -> str:
+    parsed = urllib.parse.urlsplit(endpoint)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("metrics endpoints must be absolute http(s) URLs")
+    path = parsed.path.rstrip("/")
+    if not path:
+        path = "/metrics"
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, ""))
+
+
+def post_json(url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=canonical_json(payload),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read(4096).decode("utf-8", errors="replace")
+        raise RuntimeError(f"POST {url} returned HTTP {error.code}: {detail}") from error
+    try:
+        decoded = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"POST {url} returned invalid JSON") from error
+    if not isinstance(decoded, dict):
+        raise RuntimeError(f"POST {url} returned a non-object JSON response")
+    return decoded
+
+
+def token_ids(endpoint: str, model: str, text: str, timeout: float) -> list[int]:
+    response = post_json(
+        tokenizer_url(endpoint, "tokenize"),
+        {"model": model, "prompt": text, "add_special_tokens": False},
+        timeout,
+    )
+    tokens = response.get("tokens")
+    if not isinstance(tokens, list) or not all(isinstance(item, int) for item in tokens):
+        raise RuntimeError("vLLM /tokenize response did not include integer tokens")
+    return tokens
+
+
+def detokenize(endpoint: str, model: str, tokens: list[int], timeout: float) -> str:
+    response = post_json(
+        tokenizer_url(endpoint, "detokenize"),
+        {"model": model, "tokens": tokens},
+        timeout,
+    )
+    prompt = response.get("prompt")
+    if not isinstance(prompt, str):
+        raise RuntimeError("vLLM /detokenize response did not include prompt text")
+    return prompt
+
+
+def deterministic_text(seed: int, character_count: int) -> str:
+    rng = random.Random(seed)
+    parts = ["Synthetic external-cache benchmark corpus.\n"]
+    length = len(parts[0])
+    sentence_words: list[str] = []
+    while length < character_count:
+        sentence_words.append(WORDS[rng.randrange(len(WORDS))])
+        if len(sentence_words) == 16:
+            sentence = " ".join(sentence_words).capitalize() + ".\n"
+            parts.append(sentence)
+            length += len(sentence)
+            sentence_words.clear()
+    if sentence_words and length < character_count:
+        tail = " ".join(sentence_words) + ".\n"
+        parts.append(tail)
+    return "".join(parts)[:character_count]
+
+
+def prefix_for_token_target(
+    endpoint: str, model: str, target: int, seed: int, timeout: float
+) -> tuple[str, int]:
+    character_count = max(1024, target * 5)
+    while True:
+        candidate = deterministic_text(seed, character_count)
+        candidate_tokens = token_ids(endpoint, model, candidate, timeout)
+        if len(candidate_tokens) >= target + 32:
+            break
+        character_count *= 2
+
+    low = max(1, target - 64)
+    high = min(len(candidate_tokens), target + 64)
+    checked: set[int] = set()
+    while low <= high:
+        token_count = (low + high) // 2
+        checked.add(token_count)
+        text = detokenize(endpoint, model, candidate_tokens[:token_count], timeout)
+        actual = len(token_ids(endpoint, model, text, timeout))
+        if actual == target:
+            return text, actual
+        if actual < target:
+            low = token_count + 1
+        else:
+            high = token_count - 1
+
+    for token_count in range(max(1, target - 128), min(len(candidate_tokens), target + 128) + 1):
+        if token_count in checked:
+            continue
+        text = detokenize(endpoint, model, candidate_tokens[:token_count], timeout)
+        actual = len(token_ids(endpoint, model, text, timeout))
+        if actual == target:
+            return text, actual
+    raise RuntimeError(
+        f"could not construct a prefix that re-tokenizes to exactly {target} tokens; "
+        "use --prefix-chars or reuse a previously saved corpus"
+    )
+
+
+def expected_corpus_config(args: argparse.Namespace) -> dict[str, Any]:
+    target_mode = "tokens" if args.prefix_tokens is not None else "characters"
+    target_value = args.prefix_tokens if args.prefix_tokens is not None else args.prefix_chars
+    return {
+        "generator_version": GENERATOR_VERSION,
+        "model": args.model,
+        "prefix_target_mode": target_mode,
+        "prefix_target": target_value,
+        "request_count": args.request_count,
+        "seed": args.seed,
+    }
+
+
+def validate_corpus(corpus: dict[str, Any], expected: dict[str, Any]) -> None:
+    if corpus.get("format_version") != CORPUS_FORMAT_VERSION:
+        raise ValueError("unsupported corpus format_version")
+    if corpus.get("config") != expected:
+        raise ValueError("saved corpus config does not match this command")
+    prefix = corpus.get("prefix")
+    suffixes = corpus.get("suffixes")
+    if not isinstance(prefix, str) or not isinstance(suffixes, list):
+        raise ValueError("saved corpus is missing prefix or suffixes")
+    if len(suffixes) != expected["request_count"] or not all(isinstance(item, str) for item in suffixes):
+        raise ValueError("saved corpus suffix count is invalid")
+    content = {key: value for key, value in corpus.items() if key != "corpus_sha256"}
+    if corpus.get("corpus_sha256") != sha256_bytes(canonical_json(content)):
+        raise ValueError("saved corpus checksum mismatch")
+
+
+def load_or_create_corpus(args: argparse.Namespace) -> tuple[dict[str, Any], str, bool]:
+    expected = expected_corpus_config(args)
+    config_id = sha256_bytes(canonical_json(expected))[:16]
+    path = args.corpus_file or os.path.join(args.output_dir, f"corpus-{config_id}.json")
+    if os.path.exists(path):
+        with open(path, "rb") as source:
+            corpus = json.load(source)
+        if not isinstance(corpus, dict):
+            raise ValueError("saved corpus must be a JSON object")
+        validate_corpus(corpus, expected)
+        return corpus, os.path.abspath(path), False
+
+    if args.corpus_file:
+        raise FileNotFoundError(f"--corpus-file does not exist: {path}")
+    if args.prefix_tokens is not None:
+        prefix, actual_tokens = prefix_for_token_target(
+            args.endpoint, args.model, args.prefix_tokens, args.seed, args.timeout
+        )
+    else:
+        prefix = deterministic_text(args.seed, args.prefix_chars)
+        actual_tokens = None
+
+    suffix_rng = random.Random(args.seed ^ 0xD1F5CAFE)
+    suffixes = [
+        "\n\n[benchmark request %06d nonce %016x]\n"
+        "Continue the synthetic document with a concise deterministic analysis."
+        % (index, suffix_rng.getrandbits(64))
+        for index in range(args.request_count)
+    ]
+    corpus = {
+        "format_version": CORPUS_FORMAT_VERSION,
+        "config": expected,
+        "prefix": prefix,
+        "suffixes": suffixes,
+        "prefix_characters": len(prefix),
+        "prefix_tokens": actual_tokens,
+        "prefix_sha256": sha256_bytes(prefix.encode("utf-8")),
+    }
+    corpus["corpus_sha256"] = sha256_bytes(canonical_json(corpus))
+    atomic_write(path, canonical_json(corpus) + b"\n")
+    return corpus, os.path.abspath(path), True
+
+
+def snapshot_metrics(
+    endpoints: list[tuple[str, str]], phase: str, run_stem: str, output_dir: str, timeout: float
+) -> list[dict[str, Any]]:
+    snapshots: list[dict[str, Any]] = []
+    for index, (kind, endpoint) in enumerate(endpoints):
+        started = utc_now()
+        url = metrics_url(endpoint)
+        record: dict[str, Any] = {"kind": kind, "url": url, "phase": phase, "timestamp": started}
+        try:
+            request = urllib.request.Request(url, headers={"Accept": "text/plain"}, method="GET")
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read()
+                status = response.status
+            filename = f"{run_stem}.metrics-{phase}-{kind}-{index}.prom"
+            path = os.path.join(output_dir, filename)
+            atomic_write(path, body)
+            record.update({
+                "success": True,
+                "http_status": status,
+                "bytes": len(body),
+                "sha256": sha256_bytes(body),
+                "path": os.path.abspath(path),
+            })
+        except (OSError, urllib.error.URLError, ValueError) as error:
+            record.update({"success": False, "error": f"{type(error).__name__}: {error}"})
+        snapshots.append(record)
+    return snapshots
+
+
+def stream_request(
+    args: argparse.Namespace,
+    corpus: dict[str, Any],
+    request_index: int,
+    run_started_ns: int,
+    start_gate: threading.Event,
+    active_state: dict[str, Any],
+) -> dict[str, Any]:
+    start_gate.wait()
+    prompt = corpus["prefix"] + corpus["suffixes"][request_index]
+    payload = {
+        "model": args.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": args.max_tokens,
+        "temperature": 0,
+        "seed": args.seed + request_index,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    started_at = utc_now()
+    started_ns = time.perf_counter_ns()
+    with active_state["lock"]:
+        active_state["active"] += 1
+        active_state["maximum"] = max(active_state["maximum"], active_state["active"])
+        active_at_start = active_state["active"]
+
+    first_token_ns: int | None = None
+    completion_hasher = hashlib.sha256()
+    completion_characters = 0
+    output_chunks = 0
+    usage_completion_tokens: int | None = None
+    finish_reason: str | None = None
+    saw_done = False
+    error_text: str | None = None
+    http_status: int | None = None
+    try:
+        request = urllib.request.Request(
+            completion_url(args.endpoint),
+            data=canonical_json(payload),
+            headers={"Content-Type": "application/json", "Accept": "text/event-stream"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=args.timeout) as response:
+            http_status = response.status
+            for raw_line in response:
+                line = raw_line.decode("utf-8", errors="strict").strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    saw_done = True
+                    break
+                if not data:
+                    continue
+                event = json.loads(data)
+                if not isinstance(event, dict):
+                    continue
+                if "error" in event:
+                    raise RuntimeError(f"stream error: {event['error']}")
+                usage = event.get("usage")
+                if isinstance(usage, dict) and isinstance(usage.get("completion_tokens"), int):
+                    usage_completion_tokens = usage["completion_tokens"]
+                choices = event.get("choices")
+                if not isinstance(choices, list):
+                    continue
+                for choice in choices:
+                    if not isinstance(choice, dict):
+                        continue
+                    if choice.get("finish_reason") is not None:
+                        finish_reason = str(choice["finish_reason"])
+                    delta = choice.get("delta")
+                    if not isinstance(delta, dict):
+                        continue
+                    pieces = []
+                    for field in ("reasoning_content", "content"):
+                        value = delta.get(field)
+                        if isinstance(value, str) and value:
+                            pieces.append(value)
+                    for piece in pieces:
+                        if first_token_ns is None:
+                            first_token_ns = time.perf_counter_ns()
+                        encoded = piece.encode("utf-8")
+                        completion_hasher.update(encoded)
+                        completion_characters += len(piece)
+                        output_chunks += 1
+    except urllib.error.HTTPError as error:
+        detail = error.read(4096).decode("utf-8", errors="replace")
+        error_text = f"HTTPError: HTTP {error.code}: {detail}"
+        http_status = error.code
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, RuntimeError) as error:
+        error_text = f"{type(error).__name__}: {error}"
+    finally:
+        ended_ns = time.perf_counter_ns()
+        ended_at = utc_now()
+        with active_state["lock"]:
+            active_state["active"] -= 1
+
+    success = error_text is None and first_token_ns is not None and (saw_done or finish_reason is not None)
+    output_tokens = usage_completion_tokens if usage_completion_tokens is not None else output_chunks
+    return {
+        "request_index": request_index,
+        "round_name": args.round_name,
+        "success": success,
+        "error": error_text,
+        "http_status": http_status,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "scheduled_offset_seconds": (started_ns - run_started_ns) / 1e9,
+        "ttft_seconds": (first_token_ns - started_ns) / 1e9 if first_token_ns is not None else None,
+        "e2e_seconds": (ended_ns - started_ns) / 1e9,
+        "output_tokens": output_tokens,
+        "output_tokens_source": "usage.completion_tokens" if usage_completion_tokens is not None else "nonempty_stream_chunks",
+        "output_chunks": output_chunks,
+        "output_characters": completion_characters,
+        "output_sha256": completion_hasher.hexdigest(),
+        "finish_reason": finish_reason,
+        "saw_done": saw_done,
+        "configured_concurrency": args.concurrency,
+        "active_at_start": active_at_start,
+        "prompt_sha256": sha256_bytes(prompt.encode("utf-8")),
+        "corpus_sha256": corpus["corpus_sha256"],
+    }
+
+
+def percentile(values: list[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def latency_summary(values: list[float]) -> dict[str, float | None]:
+    return {
+        "min": min(values) if values else None,
+        "mean": statistics.fmean(values) if values else None,
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "p99": percentile(values, 0.99),
+        "max": max(values) if values else None,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True, help="vLLM base URL or /v1/chat/completions URL")
+    parser.add_argument("--model", required=True)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--prefix-tokens", type=int, help="exact prefix token target via vLLM tokenize APIs")
+    target.add_argument("--prefix-chars", type=int, help="exact prefix character target")
+    parser.add_argument("--request-count", type=int, required=True)
+    parser.add_argument("--concurrency", type=int, required=True)
+    parser.add_argument("--max-tokens", type=int, required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument(
+        "--round-name", required=True, choices=("cold", "populate", "hot"),
+        help="measurement label only; never changes or resets cache state",
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--corpus-file",
+        help="reuse an existing saved corpus; its seed, model, size, and request count must match",
+    )
+    parser.add_argument(
+        "--vllm-metrics-endpoint", action="append", default=[],
+        help="optional vLLM Prometheus URL; repeat for multiple endpoints",
+    )
+    parser.add_argument(
+        "--dfkv-metrics-endpoint", action="append", default=[],
+        help="optional dfkv Prometheus URL; repeat for multiple endpoints",
+    )
+    parser.add_argument("--timeout", type=float, default=600.0, help="HTTP timeout in seconds")
+    args = parser.parse_args(argv)
+    for name in ("request_count", "concurrency", "max_tokens"):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    target_value = args.prefix_tokens if args.prefix_tokens is not None else args.prefix_chars
+    if target_value is None or target_value <= 0:
+        parser.error("prefix target must be positive")
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    completion_url(args.endpoint)
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    invocation = list(sys.argv if argv is None else [sys.argv[0], *argv])
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    corpus, corpus_path, corpus_created = load_or_create_corpus(args)
+    timestamp_stem = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    run_stem = f"{args.round_name}-{timestamp_stem}"
+    raw_path = os.path.abspath(os.path.join(args.output_dir, run_stem + ".requests.jsonl"))
+    summary_path = os.path.abspath(os.path.join(args.output_dir, run_stem + ".summary.json"))
+    metric_endpoints = (
+        [("vllm", item) for item in args.vllm_metrics_endpoint]
+        + [("dfkv", item) for item in args.dfkv_metrics_endpoint]
+    )
+
+    started_at = utc_now()
+    before_snapshots = snapshot_metrics(
+        metric_endpoints, "before", run_stem, args.output_dir, args.timeout
+    )
+    active_state: dict[str, Any] = {"active": 0, "maximum": 0, "lock": threading.Lock()}
+    start_gate = threading.Event()
+    run_started_ns = time.perf_counter_ns()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+        futures = [
+            executor.submit(
+                stream_request, args, corpus, index, run_started_ns, start_gate, active_state
+            )
+            for index in range(args.request_count)
+        ]
+        start_gate.set()
+        rows = [future.result() for future in concurrent.futures.as_completed(futures)]
+    run_ended_ns = time.perf_counter_ns()
+    ended_at = utc_now()
+    after_snapshots = snapshot_metrics(
+        metric_endpoints, "after", run_stem, args.output_dir, args.timeout
+    )
+
+    rows.sort(key=lambda row: row["request_index"])
+    raw = b"".join(canonical_json(row) + b"\n" for row in rows)
+    atomic_write(raw_path, raw)
+    successful = [row for row in rows if row["success"]]
+    ttft = [float(row["ttft_seconds"]) for row in successful]
+    e2e = [float(row["e2e_seconds"]) for row in successful]
+    source_counts: dict[str, int] = {}
+    for row in rows:
+        source = str(row["output_tokens_source"])
+        source_counts[source] = source_counts.get(source, 0) + 1
+
+    config = {
+        "endpoint": args.endpoint,
+        "completion_url": completion_url(args.endpoint),
+        "model": args.model,
+        "prefix_tokens": args.prefix_tokens,
+        "prefix_chars": args.prefix_chars,
+        "request_count": args.request_count,
+        "concurrency": args.concurrency,
+        "max_tokens": args.max_tokens,
+        "seed": args.seed,
+        "round_name": args.round_name,
+        "output_dir": os.path.abspath(args.output_dir),
+        "corpus_file": corpus_path,
+        "vllm_metrics_endpoints": list(args.vllm_metrics_endpoint),
+        "dfkv_metrics_endpoints": list(args.dfkv_metrics_endpoint),
+        "timeout": args.timeout,
+    }
+    summary = {
+        "format_version": 1,
+        "invocation": invocation,
+        "config": config,
+        "timestamps": {"started_at": started_at, "ended_at": ended_at},
+        "duration_seconds": (run_ended_ns - run_started_ns) / 1e9,
+        "cache_policy": "round name is a label; benchmark never resets external or local cache",
+        "corpus": {
+            "path": corpus_path,
+            "created_by_this_run": corpus_created,
+            "sha256": corpus["corpus_sha256"],
+            "prefix_sha256": corpus["prefix_sha256"],
+            "prefix_characters": corpus["prefix_characters"],
+            "prefix_tokens": corpus["prefix_tokens"],
+        },
+        "requests": {
+            "raw_jsonl": raw_path,
+            "total": len(rows),
+            "successful": len(successful),
+            "failed": len(rows) - len(successful),
+            "success_rate": len(successful) / len(rows),
+        },
+        "concurrency": {
+            "configured": args.concurrency,
+            "effective_limit": min(args.concurrency, args.request_count),
+            "maximum_observed": active_state["maximum"],
+        },
+        "ttft_seconds": latency_summary(ttft),
+        "e2e_seconds": latency_summary(e2e),
+        "output_tokens": {
+            "total": sum(int(row["output_tokens"]) for row in successful),
+            "mean_per_success": (
+                statistics.fmean(int(row["output_tokens"]) for row in successful)
+                if successful else None
+            ),
+            "source_request_counts": source_counts,
+        },
+        "metrics_snapshots": {"before": before_snapshots, "after": after_snapshots},
+    }
+    atomic_write(summary_path, json.dumps(summary, indent=2, sort_keys=True, ensure_ascii=False).encode("utf-8") + b"\n")
+    print(json.dumps({
+        "summary": summary_path,
+        "raw_jsonl": raw_path,
+        "corpus": corpus_path,
+        "successful": len(successful),
+        "failed": len(rows) - len(successful),
+    }, sort_keys=True))
+    return 0 if len(successful) == len(rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/python/vllm_external_cache_benchmark.py
+++ b/test/python/vllm_external_cache_benchmark.py
@@ -28,8 +28,19 @@ import urllib.request
 from typing import Any
 
 
-CORPUS_FORMAT_VERSION = 1
+CORPUS_FORMAT_VERSION = 2
 GENERATOR_VERSION = "dfkv-vllm-long-prefix-v1"
+DEPLOYMENT_IDENTITY_FIELDS = (
+    "model",
+    "model_revision",
+    "vllm_version",
+    "vllm_commit",
+    "dfkv_version",
+    "dfkv_build_commit",
+    "connector_layout",
+    "connector_version",
+    "deployment_manifest_hash",
+)
 WORDS = (
     "amber", "aperture", "archive", "balance", "beacon", "binary", "canvas",
     "cascade", "circuit", "context", "delta", "deterministic", "engine",
@@ -213,6 +224,58 @@ def prefix_for_token_target(
     )
 
 
+def deployment_identity(args: argparse.Namespace) -> dict[str, str | None]:
+    """Return the fixed-schema, operator-supplied deployment identity."""
+    return {
+        "model": args.model,
+        "model_revision": args.model_revision,
+        "vllm_version": args.vllm_version,
+        "vllm_commit": args.vllm_commit,
+        "dfkv_version": args.dfkv_version,
+        "dfkv_build_commit": args.dfkv_build_commit,
+        "connector_layout": args.connector_layout,
+        "connector_version": args.connector_version,
+        "deployment_manifest_hash": args.deployment_manifest_hash,
+    }
+
+
+def corpus_compatibility_identity(
+    identity: dict[str, str | None],
+) -> dict[str, str | None]:
+    """Identity fields that affect the corpus model/tokenizer contract."""
+    return {
+        "model": identity["model"],
+        "model_revision": identity["model_revision"],
+    }
+
+
+def require_summary_identity(
+    path: str | None, expected: dict[str, str | None]
+) -> str | None:
+    if path is None:
+        return None
+    with open(path, "rb") as source:
+        raw = source.read()
+    summary = json.loads(raw)
+    if not isinstance(summary, dict):
+        raise ValueError("identity reference summary must be a JSON object")
+    actual = summary.get("deployment_identity")
+    if not isinstance(actual, dict):
+        raise ValueError("identity reference summary is missing deployment_identity")
+    if tuple(sorted(actual)) != tuple(sorted(DEPLOYMENT_IDENTITY_FIELDS)):
+        raise ValueError("identity reference summary has an invalid deployment_identity schema")
+    mismatches = [
+        field for field in DEPLOYMENT_IDENTITY_FIELDS
+        if actual.get(field) != expected[field]
+    ]
+    if mismatches:
+        raise ValueError(
+            "deployment identity does not match reference summary fields: "
+            + ", ".join(mismatches)
+        )
+    return sha256_bytes(raw)
+
+
 def expected_corpus_config(args: argparse.Namespace) -> dict[str, Any]:
     target_mode = "tokens" if args.prefix_tokens is not None else "characters"
     target_value = args.prefix_tokens if args.prefix_tokens is not None else args.prefix_chars
@@ -226,11 +289,25 @@ def expected_corpus_config(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
-def validate_corpus(corpus: dict[str, Any], expected: dict[str, Any]) -> None:
+def validate_corpus(
+    corpus: dict[str, Any],
+    expected: dict[str, Any],
+    current_identity: dict[str, str | None],
+) -> None:
     if corpus.get("format_version") != CORPUS_FORMAT_VERSION:
         raise ValueError("unsupported corpus format_version")
     if corpus.get("config") != expected:
         raise ValueError("saved corpus config does not match this command")
+    saved_identity = corpus.get("deployment_identity")
+    if not isinstance(saved_identity, dict):
+        raise ValueError("saved corpus is missing deployment_identity")
+    if tuple(sorted(saved_identity)) != tuple(sorted(DEPLOYMENT_IDENTITY_FIELDS)):
+        raise ValueError("saved corpus has an invalid deployment_identity schema")
+    compatibility = corpus.get("compatibility_identity")
+    if compatibility != corpus_compatibility_identity(saved_identity):
+        raise ValueError("saved corpus has inconsistent compatibility identity")
+    if compatibility != corpus_compatibility_identity(current_identity):
+        raise ValueError("saved corpus model identity does not match this command")
     prefix = corpus.get("prefix")
     suffixes = corpus.get("suffixes")
     if not isinstance(prefix, str) or not isinstance(suffixes, list):
@@ -244,14 +321,18 @@ def validate_corpus(corpus: dict[str, Any], expected: dict[str, Any]) -> None:
 
 def load_or_create_corpus(args: argparse.Namespace) -> tuple[dict[str, Any], str, bool]:
     expected = expected_corpus_config(args)
-    config_id = sha256_bytes(canonical_json(expected))[:16]
+    identity = deployment_identity(args)
+    config_id = sha256_bytes(canonical_json({
+        "config": expected,
+        "compatibility_identity": corpus_compatibility_identity(identity),
+    }))[:16]
     path = args.corpus_file or os.path.join(args.output_dir, f"corpus-{config_id}.json")
     if os.path.exists(path):
         with open(path, "rb") as source:
             corpus = json.load(source)
         if not isinstance(corpus, dict):
             raise ValueError("saved corpus must be a JSON object")
-        validate_corpus(corpus, expected)
+        validate_corpus(corpus, expected, identity)
         return corpus, os.path.abspath(path), False
 
     if args.corpus_file:
@@ -274,6 +355,8 @@ def load_or_create_corpus(args: argparse.Namespace) -> tuple[dict[str, Any], str
     corpus = {
         "format_version": CORPUS_FORMAT_VERSION,
         "config": expected,
+        "deployment_identity": identity,
+        "compatibility_identity": corpus_compatibility_identity(identity),
         "prefix": prefix,
         "suffixes": suffixes,
         "prefix_characters": len(prefix),
@@ -292,7 +375,12 @@ def snapshot_metrics(
     for index, (kind, endpoint) in enumerate(endpoints):
         started = utc_now()
         url = metrics_url(endpoint)
-        record: dict[str, Any] = {"kind": kind, "url": url, "phase": phase, "timestamp": started}
+        record: dict[str, Any] = {
+            "kind": kind,
+            "endpoint_sha256": sha256_bytes(endpoint.encode("utf-8")),
+            "phase": phase,
+            "timestamp": started,
+        }
         try:
             request = urllib.request.Request(url, headers={"Accept": "text/plain"}, method="GET")
             with urllib.request.urlopen(request, timeout=timeout) as response:
@@ -306,10 +394,10 @@ def snapshot_metrics(
                 "http_status": status,
                 "bytes": len(body),
                 "sha256": sha256_bytes(body),
-                "path": os.path.abspath(path),
+                "artifact": filename,
             })
         except (OSError, urllib.error.URLError, ValueError) as error:
-            record.update({"success": False, "error": f"{type(error).__name__}: {error}"})
+            record.update({"success": False, "error_type": type(error).__name__})
         snapshots.append(record)
     return snapshots
 
@@ -372,7 +460,7 @@ def stream_request(
                 if not isinstance(event, dict):
                     continue
                 if "error" in event:
-                    raise RuntimeError(f"stream error: {event['error']}")
+                    raise RuntimeError("stream reported an error")
                 usage = event.get("usage")
                 if isinstance(usage, dict) and isinstance(usage.get("completion_tokens"), int):
                     usage_completion_tokens = usage["completion_tokens"]
@@ -400,11 +488,11 @@ def stream_request(
                         completion_characters += len(piece)
                         output_chunks += 1
     except urllib.error.HTTPError as error:
-        detail = error.read(4096).decode("utf-8", errors="replace")
-        error_text = f"HTTPError: HTTP {error.code}: {detail}"
+        error.read(4096)
+        error_text = f"HTTPError: HTTP {error.code}"
         http_status = error.code
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, RuntimeError) as error:
-        error_text = f"{type(error).__name__}: {error}"
+        error_text = type(error).__name__
     finally:
         ended_ns = time.perf_counter_ns()
         ended_at = utc_now()
@@ -465,6 +553,23 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--endpoint", required=True, help="vLLM base URL or /v1/chat/completions URL")
     parser.add_argument("--model", required=True)
+    identity = parser.add_argument_group("deployment identity")
+    identity.add_argument("--model-revision", help="exact model revision or artifact digest")
+    identity.add_argument("--vllm-version", help="exact deployed vLLM version")
+    identity.add_argument("--vllm-commit", help="exact deployed vLLM source commit")
+    identity.add_argument("--dfkv-version", help="exact deployed dfkv version")
+    identity.add_argument("--dfkv-build-commit", help="exact deployed libdfkv build commit")
+    identity.add_argument("--connector-layout", help="exact connector storage layout identity")
+    identity.add_argument("--connector-version", help="exact deployed connector package version")
+    identity.add_argument(
+        "--deployment-manifest-hash",
+        help="exact digest of the immutable deployment manifest",
+    )
+    identity.add_argument(
+        "--require-identity-summary",
+        metavar="FILE",
+        help="fail before requests unless FILE has the same deployment identity",
+    )
     target = parser.add_mutually_exclusive_group(required=True)
     target.add_argument("--prefix-tokens", type=int, help="exact prefix token target via vLLM tokenize APIs")
     target.add_argument("--prefix-chars", type=int, help="exact prefix character target")
@@ -479,7 +584,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--output-dir", required=True)
     parser.add_argument(
         "--corpus-file",
-        help="reuse an existing saved corpus; its seed, model, size, and request count must match",
+        help="reuse a saved corpus; generation config and model identity must match",
     )
     parser.add_argument(
         "--vllm-metrics-endpoint", action="append", default=[],
@@ -504,8 +609,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
-    invocation = list(sys.argv if argv is None else [sys.argv[0], *argv])
     args = parse_args(sys.argv[1:] if argv is None else argv)
+    current_identity = deployment_identity(args)
+    identity_reference_sha256 = require_summary_identity(
+        args.require_identity_summary, current_identity
+    )
     os.makedirs(args.output_dir, exist_ok=True)
 
     corpus, corpus_path, corpus_created = load_or_create_corpus(args)
@@ -552,8 +660,7 @@ def main(argv: list[str] | None = None) -> int:
         source_counts[source] = source_counts.get(source, 0) + 1
 
     config = {
-        "endpoint": args.endpoint,
-        "completion_url": completion_url(args.endpoint),
+        "endpoint_sha256": sha256_bytes(args.endpoint.encode("utf-8")),
         "model": args.model,
         "prefix_tokens": args.prefix_tokens,
         "prefix_chars": args.prefix_chars,
@@ -562,29 +669,34 @@ def main(argv: list[str] | None = None) -> int:
         "max_tokens": args.max_tokens,
         "seed": args.seed,
         "round_name": args.round_name,
-        "output_dir": os.path.abspath(args.output_dir),
-        "corpus_file": corpus_path,
-        "vllm_metrics_endpoints": list(args.vllm_metrics_endpoint),
-        "dfkv_metrics_endpoints": list(args.dfkv_metrics_endpoint),
+        "corpus_file": os.path.basename(corpus_path),
+        "vllm_metrics_endpoint_count": len(args.vllm_metrics_endpoint),
+        "dfkv_metrics_endpoint_count": len(args.dfkv_metrics_endpoint),
         "timeout": args.timeout,
     }
     summary = {
-        "format_version": 1,
-        "invocation": invocation,
+        "format_version": 2,
+        "deployment_identity": current_identity,
+        "identity_requirement": {
+            "enforced": identity_reference_sha256 is not None,
+            "reference_summary_sha256": identity_reference_sha256,
+        },
         "config": config,
         "timestamps": {"started_at": started_at, "ended_at": ended_at},
         "duration_seconds": (run_ended_ns - run_started_ns) / 1e9,
         "cache_policy": "round name is a label; benchmark never resets external or local cache",
         "corpus": {
-            "path": corpus_path,
+            "artifact": os.path.basename(corpus_path),
             "created_by_this_run": corpus_created,
             "sha256": corpus["corpus_sha256"],
             "prefix_sha256": corpus["prefix_sha256"],
             "prefix_characters": corpus["prefix_characters"],
             "prefix_tokens": corpus["prefix_tokens"],
+            "deployment_identity": corpus["deployment_identity"],
+            "compatibility_identity": corpus["compatibility_identity"],
         },
         "requests": {
-            "raw_jsonl": raw_path,
+            "raw_jsonl_artifact": os.path.basename(raw_path),
             "total": len(rows),
             "successful": len(successful),
             "failed": len(rows) - len(successful),

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -37,6 +37,31 @@ namespace {
 // (RDMA pins registered memory); the test values are a few KB.
 constexpr size_t kMaxMsg = 256 * 1024;
 
+class ScopedEnv {
+ public:
+  ScopedEnv(const char* name, const char* value) : name_(name) {
+    if (const char* old = std::getenv(name)) {
+      had_old_ = true;
+      old_ = old;
+    }
+    ::setenv(name, value, 1);
+  }
+  ~ScopedEnv() {
+    if (had_old_)
+      ::setenv(name_.c_str(), old_.c_str(), 1);
+    else
+      ::unsetenv(name_.c_str());
+  }
+
+  ScopedEnv(const ScopedEnv&) = delete;
+  ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+ private:
+  std::string name_;
+  std::string old_;
+  bool had_old_ = false;
+};
+
 std::string SelfHdr() { return "test/model"; }
 void ConfigureTestRecvSegment() {
   // Keep Soft-RoCE CI below modest RLIMIT_MEMLOCK. Production defaults to
@@ -924,16 +949,14 @@ TEST(RdmaLoopback, BatchPutRejectsEmptyValue) {
   EXPECT_EQ(out, nonempty);
 }
 
-// Scatter-gather over RDMA: BatchPutSg gathers N caller buffers into one stored
-// blob via a multi-SGE SEND; BatchGetAutoSg scatters the stored blob across N
-// caller buffers via a multi-SGE RECV. Exercises the real PostSendScatterMulti /
-// PostRecvScatterMulti datapath (not the concat fallback). Covers N=1, N=2,
-// N=29 (max_sge-1), variable sizes, the >29 guard, and depth-one windowing.
+// Scatter-gather over RDMA: one logical object may span any number of caller
+// descriptors. The transport windows that descriptor stream to the negotiated
+// HCA SGE limit without changing object identity or byte order.
 TEST(RdmaLoopback, ScatterGatherRoundtripOverRdma) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   // The configured ordinary-data depth stays >1; the dedicated SG lane must
   // nevertheless use depth-one windows.
-  ::setenv("DFKV_RDMA_DEPTH", "4", 1);
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
   RdmaNode node("sg");
   RdmaTransport rt(kMaxMsg);
   KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
@@ -953,38 +976,70 @@ TEST(RdmaLoopback, ScatterGatherRoundtripOverRdma) {
     std::vector<const void*> ptrs;
     for (auto& s : src) ptrs.push_back(s.data());
     KvPutItemSg put{key, ptrs, sizes};
-    auto pr = c.BatchPutSg({put});
+    const auto pr = c.BatchPutSg({put});
+    ASSERT_EQ(pr.size(), 1u);
     ASSERT_TRUE(pr[0]) << "put " << key;
     std::vector<std::string> dst(sizes.size());
     std::vector<void*> dptrs;
-    for (size_t i = 0; i < sizes.size(); ++i) { dst[i].assign(sizes[i], '\0'); dptrs.push_back(&dst[i][0]); }
+    for (size_t i = 0; i < sizes.size(); ++i) {
+      dst[i].assign(sizes[i], '\0');
+      dptrs.push_back(dst[i].data());
+    }
     KvGetItemSg get{key, dptrs, sizes};
     std::vector<size_t> lens;
-    auto gr = c.BatchGetAutoSg({get}, &lens);
+    const auto gr = c.BatchGetAutoSg({get}, &lens);
+    ASSERT_EQ(gr.size(), 1u);
     ASSERT_TRUE(gr[0]) << "get " << key;
     size_t total = 0; for (size_t s : sizes) total += s;
     EXPECT_EQ(lens[0], total);
     for (size_t i = 0; i < sizes.size(); ++i) EXPECT_EQ(dst[i], src[i]) << key << " seg " << i;
   };
 
+  const size_t max_sg = rt.MaxSgPayloadSegs();
+  ASSERT_GE(max_sg, 2u);
   roundtrip("sg_n1", std::vector<size_t>(1, 4096));
   roundtrip("sg_n2", std::vector<size_t>(2, 2048));
-  roundtrip("sg_n29", std::vector<size_t>(29, 256));         // max payload SGEs
-  roundtrip("sg_var", {1, 7, 64, 333, 4096, 11});            // variable per-seg sizes
+  roundtrip("sg_exact_max", std::vector<size_t>(max_sg, 256));
+  roundtrip("sg_max_plus_one", std::vector<size_t>(max_sg + 1, 193));
+  roundtrip("sg_multi_window", std::vector<size_t>(max_sg * 3 + 5, 71));
+  roundtrip("sg_var", {1, 7, 64, 333, 4096, 11});
+  roundtrip("sg_zero_descriptors", {17, 0, 31, 0, 9});
 
-  // >29 segments: rejected by the guard (put fails, get is a miss) — no corruption.
+  // Insufficient aggregate capacity is rejected before any destination byte is
+  // touched, even when both the value and destination cross WR boundaries.
   {
-    std::vector<size_t> sizes(30, 16);
-    auto src = make_chunks("sg_over", sizes);
-    std::vector<const void*> ptrs; for (auto& s : src) ptrs.push_back(s.data());
-    KvPutItemSg put{"sg_over", ptrs, sizes};
-    EXPECT_FALSE(c.BatchPutSg({put})[0]);
-    std::vector<std::string> dst(30);
+    std::vector<size_t> sizes(max_sg + 3, 32);
+    auto src = make_chunks("sg_small_cap", sizes);
+    std::vector<const void*> ptrs;
+    for (auto& s : src) ptrs.push_back(s.data());
+    const auto put = c.BatchPutSg({{"sg_small_cap", ptrs, sizes}});
+    ASSERT_EQ(put.size(), 1u);
+    ASSERT_TRUE(put[0]);
+
+    std::vector<size_t> caps = sizes;
+    ASSERT_FALSE(caps.empty());
+    --caps.back();
+    std::vector<std::string> dst(caps.size());
     std::vector<void*> dptrs;
-    for (int i = 0; i < 30; ++i) { dst[i].assign(16, '\0'); dptrs.push_back(&dst[i][0]); }
-    KvGetItemSg get{"sg_over", dptrs, sizes};
+    for (size_t i = 0; i < caps.size(); ++i) {
+      dst[i].assign(caps[i], '\x5a');
+      dptrs.push_back(dst[i].data());
+    }
     std::vector<size_t> lens;
-    EXPECT_FALSE(c.BatchGetAutoSg({get}, &lens)[0]);
+    const auto get = c.BatchGetAutoSg(
+        {{"sg_small_cap", dptrs, caps}}, &lens);
+    ASSERT_EQ(get.size(), 1u);
+    EXPECT_FALSE(get[0]);
+    ASSERT_EQ(lens.size(), 1u);
+    EXPECT_EQ(lens[0], 0u);
+    for (const auto& segment : dst)
+      EXPECT_EQ(segment, std::string(segment.size(), '\x5a'));
+
+    std::string contiguous;
+    for (const auto& segment : src) contiguous += segment;
+    std::string out(contiguous.size(), '\0');
+    ASSERT_TRUE(c.Get("sg_small_cap", out.data(), out.size()));
+    EXPECT_EQ(out, contiguous);
   }
 
   // Multi-key fan-out crosses the SG lane's depth-one send window. Pin client
@@ -1003,6 +1058,7 @@ TEST(RdmaLoopback, ScatterGatherRoundtripOverRdma) {
       puts[i] = {"sgm" + std::to_string(i), ptrs, sizes};
     }
     auto pr = c.BatchPutSg(puts);
+    ASSERT_EQ(pr.size(), static_cast<size_t>(N));
     for (int i = 0; i < N; ++i) ASSERT_TRUE(pr[i]) << i;
     std::vector<std::vector<std::string>> dsts(N);
     std::vector<KvGetItemSg> gets(N);
@@ -1017,12 +1073,108 @@ TEST(RdmaLoopback, ScatterGatherRoundtripOverRdma) {
     }
     std::vector<size_t> lens;
     auto gr = c.BatchGetAutoSg(gets, &lens);
+    ASSERT_EQ(gr.size(), static_cast<size_t>(N));
+    ASSERT_EQ(lens.size(), static_cast<size_t>(N));
     for (int i = 0; i < N; ++i) {
       ASSERT_TRUE(gr[i]) << i;
-      for (size_t j = 0; j < srcs[i].size(); ++j) EXPECT_EQ(dsts[i][j], srcs[i][j]) << i << " " << j;
+      size_t expected_len = 0;
+      for (size_t j = 0; j < srcs[i].size(); ++j) {
+        expected_len += srcs[i][j].size();
+        EXPECT_EQ(dsts[i][j], srcs[i][j]) << i << " " << j;
+      }
+      EXPECT_EQ(lens[i], expected_len) << i;
     }
   }
-  ::unsetenv("DFKV_RDMA_DEPTH");
+}
+
+TEST(RdmaLoopback, MultiWrLaterWindowFailureIsAtomicAndReclaimsState) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ScopedEnv idle_reclaim("DFKV_RDMA_IDLE_MS", "2000");
+  RdmaNode node("sgabort");
+  const uint64_t transient_baseline =
+      rdma::RcEndpoint::TransientUserMrActive();
+  const uint64_t active_baseline = node.rsrv->ActiveConns();
+  const auto wait_for_active_at_most = [&node](uint64_t limit) {
+    for (int i = 0; i < 2000 && node.rsrv->ActiveConns() > limit; ++i)
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    return node.rsrv->ActiveConns();
+  };
+
+  std::vector<std::string> src;
+  std::vector<const void*> ptrs;
+  std::vector<size_t> sizes;
+  {
+    RdmaTransport rt(kMaxMsg);
+    const size_t max_sg = rt.MaxSgPayloadSegs();
+    ASSERT_GE(max_sg, 2u);
+    src.resize(max_sg + 7);
+    for (size_t i = 0; i < src.size(); ++i) {
+      src[i].assign(97 + i % 11, static_cast<char>('a' + i % 26));
+      ptrs.push_back(src[i].data());
+      sizes.push_back(src[i].size());
+    }
+    KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+    const uint64_t active_before_fault = node.rsrv->ActiveConns();
+    const uint64_t opened_before_fault = node.rsrv->V2Conns();
+    std::vector<bool> failed;
+    {
+      ScopedEnv abort_window("DFKV_RDMA_TEST_ABORT_MULTIWR_WINDOW", "2");
+      failed = c.BatchPutSg(
+          {{"sg_later_window_abort", ptrs, sizes}});
+    }
+    ASSERT_EQ(failed.size(), 1u);
+    EXPECT_FALSE(failed[0]);
+    const uint64_t opened_delta =
+        node.rsrv->V2Conns() - opened_before_fault;
+    ASSERT_GT(opened_delta, 0u);
+    // ActiveConns is a server-side gauge: destroying an RC peer may leave its
+    // silent server half alive until the idle reaper runs.  Allow every healthy
+    // connection opened by the operation, but require the faulted QP itself to
+    // disappear.  One leaked QP therefore exceeds this bound by exactly one.
+    const uint64_t max_active_after_fault =
+        active_before_fault + opened_delta - 1;
+    EXPECT_LE(wait_for_active_at_most(max_active_after_fault),
+              max_active_after_fault);
+    EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), transient_baseline);
+  }
+
+  EXPECT_LE(wait_for_active_at_most(active_baseline), active_baseline);
+  EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), transient_baseline);
+
+  EXPECT_EQ(node.srv->Count(), 0u);
+  // A failed logical PUT never commits a readable prefix. Once fault injection
+  // is removed, the same object succeeds and round-trips on a fresh connection.
+  {
+    RdmaTransport rt(kMaxMsg);
+    KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+    EXPECT_FALSE(c.Exist("sg_later_window_abort"));
+    const auto put = c.BatchPutSg(
+        {{"sg_later_window_abort", ptrs, sizes}});
+    ASSERT_EQ(put.size(), 1u);
+    ASSERT_TRUE(put[0]);
+    std::vector<std::string> dst(src.size());
+    std::vector<void*> dptrs;
+    for (size_t i = 0; i < src.size(); ++i) {
+      dst[i].assign(src[i].size(), '\0');
+      dptrs.push_back(dst[i].data());
+    }
+    std::vector<size_t> lens;
+    const auto get = c.BatchGetAutoSg(
+        {{"sg_later_window_abort", dptrs, sizes}}, &lens);
+    ASSERT_EQ(get.size(), 1u);
+    ASSERT_TRUE(get[0]);
+    ASSERT_EQ(lens.size(), 1u);
+    size_t expected_len = 0;
+    for (size_t i = 0; i < src.size(); ++i) {
+      expected_len += src[i].size();
+      EXPECT_EQ(dst[i], src[i]) << i;
+    }
+    EXPECT_EQ(lens[0], expected_len);
+  }
+  EXPECT_LE(wait_for_active_at_most(active_baseline), active_baseline);
+  EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), transient_baseline);
+  node.rsrv->Stop();
+  EXPECT_EQ(node.rsrv->ActiveConns(), 0u);
 }
 
 TEST(RdmaLoopback, ScatterGatherGetUsesDedicatedPool) {

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -44,7 +44,10 @@ class ScopedEnv {
       had_old_ = true;
       old_ = old;
     }
-    ::setenv(name, value, 1);
+    if (value)
+      ::setenv(name, value, 1);
+    else
+      ::unsetenv(name);
   }
   ~ScopedEnv() {
     if (had_old_)
@@ -1530,6 +1533,177 @@ struct RdmaUringNode {
     fs::remove_all(dir);
   }
 };
+
+TEST(RdmaLoopback, MultiWindowGetDepthFourKeepsLogicalOperationsIsolated) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv recv_segment("DFKV_RDMA_RECV_SEGMENT_SIZE", "33554432");
+  ScopedEnv idle_reclaim("DFKV_RDMA_IDLE_MS", "200");
+  ScopedEnv sync_prepared_reads("DFKV_SERVER_URING", "0");
+  // The malformed-window injection is local to the deliberate fault below.
+  // Force it off even when the test process inherited the variable, then
+  // restore the inherited value when the test exits.
+  ScopedEnv bad_get_op_id_disabled(
+      "DFKV_RDMA_TEST_BAD_GET_OP_ID_WINDOW", nullptr);
+  RdmaUringNode node("getopid");
+  ASSERT_EQ(node.rsrv->PipelineDepth(), 4u);
+
+  const uint64_t transient_baseline =
+      rdma::RcEndpoint::TransientUserMrActive();
+  const uint64_t active_baseline = node.rsrv->ActiveConns();
+  const auto wait_for_active_at_most = [&node](uint64_t limit) {
+    for (int i = 0; i < 1000 && node.rsrv->ActiveConns() > limit; ++i)
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    return node.rsrv->ActiveConns();
+  };
+
+  {
+    RdmaTransport rt(kMaxMsg);
+    KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+    c.set_batch_concurrency(1);  // one QP; concurrency is the negotiated depth
+    ASSERT_EQ(
+        CounterVal(rt.MetricsText(), "dfkv_rdma_client_pipeline_depth"), 4);
+
+    const size_t targets_per_window = rt.MaxSgPayloadSegs();
+    ASSERT_GE(targets_per_window, 2u);
+    const size_t segment_count = targets_per_window * 3 + 5;
+    std::vector<size_t> sizes(segment_count);
+    for (size_t segment = 0; segment < segment_count; ++segment)
+      sizes[segment] = 73 + segment % 29;
+
+    constexpr size_t kItems = 2;
+    std::vector<std::string> values(kItems);
+    for (size_t item = 0; item < kItems; ++item) {
+      for (size_t segment = 0; segment < segment_count; ++segment) {
+        for (size_t byte = 0; byte < sizes[segment]; ++byte) {
+          values[item].push_back(static_cast<char>(
+              (item * 151 + segment * 41 + byte * 17) & 0xff));
+        }
+      }
+      ASSERT_TRUE(c.Put("getopid_" + std::to_string(item),
+                        values[item].data(), values[item].size()));
+    }
+    ASSERT_NE(values[0], values[1]);
+
+    std::vector<std::vector<std::string>> dst(
+        kItems, std::vector<std::string>(segment_count));
+    std::vector<KvGetItemSg> gets;
+    for (size_t item = 0; item < kItems; ++item) {
+      std::vector<void*> ptrs;
+      for (size_t segment = 0; segment < segment_count; ++segment) {
+        dst[item][segment].assign(sizes[segment], '\0');
+        ptrs.push_back(dst[item][segment].data());
+      }
+      gets.push_back(
+          {"getopid_" + std::to_string(item), ptrs, sizes});
+    }
+
+    const long slot_changes_before = CounterVal(
+        node.rsrv->MetricsText(),
+        "dfkv_rdma_v2_get_continuation_slot_changes_total");
+    std::vector<size_t> lengths;
+    const auto got = c.BatchGetAutoSg(gets, &lengths);
+    ASSERT_EQ(got.size(), kItems);
+    ASSERT_EQ(lengths.size(), kItems);
+    for (size_t item = 0; item < kItems; ++item) {
+      ASSERT_TRUE(got[item]) << "logical GET " << item;
+      EXPECT_EQ(lengths[item], values[item].size());
+      std::string flattened;
+      for (size_t segment = 0; segment < segment_count; ++segment)
+        flattened += dst[item][segment];
+      EXPECT_EQ(flattened, values[item]) << "logical GET " << item;
+      EXPECT_NE(flattened, values[1 - item])
+          << "continuation state crossed logical GET identities";
+    }
+    const long slot_changes_after = CounterVal(
+        node.rsrv->MetricsText(),
+        "dfkv_rdma_v2_get_continuation_slot_changes_total");
+    ASSERT_GE(slot_changes_before, 0);
+    EXPECT_GE(slot_changes_after - slot_changes_before, 2)
+        << "test did not move continuations across receive WQE slots";
+    EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), transient_baseline);
+
+    // Corrupt the stable identity on window two. The server must reject the
+    // continuation, destroy that operation's PreparedRead/state, and never
+    // issue writes for any later window. The transport retires the failed QP.
+    std::vector<std::string> poisoned_dst(
+        segment_count, std::string());
+    std::vector<void*> poisoned_ptrs;
+    for (size_t segment = 0; segment < segment_count; ++segment) {
+      poisoned_dst[segment].assign(sizes[segment], '\x5a');
+      poisoned_ptrs.push_back(poisoned_dst[segment].data());
+    }
+    const uint64_t active_before_fault = node.rsrv->ActiveConns();
+    const uint64_t opened_before_fault = node.rsrv->V2Conns();
+    std::vector<bool> failed;
+    std::vector<size_t> failed_lengths;
+    {
+      ScopedEnv bad_id("DFKV_RDMA_TEST_BAD_GET_OP_ID_WINDOW", "2");
+      failed = c.BatchGetAutoSg(
+          {{"getopid_0", poisoned_ptrs, sizes}}, &failed_lengths);
+    }
+    ASSERT_EQ(failed.size(), 1u);
+    EXPECT_FALSE(failed[0]);
+    ASSERT_EQ(failed_lengths.size(), 1u);
+    EXPECT_EQ(failed_lengths[0], 0u);
+    size_t first_window_offset = 0;
+    for (size_t segment = 0; segment < targets_per_window; ++segment) {
+      EXPECT_EQ(poisoned_dst[segment],
+                values[0].substr(first_window_offset, sizes[segment]))
+          << "fault injection ran before the first window, segment " << segment;
+      first_window_offset += sizes[segment];
+    }
+    for (size_t segment = targets_per_window;
+         segment < segment_count; ++segment) {
+      EXPECT_EQ(poisoned_dst[segment],
+                std::string(sizes[segment], '\x5a'))
+          << "server mutated a destination after rejecting bad op id, segment "
+          << segment;
+    }
+
+    const uint64_t opened_delta =
+        node.rsrv->V2Conns() - opened_before_fault;
+    ASSERT_GT(opened_delta, 0u);
+    ASSERT_GT(active_before_fault, active_baseline);
+    const uint64_t cleanup_limit = active_before_fault - 1;
+    EXPECT_LE(wait_for_active_at_most(cleanup_limit), cleanup_limit)
+        << "malformed continuation connection did not retire";
+    EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), transient_baseline);
+    ASSERT_EQ(std::getenv("DFKV_RDMA_TEST_BAD_GET_OP_ID_WINDOW"), nullptr);
+
+    // A fresh logical ID on the same key must not inherit rejected sequence
+    // state or a stale PreparedRead owner.
+    std::vector<std::string> recovered_dst(
+        segment_count, std::string());
+    std::vector<void*> recovered_ptrs;
+    for (size_t segment = 0; segment < segment_count; ++segment) {
+      recovered_dst[segment].assign(sizes[segment], '\0');
+      recovered_ptrs.push_back(recovered_dst[segment].data());
+    }
+    std::vector<size_t> recovered_lengths;
+    // A transport error marks the node unhealthy in the public KVClient API.
+    // Use fresh client health state while retaining the same transport/pool:
+    // recovery therefore tests QP retirement/redial rather than an intentional
+    // client cooldown, and still catches a poisoned pooled endpoint.
+    KVClient recovery_client({{"n", node.addr}}, SelfHdr(), &rt);
+    recovery_client.set_batch_concurrency(1);
+    const auto recovered = recovery_client.BatchGetAutoSg(
+        {{"getopid_0", recovered_ptrs, sizes}}, &recovered_lengths);
+    ASSERT_EQ(recovered.size(), 1u);
+    ASSERT_TRUE(recovered[0]);
+    ASSERT_EQ(recovered_lengths.size(), 1u);
+    EXPECT_EQ(recovered_lengths[0], values[0].size());
+    std::string recovered_value;
+    for (const auto& segment : recovered_dst) recovered_value += segment;
+    EXPECT_EQ(recovered_value, values[0]);
+    EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), transient_baseline);
+  }
+
+  EXPECT_LE(wait_for_active_at_most(active_baseline), active_baseline);
+  EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), transient_baseline);
+  node.rsrv->Stop();
+  EXPECT_EQ(node.rsrv->ActiveConns(), 0u);
+}
 
 // Correctness proof for the io_uring async-GET path: many concurrent GETs over a
 // SINGLE pooled connection, with the depth high enough that several requests are

--- a/test/transport/wire_test.cc
+++ b/test/transport/wire_test.cc
@@ -1,6 +1,7 @@
 // Wire-framing encode/decode: round-trips plus the negative paths a hostile or
 // version-skewed peer can take (bad version byte, oversized declared length).
 #include "transport/wire.h"
+#include "transport/rdma_protocol.h"
 
 #include <cstring>
 
@@ -26,7 +27,9 @@ TEST(Wire, ReqRoundTrip) {
 
 TEST(Wire, TenantScopedEpochAndPrefixAreExact) {
   EXPECT_EQ(kNativeProtoTcp, 6);
-  EXPECT_EQ(kNativeProtoRdmaV2, 7);
+  EXPECT_EQ(kNativeProtoRdmaV2, 8);
+  EXPECT_EQ(kRdmaGetWindowMagic, 0x3357474du);  // "MGW3" little-endian
+  EXPECT_EQ(rdma::kV2ProbeMagic, 0x33564644u);  // "DFV3" little-endian
   EXPECT_EQ(kReqPrefix, 50u);
 }
 
@@ -154,6 +157,34 @@ TEST(Wire, V2GetScatterRoundTrip) {
   EXPECT_EQ(get.targets[0].addr, targets[0].addr);
   EXPECT_EQ(get.targets[1].rkey, targets[1].rkey);
   EXPECT_EQ(get.Capacity(), 4096u);
+}
+
+TEST(Wire, V2MultiWindowGetCarriesStableOperationIdentity) {
+  char buf[256] = {};
+  const BlockKey key{1, 2, 3};
+  const std::vector<RdmaWriteTarget> targets{
+      {0x1000, 7, 8}, {0x2000, 9, 8}};
+  size_t encoded = 0;
+  ASSERT_TRUE(EncodeRdmaGetReqWindow(
+      buf, sizeof(buf), key, 0, 64, targets,
+      /*operation_id=*/3, /*window_index=*/1, /*window_count=*/4,
+      /*logical_offset=*/16, /*total_capacity=*/64, &encoded));
+  EXPECT_EQ(net::GetU32(buf + kReqPrefix + 4), 0x3357474du);
+  EXPECT_EQ(net::GetU32(buf + kReqPrefix + 8), 3u);
+
+  ReqFields req{};
+  RdmaGetFields get;
+  ASSERT_TRUE(DecodeRdmaGetReq(buf, encoded, &req, &get));
+  EXPECT_EQ(req.Key(), key);
+  EXPECT_EQ(get.operation_id, 3u);
+  EXPECT_EQ(get.window_index, 1u);
+  EXPECT_EQ(get.window_count, 4u);
+  EXPECT_EQ(get.logical_offset, 16u);
+  EXPECT_EQ(get.total_capacity, 64u);
+  EXPECT_EQ(get.Capacity(), 16u);
+
+  net::PutU32(buf + kReqPrefix + 4, 0x3257474du);  // old "MGW2"
+  EXPECT_FALSE(DecodeRdmaGetReq(buf, encoded, &req, &get));
 }
 
 TEST(Wire, V2GetRejectsShortCapacityAndMalformedTarget) {


### PR DESCRIPTION
## Summary
- make vLLM cache lookup asynchronous with binary hash IPC
- store each logical KV chunk as one multi-WR object
- add bounded concurrent receive workers and lifecycle fencing
- bind depth-K RDMA GET continuations to stable operation IDs
- add deterministic lifecycle, wire, TCP, and real-HCA regressions

## Compatibility
- RDMA wire epoch advances to 8 (MGW3/DFV3); mixed old/new peers fail closed
- connector storage layout advances to vllm-multiwr-v2; no implicit fallback or mixed reads

## Verification
- local connector tests: 13/13 PASS
- local worker tests: 25/25 PASS
- 0064 real-HCA rdma_loopback_test: 43/43 PASS
- 0064 wire_test: 17/17 PASS
- 0064 KVClient SG test: PASS
- GLM-5.2-NVFP4 benchmark and release evidence recorded in task report