### PR TITLE
fix(rdma): retain configured rails across degraded boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,41 @@ are the liveness signal. Native clients use the single immutable
 `mds_endpoints` + `mds_group`. MDS mode polls the directory and rebuilds the
 weighted consistent-hash ring whenever its epoch advances. Two-layer offline
 detection: **layer-2** — etcd lease expiry → MDS view changes → client epoch →
-ring rebuild (authoritative removal, ≤ 30 s); **layer-1** — `PeerHealth` fast
-avoidance short-circuits transport failures to misses during a cooldown. There
-is no post-open membership mutation API in v2. For rings still running v1.x
+ring rebuild (authoritative removal after the 30 s lease TTL plus etcd, MDS RPC,
+and client-polling delay; this is not a 30 s upper bound); **layer-1** —
+`PeerHealth` fast avoidance short-circuits transport failures to misses during
+a cooldown. There is no post-open membership mutation API in v2. For rings still running v1.x
 nodes/clients, `DFKV_MDS_ACCEPT_LEGACY=1` enables a dual-protocol shim on the
 MDS control plane (ring-level isolation still applies) — see
 `docs/DEPLOY.md` §2b.
+
+**RDMA server rail admission** is deliberately asymmetric. With no device
+list, automatic discovery remains `ACTIVE`-only. An explicit
+`dfkv_server --rdma-dev` list instead defines a fixed topology in configured
+first-occurrence order: a present but `DOWN` rail is still opened, initialized
+(anchor plus every required MR), and monitored. A missing/unopenable device,
+port- or GID-query failure, or any anchor/MR initialization failure aborts startup.
+The daemon may start with an initialized `DOWN` rail, but the whole node stays
+out of the placement ring until **every initialized/resolved rail**, including
+the auto-discovered rail when no list is configured, is `ACTIVE`/`LinkUp` for
+the recovery sample streak. The default is three successful sampling
+opportunities. At the nominal 10 s registrar cadence this usually takes about
+20–30 s depending on phase, plus registrar connection/RPC delays, and can take
+longer while MDS is unreachable; it is not a wall-clock upper bound. The node
+then rejoins without a restart. This fail-closed policy trades the node's entire
+cache capacity while any one resolved rail is unhealthy for immutable,
+index-aligned multi-rail topology. Startup
+cardinalities and current health are described in
+[`docs/DEPLOY.md`](docs/DEPLOY.md) and
+[`docs/METRICS.md`](docs/METRICS.md).
 
 **Client registration** (who is using dfkv): cache *consumers* (inference
 connector instances — vLLM / LMCache / SGLang HiCache) register themselves with
 the MDS under a disjoint etcd prefix (`/dfkv/v1/groups/<g>/clients/<id>`) so
 they never enter the placement ring. The same lease/heartbeat contract as nodes
-applies — a dead connector's key expires out of etcd within the TTL, no explicit
-deregister, no stale keys. Connectors set
+applies — a dead connector's key expires after the lease TTL plus etcd
+processing delay, not within a strict TTL upper bound; no explicit deregister
+or permanent stale key is required. Connectors set
 `DFKV_CLIENT_OPT_REGISTER_WITH_MDS`, `client_id`, `client_info`, and heartbeat
 fields in `dfkv_client_options_v2` when MDS discovery is used (opt out with
 `DFKV_CLIENT_REGISTER=0`).
@@ -201,8 +223,12 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
 - **Observability** ([docs/METRICS.md](docs/METRICS.md)): opt-in embedded Prometheus
   `/metrics` on `dfkv_server` and `dfkv_mds` (`--metrics-port`); sampled op-latency
   histogram, eviction/error/per-disk/RDMA counters server-side; client-side counters
-  (peer health, IO errors) via `dfkv_stats_snapshot` + a plugin poller. **Opt-in and
-  off the datapath** — no `--metrics-port` ⇒ no listener, behavior unchanged.
+  (peer health, IO errors) via `dfkv_stats_snapshot` + a plugin poller. The
+  `dfkv_server_ring_eligible` and `dfkv_server_ib_device_healthy` families are
+  emitted only by an RDMA-enabled binary that is running an RDMA listener.
+  Their absence from a TCP-only binary or an RDMA build without a listener is
+  expected and must not be coerced to zero by dashboards or alerts. **Opt-in and
+  off the datapath** — no `--metrics-port` ⇒ no metrics listener, behavior unchanged.
   The three connectors (vLLM / LMCache / SGLang HiCache) can also **push** fleet
   metrics (ops/keys/bytes, op latency, per-peer latency) over OTLP to a central
   Collector → Grafana — opt-in via `DFKV_METRICS_ENABLED=1`, **zero-dependency stdlib
@@ -266,12 +292,12 @@ fabric selection and capacity explicit.
 
 | Knob | Recommended | Why |
 |---|---|---|
-| `--rdma-dev` | leave unset for one local HCA; list the fabric explicitly for multi-rail | Unset selects the first `ACTIVE` local HCA (peer names may differ). A comma list opts into multi-rail, anchors only listed active devices, and requires compatible names/fabric on both hosts; inactive entries are rejected. |
+| `--rdma-dev` | leave unset for one local HCA; list the fabric explicitly for multi-rail | Unset resolves and initializes the first `ACTIVE` local HCA (peer names may differ). An explicit comma list defines a fixed topology in first-occurrence order: every listed device must be present/openable with complete provider metadata, including a successful GID query, and complete anchor/MR initialization; a present `DOWN` entry remains initialized and monitored rather than being rejected. Both hosts still require compatible names/fabric. |
 | `DFKV_DISK_HASH_WEIGHT` | `10` | Flattens the intra-server disk ring share from ±20 % to ±3 % so the hottest disk stops gating the whole node (+5–6 % cold read, ~2× lower p99). **Re-routes existing keys** (cache miss + refill) — flip together with a restart/upgrade window. |
 | `--rdma-depth` | `4` (default) | Handshake window is `min(client, server)`. Single-connection PUT/GET bandwidth is depth-flat once connected, but production connector batches require both sides to expose the same bounded window; a 1-vs-4 mismatch caused burst PUT failures and a 29.8% hot-round regression on GLM-5.2. Depth 4 with the default 4 MiB declaration leases about 16 MiB per data QP, so a 16 GiB receive segment admits about 1024 QPs. Increase only for a measured latency-bound path and budget `depth × slot_size` per pooled QP. |
 | `DFKV_RDMA_IDLE_MS` | `30000` for frequently replaced clients; otherwise default `600000` | Server dead-client reaper. A short interval bounds leaked receive-segment leases, but live clients must set `DFKV_RDMA_KEEPALIVE_MS` below this value or their next GET pays stale-QP recovery. |
-| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | Server samples every configured IB rail before each MDS heartbeat. Any query failure or non-ACTIVE/LinkUp rail removes the node from placement immediately; this many consecutive healthy samples re-admit it. |
-| `DFKV_RDMA_HEALTH_FILE` | unset | Diagnostic-only health input (`device port_state phys_state`, one per configured rail) for controlled fault injection. Production MUST leave this unset so health comes from sysfs. |
+| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | With an RDMA listener, the server gates placement on every initialized/resolved IB rail, including the auto-discovered rail. Any query failure or non-ACTIVE/LinkUp rail removes the node immediately; three successful sampling opportunities re-admit it. At the nominal 10 s registrar cadence this is usually about 20–30 s depending on phase, plus registrar connection/RPC delays, and can be longer while MDS is unreachable; it is not an upper bound. |
+| `DFKV_RDMA_HEALTH_FILE` | unset | Diagnostic-only health input (`device port_state phys_state`, one per initialized/resolved rail, including an auto-discovered rail) for controlled fault injection. Production MUST leave this unset so health comes from sysfs. |
 | `--ram-tier` / `--ram-tier-bytes` / `--ram-tier-shards` | on / sized to the node / `16` for ≥100 GiB arenas | Large arenas contend on the shard locks under mixed load (+40 % mixed R/W at 16 shards on a 128 GiB arena); small (≤16 GiB) arenas are fine at the default 8. |
 | `--store-engine` | `slab` | Index rebuilds on restart; removes file-per-block hazards. |
 | `DFKV_TCP_FIRST_REQ_MS` / `DFKV_MDS_FIRST_REQ_MS` / `DFKV_METRICS_FIRST_REQ_MS` | `30000` (default) / `0` = off | First-request deadline per listener: a connection that sends nothing before the deadline is dropped, capping idle pre-auth connections. |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -17,8 +17,8 @@ dfkv 把**控制面**与**数据面**解耦：
 
 - **控制面 = TCP + 两边 SEND/RECV**：bootstrap TCP 只交换设备/QP/receive-segment 描述；RDMA QP 的 request descriptor 有界，response buffer 显式预留 `18-byte prefix + 32 KiB`，使 32-KiB `Members` 在 control lane 完整返回；更大响应直接失败、不截断。
 - **payload = one-sided RDMA**：v2 PUT 用 `RDMA_WRITE_WITH_IMM` 直落 server 共享 receive-segment slot，GET 由 server `RDMA_WRITE` 到 client 提交的 `{addr,rkey,len}`。数据 fabric 无需 IP。
-- **设备发现**：留空时两端各选本地首个 port 1 `ACTIVE` HCA；显式逗号白名单才开启多轨轮转，多 fabric 节点须过滤到两端同名且互通的 fabric。
-- **失败策略**：未设 `DFKV_RDMA` 时选择 TCP；一旦选择 RDMA，client/server 必须完成 v2 协商和共享 segment 注册，失败即拒绝启动或连接。
+- **设备发现**：留空时自动发现策略保持 `ACTIVE`-only（两端各选本地首个 port 1 `ACTIVE` HCA）；显式逗号白名单定义固定 topology，按配置首次出现顺序去重，且 server 会接纳**存在但启动时 DOWN** 的设备完成 anchor/MR 初始化并持续监控。多 fabric 节点仍须过滤到两端同名且互通的 fabric。
+- **失败策略**：未设 `DFKV_RDMA` 时选择 TCP；一旦选择 RDMA，显式设备缺失、open/port/GID query 失败，或任一 configured rail 的 anchor、共享 receive-segment MR、RAM/user MR 初始化失败，均拒绝启动而不缩小 topology。present DOWN 本身不拒绝启动，但整个节点保持 ring-ineligible，直至全部 initialized/resolved rail（包括未配置列表时自动发现的 rail）通过恢复采样门；无需重启。
 
 发现：默认走 **MDS 动态发现**（etcd + dfkv_mds，见 §2b）；静态成员表仍作为遗留/单节点备用路径（见 §4-legacy）。无副本（一致性哈希单属主，节点挂 = 该分片 miss → 重算）。
 
@@ -175,10 +175,13 @@ Type=simple
 # 的公式按 peak live + pooled QP 复算）。
 Environment=DFKV_RDMA_DEPTH=4
 Environment=DFKV_RDMA_RECV_SEGMENT_SIZE=17179869184
-# 8×400G 轨全轨白名单 + NUMA：B200 生产 host 一台带 8 个 HCA 轨；
-# server 两端白名单到**同名互通**一组轨；client 的 `DFKV_RDMA_NUMA=1` 后每 rank 优先本 NUMA 轨，
-# 本地轨全不可准入时降级重试全部 enabled rail（rail_select.h/rdma_transport.cc:399-413）。
-# --rdma-dev 直传 RDMA server，胜过同名 env；client 侧 `DFKV_RDMA_DEV` 另行注入（CONNECTORS §1.2）。
+# 8×400G 轨全轨白名单 + NUMA：B200 生产 host 一台带 8 个 HCA 轨。
+# 显式白名单是固定 topology：保留首次出现顺序；present DOWN rail 仍必须完成
+# anchor/共享 segment/所有配置 MR 初始化，随后由 health monitor 等待 LinkUp。
+# server/client 两端白名单到**同名互通**一组轨；client 的 `DFKV_RDMA_NUMA=1`
+# 后每 rank 优先本 NUMA 轨，本地轨全不可准入时降级重试全部 enabled rail
+# （rail_select.h/rdma_transport.cc）。`--rdma-dev` 直传 RDMA server，胜过同名
+# env；client 侧 `DFKV_RDMA_DEV` 另行注入（CONNECTORS §1.2）。
 Environment=DFKV_RDMA_NUMA=1
 # v2.0.0 监听器加固（PR#240）：首帧 30s absolute deadline 断 slow-dribble,
 # metrics 端口连接数上限 64（防连接占用打满）,
@@ -278,7 +281,7 @@ WantedBy=multi-user.target
 ```bash
 systemctl daemon-reload && systemctl enable --now dfkv
 journalctl -u dfkv -n 10 --no-pager
-# 应见 "PORT 28000" + "RDMA listening (TCP bootstrap) on port 28001, dev=ib7s400p0"
+# 应见 "PORT 28000" + "rdma topology startup: configured=8 initialized=8 ACTIVE=<n> inactive=<names|(none)>"
 #      + "dfkv_server MDS registration loop started group=default id=n57 advertise=192.168.1.57:28001"
 # 首次成功后另见 "dfkv_server registered with MDS group=default id=n57"
 ```
@@ -290,21 +293,45 @@ journalctl -u dfkv -n 10 --no-pager
 > startup 和首次 MDS 注册完成。首次成功后 readiness latch 不因瞬时 heartbeat
 > 失败清零，已注册节点继续运行并在 MDS 恢复后续租；必须同时监控
 > [METRICS.md](METRICS.md) 的 registrar heartbeat 指标。
+> RDMA startup 日志
+> `rdma topology startup: configured=N initialized=N ACTIVE=M inactive=...`
+> 分别给出 `configured`（显式列表按首次出现去重；自动发现时为 0）、
+> `initialized`（自动发现或显式配置后 resolved、且 anchor 和启动所需 MR 全部
+> 完成的 rail）及启动瞬间 verbs port `IBV_PORT_ACTIVE` rail 数。显式部署必须
+> 看到 `configured == initialized`；`ACTIVE` 可以较小，此时启动成功但
+> `dfkv_server_ring_eligible=0`。运行期 rail 总数/顺序 immutable，健康门覆盖
+> **全部 initialized/resolved rail**，包括 auto 模式选出的 rail；当前
+> ACTIVE+LinkUp 健康数应从 `sum(dfkv_server_ib_device_healthy)` 读取，不能把
+> 启动 `ACTIVE` 快照当成当前状态。这两个 `dfkv_server_*` IB health family
+> 仅在 RDMA-enabled binary 实际启动 RDMA listener 时输出；TCP-only binary
+> 或未启动 RDMA listener 的进程缺少它们是预期行为，告警不得把缺失补成 0。
 > server 的 bootstrap 监听 `0.0.0.0`，靠防火墙限制在内网。优雅关闭已修（`systemctl stop` 约 1s 退出）。
-> **多轨与 NUMA**：server 启动时 anchor 白名单内全部 active rail；client 以
-> `DFKV_RDMA_RAIL_CREDITS` 的 per-rail credit、归一化 inflight、延迟和本地
-> rail 错误分数选轨（分数相同时按发现顺序稳定选择）。留空时两端各选本地首个
-> ACTIVE HCA，适合 local device 名不同的单 fabric 主机；显式
-> `--rdma-dev` / `DFKV_RDMA_DEV` 是权威白名单并把具体设备选择发给 peer，故
-> 生产多 fabric 主机必须在两端过滤到**同名且互通**的一组设备。设备名上限
-> 18 字节（v2 dev frame 中 name + capability trailer 共 32 字节），超长的
-> 白名单/anchor 设备名在启动时 fail-fast 拒绝，不会截断后误配。
-> `DFKV_RDMA_NUMA=1` 在每次 Acquire 读取 caller NUMA；白名单内存在 local
-> rail 时严格优先 local mask。caller NUMA 未知或没有 local rail 时回退全部
-> 白名单；全部 local rail 都不可准入（被隔离或 credit 耗尽）时也会降级为
-> 全 enabled rail 重试一次——local 是严格偏好而不是可用性闸门，不阻止
-> progress。receive segment 仍是单块 process-wide 分配，不是
-> per-NUMA/per-rail 分片。
+> **多轨与 NUMA**：两端自动发现留空时仍只选首个 ACTIVE HCA。server 的显式
+> `--rdma-dev` 是固定 anchor 白名单：按首次出现顺序去重并固定索引；client 的
+> `DFKV_RDMA_DEV` 是独立的数据面选择，仍须指向当前可用且与 server 同名互通的
+> rail。server 对每个 provider metadata 完整（包括 GID query 成功）的 configured
+> rail 建立 anchor、共享 receive-segment MR 及所有已配置 MR，**不会因为启动时
+> DOWN 就删轨或重排**。任一 rail missing/open/port/GID query/anchor/MR 失败都
+> fail-fast，不以子集启动。设备名在 peer
+> 显式选轨 frame 中上限 18 字节；超长 server anchor 只能作为 default anchor
+> 访问，生产两端显式白名单不得使用。生产多 fabric 主机仍须在两端过滤到
+> **同名且互通**设备。client 以 `DFKV_RDMA_RAIL_CREDITS` 的 per-rail credit、
+> 归一化 inflight、延迟和本地 rail 错误分数选轨（分数相同时按固定发现顺序
+> 选择）。`DFKV_RDMA_NUMA=1` 在每次 Acquire 读取 caller NUMA；白名单内存在
+> local rail 时严格优先 local mask。caller NUMA 未知或没有 local rail 时回退
+> 全部白名单；全部 local rail 都不可准入（被隔离或 credit 耗尽）时也会降级为
+> 全 enabled rail 重试一次——local 是严格偏好而不是可用性闸门。receive
+> segment 仍是单块 process-wide 分配，不是 per-NUMA/per-rail 分片。
+>
+> **boot-degraded 与容量取舍**：present DOWN rail 完成初始化后留在固定
+> topology 和 metrics label 集合中；任一 initialized/resolved rail（包括 auto
+> 模式选出的 rail）当前不是 ACTIVE/LinkUp，节点就以 `DEGRADED` 注册并整体退出
+> placement ring。其余健康 rail 不承接该节点的部分流量，因此代价是临时损失
+> 该节点**全部** cache capacity/vnode share，而不是只损失一条 rail 的带宽。
+> 恢复门默认要求三个连续成功的本地健康采样机会。按 registrar 名义 10 s 节拍，
+> LinkUp 后通常约 20–30 s（取决于采样相位）完成三次，但还要叠加 registrar
+> 建连/RPC 及 MDS 对外可见延迟；MDS 不可达时采样/发布可更久，因此这不是
+> wall-clock 上界。门满足后同一进程自动 rejoin，**LinkUp 后无需 restart**。
 >
 > **失败域隔离**：TCP bootstrap、peer 不可达、epoch/QP frame/receive-segment
 > 不兼容属于 endpoint 失败：立即归还 rail credit，由 client `PeerHealth` 对该
@@ -379,7 +406,7 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 | `--cap <bytes>` | —（必填） | 节点总容量（LRU 超限触发自裁） |
 | `--port <p>` | 0(临时） | TCP bootstrap+数据端口；0=随机 |
 | `--rdma-port <p>` | —（RDMA build 必填） | RDMA bootstrap 端口（含 RDMA 时开启） |
-| `--rdma-dev` | first ACTIVE 本地 | RDMA 白名单（逗号）；与 `DFKV_RDMA_DEV` 不同：这是 server 的 anchor |
+| `--rdma-dev` | first ACTIVE 本地 | server RDMA 白名单（逗号）；留空保持 ACTIVE-only 自动发现。显式列表按首次出现去重，present DOWN 也须初始化并监控；missing/open/query/任一 anchor 或 MR 失败则拒绝启动 |
 | `--mds <ip:port,...>` | —（生产必须） | 注册进的 MDS 列表；配后须配 `--group/--id/--advertise` |
 | `--group` | `"default"` | ring 名 |
 | `--id <id>` | 主机名 | server 节点 id（与 `--advertise` 联动） |
@@ -499,8 +526,8 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 | `DFKV_READ_SHARD_KEYS` | `16` | client 每个 read shard 的目标 key 数；server 不读取 |
 | `DFKV_MDS_IO_TIMEOUT_S` | `60` | MDS 控制面帧读写超时（MDS 进程该） |
 | `DFKV_MDS_ETCD_PROBE_MS` | `30000` | MDS 与 etcd 存活探测窗（MDS 进程该） |
-| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | server 在每次 MDS 心跳前检查全部 resolved RDMA rail；任一 rail 查询失败或非 ACTIVE/LinkUp 立即退 placement ring，连续该次数健康后恢复入环 |
-| `DFKV_RDMA_HEALTH_FILE` | 未设置（生产必须未设置） | 仅用于受控故障注入；每行 `device port_state phys_state`，缺失已配置设备按查询失败处理。生产从 sysfs 读取 |
+| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | 仅有 RDMA listener 时生效。健康门检查固定的全部 initialized/resolved rail（包括 auto-discovered rail）；任一 query 失败或非 ACTIVE/LinkUp 立即退整节点。恢复要求连续三个成功采样机会，不是固定时长：启动先采样一次，后续在 registrar 建连后、每次 MDS 注册/心跳 RPC 发送前采样。heartbeat 名义间隔 10 s，通常约 20–30 s（取决于相位），另加建连/RPC/发布延迟；MDS 不可达时可能更久，无 wall-clock 上界 |
+| `DFKV_RDMA_HEALTH_FILE` | 未设置（生产必须未设置） | 仅用于受控故障注入；每行 `device port_state phys_state`，缺失任一 initialized/resolved 设备（包括 auto-discovered rail）按 query 失败处理。生产从 sysfs 读取 |
 | `DFKV_TENANT_QUOTAS_COUNT` | — | tenant 配额文件预期条数（容量校验） |
 
 #### 未收录的常见误配 → 详见 CONNECTORS.md §1.7
@@ -651,21 +678,43 @@ Rollback trigger and procedure:
 
 ## 5. 上线顺序 + 冒烟（无需 GPU）
 
-1. （MDS 路径）起 etcd，再起所有 `dfkv_mds` 副本（§2b），确认日志 "listening"。
-2. 所有节点起 `dfkv_server`（§3），确认 PORT + "registered with MDS" 日志。
-3. 冒烟（任一能访问内网的机器）：
+1. 对最终显式 rail 列表做**只读、无状态变更**的 clean preflight；设备必须存在且
+   verbs open/query 成功，`DOWN`/`LinkDown` 只记录、不在这里删出配置或强制拉链：
+   ```bash
+   set -eu
+   for dev in ib7s400p0 ib7s400p1 ib7s400p2 ib7s400p3 \
+              ib7s400p4 ib7s400p5 ib7s400p6 ib7s400p7; do
+     test -r "/sys/class/infiniband/$dev/ports/1/state" &&
+       test -r "/sys/class/infiniband/$dev/ports/1/phys_state" || exit 1
+     ibv_devinfo -d "$dev" >/dev/null
+     printf '%s state=%s phys_state=%s\n' "$dev" \
+       "$(cat "/sys/class/infiniband/$dev/ports/1/state")" \
+       "$(cat "/sys/class/infiniband/$dev/ports/1/phys_state")"
+   done
+   ```
+   此检查不能代替真实 anchor/MR 初始化；确认 unit 有 `LimitMEMLOCK=infinity`
+   后由 `dfkv_server` 启动结果作为最终门。不得为了“先起进程”临时缩短
+   `--rdma-dev`，否则固定 topology/容量语义已改变。
+2. （MDS 路径）起 etcd，再起所有 `dfkv_mds` 副本（§2b），确认日志 "listening"。
+3. 所有节点起 `dfkv_server`（§3）。启动日志
+   `rdma topology startup: configured=N initialized=N ACTIVE=M inactive=...`
+   必须显示显式部署 `configured == initialized`；允许 `ACTIVE < configured`，
+   但此时 `dfkv_server_ring_eligible=0`，节点是已初始化、可监控但不承载
+   placement 的 `DEGRADED` 成员。missing/open/port/GID query 或任一 anchor/MR
+   失败必须使服务启动失败。
+4. 冒烟（任一能访问内网的机器；只对 ring-eligible 节点执行）：
    ```bash
    dfkv_smoke --members n57=192.168.1.57:28000 --size 2752512                          # TCP
    DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 dfkv_smoke --members n57=192.168.1.57:28001 --size 2752512
    ```
-4. 端到端零拷贝校验（插件 → libdfkv → RDMA → server，验证 payload 直落缓冲）：
+5. 端到端零拷贝校验（插件 → libdfkv → RDMA → server，验证 payload 直落缓冲）：
    ```bash
    DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 DFKV_MEMBERS='n=192.168.1.57:28001' \
      python3 test/python/rdma_e2e_validate.py    # 期望 RESULT: ZERO-COPY RDMA E2E OK
    # 随后在 server /metrics 确认 v2_ready=1、v2_conns_opened_total 增长且 free_bytes 有余量
    ```
-5. 压测（可选）：`DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 dfkv_bench --members ... --size 2752512 --count 8000 --threads 64`。
-6. 在**一个受控 SGLang 副本**上切 `dynamic` 后端，发共享长前缀请求看命中上涨，确认后推广。
+6. 压测（可选）：`DFKV_RDMA=1 DFKV_RDMA_DEV=ib7s400p0 dfkv_bench --members ... --size 2752512 --count 8000 --threads 64`。
+7. 在**一个受控 SGLang 副本**上切 `dynamic` 后端，发共享长前缀请求看命中上涨，确认后推广。
 
 ### 5b. 候选版本负载回归门
 `DFKV_BENCH_STALL_MS=<毫秒>` 只由 `dfkv_bench` 读取；超过阈值的 GET batch

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -21,6 +21,13 @@
 还要求本地 startup 完成以及（配置 MDS 时）首次注册成功。首次注册 latch 后，
 瞬时 heartbeat 丢失不会清 readiness；用下述 heartbeat 指标单独告警。未配置
 MDS 的 node 仅等待本地 startup 和动态 storage health。
+IB ring eligibility is intentionally independent of these HTTP checks. Only an
+RDMA-enabled binary with an active RDMA listener constructs the health monitor
+and emits `dfkv_server_ring_eligible` /
+`dfkv_server_ib_device_healthy`; their absence from a TCP-only binary or an
+RDMA build without a listener is expected. When present, an initialized server
+with a `DOWN` rail can keep `/healthz` and `/readyz` at 200 while
+`dfkv_server_ring_eligible=0` excludes the whole node from placement.
 `dfkv_mds` 的语义不同：`/healthz` 是纯进程 liveness，**不 probe etcd**——
 否则一次秒级 etcd 抖动会让 kubelet 同时重启全部 MDS 副本，CrashLoop 比抖动
 更久并引发 lease 集体过期。`/readyz` 保留 etcd 依赖检查，但经 TTL-debounced
@@ -76,8 +83,6 @@ dfkvctl stat <ip:port>                        # 单节点原始 /metrics 文本�
 | `dfkv_uptime_seconds` | gauge | 启动至今秒数 |
 | `dfkv_storage_healthy` | gauge | 当前 disk group 与显式请求 RAM tier 的 terminal health；0 时 `/healthz`、`/readyz` 均为 503 |
 | `dfkv_server_startup_complete` / `dfkv_server_mds_registration_ready` / `dfkv_server_healthy` / `dfkv_server_ready` | gauge | startup、本次首次 MDS 注册门、本地动态 health、三者合取；`dfkvctl stat --all` 用这组稳定 gauge 判定节点健康 |
-| `dfkv_server_ring_eligible` | gauge | 全部 configured IB rail 当前是否允许节点进入 placement ring；故障时为 0，但 server 进程和 `/healthz` 保持在线 |
-| `dfkv_server_ib_device_healthy{device}` | gauge | 各 resolved RDMA 设备 port 1 是否同时为 ACTIVE 与 LinkUp；设备 label 来自启动时固定集合 |
 | `dfkv_cache_put_total` / `dfkv_cache_hit_total` / `dfkv_cache_miss_total` | counter | PUT / GET 命中 / GET 未命中 |
 | `dfkv_exist_hit_total` / `dfkv_exist_miss_total` | counter | Exist 命中 / 未命中 |
 | `dfkv_remove_ok_total` / `dfkv_remove_miss_total` | counter | Remove 删掉了块 / 目标本就不存在（partial save 清理等路径的诊断分型） |
@@ -118,14 +123,52 @@ Tenant 标签**只**来自启动时有界配置文件中的 16-hex hash；默认
 此时 cache `/readyz` 保持 200，恢复后续租。`rate(dfkv_tcp_rejected_connections_total[5m]) > 0`
 触发时同步看 `dfkv_open_connections / dfkv_tcp_max_connections`。
 
-RDMA 构建额外（折叠进同一 /metrics）：
+IB rail 告警必须按**节点**聚合：
+`min by (instance) (dfkv_server_ib_device_healthy) == 0` 或
+`dfkv_server_ring_eligible == 0` 表示该节点的**全部** cache capacity 已从
+placement ring 移除，不能把其余健康 rail 当成部分容量仍可路由。这两个查询在
+TCP-only server 或未启动 RDMA listener 的 RDMA build 上不会返回序列，这是预期
+行为；不得用 `or vector(0)` 等方式把缺失补成 unhealthy。若要告警“应有但缺失”，
+必须用明确标识 RDMA-listener 部署的 scrape inventory，例如：
+```promql
+(up{job="dfkv-server-rdma"} == 1)
+  unless on(job, instance) dfkv_server_ring_eligible{job="dfkv-server-rdma"}
+```
+不能对混合 TCP/RDMA job 全局使用 `absent()`。
+
+默认 `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES=3`。健康门覆盖全部
+initialized/resolved rail，包括未配置设备列表时 auto-discovered 的 rail；任一
+query 失败或 non-ACTIVE/LinkUp 样本立即清零 streak 并退环。恢复要求三个连续
+成功的本地健康采样机会，而不是固定时长。启动时先采样一次，后续在 registrar
+成功建立连接后、每次注册/心跳 RPC 发送前采样（heartbeat 名义间隔 10 s），MDS
+只在 RPC 成功后看到新状态。因此 LinkUp 后通常约 20–30 s（取决于采样相位）
+完成三个样本，还要叠加 registrar 建连/RPC 与发布延迟；MDS 不可达时可能更久。
+这不是 wall-clock 上界。**无需重启**；重启反而丢弃已初始化 topology 并重新
+承担全部 anchor/MR 启动成本。
+
+四种 rail 口径不能混用：
+
+| 口径 | 权威来源 | 解释 |
+|---|---|---|
+| configured | startup log `configured=N` | 显式列表按首次出现去重后的意图；auto 模式为 0 |
+| initialized/resolved | startup log `initialized=N`；成功启动后 `dfkv_rdma_recv_segment_registered_rails` | 自动发现或显式配置后已完成 anchor、共享 segment 和全部启动 MR 的固定 topology；auto 模式包含选出的 rail |
+| startup-ACTIVE | startup log `ACTIVE=N` / `inactive=...` | 仅启动瞬间的 verbs port-state 快照，不会随恢复改写 |
+| current healthy | `sum by (instance) (dfkv_server_ib_device_healthy)`；最终门为 `dfkv_server_ring_eligible` | 固定 initialized/resolved 集合中当前 ACTIVE+LinkUp 数；仅 RDMA listener 存在时输出 |
+
+仅在 **RDMA-enabled binary 实际启动 RDMA listener** 时额外输出（折叠进同一
+`/metrics`）；TCP-only binary 或未启动 RDMA listener 时下列 family 不存在：
+
+| 指标 | 类型 | 含义 |
+|---|---|---|
+| `dfkv_server_ring_eligible` | gauge | **当前**全部 initialized/resolved IB rail（包括 auto-discovered rail）是否满足恢复门；任一设备 query 失败或不是 ACTIVE/LinkUp 时为 0，整个节点（不是单 rail 容量）退出 placement ring，但进程、`/healthz`、`/readyz` 保持在线 |
+| `dfkv_server_ib_device_healthy{device}` | gauge | 各 initialized/resolved RDMA 设备 port 1 的**当前**状态是否同时为 ACTIVE 与 LinkUp；`device` 集合与顺序在启动后固定，包含 auto-discovered rail，也包含显式配置的启动时 DOWN rail |
 | `dfkv_rdma_completions_total` / `dfkv_rdma_completion_errors_total` | counter | RDMA 请求完成 / 错误完成 |
 | `dfkv_rdma_active_conns` | gauge | 当前服务中的 RDMA 连接 |
 | `dfkv_rdma_v2_conns_opened_total` | counter | server 累计打开的 v2 连接 |
 | `dfkv_rdma_v2_put_writes_total` / `dfkv_rdma_v2_get_writes_total` | counter | server 实际收到的 `WRITE_WITH_IMM` PUT / 实际发出的 RDMA WRITE GET payload |
 | `dfkv_rdma_recv_segment_bytes` / `dfkv_rdma_recv_segment_free_bytes` | gauge | process-wide receive segment 总字节 / 当前未租 lease 字节；free 接近 0 时新连接会被拒绝 |
-| `dfkv_rdma_recv_segment_registered_rails` | gauge | 成功把共享 segment 注册到共享 PD 的 rail 数；应等于选中 rail 数 |
-| `dfkv_rdma_v2_ready` | gauge | 至少一个 rail 完成共享 segment 注册；进程就绪后应为 1 |
+| `dfkv_rdma_recv_segment_registered_rails` | gauge | 成功把共享 segment 注册到共享 PD 的 initialized rail 数；显式 topology 启动成功后必须等于 configured rail 数，包括启动时 DOWN 的 rail |
+| `dfkv_rdma_v2_ready` | gauge | shared receive segment 是否已建立；启动成功后应为 1，不能替代逐 rail 注册数和健康检查 |
 | `dfkv_uring_reads_total` / `dfkv_uring_init_fallbacks_total` | counter | io_uring 路径真实提交的读数（**>0 = 路径确实激活**，外部可证）/ 想用 uring 但 ring 初始化失败静默回退同步的连接数（>0 = 配了没生效，查内核/权限） |
 | `dfkv_rdma_idle_reclaims_total` | counter | 空闲超时回收的连接数 |
 | `dfkv_rdma_segment_evictions_total` | counter | receive segment 空间不足时主动淘汰连接的次数；增长说明 segment/连接预算不足 |
@@ -134,9 +177,20 @@ RDMA 构建额外（折叠进同一 /metrics）：
 | `dfkv_rdma_rail_put_writes_total{dev}` / `dfkv_rdma_rail_put_bytes_total{dev}` | counter | 每 rail 收到的 PUT one-sided writes / payload bytes |
 | `dfkv_rdma_rail_get_writes_total{dev}` / `dfkv_rdma_rail_get_bytes_total{dev}` | counter | 每 rail 发出的 GET one-sided writes / payload bytes |
 
-> **v2 上线判据**：client/server 两侧连接总数增长，PUT/GET write counter
-> 随负载增长，`dfkv_rdma_v2_ready=1` 且 `dfkv_rdma_recv_segment_free_bytes` 有容量余量。启动失败
-> 或连接拒绝时检查 segment 容量、每轨注册日志和两端协议版本。
+> **v2 上线判据**：启动日志
+> `rdma topology startup: configured=N initialized=N ACTIVE=M inactive=...`
+> 精确区分显式 configured、自动发现或显式配置后完成 anchor/MR 的
+> initialized/resolved，以及启动瞬间 verbs port `IBV_PORT_ACTIVE` 快照；
+> 自动发现的 `configured=0` 但 initialized 集合包含选出的 rail，显式 topology
+> 则必须
+> `configured == initialized == dfkv_rdma_recv_segment_registered_rails`，而
+> `ACTIVE` 可以更小。RDMA listener 运行期用固定 initialized/resolved 集合
+> `dfkv_server_ib_device_healthy{device}` 统计 current ACTIVE+LinkUp healthy，
+> 并以 `dfkv_server_ring_eligible` 判断整节点是否可放置。随后确认
+> client/server 两侧连接总数增长、PUT/GET write counter 随负载增长、
+> `dfkv_rdma_v2_ready=1` 且 `dfkv_rdma_recv_segment_free_bytes` 有容量余量。
+> 启动失败或连接拒绝时检查缺失/open/port/GID query 错误、每轨
+> anchor/MR/segment 注册日志、segment 容量和两端协议版本。
 
 读侧 convoy 合并与直读晋升（`DFKV_READ_COALESCE=1` 时才有增量；恒零 = 开关没生效）：
 | `dfkv_read_coalesce_leaders_total` | counter | 经 coalescer 登记并完成的读（同步 leader + io_uring flight 各计一次；>0 = 合并路径确实在环内） |

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -65,6 +65,54 @@ size_t RecvSegmentBytes() {
                               std::to_string(bytes));
   return bytes;
 }
+
+const char* DiscoveryStatusName(rdma::RdmaDiscoveryStatus status) {
+  switch (status) {
+    case rdma::RdmaDiscoveryStatus::kOk:
+      return "ok";
+    case rdma::RdmaDiscoveryStatus::kDeviceListFailed:
+      return "device-list-failed";
+    case rdma::RdmaDiscoveryStatus::kConfiguredDeviceMissing:
+      return "configured-device-missing";
+    case rdma::RdmaDiscoveryStatus::kDeviceOpenFailed:
+      return "device-open-failed";
+    case rdma::RdmaDiscoveryStatus::kPortQueryFailed:
+      return "port-query-failed";
+    case rdma::RdmaDiscoveryStatus::kGidQueryFailed:
+      return "gid-query-failed";
+  }
+  return "unknown";
+}
+
+void LogTopologySummary(size_t configured, size_t initialized,
+                        const std::vector<rdma::RdmaDevInfo>& devices,
+                        bool discovery_complete = true,
+                        const std::string& unresolved = {}) {
+  size_t active = 0;
+  std::string inactive;
+  for (const auto& device : devices) {
+    if (device.active) {
+      ++active;
+      continue;
+    }
+    if (!inactive.empty()) inactive += ",";
+    inactive += device.name;
+  }
+  std::string summary =
+      "rdma topology startup: configured=" + std::to_string(configured) +
+      " initialized=" + std::to_string(initialized);
+  if (discovery_complete) {
+    summary += " ACTIVE=" + std::to_string(active) +
+               " inactive=" + (inactive.empty() ? "(none)" : inactive);
+  } else {
+    summary += " probed=" + std::to_string(devices.size()) +
+               " observed_ACTIVE=" + std::to_string(active) +
+               " observed_inactive=" +
+               (inactive.empty() ? "(none)" : inactive);
+  }
+  if (!unresolved.empty()) summary += " unresolved=" + unresolved;
+  DFKV_LOG_INFO(summary);
+}
 }  // namespace
 
 RdmaServer::RdmaServer(Handler handler, size_t max_msg,
@@ -85,7 +133,10 @@ RdmaServer::RdmaServer(Handler handler, size_t max_msg,
     size_t c = dev_name_.find(',', i);
     if (c == std::string::npos) c = dev_name_.size();
     std::string d = dev_name_.substr(i, c - i);
-    if (!d.empty()) anchor_devs_.push_back(d);
+    if (!d.empty() &&
+        std::find(anchor_devs_.begin(), anchor_devs_.end(), d) ==
+            anchor_devs_.end())
+      anchor_devs_.push_back(d);
     i = c + 1;
   }
   if (anchor_devs_.empty()) anchor_devs_.push_back("");
@@ -124,37 +175,73 @@ Status RdmaServer::Start(int port) {
   socklen_t sl = sizeof(sa);
   ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&sa), &sl);
   port_ = ntohs(sa.sin_port);
-  // Resolve an explicit comma list as an ACTIVE-device whitelist. With no
-  // override, preserve host-local device semantics by selecting only the first
-  // ACTIVE HCA; multi-rail is opt-in because names need not match on peers.
+  // Automatic discovery remains ACTIVE-only and selects the first verbs HCA.
+  // Explicit configuration is different: every named HCA must resolve, but an
+  // initially inactive port remains a fixed rail so runtime health can recover
+  // it without changing topology indices.
   std::vector<std::string> requested_devices;
-  for (const auto& device : anchor_devs_) {
-    if (!device.empty()) requested_devices.push_back(device);
-  }
-  auto active_devices = rdma::RdmaTopology::Discover(requested_devices);
-  if (auto_device_ && active_devices.size() > 1) active_devices.resize(1);
-  if (active_devices.empty()) {
+  if (!auto_device_) requested_devices = anchor_devs_;
+  const rdma::RdmaDiscoveryPolicy discovery_policy =
+      auto_device_ ? rdma::RdmaDiscoveryPolicy::kActiveOnly
+                   : rdma::RdmaDiscoveryPolicy::kAllowInactive;
+  rdma::RdmaDiscoveryResult discovery =
+      discover_for_test_
+          ? discover_for_test_(requested_devices, discovery_policy)
+          : rdma::RdmaTopology::Discover(requested_devices, discovery_policy);
+  if (!discovery.ok()) {
+    LogTopologySummary(requested_devices.size(), 0,
+                       discovery.observed_devices, false,
+                       discovery.failed_device);
     DFKV_LOG_ERROR(
-        requested_devices.empty()
-            ? "rdma: no ACTIVE device found"
-            : "rdma: none of the configured devices is ACTIVE");
+        "rdma: device discovery failed: status=" +
+        std::string(DiscoveryStatusName(discovery.status)) +
+        (discovery.failed_device.empty()
+             ? std::string()
+             : " device=" + discovery.failed_device));
     ::close(listen_fd_);
     listen_fd_ = -1;
     return Status::kIOError;
   }
-  anchor_devs_.clear();
+  if (auto_device_ && discovery.devices.size() > 1)
+    discovery.devices.resize(1);
+  if (discovery.devices.empty()) {
+    LogTopologySummary(requested_devices.size(), 0, discovery.devices);
+    DFKV_LOG_ERROR("rdma: no ACTIVE device found");
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return Status::kIOError;
+  }
+  if (!auto_device_) {
+    bool exact = discovery.devices.size() == requested_devices.size();
+    for (size_t i = 0; exact && i < requested_devices.size(); ++i)
+      exact = discovery.devices[i].name == requested_devices[i];
+    if (!exact) {
+      LogTopologySummary(requested_devices.size(), 0, discovery.devices);
+      DFKV_LOG_ERROR(
+          "rdma: explicit discovery returned a partial or reordered topology");
+      ::close(listen_fd_);
+      listen_fd_ = -1;
+      return Status::kIOError;
+    }
+  }
+
+  std::vector<std::string> resolved_device_names;
+  resolved_device_names.reserve(discovery.devices.size());
   std::string resolved_devices;
-  for (const auto& device : active_devices) {
-    anchor_devs_.push_back(device.name);
+  for (const auto& device : discovery.devices) {
+    resolved_device_names.push_back(device.name);
     if (!resolved_devices.empty()) resolved_devices += ",";
     resolved_devices += device.name;
   }
+  anchor_devs_ = std::move(resolved_device_names);
   dev_name_ = anchor_devs_.front();
   config_dump::RecordResolved("DFKV_RDMA_DEV", resolved_devices);
+
   // Allocate the mandatory process-wide receive segment before opening anchors.
   recv_segment_bytes_ = RecvSegmentBytes();
   const size_t min_slot_bytes = rdma::V2SlotSize(max_msg_);
   if (!rdma::V2RecvSegmentFitsOneSlot(recv_segment_bytes_, max_msg_)) {
+    LogTopologySummary(requested_devices.size(), 0, discovery.devices);
     DFKV_LOG_ERROR(
         "rdma: configured v2 receive segment (" +
         std::to_string(recv_segment_bytes_) +
@@ -168,6 +255,7 @@ Status RdmaServer::Start(int port) {
     return Status::kIOError;
   }
   if (!recv_segment_.Init(recv_segment_bytes_, rdma::kV2DataOffset)) {
+    LogTopologySummary(requested_devices.size(), 0, discovery.devices);
     DFKV_LOG_ERROR("rdma: unable to allocate required v2 receive segment (" +
                    std::to_string(recv_segment_bytes_) + " bytes)");
     recv_segment_bytes_ = 0;
@@ -175,42 +263,53 @@ Status RdmaServer::Start(int port) {
     listen_fd_ = -1;
     return Status::kIOError;
   }
-  recv_segment_registered_rails_ = 0;
-  for (const auto& d : anchor_devs_) {
-    auto anchor = std::make_unique<rdma::RcEndpoint>();
-    if (!anchor->Open(d.empty() ? nullptr : d.c_str(),
-                      rdma::kV2ControlCap, 1)) {
-      DFKV_LOG_ERROR("rdma: failed to open required v2 device " +
-                     (d.empty() ? std::string("(auto)") : d));
-      continue;
+
+  std::vector<std::unique_ptr<rdma::RcEndpoint>> initialized_anchors;
+  initialized_anchors.reserve(anchor_devs_.size());
+  for (const auto& device : anchor_devs_) {
+    std::unique_ptr<rdma::RcEndpoint> anchor;
+    if (initialize_anchor_for_test_) {
+      anchor = initialize_anchor_for_test_(
+          device, user_regions_, recv_segment_.data(), recv_segment_.size());
+    } else {
+      anchor = std::make_unique<rdma::RcEndpoint>();
+      if (!anchor->Open(device.c_str(), rdma::kV2ControlCap, 1)) {
+        DFKV_LOG_ERROR("rdma: failed to open required v2 device " + device);
+        anchor.reset();
+      } else if (!anchor->EnsurePoolMrs(user_regions_)) {
+        DFKV_LOG_ERROR("rdma: failed to register explicit user region on " +
+                       device);
+        anchor.reset();
+      } else if (!anchor->RegisterRemoteRegion(recv_segment_.data(),
+                                               recv_segment_.size())) {
+        DFKV_LOG_ERROR(
+            "rdma: failed to register required v2 receive segment on " +
+            device);
+        anchor.reset();
+      }
     }
-    if (!anchor->EnsurePoolMrs(user_regions_)) {
-      DFKV_LOG_ERROR("rdma: failed to register explicit user region on " +
-                     (d.empty() ? std::string("(auto)") : d));
-      continue;
+    if (!anchor) {
+      LogTopologySummary(requested_devices.size(),
+                         initialized_anchors.size(), discovery.devices);
+      DFKV_LOG_ERROR(
+          "rdma: every resolved rail must initialize; startup aborted");
+      recv_segment_registered_rails_ = 0;
+      ::close(listen_fd_);
+      listen_fd_ = -1;
+      return Status::kIOError;
     }
-    if (!anchor->RegisterRemoteRegion(recv_segment_.data(),
-                                      recv_segment_.size())) {
-      DFKV_LOG_ERROR("rdma: failed to register required v2 receive segment on " +
-                     (d.empty() ? std::string("(auto)") : d));
-      continue;
-    }
-    ++recv_segment_registered_rails_;
-    anchors_.push_back(std::move(anchor));
+    initialized_anchors.push_back(std::move(anchor));
   }
-  if (anchors_.size() != anchor_devs_.size() ||
-      recv_segment_registered_rails_ != anchor_devs_.size()) {
-    DFKV_LOG_ERROR(
-        "rdma: v2 receive segment was not established on every selected rail");
-    anchors_.clear();
-    ::close(listen_fd_);
-    listen_fd_ = -1;
-    return Status::kIOError;
-  }
-  rail_stats_.clear();
-  rail_stats_.reserve(anchor_devs_.size());
+
+  std::vector<std::unique_ptr<RailStats>> initialized_stats;
+  initialized_stats.reserve(anchor_devs_.size());
   for (size_t i = 0; i < anchor_devs_.size(); ++i)
-    rail_stats_.push_back(std::make_unique<RailStats>());
+    initialized_stats.push_back(std::make_unique<RailStats>());
+  anchors_ = std::move(initialized_anchors);
+  rail_stats_ = std::move(initialized_stats);
+  recv_segment_registered_rails_ = anchors_.size();
+  LogTopologySummary(requested_devices.size(), anchors_.size(),
+                     discovery.devices);
   if (anchor_devs_.size() > 1)
     DFKV_LOG_INFO("rdma multi-rail anchors: " +
                   std::to_string(anchors_.size()) + "/" +
@@ -410,7 +509,7 @@ void RdmaServer::Serve(int boot_fd) {
   const auto rail_it =
       std::find(anchor_devs_.begin(), anchor_devs_.end(), dev);
   if (rail_it == anchor_devs_.end()) {
-    DFKV_LOG_ERROR("rdma: client requested device outside the ACTIVE filter: " +
+    DFKV_LOG_ERROR("rdma: client requested device outside the fixed topology: " +
                    dev);
     ::close(boot_fd);
     return;

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -1,10 +1,10 @@
 /* RDMA cache-node listener — native v2 libibverbs RC. Bounded 32,786-byte
  * per-QP control buffers share a process-wide registered payload segment.
  * Peers that cannot negotiate v2 are rejected.
- * The listener is a TCP socket used only for capability/QP bootstrap. Startup
- * discovers ACTIVE HCAs (or applies the configured whitelist), anchors their
- * shared PD/MRs, and each accepted connection opens an RC QP on its requested
- * rail. shutdown(listen_fd) keeps Stop() interruptible. */
+ * The TCP listener only bootstraps QPs. Startup discovers the first ACTIVE HCA
+ * automatically, or resolves every explicitly configured HCA into a fixed
+ * topology (including initially inactive ports), then anchors shared PD/MRs.
+ * shutdown(listen_fd) keeps Stop() interruptible. */
 #ifndef DFKV_RDMA_SERVER_H_
 #define DFKV_RDMA_SERVER_H_
 
@@ -25,8 +25,10 @@
 #include "common/status.h"
 #include "transport/rdma_recv_segment.h"
 #include "transport/rdma_verbs.h"  // rdma::RcEndpoint
+#include "transport/rdma_topology.h"
 
 namespace dfkv {
+class RdmaServerTestPeer;
 
 class RdmaServer {
  public:
@@ -79,6 +81,8 @@ class RdmaServer {
   Status Start(int port);  // TCP bootstrap port
   void Stop();
   int port() const { return port_; }
+  // Explicit-mode failures retain the complete requested order; diagnostic
+  // probe evidence never replaces this with a partially discovered topology.
   const std::vector<std::string>& DeviceNames() const { return anchor_devs_; }
 
   // Observability (used by tests): number of Serve threads not yet reaped.
@@ -173,13 +177,24 @@ class RdmaServer {
   std::atomic<uint64_t> segment_evictions_{0};
   size_t recv_segment_bytes_ = 0;
   size_t recv_segment_registered_rails_ = 0;
-  // One anchor per explicitly resolved ACTIVE rail holds a lifetime shared
-  // device reference and registers the receive segment and caller pools on
-  // that rail's PD. With no filter, only the first ACTIVE local rail is
-  // anchored: HCA names are host-local configuration, never peer identities.
+  // One anchor per resolved rail holds a lifetime shared device reference and
+  // registers the receive segment and caller pools on that rail's PD. Auto
+  // mode anchors only the first ACTIVE local rail. An explicit list is fixed
+  // at startup and may include inactive ports so they can recover in place.
   std::vector<std::unique_ptr<rdma::RcEndpoint>> anchors_;
-  std::vector<std::string> anchor_devs_;  // configured filter, then active rails
+  std::vector<std::string> anchor_devs_;  // fixed resolved rail names
   std::vector<std::unique_ptr<RailStats>> rail_stats_;  // indexed with anchor_devs_
+  // Narrow hardware-free startup seams, private and reachable only through the
+  // test peer. Production always calls verbs discovery and materializes real
+  // anchors.
+  std::function<rdma::RdmaDiscoveryResult(
+      const std::vector<std::string>&, rdma::RdmaDiscoveryPolicy)>
+      discover_for_test_;
+  std::function<std::unique_ptr<rdma::RcEndpoint>(
+      const std::string&, const std::vector<std::pair<void*, size_t>>&,
+      void*, size_t)>
+      initialize_anchor_for_test_;
+  friend class RdmaServerTestPeer;
   std::atomic<uint64_t> uring_reads_{0}, uring_init_fallbacks_{0};
   std::atomic<uint64_t> v2_conns_{0}, v2_put_writes_{0}, v2_get_writes_{0};
   std::atomic<uint64_t> v2_get_continuation_slot_changes_{0};

--- a/src/transport/rdma_topology.cc
+++ b/src/transport/rdma_topology.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 #include "utils/log.h"
@@ -38,70 +39,155 @@ std::vector<RdmaDevInfo> RdmaTopology::FilterActive(
   return out;
 }
 
-std::vector<RdmaDevInfo> RdmaTopology::Discover(
-    const std::vector<std::string>& filter) {
-  int count = 0;
-  ibv_device** list = ibv_get_device_list(&count);
-  if (!list || count == 0) {
-    if (list) ibv_free_device_list(list);
-    DFKV_LOG_WARN("rdma: no verbs devices found");
-    return {};
+RdmaDiscoveryResult RdmaTopology::ResolveDiscovery(
+    const std::vector<RdmaDiscoveryProbe>& probes,
+    const std::vector<std::string>& filter, RdmaDiscoveryPolicy policy) {
+  RdmaDiscoveryResult result;
+  if (policy == RdmaDiscoveryPolicy::kActiveOnly) {
+    std::vector<RdmaDevInfo> candidates;
+    candidates.reserve(probes.size());
+    for (const auto& probe : probes) {
+      if (probe.status == RdmaDiscoveryStatus::kOk ||
+          probe.status == RdmaDiscoveryStatus::kGidQueryFailed) {
+        candidates.push_back(probe.device);
+      }
+    }
+    result.devices = FilterActive(candidates, filter);
+    return result;
   }
 
-  std::vector<RdmaDevInfo> candidates;
-  candidates.reserve(static_cast<size_t>(count));
+  const auto fail = [&](RdmaDiscoveryStatus status,
+                        const std::string& device) {
+    result.observed_devices = std::move(result.devices);
+    result.devices.clear();
+    result.status = status;
+    result.failed_device = device;
+  };
+  if (filter.empty()) {
+    result.devices.reserve(probes.size());
+    for (const auto& probe : probes) {
+      if (probe.status != RdmaDiscoveryStatus::kOk) {
+        fail(probe.status, probe.device.name);
+        return result;
+      }
+      const bool duplicate = std::any_of(
+          result.devices.begin(), result.devices.end(),
+          [&](const RdmaDevInfo& selected) {
+            return selected.name == probe.device.name;
+          });
+      if (!duplicate) result.devices.push_back(probe.device);
+    }
+    return result;
+  }
+
+  result.devices.reserve(filter.size());
+  for (const auto& requested : filter) {
+    const bool duplicate = std::any_of(
+        result.devices.begin(), result.devices.end(),
+        [&](const RdmaDevInfo& selected) {
+          return selected.name == requested;
+        });
+    if (duplicate) continue;
+
+    const auto probe = std::find_if(
+        probes.begin(), probes.end(), [&](const RdmaDiscoveryProbe& candidate) {
+          return candidate.device.name == requested;
+        });
+    if (probe == probes.end()) {
+      fail(RdmaDiscoveryStatus::kConfiguredDeviceMissing, requested);
+      return result;
+    }
+    if (probe->status != RdmaDiscoveryStatus::kOk) {
+      fail(probe->status, requested);
+      return result;
+    }
+    result.devices.push_back(probe->device);
+  }
+  return result;
+}
+
+std::vector<RdmaDevInfo> RdmaTopology::Discover(
+    const std::vector<std::string>& filter) {
+  return Discover(filter, RdmaDiscoveryPolicy::kActiveOnly).devices;
+}
+
+RdmaDiscoveryResult RdmaTopology::Discover(
+    const std::vector<std::string>& filter, RdmaDiscoveryPolicy policy) {
+  int count = 0;
+  ibv_device** list = ibv_get_device_list(&count);
+  if (!list) {
+    DFKV_LOG_WARN("rdma: ibv_get_device_list failed");
+    RdmaDiscoveryResult result;
+    result.status = RdmaDiscoveryStatus::kDeviceListFailed;
+    return result;
+  }
+  if (count == 0) DFKV_LOG_WARN("rdma: no verbs devices found");
+
+  std::vector<RdmaDiscoveryProbe> probes;
+  probes.reserve(static_cast<size_t>(count));
   for (int i = 0; i < count; ++i) {
     const char* raw_name = ibv_get_device_name(list[i]);
     if (!raw_name) continue;
     const std::string name(raw_name);
     if (!Contains(filter, name)) continue;
 
-    ibv_context* context = ibv_open_device(list[i]);
+    RdmaDiscoveryProbe probe;
+    probe.device.name = name;
+    std::unique_ptr<ibv_context, decltype(&ibv_close_device)> context(
+        ibv_open_device(list[i]), &ibv_close_device);
     if (!context) {
       DFKV_LOG_WARN("rdma: skipping device " + name +
                     ": ibv_open_device failed");
+      probe.status = RdmaDiscoveryStatus::kDeviceOpenFailed;
+      probes.push_back(std::move(probe));
       continue;
     }
 
     ibv_port_attr port{};
-    if (ibv_query_port(context, 1, &port) != 0) {
+    if (ibv_query_port(context.get(), 1, &port) != 0) {
       DFKV_LOG_WARN("rdma: skipping device " + name +
                     ": ibv_query_port(1) failed");
-      ibv_close_device(context);
+      probe.status = RdmaDiscoveryStatus::kPortQueryFailed;
+      probes.push_back(std::move(probe));
       continue;
     }
 
-    RdmaDevInfo info;
-    info.name = name;
-    info.numa_node = numa::DeviceNode(name.c_str());
-    info.lid = port.lid;
-    info.active = port.state == IBV_PORT_ACTIVE;
-    union ibv_gid gid{};
-    if (ibv_query_gid(context, 1, 0, &gid) == 0)
-      std::memcpy(info.gid.data(), gid.raw, info.gid.size());
-    ibv_close_device(context);
+    probe.device.numa_node = numa::DeviceNode(name.c_str());
+    probe.device.lid = port.lid;
+    probe.device.active = port.state == IBV_PORT_ACTIVE;
+    union ibv_gid gid {};
+    if (ibv_query_gid(context.get(), 1, 0, &gid) != 0) {
+      DFKV_LOG_WARN("rdma: device " + name +
+                    ": ibv_query_gid(1, 0) failed");
+      probe.status = RdmaDiscoveryStatus::kGidQueryFailed;
+    } else {
+      std::memcpy(probe.device.gid.data(), gid.raw, probe.device.gid.size());
+    }
 
-    if (!info.active) {
-      DFKV_LOG_WARN("rdma: skipping device " + name + ": port 1 state=" +
+    if (!probe.device.active) {
+      DFKV_LOG_WARN("rdma: device " + name + ": port 1 state=" +
                     std::to_string(static_cast<int>(port.state)) +
                     " (ACTIVE=" +
                     std::to_string(static_cast<int>(IBV_PORT_ACTIVE)) + ")");
     }
-    candidates.push_back(std::move(info));
+    probes.push_back(std::move(probe));
   }
   ibv_free_device_list(list);
 
-  std::vector<RdmaDevInfo> active = FilterActive(candidates, filter);
-  for (const auto& requested : filter) {
-    const bool found = std::any_of(
-        active.begin(), active.end(), [&](const RdmaDevInfo& device) {
-          return device.name == requested;
-        });
-    if (!found)
-      DFKV_LOG_WARN("rdma: configured device " + requested +
-                    " is absent or not ACTIVE");
+  auto result = ResolveDiscovery(probes, filter, policy);
+  if (policy == RdmaDiscoveryPolicy::kActiveOnly) {
+    for (const auto& requested : filter) {
+      const bool found = std::any_of(
+          result.devices.begin(), result.devices.end(),
+          [&](const RdmaDevInfo& device) {
+            return device.name == requested;
+          });
+      if (!found)
+        DFKV_LOG_WARN("rdma: configured device " + requested +
+                      " is absent or not ACTIVE");
+    }
   }
-  return active;
+  return result;
 }
 
 RailCandidates RdmaTopology::CandidatesFor(int numa_node,

--- a/src/transport/rdma_topology.h
+++ b/src/transport/rdma_topology.h
@@ -1,9 +1,8 @@
 /* RDMA device discovery and runtime rail selection.
  *
- * Device names supplied through DFKV_RDMA_DEV are a whitelist, never a bypass
- * around link-state checks. Only port-1 devices in IBV_PORT_ACTIVE state are
- * returned, so an unconfigured client automatically uses every healthy rail
- * and an explicit list safely degrades when one member is down. */
+ * Automatic discovery returns only port-1 devices in IBV_PORT_ACTIVE state.
+ * Explicitly configured topologies may opt into retaining inactive ports so
+ * their stable rail indexes survive a boot-time hardware degradation. */
 #ifndef DFKV_RDMA_TOPOLOGY_H_
 #define DFKV_RDMA_TOPOLOGY_H_
 
@@ -23,6 +22,43 @@ struct RdmaDevInfo {
   uint16_t lid = 0;
   std::array<uint8_t, 16> gid{};
   bool active = false;
+};
+
+enum class RdmaDiscoveryPolicy : uint8_t {
+  kActiveOnly,
+  kAllowInactive,
+};
+
+enum class RdmaDiscoveryStatus : uint8_t {
+  kOk,
+  kDeviceListFailed,
+  kConfiguredDeviceMissing,
+  kDeviceOpenFailed,
+  kPortQueryFailed,
+  kGidQueryFailed,
+};
+
+// A non-kOk result is fail-closed: devices is empty and failed_device names
+// the configured rail when the failure is device-specific.
+struct RdmaDiscoveryResult {
+  std::vector<RdmaDevInfo> devices;
+  RdmaDiscoveryStatus status = RdmaDiscoveryStatus::kOk;
+  std::string failed_device;
+
+  // Provider-complete rails observed before an explicit discovery failure.
+  // Unlike devices, this evidence is preserved for truthful diagnostics when
+  // fail-closed resolution rejects the topology.
+  std::vector<RdmaDevInfo> observed_devices;
+
+  bool ok() const { return status == RdmaDiscoveryStatus::kOk; }
+};
+
+// One deterministic device-enumeration outcome. Failed probes carry only the
+// device name, except kGidQueryFailed retains metadata for legacy ACTIVE-only
+// resolution; successful probes carry the complete RdmaDevInfo.
+struct RdmaDiscoveryProbe {
+  RdmaDevInfo device;
+  RdmaDiscoveryStatus status = RdmaDiscoveryStatus::kOk;
 };
 
 enum class RailLocality : uint8_t {
@@ -49,13 +85,23 @@ class RdmaTopology {
  public:
   explicit RdmaTopology(std::vector<RdmaDevInfo> devices);
 
-  // Enumerate port 1 on every verbs device, apply the optional name whitelist,
-  // and return only ports whose state is IBV_PORT_ACTIVE.
+  // Default discovery remains ACTIVE-only.
   static std::vector<RdmaDevInfo> Discover(
       const std::vector<std::string>& filter = {});
 
-  // Pure filtering seam shared by Discover and the hardware-free unit tests.
-  // Preserves enumeration order and removes duplicate names.
+  // Typed discovery for explicit topology construction. kAllowInactive
+  // preserves configured first-occurrence order and fails closed unless every
+  // configured device has complete provider metadata, including a queried GID.
+  static RdmaDiscoveryResult Discover(
+      const std::vector<std::string>& filter, RdmaDiscoveryPolicy policy);
+
+  // Pure resolution seam used by Discover and hardware-free unit tests.
+  static RdmaDiscoveryResult ResolveDiscovery(
+      const std::vector<RdmaDiscoveryProbe>& probes,
+      const std::vector<std::string>& filter, RdmaDiscoveryPolicy policy);
+
+  // Pure ACTIVE-only filtering seam. Preserves enumeration order and removes
+  // duplicate names.
   static std::vector<RdmaDevInfo> FilterActive(
       const std::vector<RdmaDevInfo>& candidates,
       const std::vector<std::string>& filter = {});

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -31,6 +31,34 @@
 namespace fs = std::filesystem;
 using namespace dfkv;  // NOLINT
 
+namespace dfkv {
+class RdmaServerTestPeer {
+ public:
+  using DiscoverFn = std::function<rdma::RdmaDiscoveryResult(
+      const std::vector<std::string>&, rdma::RdmaDiscoveryPolicy)>;
+  using InitializeAnchorFn = std::function<std::unique_ptr<rdma::RcEndpoint>(
+      const std::string&, const std::vector<std::pair<void*, size_t>>&,
+      void*, size_t)>;
+
+  static void SetDiscovery(RdmaServer* server, DiscoverFn discover) {
+    server->discover_for_test_ = std::move(discover);
+  }
+  static void SetInitializeAnchor(RdmaServer* server,
+                                  InitializeAnchorFn initialize) {
+    server->initialize_anchor_for_test_ = std::move(initialize);
+  }
+  static size_t AnchorCount(const RdmaServer& server) {
+    return server.anchors_.size();
+  }
+  static size_t RailStatsCount(const RdmaServer& server) {
+    return server.rail_stats_.size();
+  }
+  static size_t RegisteredRailCount(const RdmaServer& server) {
+    return server.recv_segment_registered_rails_;
+  }
+};
+}  // namespace dfkv
+
 namespace {
 
 // Small per-buffer cap so the test stays well under a modest RLIMIT_MEMLOCK
@@ -154,6 +182,182 @@ struct FakePoolRail {
 };
 
 }  // namespace
+
+TEST(RdmaServerStartup, AutoModeKeepsFirstActiveDeviceSemantics) {
+  ScopedEnv configured_device("DFKV_RDMA_DEV", nullptr);
+  ScopedEnv recv_segment("DFKV_RDMA_RECV_SEGMENT_SIZE", "1048576");
+  RdmaServer server(
+      [](uint8_t, const BlockKey&, uint64_t, uint64_t, const char*, uint64_t,
+         std::string*, size_t*) { return Status::kInvalid; },
+      kMaxMsg);
+  RdmaServerTestPeer::SetDiscovery(
+      &server,
+      [](const std::vector<std::string>& requested,
+         rdma::RdmaDiscoveryPolicy policy) {
+        EXPECT_TRUE(requested.empty());
+        EXPECT_EQ(policy, rdma::RdmaDiscoveryPolicy::kActiveOnly);
+        rdma::RdmaDevInfo first;
+        first.name = "mlx5_first";
+        first.active = true;
+        rdma::RdmaDevInfo second;
+        second.name = "mlx5_second";
+        second.active = true;
+        rdma::RdmaDiscoveryResult result;
+        result.devices = {first, second};
+        return result;
+      });
+  std::vector<std::string> initialized;
+  RdmaServerTestPeer::SetInitializeAnchor(
+      &server,
+      [&initialized](
+          const std::string& device,
+          const std::vector<std::pair<void*, size_t>>&, void*, size_t) {
+        initialized.push_back(device);
+        return std::make_unique<rdma::RcEndpoint>();
+      });
+
+  ASSERT_EQ(server.Start(0), Status::kOk);
+  EXPECT_EQ(server.DeviceNames(),
+            (std::vector<std::string>{"mlx5_first"}));
+  EXPECT_EQ(initialized, server.DeviceNames());
+  EXPECT_EQ(RdmaServerTestPeer::AnchorCount(server), 1u);
+  EXPECT_EQ(RdmaServerTestPeer::RailStatsCount(server), 1u);
+  EXPECT_EQ(RdmaServerTestPeer::RegisteredRailCount(server), 1u);
+  server.Stop();
+}
+
+TEST(RdmaServerStartup, ExplicitInactiveRailRemainsInFixedTopology) {
+  ScopedEnv recv_segment("DFKV_RDMA_RECV_SEGMENT_SIZE", "1048576");
+  RdmaServer server(
+      [](uint8_t, const BlockKey&, uint64_t, uint64_t, const char*, uint64_t,
+         std::string*, size_t*) { return Status::kInvalid; },
+      kMaxMsg, "mlx5_active,mlx5_down,mlx5_active");
+  RdmaServerTestPeer::SetDiscovery(
+      &server,
+      [](const std::vector<std::string>& requested,
+         rdma::RdmaDiscoveryPolicy policy) {
+        EXPECT_EQ(requested,
+                  (std::vector<std::string>{"mlx5_active", "mlx5_down"}));
+        EXPECT_EQ(policy, rdma::RdmaDiscoveryPolicy::kAllowInactive);
+        rdma::RdmaDevInfo active;
+        active.name = "mlx5_active";
+        active.active = true;
+        rdma::RdmaDevInfo inactive;
+        inactive.name = "mlx5_down";
+        inactive.active = false;
+        rdma::RdmaDiscoveryResult result;
+        result.devices = {active, inactive};
+        return result;
+      });
+  std::vector<std::string> initialized;
+  RdmaServerTestPeer::SetInitializeAnchor(
+      &server,
+      [&initialized](
+          const std::string& device,
+          const std::vector<std::pair<void*, size_t>>&, void*, size_t) {
+        initialized.push_back(device);
+        return std::make_unique<rdma::RcEndpoint>();
+      });
+
+  ASSERT_EQ(server.Start(0), Status::kOk);
+  EXPECT_EQ(server.DeviceNames(),
+            (std::vector<std::string>{"mlx5_active", "mlx5_down"}));
+  EXPECT_EQ(initialized, server.DeviceNames());
+  EXPECT_EQ(RdmaServerTestPeer::AnchorCount(server), 2u);
+  EXPECT_EQ(RdmaServerTestPeer::RailStatsCount(server), 2u);
+  EXPECT_EQ(RdmaServerTestPeer::RegisteredRailCount(server), 2u);
+  server.Stop();
+}
+
+TEST(RdmaServerStartup, PartialAnchorMaterializationFailsAtomically) {
+  ScopedEnv recv_segment("DFKV_RDMA_RECV_SEGMENT_SIZE", "1048576");
+  RdmaServer server(
+      [](uint8_t, const BlockKey&, uint64_t, uint64_t, const char*, uint64_t,
+         std::string*, size_t*) { return Status::kInvalid; },
+      kMaxMsg, "mlx5_0,mlx5_1");
+  RdmaServerTestPeer::SetDiscovery(
+      &server,
+      [](const std::vector<std::string>&,
+         rdma::RdmaDiscoveryPolicy policy) {
+        EXPECT_EQ(policy, rdma::RdmaDiscoveryPolicy::kAllowInactive);
+        rdma::RdmaDevInfo first;
+        first.name = "mlx5_0";
+        first.active = true;
+        rdma::RdmaDevInfo second;
+        second.name = "mlx5_1";
+        second.active = false;
+        rdma::RdmaDiscoveryResult result;
+        result.devices = {first, second};
+        return result;
+      });
+  size_t attempts = 0;
+  RdmaServerTestPeer::SetInitializeAnchor(
+      &server,
+      [&attempts](
+          const std::string&, const std::vector<std::pair<void*, size_t>>&,
+          void*, size_t) -> std::unique_ptr<rdma::RcEndpoint> {
+        if (++attempts == 2) return nullptr;
+        return std::make_unique<rdma::RcEndpoint>();
+      });
+
+  EXPECT_EQ(server.Start(0), Status::kIOError);
+  EXPECT_EQ(attempts, 2u);
+  EXPECT_EQ(server.DeviceNames(),
+            (std::vector<std::string>{"mlx5_0", "mlx5_1"}));
+  EXPECT_EQ(RdmaServerTestPeer::AnchorCount(server), 0u);
+  EXPECT_EQ(RdmaServerTestPeer::RailStatsCount(server), 0u);
+  EXPECT_EQ(RdmaServerTestPeer::RegisteredRailCount(server), 0u);
+}
+
+TEST(RdmaServerStartup, ExplicitResolutionFailureNeverShrinksTopology) {
+  RdmaServer server(
+      [](uint8_t, const BlockKey&, uint64_t, uint64_t, const char*, uint64_t,
+         std::string*, size_t*) { return Status::kInvalid; },
+      kMaxMsg, "mlx5_present,mlx5_missing");
+  RdmaServerTestPeer::SetDiscovery(
+      &server,
+      [](const std::vector<std::string>& requested,
+         rdma::RdmaDiscoveryPolicy policy) {
+        EXPECT_EQ(requested,
+                  (std::vector<std::string>{"mlx5_present", "mlx5_missing"}));
+        EXPECT_EQ(policy, rdma::RdmaDiscoveryPolicy::kAllowInactive);
+        rdma::RdmaDiscoveryResult result;
+        result.status =
+            rdma::RdmaDiscoveryStatus::kConfiguredDeviceMissing;
+        result.failed_device = "mlx5_missing";
+        rdma::RdmaDevInfo observed;
+        observed.name = "mlx5_present";
+        observed.active = true;
+        result.observed_devices = {observed};
+        return result;
+      });
+  size_t anchor_attempts = 0;
+  RdmaServerTestPeer::SetInitializeAnchor(
+      &server,
+      [&anchor_attempts](
+          const std::string&, const std::vector<std::pair<void*, size_t>>&,
+          void*, size_t) -> std::unique_ptr<rdma::RcEndpoint> {
+        ++anchor_attempts;
+        return std::make_unique<rdma::RcEndpoint>();
+      });
+
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(server.Start(0), Status::kIOError);
+  const std::string logs = testing::internal::GetCapturedStderr();
+  EXPECT_NE(logs.find("configured=2 initialized=0 probed=1 "
+                      "observed_ACTIVE=1 observed_inactive=(none) "
+                      "unresolved=mlx5_missing"),
+            std::string::npos)
+      << logs;
+  EXPECT_EQ(logs.find(" ACTIVE=0 inactive=(none)"), std::string::npos)
+      << logs;
+  EXPECT_EQ(anchor_attempts, 0u);
+  EXPECT_EQ(server.DeviceNames(),
+            (std::vector<std::string>{"mlx5_present", "mlx5_missing"}));
+  EXPECT_EQ(RdmaServerTestPeer::AnchorCount(server), 0u);
+  EXPECT_EQ(RdmaServerTestPeer::RailStatsCount(server), 0u);
+  EXPECT_EQ(RdmaServerTestPeer::RegisteredRailCount(server), 0u);
+}
 
 TEST(RdmaSafety, CompletionDeadlineUsesOneAbsoluteBudget) {
   using Clock = CompletionDeadline::Clock;

--- a/test/transport/rdma_topology_test.cc
+++ b/test/transport/rdma_topology_test.cc
@@ -2,14 +2,18 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <string>
 #include <vector>
 
 namespace {
 
-using dfkv::rdma::RdmaDevInfo;
-using dfkv::rdma::RdmaTopology;
 using dfkv::rdma::RailLocality;
+using dfkv::rdma::RdmaDevInfo;
+using dfkv::rdma::RdmaDiscoveryPolicy;
+using dfkv::rdma::RdmaDiscoveryProbe;
+using dfkv::rdma::RdmaDiscoveryStatus;
+using dfkv::rdma::RdmaTopology;
 
 RdmaDevInfo Device(std::string name, bool active, int numa_node = -1) {
   RdmaDevInfo info;
@@ -17,6 +21,15 @@ RdmaDevInfo Device(std::string name, bool active, int numa_node = -1) {
   info.active = active;
   info.numa_node = numa_node;
   return info;
+}
+
+RdmaDiscoveryProbe Probe(
+    std::string name, bool active,
+    RdmaDiscoveryStatus status = RdmaDiscoveryStatus::kOk) {
+  RdmaDiscoveryProbe probe;
+  probe.device = Device(std::move(name), active);
+  probe.status = status;
+  return probe;
 }
 
 TEST(RdmaTopology, DiscoveryDropsDownPortsWithoutAFilter) {
@@ -59,6 +72,124 @@ TEST(RdmaTopology, DuplicateCandidatesRemainOneRail) {
 
   ASSERT_EQ(selected.size(), 1u);
   EXPECT_EQ(selected[0].name, "ib7s400p0");
+}
+
+TEST(RdmaTopology, TypedActiveOnlyResolutionFiltersInactiveAndFailedProbes) {
+  const std::vector<RdmaDiscoveryProbe> probes{
+      Probe("ib0", false), Probe("ib1", true),
+      Probe("ib2", false, RdmaDiscoveryStatus::kDeviceOpenFailed),
+      Probe("ib3", true)};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, {}, RdmaDiscoveryPolicy::kActiveOnly);
+
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result.devices.size(), 2u);
+  EXPECT_EQ(result.devices[0].name, "ib1");
+  EXPECT_EQ(result.devices[1].name, "ib3");
+}
+
+TEST(RdmaTopology, ActiveOnlyPreservesLegacyGidQueryFailureBehavior) {
+  const std::vector<RdmaDiscoveryProbe> probes{
+      Probe("ib0", true, RdmaDiscoveryStatus::kGidQueryFailed),
+      Probe("ib1", true)};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, {}, RdmaDiscoveryPolicy::kActiveOnly);
+
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result.devices.size(), 2u);
+  EXPECT_EQ(result.devices[0].name, "ib0");
+  EXPECT_EQ(result.devices[0].gid, (std::array<uint8_t, 16>{}));
+  EXPECT_EQ(result.devices[1].name, "ib1");
+}
+
+TEST(RdmaTopology, AllowInactiveRetainsStateInConfiguredOrder) {
+  const std::vector<RdmaDiscoveryProbe> probes{
+      Probe("ib0", true), Probe("ib1", false), Probe("ib2", true)};
+  const std::vector<std::string> configured{"ib2", "ib1", "ib0"};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, configured, RdmaDiscoveryPolicy::kAllowInactive);
+
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result.devices.size(), 3u);
+  EXPECT_EQ(result.devices[0].name, "ib2");
+  EXPECT_TRUE(result.devices[0].active);
+  EXPECT_EQ(result.devices[1].name, "ib1");
+  EXPECT_FALSE(result.devices[1].active);
+  EXPECT_EQ(result.devices[2].name, "ib0");
+  EXPECT_TRUE(result.devices[2].active);
+}
+
+TEST(RdmaTopology, AllowInactiveUsesFirstConfiguredOccurrence) {
+  const std::vector<RdmaDiscoveryProbe> probes{
+      Probe("ib0", true), Probe("ib1", false)};
+  const std::vector<std::string> configured{"ib1", "ib0", "ib1", "ib0"};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, configured, RdmaDiscoveryPolicy::kAllowInactive);
+
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result.devices.size(), 2u);
+  EXPECT_EQ(result.devices[0].name, "ib1");
+  EXPECT_EQ(result.devices[1].name, "ib0");
+}
+
+TEST(RdmaTopology, AllowInactiveFailsClosedForMissingConfiguredDevice) {
+  const std::vector<RdmaDiscoveryProbe> probes{Probe("ib0", true)};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, {"ib0", "ib-missing"}, RdmaDiscoveryPolicy::kAllowInactive);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.status, RdmaDiscoveryStatus::kConfiguredDeviceMissing);
+  EXPECT_EQ(result.failed_device, "ib-missing");
+  EXPECT_TRUE(result.devices.empty());
+}
+
+TEST(RdmaTopology, AllowInactiveFailsClosedForDeviceOpenFailure) {
+  const std::vector<RdmaDiscoveryProbe> probes{
+      Probe("ib0", true),
+      Probe("ib1", false, RdmaDiscoveryStatus::kDeviceOpenFailed)};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, {"ib0", "ib1"}, RdmaDiscoveryPolicy::kAllowInactive);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.status, RdmaDiscoveryStatus::kDeviceOpenFailed);
+  EXPECT_EQ(result.failed_device, "ib1");
+  EXPECT_TRUE(result.devices.empty());
+}
+
+TEST(RdmaTopology, AllowInactiveFailsClosedForPortQueryFailure) {
+  const std::vector<RdmaDiscoveryProbe> probes{
+      Probe("ib0", false, RdmaDiscoveryStatus::kPortQueryFailed),
+      Probe("ib1", true)};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, {"ib0", "ib1"}, RdmaDiscoveryPolicy::kAllowInactive);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.status, RdmaDiscoveryStatus::kPortQueryFailed);
+  EXPECT_EQ(result.failed_device, "ib0");
+  EXPECT_TRUE(result.devices.empty());
+}
+
+TEST(RdmaTopology, AllowInactiveFailsClosedForGidQueryFailure) {
+  const std::vector<RdmaDiscoveryProbe> probes{
+      Probe("ib0", true),
+      Probe("ib1", true, RdmaDiscoveryStatus::kGidQueryFailed)};
+
+  const auto result = RdmaTopology::ResolveDiscovery(
+      probes, {"ib0", "ib1"}, RdmaDiscoveryPolicy::kAllowInactive);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.status, RdmaDiscoveryStatus::kGidQueryFailed);
+  EXPECT_EQ(result.failed_device, "ib1");
+  EXPECT_TRUE(result.devices.empty());
+  ASSERT_EQ(result.observed_devices.size(), 1u);
+  EXPECT_EQ(result.observed_devices[0].name, "ib0");
 }
 
 TEST(RdmaTopology, SelectsLocalRailsRoundRobin) {


### PR DESCRIPTION
## Summary
- keep explicitly configured, present RDMA rails in the immutable server topology even when booting DOWN
- fail closed on missing/open/port/GID/anchor/MR failures; keep automatic discovery ACTIVE-only
- expose truthful configured/initialized/ACTIVE startup cardinality and document node-level health recovery

## Verification
- local focused topology/server tests PASS; complete local CTest PASS
- xb01-gpu-200b-0064 real-HCA: server booted on ib7s400p4 while physical port DOWN with configured=1 initialized=1 ACTIVE=0
- same PID recovered to ACTIVE/ring eligible after LinkUp without restart
- 10 DOWN/UP cycles PASS; receive segment returned fully free; active connections 0
- 1 MiB RDMA benchmark: PUT 128/128 and GET 128/128, completion/rail/CQ errors 0
- real-HCA rdma_topology_test 20/20 and rdma_loopback_test 47/47 PASS

Only the authorized 0064 development node was changed; production rollout is out of scope.