### PR TITLE
fix(rdma): recover GETs across failed client rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,17 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
 - **Observability** ([docs/METRICS.md](docs/METRICS.md)): opt-in embedded Prometheus
   `/metrics` on `dfkv_server` and `dfkv_mds` (`--metrics-port`); sampled op-latency
   histogram, eviction/error/per-disk/RDMA counters server-side; client-side counters
-  (peer health, IO errors) via `dfkv_stats_snapshot` + a plugin poller. The
-  `dfkv_server_ring_eligible` and `dfkv_server_ib_device_healthy` families are
-  emitted only by an RDMA-enabled binary that is running an RDMA listener.
-  Their absence from a TCP-only binary or an RDMA build without a listener is
-  expected and must not be coerced to zero by dashboards or alerts. **Opt-in and
+  (peer health, IO errors, per-rail quarantine/recovery,
+  `dfkv_rdma_client_cross_rail_retries_total`,
+  `dfkv_rdma_client_cross_rail_retry_successes_total`, and
+  `dfkv_rdma_client_cross_rail_retry_exhausted_total`) via
+  `dfkv_stats_snapshot` + a plugin poller. Client RDMA families exist only
+  when the RDMA transport is in use and that snapshot is exported; absence from
+  a TCP-only process is expected. Server `dfkv_server_ring_eligible` and
+  `dfkv_server_ib_device_healthy` families are emitted only by an RDMA-enabled
+  binary running an RDMA listener. Their absence from a TCP-only binary or an
+  RDMA build without a listener must not be coerced to zero by dashboards or
+  alerts. **Opt-in and
   off the datapath** — no `--metrics-port` ⇒ no metrics listener, behavior unchanged.
   The three connectors (vLLM / LMCache / SGLang HiCache) can also **push** fleet
   metrics (ops/keys/bytes, op latency, per-peer latency) over OTLP to a central
@@ -276,6 +282,25 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
   rail NUMA node; the single shared receive segment is registered on each
   selected rail but is not separately NUMA-allocated per rail. Off by default;
   vendor-neutral (sysfs + `sched_getcpu`, no libnuma/CUDA).
+- **Client-local rail recovery**: local device/verbs evidence (`Open`, local QP
+  transition, MR registration/refresh, post/CQ API failure, or a locally
+  classified WC) is `kRailFailure`; peer/bootstrap/protocol failure, remote/RNR/
+  retry/flush WC, silent completion timeout, resource admission, cancellation,
+  and invalid input are not. A first-attempt `kRailFailure` retires the failed
+  endpoint and synchronously tears down its QP/MRs before one fresh retry. The
+  retry excludes that rail from both NUMA-preferred and fallback selection, so
+  it uses a distinct topology-enabled local rail whenever one exists. There are
+  at most two physical attempts. A one-rail topology may instead make the one
+  fresh retry on that same rail, but it never reuses the failed QP or bypasses
+  quarantine, cooldown, credits, or the single recovery-probe gate.
+- **Bounded at-least-once replay**: a rail retry replays the existing whole
+  logical PUT/GET/batch/SG operation after teardown; it does not promise
+  exactly-once PUT execution when a remote commit preceded a lost completion.
+  This is client-only recovery and is separate from server node/ring health
+  (`DFKV_RDMA_HEALTH_FILE` and `dfkv_server_ring_eligible`). It changes neither
+  the RDMA wire protocol nor server behavior, so upgraded clients remain
+  compatible with mixed-version servers that already speak the same RDMA v2
+  protocol.
 - **SGLang HiCache pool-aware v2 interface** (`batch_set_v2`/`batch_get_v2` +
   PoolTransfer) for multi-pool models (Mamba/SWA/DeepSeek-V4).
 - **Packaging**: CPack (deb/rpm/tgz) + Dockerfile; **graceful shutdown**; leveled logging.
@@ -309,6 +334,9 @@ fabric selection and capacity explicit.
 |---|---|---|
 | `DFKV_RDMA_DEV` | leave unset for one local HCA; use the same fabric whitelist on both hosts for multi-rail | Unset lets each endpoint select its own first `ACTIVE` local HCA, so local names may differ. A comma list explicitly enables multi-rail and is sent to the peer; every listed name must exist and be on the intended interoperable fabric at both ends. |
 | `DFKV_RDMA_DEPTH` | `4` (default) | Keep client/server defaults aligned for connector batch correctness. Throughput scaling comes from multiple pooled connections, not raising one QP's depth; lowering depth reduces receive-segment consumption only after validating the real engine workload. |
+| `DFKV_RDMA_RAIL_ERROR_THRESHOLD` | `3` (default) | Consecutive client-local rail failures required to quarantine that rail; endpoint/peer failures do not contribute. |
+| `DFKV_RDMA_RAIL_COOLDOWN_MS` | `5000` (default) | Quarantine duration. No admission occurs during cooldown; afterward exactly one real operation is admitted as the recovery probe. Probe success clears the rail state, local failure starts another cooldown, and endpoint failure proves neither recovery nor a new local fault. |
+| local-rail attempts | fixed at `2` (not configurable) | One initial attempt plus at most one fresh retry after `kRailFailure`; a distinct enabled local rail is mandatory when present. A one-rail topology may retry fresh on the same rail without bypassing quarantine. |
 | `DFKV_RDMA_KEEPALIVE_MS` | `15000` (default); `0` = off | Sends lightweight membership probes over every idle pooled QP. Live clients keep their QPs and avoid first-GET reconnect tails; exited clients send no probes and remain reclaimable. Keep the interval strictly below the server reap interval. |
 | `DFKV_RDMA_POOL_MAX` | `16` (default) | Maximum idle QPs retained per server and per lane, across all rails. It is not a process-wide connection cap. Raise only when connection-open metrics grow on repeated steady-state rounds; each retained QP leases `depth × align4K(4096 + declared_max_block)` from the server receive segment. |
 | `DFKV_RDMA_ENDPOINT_CACHE_MAX` | `256` (default, process-wide) | Hard cap on live client RDMA endpoints across all `RdmaTransport` instances. Under pressure, the requesting transport applies a SIEVE second-chance scan to its idle data/SG/control endpoints, destroys one cold QP, then retries admission. A hot cache hit sets only one visited bit; no LRU mutation occurs on the datapath. |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -333,13 +333,36 @@ journalctl -u dfkv -n 10 --no-pager
 > 建连/RPC 及 MDS 对外可见延迟；MDS 不可达时采样/发布可更久，因此这不是
 > wall-clock 上界。门满足后同一进程自动 rejoin，**LinkUp 后无需 restart**。
 >
-> **失败域隔离**：TCP bootstrap、peer 不可达、epoch/QP frame/receive-segment
-> 不兼容属于 endpoint 失败：立即归还 rail credit，由 client `PeerHealth` 对该
-> node 做 bounded cooldown，不增加共享 HCA 的 consecutive failure，也不会让
-> node A 隔离 node B 的健康 rail。只有本地 device open、verbs/QP transition、
-> post 或 CQ 失败才按 `DFKV_RDMA_RAIL_ERROR_THRESHOLD` 隔离 rail
-> `DFKV_RDMA_RAIL_COOLDOWN_MS`；cooldown 到期仍以单 probe 成功恢复，endpoint
-> 失败既不误恢复也不重新惩罚 rail。
+> **client-local 失败域与有界重放**：本地 device open、QP transition、
+> MR register/refresh、post/CQ verbs API 失败，以及被分类为 local 的 WC
+> （`LOC_*`、`FATAL`、`GENERAL`）才是 `kRailFailure`。TCP bootstrap、peer
+> 不可达、probe/协商/protocol/receive-segment/decode 失败，remote/retry/RNR/
+> response-timeout/flush WC，以及没有 local-error WC 的 completion deadline
+> 是 endpoint 失败；resource/rail-credit admission、cancel 和 invalid input
+> 也不是 rail 健康证据。后两类不会增加 rail consecutive errors 或错误恢复
+> rail，endpoint 失败仍由 `PeerHealth` 处理。
+>
+> 首次 `kRailFailure` 后，client 必须先 retire endpoint，并同步完成 QP/CQ/MR
+> teardown，才会建立 fresh endpoint 做**至多一次**重试；物理尝试总数固定为
+> 2，不可配置。第二次选择从 NUMA preferred 和 fallback 两个集合同时排除故障
+> rail，只要 topology 中存在另一条 enabled rail 就必须换轨；不能因为另一轨
+> credit 耗尽、正在 quarantine 或 cooldown 就回到原轨。单轨部署没有另一条
+> topology-enabled rail 时可做一次 fresh 同轨重试，但绝不复用故障 QP，也不
+> 绕过 quarantine/cooldown/backpressure。
+>
+> 该重试会从头重放现有整个 logical PUT/GET/batch/SG operation，语义仍是
+> **at-least-once**：若 PUT 已在远端 commit 而本地 completion 丢失，同一覆盖
+> 写可能执行两次，不提供 exactly-once 或 concurrent-writer isolation。它与
+> pooled stale-QP 的既有 fresh-endpoint retry 分开计数。实现完全在 client，
+> 与 server 的 `DFKV_RDMA_HEALTH_FILE`、`dfkv_server_ring_eligible` 整节点
+> 退环/恢复机制无关；**不修改 RDMA wire protocol 或 server 行为**，因此升级
+> client 与仍支持同一 RDMA v2 protocol 的混合版本 server 兼容。
+>
+> **client-local quarantine 恢复**：默认连续 3 次 `kRailFailure` 后隔离该
+> rail 5000 ms。cooldown 前不准入；到期仅一个真实 operation 获得 recovery
+> probe，其他 caller 继续跳过。probe success 清除 consecutive errors/
+> quarantine 并记录 recovery；probe local failure 重启完整 cooldown；probe
+> endpoint failure 只释放 probe ownership，既不证明恢复也不增加 local fault。
 >
 > **v2 segment 预算**：`slot=align4K(4096 + max_raw_payload)`；
 > `segment >= Σ(live + client-pool-idle data/control QP × depth × slot)`。lease
@@ -439,22 +462,23 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 | `--max-msg`（或 `DFKV_RDMA_MAX_PAYLOAD_BYTES`） | `32 MiB` | 单笔 payload 硬上限（RDMA 与 TCP 数据路径同受此限） |
 | `--version, -V` / `--help` | — | 打印版本/帮助并退出 |
 
-#### b. RDMA 传输面（均在 dfkv_server 进程读取）
+#### b. RDMA 传输面（server/client 读取方见各项说明）
 
 | env | 默认 | 说明 |
 |---|---|---|
-| `DFKV_RDMA_RECV_SEGMENT_SIZE` | 动态 | v2 共享 receive segment 总大小；`slot=align4K(4096+max_raw_payload)`，容量按 expected live QP×depth×slot 预算 |
-| `DFKV_RDMA_CONNECT_MS` | — | IB QP 建连超时 |
-| `DFKV_RDMA_IO_MS` | — | 控制面帧读写超时 |
-| `DFKV_RDMA_BATCH_OP_TIMEOUT_MS` | 0=跟随 RDMA_OP | multi-item Cache/Range/Exist、SG 窗口总期限 |
-| `DFKV_RDMA_POOL_MAX` | `16` | client 侧每 server、每 lane、跨所有 rail 的 idle QP 保留上限，不是进程总连接上限；只在稳定负载仍反复建连时上调 |
-| `DFKV_RDMA_RAIL_CREDITS` | 默认 `64`, 硬上限 4096 | client 每 rail QP 信用数（inflight 上限），>server depth 会回退 |
-| `DFKV_RDMA_RAIL_BACKPRESSURE_MS` | `10` | Acquire 失败重试 backoff |
-| `DFKV_RDMA_RAIL_COOLDOWN_MS` | `5000` | rail quarantine 冷却期；期间只允许 1 个 recovery probe |
-| `DFKV_RDMA_RAIL_ERROR_THRESHOLD` | `3` | 连锁本地 verbs/CQ/post 错误才 quarantine rail |
-| `DFKV_RDMA_RAIL_LATENCY_WEIGHT` | — | rail selection 的延迟 EWMA 权重 |
-| `DFKV_RDMA_RAIL_ERROR_PENALTY_US` | — | rail selection 的错误分数惩罚微秒 |
-| `DFKV_RDMA_IDLE_MS` | — | idle QP 重回收周期 |
+| `DFKV_RDMA_RECV_SEGMENT_SIZE` | 动态 | server：v2 共享 receive segment 总大小；`slot=align4K(4096+max_raw_payload)`，容量按 expected live QP×depth×slot 预算 |
+| `DFKV_RDMA_CONNECT_MS` | — | client：IB QP 建连超时 |
+| `DFKV_RDMA_IO_MS` | — | client：控制面帧读写超时 |
+| `DFKV_RDMA_BATCH_OP_TIMEOUT_MS` | 0=跟随 RDMA_OP | client：multi-item Cache/Range/Exist、SG 窗口总期限 |
+| `DFKV_RDMA_POOL_MAX` | `16` | client：每 server、每 lane、跨所有 rail 的 idle QP 保留上限，不是进程总连接上限；只在稳定负载仍反复建连时上调 |
+| `DFKV_RDMA_RAIL_CREDITS` | 默认 `64`, 硬上限 4096 | client：每 rail QP 信用数（inflight 上限），>server depth 会回退 |
+| `DFKV_RDMA_RAIL_BACKPRESSURE_MS` | `10` | client：Acquire 失败重试 backoff |
+| `DFKV_RDMA_RAIL_COOLDOWN_MS` | `5000` | client-local rail quarantine 冷却期；冷却期间不准入，期满仅允许 1 个真实 operation 作为 recovery probe |
+| `DFKV_RDMA_RAIL_ERROR_THRESHOLD` | `3` | client：连续 `kRailFailure` 达到该值才 quarantine；peer/endpoint、admission、timeout（无 local-error WC）、cancel 和 invalid input 不计入 |
+| client-local rail attempts | 固定 `2`（不可配置） | client：初次尝试加至多一次 fresh retry；存在另一条 topology-enabled rail 时必须换轨，单轨才可 fresh 同轨且不得绕过 quarantine |
+| `DFKV_RDMA_RAIL_LATENCY_WEIGHT` | — | client：rail selection 的延迟 EWMA 权重 |
+| `DFKV_RDMA_RAIL_ERROR_PENALTY_US` | — | client：rail selection 的错误分数惩罚微秒 |
+| `DFKV_RDMA_IDLE_MS` | — | server：idle QP 重回收周期 |
 
 #### c. TCP 连接池（client 读，但 server 运维也受影响）
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -347,14 +347,17 @@ C 客户端快照还含传输级指标（RDMA 构建）：
 | `dfkv_rdma_client_oversize_rejects_total` | counter | 分配、注册或发帖前因超过声明上限而拒绝的操作 |
 | `dfkv_rdma_client_v2_probe_attempts_total` / `dfkv_rdma_client_v2_probe_failures_total` | counter | 必选 v2 bootstrap probe 尝试 / 失败 |
 | `dfkv_rdma_client_stale_pool_retries_total` | counter | pooled QP 失败后改用 fresh connection 的重试 |
+| `dfkv_rdma_client_cross_rail_retries_total` | counter | 无 label 的 process counter；client-local `kRailFailure` 后启动的 logical-operation replay；一次调用最多加 1，不按 batch window 计数。存在另一条 topology-enabled rail 时 retry 必须换轨 |
+| `dfkv_rdma_client_cross_rail_retry_successes_total` | counter | 无 label 的 process counter；上述 retry 最终成功的 logical operation 数 |
+| `dfkv_rdma_client_cross_rail_retry_exhausted_total` | counter | 无 label 的 process counter；已启动上述 retry、但第二次物理尝试仍失败的 logical operation 数 |
 | `dfkv_rdma_client_completion_timeouts_total` | counter | 消耗完一次绝对 completion-window deadline 的窗口；部分完成不重置预算 |
 | `dfkv_rdma_client_keepalive_attempts_total` / `dfkv_rdma_client_keepalive_successes_total` / `dfkv_rdma_client_keepalive_failures_total` | counter | idle pooled QP 的保活尝试 / 成功 / 失败并退役连接；仅 `DFKV_RDMA_KEEPALIVE_MS>0` 时增长 |
 | `dfkv_rdma_client_rail_conns_total{dev}` / `dfkv_rdma_client_rail_selections_total{dev}` | counter | 每 rail 新连接 / 准入分布 |
 | `dfkv_rdma_client_rail_inflight{dev}` / `dfkv_rdma_client_rail_credits_available{dev}` | gauge | 当前已租 / 可用 request credits |
 | `dfkv_rdma_client_rail_credits_exhausted_total{dev}` | counter | 因 local candidate credit 不足跳过次数 |
-| `dfkv_rdma_client_rail_errors_total{dev}` / `dfkv_rdma_client_rail_consecutive_errors{dev}` | counter / gauge | **仅本地** verbs/device/post/CQ 失败累计 / 当前连续值 |
-| `dfkv_rdma_client_endpoint_errors_total{dev}` | counter | peer bootstrap/不可达/协议 frame 失败；credit 已归还，**不惩罚 rail** |
-| `dfkv_rdma_client_rail_quarantines_total{dev}` / `dfkv_rdma_client_rail_quarantined{dev}` / `dfkv_rdma_client_rail_recovery_probe{dev}` / `dfkv_rdma_client_rail_recoveries_total{dev}` | counter / gauge / gauge / counter | rail 隔离切换 / 隔离状态（直到真实成功）/ 单个在飞 recovery probe / 成功恢复 |
+| `dfkv_rdma_client_rail_errors_total{dev}` / `dfkv_rdma_client_rail_consecutive_errors{dev}` | counter / gauge | **仅本地** device open、QP transition、MR register/refresh、post/CQ verbs API 失败和 local WC 累计 / 当前连续值 |
+| `dfkv_rdma_client_endpoint_errors_total{dev}` | counter | peer bootstrap/不可达/probe/protocol/receive-segment/decode、remote/RNR/retry/timeout/flush WC；credit 已归还，**不惩罚或恢复 rail**。没有 local-error WC 的 completion deadline 也属 endpoint，不触发 cross-rail retry |
+| `dfkv_rdma_client_rail_quarantines_total{dev}` / `dfkv_rdma_client_rail_quarantined{dev}` / `dfkv_rdma_client_rail_recovery_probe{dev}` / `dfkv_rdma_client_rail_recoveries_total{dev}` | counter / gauge / gauge / counter | 连续 3 次 client-local failure 后隔离（默认 cooldown 5000 ms）/ 隔离状态 / cooldown 到期后唯一真实 probe / probe 成功恢复；probe local failure 重启 cooldown，endpoint failure 只释放 probe ownership |
 | `dfkv_rdma_client_numa_fallbacks_total{reason="caller_unknown\|no_local_rail"}` | counter | `DFKV_RDMA_NUMA=1` 无法建立 local mask 而回退全部 enabled rails |
 | `dfkv_rdma_cq_completions_total` / `dfkv_rdma_cq_errors_total` | counter | client CQ 完成 / 错误完成 |
 | `dfkv_rdma_client_pipeline_depth` | gauge | 握手解析后的有效 pipeline depth |
@@ -369,11 +372,40 @@ TCP 构建或 TCP fallback 的 C 快照 family（同样由插件镜像）：
 | `dfkv_transport_pool_backoff_endpoints` | gauge | 当前阻止连接增长的 endpoint 数 |
 | `dfkv_transport_pool_backoff_events_total` / `dfkv_transport_pool_backoff_suppressed_total` | counter | 进入 backoff / backoff 中被 fast-fail 的 acquire |
 
-所有 `{dev}` 序列数固定为进程启动时发现的 rail 数，NUMA `reason` 只有上述两个
-枚举；不会按任意 endpoint 扩张。endpoint cooldown/恢复由上表
-`dfkv_client_peer_marked_bad_total` / `dfkv_client_peer_recovered_total` 汇总，逐 peer error
-序列在 `PeerHealth` 内硬限 4096 条。因此 rail 故障、endpoint 故障和两种 quarantine
-可以分别告警，单个坏 node 不再表现为共享 HCA 故障。
+RDMA client transport family 只在 RDMA build/runtime 使用相应传输并由 client
+stats snapshot/connector poller 导出时可见；TCP-only 进程缺失这些 family 是预期
+行为，不能补 0 解释为 rail 故障。所有 `{dev}` 序列数固定为进程启动时发现的 rail
+数，NUMA `reason` 只有上述两个枚举，不会按任意 endpoint 扩张。endpoint
+cooldown/恢复由上表 `dfkv_client_peer_marked_bad_total` /
+`dfkv_client_peer_recovered_total` 汇总，逐 peer error 序列在 `PeerHealth` 内硬限
+4096 条。因此 rail 故障、endpoint 故障和两种 quarantine 可以分别告警，单个坏
+node 不再表现为共享 HCA 故障。
+
+**retry 语义与告警**：
+
+- 三个 `cross_rail` counter 只统计 `kRailFailure` 后的 replay；pooled endpoint
+  staleness 仍只计 `dfkv_rdma_client_stale_pool_retries_total`，peer/endpoint、
+  admission、cancel、invalid input 不计。每个公开调用物理尝试最多 2 次；第二次
+  使用 fresh endpoint，且在任何另一条 enabled local rail 存在时必须换轨。单轨
+  topology 才允许 fresh 同轨 retry，且不得绕过 quarantine/cooldown。
+- retry 前同步 retire 故障 endpoint 并 teardown QP/CQ/MR，然后从 item 0 重放
+  整个 logical PUT/GET/batch/SG operation。语义为 at-least-once；remote PUT
+  commit 后 completion 丢失时可能覆盖写两次，不保证 exactly-once。公开
+  `dfkv_client_op_{requests,keys}_total` 不随物理尝试翻倍，hit/bytes 只按最终
+  logical result 计，latency 包含两次尝试。
+- `rate(dfkv_rdma_client_cross_rail_retry_exhausted_total[5m]) > 0` 任何增长都
+  需要处置；它表示一次换轨（或单轨 fresh）机会仍未恢复 logical operation。
+  任一 `dfkv_rdma_client_rail_quarantined{dev} == 1` 持续超过两个默认 cooldown
+  （10 s；若修改 `DFKV_RDMA_RAIL_COOLDOWN_MS` 则使用其两倍）也应告警。
+- workload drain 后 `dfkv_rdma_client_rail_inflight{dev} != 0`，或
+  `dfkv_rdma_client_transient_user_mr_active` 未回到 drain 前基线，按资源泄漏
+  告警。`dfkv_rdma_client_rail_recovery_probe{dev}` 应在 probe 完成后归零。
+
+这是 **client-only** rail recovery，与 server 的
+`dfkv_server_ib_device_healthy` / `dfkv_server_ring_eligible` 整节点 placement
+健康门完全分离；`DFKV_RDMA_HEALTH_FILE` 只影响 server health monitor。该能力
+不改变 RDMA wire protocol 或 server 行为，升级 client 与仍支持同一 RDMA v2
+protocol 的混合版本 server 兼容。
 
 ### 3.4 连接器车队指标（三连接器 OTLP **push**，opt-in）
 §3.3 是进程本地 Prometheus **pull**。vLLM、LMCache、SGLang HiCache 还可把

--- a/src/transport/rail_select.h
+++ b/src/transport/rail_select.h
@@ -46,6 +46,9 @@ struct RailLease {
 
 enum class RailCompletion : uint8_t {
   kSuccess,
+  // Admission/resource control failure after a lease was selected. Return
+  // credits without changing either local-rail or endpoint health.
+  kAdmission,
   // The remote node/bootstrap/protocol failed. Return admission credits without
   // changing this host's HCA health or satisfying a pending recovery probe.
   kEndpointFailure,
@@ -83,31 +86,38 @@ class RailPolicy {
     for (auto& rail : rails_) rail.credits = config_.credits_per_rail;
   }
 
-  // Empty allowed means every rail. requested is clamped to the per-rail
-  // credit limit; callers must clamp their actual posting window to lease.credits.
+  // Empty allowed means every rail. A non-empty excluded mask removes matching
+  // rails after a failure in the current logical operation. requested is
+  // clamped to the per-rail credit limit; callers must clamp their actual
+  // posting window to lease.credits.
   std::optional<RailLease> TryAcquire(
       uint32_t requested, uint64_t now_us,
-      const std::vector<uint8_t>& allowed = {}) {
+      const std::vector<uint8_t>& allowed = {},
+      const std::vector<uint8_t>& excluded = {}) {
     std::lock_guard<std::mutex> lock(mu_);
-    return TryAcquireLocked(requested, now_us, allowed);
+    return TryAcquireLocked(requested, now_us, allowed, excluded);
   }
 
   // Bounded backpressure: wait for a completion or cooldown expiry, but never
   // beyond timeout_us. A zero timeout is a single non-blocking attempt.
   std::optional<RailLease> Acquire(
       uint32_t requested, uint64_t timeout_us,
-      const std::vector<uint8_t>& allowed = {}) {
+      const std::vector<uint8_t>& allowed = {},
+      const std::vector<uint8_t>& excluded = {}) {
     const auto deadline =
         std::chrono::steady_clock::now() + std::chrono::microseconds(timeout_us);
     std::unique_lock<std::mutex> lock(mu_);
     for (;;) {
       const uint64_t now_us = NowMicros();
-      if (auto lease = TryAcquireLocked(requested, now_us, allowed))
+      if (auto lease =
+              TryAcquireLocked(requested, now_us, allowed, excluded))
         return lease;
       if (timeout_us == 0 || std::chrono::steady_clock::now() >= deadline)
         return std::nullopt;
       auto wake = deadline;
-      for (const auto& rail : rails_) {
+      for (size_t i = 0; i < rails_.size(); ++i) {
+        const auto& rail = rails_[i];
+        if (!Allowed(i, allowed) || Excluded(i, excluded)) continue;
         if (rail.quarantined_until_us > now_us) {
           const auto cooldown =
               std::chrono::steady_clock::now() +
@@ -140,6 +150,11 @@ class RailPolicy {
         ++rail.recoveries;
         rail.quarantined_until_us = 0;
       }
+      rail.recovery_probe = false;
+    } else if (completion == RailCompletion::kAdmission) {
+      // Admission failure is not endpoint evidence. If this lease was the
+      // single recovery probe, leave the expired quarantine marker intact and
+      // allow a later admission to perform the real probe.
       rail.recovery_probe = false;
     } else if (completion == RailCompletion::kEndpointFailure) {
       ++rail.endpoint_errors;
@@ -212,9 +227,14 @@ class RailPolicy {
            (rail < allowed.size() && allowed[rail] != 0);
   }
 
+  bool Excluded(size_t rail, const std::vector<uint8_t>& excluded) const {
+    return rail < excluded.size() && excluded[rail] != 0;
+  }
+
   std::optional<RailLease> TryAcquireLocked(
       uint32_t requested, uint64_t now_us,
-      const std::vector<uint8_t>& allowed) {
+      const std::vector<uint8_t>& allowed,
+      const std::vector<uint8_t>& excluded) {
     bool selected_recovery = false;
     if (rails_.empty()) return std::nullopt;
     requested =
@@ -223,7 +243,7 @@ class RailPolicy {
     uint64_t selected_score = std::numeric_limits<uint64_t>::max();
     for (size_t i = 0; i < rails_.size(); ++i) {
       State& rail = rails_[i];
-      if (!Allowed(i, allowed)) continue;
+      if (!Allowed(i, allowed) || Excluded(i, excluded)) continue;
       if (rail.quarantined_until_us > now_us) continue;
       // Cooldown elapsed: this rail may serve as the single recovery probe.
       // The recovery_probe flag is set only when the lease is actually granted
@@ -267,23 +287,45 @@ class RailPolicy {
   std::vector<State> rails_;
 };
 
-// Bounded admission that prefers one candidate mask and degrades to a
-// fallback mask when no preferred rail can serve immediately — every
-// preferred rail quarantined or credit-bound — while fallback rails still
-// can. Locality stays strictly preferred whenever it is admissible; the
-// fallback is only a backstop. At most one lease is ever granted per call;
-// when neither mask can serve right away, the caller waits on the preferred
-// rails exactly as RailPolicy::Acquire with `preferred` alone would.
+// True when the preferred/fallback topology masks contain an enabled rail that
+// is not excluded by the current logical operation. This intentionally ignores
+// credits, quarantine, cooldown, and current health.
+inline bool HasUnexcludedRail(const std::vector<uint8_t>& preferred,
+                              const std::vector<uint8_t>& fallback,
+                              const std::vector<uint8_t>& excluded) {
+  const size_t rails =
+      std::max({preferred.size(), fallback.size(), excluded.size()});
+  for (size_t i = 0; i < rails; ++i) {
+    const bool enabled =
+        (i < preferred.size() && preferred[i] != 0) ||
+        (i < fallback.size() && fallback[i] != 0);
+    if (enabled && !(i < excluded.size() && excluded[i] != 0)) return true;
+  }
+  return false;
+}
+
+// Bounded admission that prefers one candidate mask and degrades to a fallback
+// mask when no preferred rail can serve immediately. Exclusion is applied to
+// both masks. When every preferred topology rail is excluded, bounded waiting
+// moves to the fallback mask instead of waiting on an impossible candidate set.
 inline std::optional<RailLease> AcquireWithFallback(
     RailPolicy& policy, uint32_t requested, uint64_t timeout_us,
     const std::vector<uint8_t>& preferred,
-    const std::vector<uint8_t>& fallback) {
+    const std::vector<uint8_t>& fallback,
+    const std::vector<uint8_t>& excluded = {}) {
   const uint64_t now = RailPolicy::NowMicros();
-  if (auto lease = policy.TryAcquire(requested, now, preferred)) return lease;
+  if (auto lease = policy.TryAcquire(requested, now, preferred, excluded))
+    return lease;
   if (!fallback.empty()) {
-    if (auto lease = policy.TryAcquire(requested, now, fallback)) return lease;
+    if (auto lease = policy.TryAcquire(requested, now, fallback, excluded))
+      return lease;
   }
-  return policy.Acquire(requested, timeout_us, preferred);
+  const bool preferred_available =
+      HasUnexcludedRail(preferred, {}, excluded);
+  return policy.Acquire(requested, timeout_us,
+                        preferred_available || fallback.empty() ? preferred
+                                                               : fallback,
+                        excluded);
 }
 
 }  // namespace rdma

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -7,6 +7,7 @@
 #include <cerrno>
 #include <cctype>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <stdexcept>
 
@@ -89,6 +90,26 @@ bool CorruptGetOperationId(size_t one_based_window, size_t window_count) {
          parsed == one_based_window;
 }
 
+bool InjectLocalRailFailure(int zero_based_attempt) {
+  const char* value =
+      std::getenv("DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS");
+  if (!value || !*value) return false;
+  const unsigned long wanted =
+      static_cast<unsigned long>(zero_based_attempt + 1);
+  const char* cursor = value;
+  while (*cursor) {
+    errno = 0;
+    char* end = nullptr;
+    const unsigned long parsed = std::strtoul(cursor, &end, 10);
+    if (errno != 0 || end == cursor) return false;
+    if (parsed == wanted) return true;
+    if (*end == '\0') return false;
+    if (*end != ',') return false;
+    cursor = end + 1;
+  }
+  return false;
+}
+
 size_t ResolveMaxPayload(size_t configured) {
   size_t n = configured ? configured : (64u << 20);
   n = EnvBytes("DFKV_RDMA_MAX_PAYLOAD_BYTES", n);
@@ -128,6 +149,77 @@ std::string JoinDevices(const std::vector<std::string>& devices) {
   return out;
 }
 
+// Test-only deterministic completion faults for replay-safe read operations.
+// The env value is a comma-separated list of
+// "<logical-call>:<attempt>:<completion-window>" specs, all one-based.
+// Eligible logical read calls are numbered only while the env is set. Each
+// operation owns its injection state and passes it explicitly to data-path
+// reaps, so pooled connection maintenance cannot consume a target window.
+// A matching successfully reaped window is surfaced once as
+// IBV_WC_GENERAL_ERR through
+// the production ReapPosted/ClassifyCompletion path.
+struct CompletionFaultTarget {
+  uint64_t call = 0;
+  uint64_t attempt = 0;
+  uint64_t window = 0;
+};
+
+class CompletionFaultOperation {
+ public:
+  explicit CompletionFaultOperation(std::atomic<uint64_t>* calls,
+                                    bool enabled = true) {
+    if (!enabled) return;
+    const char* cursor = std::getenv("DFKV_RDMA_TEST_COMPLETION_FAULT");
+    if (!cursor || !*cursor) return;
+    std::vector<CompletionFaultTarget> parsed;
+    for (;;) {
+      CompletionFaultTarget target;
+      uint64_t* fields[] = {&target.call, &target.attempt, &target.window};
+      char* end = nullptr;
+      for (size_t i = 0; i < 3; ++i) {
+        errno = 0;
+        *fields[i] = std::strtoull(cursor, &end, 10);
+        if (errno != 0 || end == cursor || *fields[i] == 0 ||
+            (i != 2 ? *end != ':' : (*end != '\0' && *end != ','))) {
+          return;
+        }
+        if (i != 2) cursor = end + 1;
+      }
+      parsed.push_back(target);
+      if (*end == '\0') break;
+      cursor = end + 1;
+      if (!*cursor) return;
+    }
+
+    const uint64_t logical_call =
+        calls->fetch_add(1, std::memory_order_relaxed) + 1;
+    for (const auto& target : parsed) {
+      if (target.call == logical_call) {
+        targets_.push_back(target);
+      }
+    }
+  }
+
+  void BeginAttempt(int zero_based_attempt) {
+    attempt_ = static_cast<uint64_t>(zero_based_attempt) + 1;
+    window_ = 0;
+  }
+
+  bool InjectAfterCompletedWindow() {
+    if (targets_.empty()) return false;
+    ++window_;
+    for (const auto& target : targets_) {
+      if (target.attempt == attempt_ && target.window == window_) return true;
+    }
+    return false;
+  }
+
+ private:
+  std::vector<CompletionFaultTarget> targets_;
+  uint64_t attempt_ = 0;
+  uint64_t window_ = 0;
+};
+
 // Local post/CQ/verbs API failures happen below the work-completion layer, so
 // no real WC status exists for them. The reap helpers report such failures as
 // this local-fault bucket so every datapath teardown can funnel through
@@ -149,7 +241,8 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
                 std::vector<uint32_t>* rbytes, int timeout_ms,
                 bool* timed_out = nullptr,
                 ibv_wc_status* worst_status = nullptr,
-                bool* had_completions = nullptr) {
+                bool* had_completions = nullptr,
+                CompletionFaultOperation* completion_fault = nullptr) {
   if (timed_out) *timed_out = false;
   if (worst_status) *worst_status = IBV_WC_SUCCESS;
   if (had_completions) *had_completions = false;
@@ -189,6 +282,11 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
       --need;
     }
   }
+  if (completion_fault && completion_fault->InjectAfterCompletedWindow()) {
+    if (worst_status) *worst_status = IBV_WC_GENERAL_ERR;
+    if (had_completions) *had_completions = true;
+    return false;
+  }
   return true;
 }
 
@@ -196,9 +294,10 @@ bool ReapWindow(rdma::RcEndpoint& ep, size_t width,
                 std::vector<uint32_t>* rbytes, int timeout_ms,
                 bool* timed_out = nullptr,
                 ibv_wc_status* worst_status = nullptr,
-                bool* had_completions = nullptr) {
+                bool* had_completions = nullptr,
+                CompletionFaultOperation* completion_fault = nullptr) {
   return ReapPosted(ep, width, width, rbytes, timeout_ms, timed_out,
-                    worst_status, had_completions);
+                    worst_status, had_completions, completion_fault);
 }
 
 // Post ordinary SEND requests with one status RECV per slot.
@@ -206,7 +305,8 @@ bool RunWindow(rdma::RcEndpoint& ep, const std::vector<size_t>& slen,
                std::vector<uint32_t>* rbytes, int timeout_ms,
                bool* timed_out = nullptr,
                ibv_wc_status* worst_status = nullptr,
-               bool* had_completions = nullptr) {
+               bool* had_completions = nullptr,
+               CompletionFaultOperation* completion_fault = nullptr) {
   for (size_t j = 0; j < slen.size(); ++j) {
     if (!ep.PostRecv(j) || !ep.PostSend(j, slen[j])) {
       // A post failure is local verbs evidence: no WC exists to reap, so
@@ -217,7 +317,7 @@ bool RunWindow(rdma::RcEndpoint& ep, const std::vector<size_t>& slen,
     }
   }
   return ReapWindow(ep, slen.size(), rbytes, timeout_ms, timed_out,
-                    worst_status, had_completions);
+                    worst_status, had_completions, completion_fault);
 }
 std::shared_ptr<rdma::ResourceBudget> ProcessResourceBudget(
     const rdma::ResourceRequest& limit) {
@@ -449,13 +549,22 @@ RdmaTransport::~RdmaTransport() {
   keepalive_cv_.notify_all();
   if (keepalive_thread_.joinable()) keepalive_thread_.join();
 
-  std::lock_guard<std::mutex> lk(mu_);
-  for (auto& [node, cs] : pool_)
-    for (Conn* c : cs) Destroy(c);
-  for (auto& [node, cs] : sg_pool_)
-    for (Conn* c : cs) Destroy(c);
-  for (auto& [node, cs] : control_pool_)
-    for (Conn* c : cs) Destroy(c);
+  std::vector<Conn*> idle;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    const auto detach = [&](auto& pools) {
+      for (auto& [node, connections] : pools) {
+        (void)node;
+        idle.insert(idle.end(), connections.begin(), connections.end());
+        connections.clear();
+      }
+      pools.clear();
+    };
+    detach(pool_);
+    detach(sg_pool_);
+    detach(control_pool_);
+  }
+  for (Conn* conn : idle) Destroy(conn);
 }
 
 bool RdmaTransport::KeepaliveConn(Conn* conn) {
@@ -534,15 +643,20 @@ void RdmaTransport::KeepaliveLoop() {
 void RdmaTransport::Destroy(Conn* c, rdma::RailCompletion completion) {
   if (!c) return;
   c->lifecycle.BeginDrain();
-  if (c->credit_held) {
-    const uint64_t now = rdma::RailPolicy::NowMicros();
-    rail_policy_->Complete(c->lease, now - c->lease_started_us, completion,
-                           now);
-    c->credit_held = false;
-  }
+  const bool credit_held = c->credit_held;
+  const rdma::RailLease lease = c->lease;
+  const uint64_t lease_started_us = c->lease_started_us;
   const bool release_budget = c->budget_held;
   const rdma::ResourceRequest budget_request = c->budget_request;
-  delete c;  // RcEndpoint dtor tears down QP/MRs before budget is returned.
+
+  // The endpoint owns the QP, CQs, and all transient/pool MRs. Destroy it
+  // synchronously before returning either rail credits or process resources,
+  // so a retry cannot overlap stale WRs that still reference caller memory.
+  delete c;
+  if (credit_held) {
+    const uint64_t now = rdma::RailPolicy::NowMicros();
+    rail_policy_->Complete(lease, now - lease_started_us, completion, now);
+  }
   if (release_budget) resource_budget_->Release(budget_request);
 }
 
@@ -596,20 +710,15 @@ bool RdmaTransport::ProbeV2(const std::string& node) const {
   return ok;
 }
 
-RdmaTransport::Conn* RdmaTransport::Acquire(
-    const std::string& node, Lane lane, bool* from_pool, bool force_new,
-    size_t requested_credits) {
-  *from_pool = false;
+RdmaTransport::AcquireResult RdmaTransport::Acquire(
+    const std::string& node, Lane lane, const AcquireOptions& options) {
   const uint32_t requested = static_cast<uint32_t>(
-      std::min<size_t>(requested_credits,
+      std::min<size_t>(options.requested_credits,
                        std::numeric_limits<uint32_t>::max()));
   // Selection is global across configured rails: first constrain candidates to
   // the caller's local NUMA rails when that topology exists, then choose least
-  // normalized inflight with latency/error penalties and stable device index as
-  // the final tie-break. Unknown/no-local topology falls back to all rails.
-  // When every NUMA-local rail is inadmissible (quarantined or credit-bound),
-  // admission retries once across every enabled rail — locality is a
-  // preference, never an availability gate.
+  // normalized inflight with latency/error penalties. The operation-local
+  // exclusion applies to both the preferred and fallback topology masks.
   const int caller_node = numa_aware_ ? numa::CurrentNode() : -1;
   const auto candidates =
       topology_->CandidatesFor(caller_node, numa_aware_);
@@ -618,38 +727,39 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
   } else if (candidates.locality == rdma::RailLocality::kNoLocal) {
     numa_no_local_fallbacks_.fetch_add(1, std::memory_order_relaxed);
   }
-  auto lease = rdma::AcquireWithFallback(*rail_policy_, requested,
-                                         rail_backpressure_us_,
-                                         candidates.allowed,
-                                         candidates.fallback);
-  if (!lease) return nullptr;
+  auto lease = rdma::AcquireWithFallback(
+      *rail_policy_, requested, rail_backpressure_us_, candidates.allowed,
+      candidates.fallback, options.excluded);
+  if (!lease) return {};
 
+  AcquireResult result;
+  result.attempted_rail = lease->rail;
   const size_t ridx = lease->rail;
   const uint64_t lease_started = rdma::RailPolicy::NowMicros();
-  const auto fail_endpoint_lease = [&] {
-    const uint64_t now = rdma::RailPolicy::NowMicros();
-    rail_policy_->Complete(*lease, now - lease_started,
-                           rdma::RailCompletion::kEndpointFailure, now);
-  };
+  const auto complete_unowned_lease =
+      [&](rdma::RailCompletion completion) {
+        const uint64_t now = rdma::RailPolicy::NowMicros();
+        rail_policy_->Complete(*lease, now - lease_started, completion, now);
+      };
 
   std::vector<std::pair<void*, size_t>> pools;
   Conn* pooled = nullptr;
   {
     std::lock_guard<std::mutex> lk(mu_);
     pools = pools_;
-    if (!force_new) {
+    if (!options.force_new) {
       auto& idle = lane == Lane::kData
                        ? pool_
                        : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
       auto it = idle.find(node);
       if (it != idle.end()) {
-        auto& candidates = it->second;
-        for (size_t i = candidates.size(); i > 0; --i) {
-          if (candidates[i - 1]->rail_index == ridx &&
-              candidates[i - 1]->lifecycle.Activate()) {
-            pooled = candidates[i - 1];
-            candidates.erase(candidates.begin() +
-                             static_cast<std::ptrdiff_t>(i - 1));
+        auto& pool_candidates = it->second;
+        for (size_t i = pool_candidates.size(); i > 0; --i) {
+          if (pool_candidates[i - 1]->rail_index == ridx &&
+              pool_candidates[i - 1]->lifecycle.Activate()) {
+            pooled = pool_candidates[i - 1];
+            pool_candidates.erase(
+                pool_candidates.begin() + static_cast<std::ptrdiff_t>(i - 1));
             break;
           }
         }
@@ -661,24 +771,27 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
     pooled->lease_started_us = lease_started;
     pooled->credit_held = true;
     pooled->visited = true;
-    endpoint_cache_hits_.fetch_add(1, std::memory_order_relaxed);
+    result.from_pool = true;
     if (!pooled->ep.EnsurePoolMrs(pools, true)) {
       Destroy(pooled, rdma::RailCompletion::kRailFailure);
-      return nullptr;
+      result.failure = AcquireFailure::kLocalRail;
+      return result;
     }
-    *from_pool = true;
-    return pooled;
+    endpoint_cache_hits_.fetch_add(1, std::memory_order_relaxed);
+    result.conn = pooled;
+    result.failure = AcquireFailure::kNone;
+    return result;
   }
+
   endpoint_cache_misses_.fetch_add(1, std::memory_order_relaxed);
   const size_t conn_depth = depth_;
   const uint64_t conn_declared =
       lane == Lane::kControl
           ? static_cast<uint64_t>(rdma::kV2ControlCap)
           : declared_;
-  const uint64_t conn_slot_bytes =
-      static_cast<uint64_t>(rdma::V2SlotSize(
-          static_cast<size_t>(std::max<uint64_t>(
-              conn_declared, rdma::kV2DataOffset))));
+  const uint64_t conn_slot_bytes = static_cast<uint64_t>(rdma::V2SlotSize(
+      static_cast<size_t>(
+          std::max<uint64_t>(conn_declared, rdma::kV2DataOffset))));
   const rdma::ResourceRequest budget_request{
       1, 1, conn_depth, conn_slot_bytes * conn_depth};
   bool budget_acquired = resource_budget_->TryAcquire(budget_request);
@@ -688,25 +801,27 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
     budget_acquired = resource_budget_->Acquire(
         budget_request, std::chrono::milliseconds(resource_acquire_ms_));
   if (!budget_acquired) {
-    fail_endpoint_lease();
-    return nullptr;
+    complete_unowned_lease(rdma::RailCompletion::kAdmission);
+    result.failure = AcquireFailure::kAdmission;
+    return result;
   }
-
 
   const std::string& dev = devs_[ridx];
   if (!ProbeV2(node)) {
     DFKV_LOG_ERROR("rdma: peer " + node +
                    " does not support the required v2 protocol");
-    fail_endpoint_lease();
+    complete_unowned_lease(rdma::RailCompletion::kEndpointFailure);
     resource_budget_->Release(budget_request);
-    return nullptr;
+    result.failure = AcquireFailure::kEndpoint;
+    return result;
   }
 
   int fd = net::Dial(node, connect_ms_, io_ms_);
   if (fd < 0) {
-    fail_endpoint_lease();
+    complete_unowned_lease(rdma::RailCompletion::kEndpointFailure);
     resource_budget_->Release(budget_request);
-    return nullptr;
+    result.failure = AcquireFailure::kEndpoint;
+    return result;
   }
   auto* conn = new Conn();
   conn->rail_index = ridx;
@@ -720,9 +835,13 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
     DFKV_LOG_WARN("rdma: device " + dev +
                   " Open failed; rail failure policy will quarantine it");
     Destroy(conn, rdma::RailCompletion::kRailFailure);
-    return nullptr;
+    result.failure = AcquireFailure::kLocalRail;
+    return result;
   }
-  { const char* bp = std::getenv("DFKV_RDMA_BUSY_POLL"); if (bp && *bp && *bp != '0') conn->ep.set_busy_poll(true); }
+  {
+    const char* bp = std::getenv("DFKV_RDMA_BUSY_POLL");
+    if (bp && *bp && *bp != '0') conn->ep.set_busy_poll(true);
+  }
 
   char devbuf[rdma::kDevNameBytes];
   rdma::EncodeDevFrame(auto_device_ ? std::string() : dev, conn_declared,
@@ -737,7 +856,8 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
       !net::ReadAll(fd, peer, rdma::kQpInfoBytes)) {
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-    return nullptr;
+    result.failure = AcquireFailure::kEndpoint;
+    return result;
   }
   const rdma::QpInfo remote = rdma::ParseQpInfo(peer);
   if (remote.protocol_version != rdma::kDevProtoV2 || remote.depth == 0) {
@@ -745,14 +865,16 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
                    " returned an invalid v2 QP negotiation");
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-    return nullptr;
+    result.failure = AcquireFailure::kEndpoint;
+    return result;
   }
   if (!conn->ep.Connect(remote)) {
     DFKV_LOG_WARN("rdma: device " + dev +
                   " failed local QP transition during v2 negotiation");
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kRailFailure);
-    return nullptr;
+    result.failure = AcquireFailure::kLocalRail;
+    return result;
   }
   conn->ep.set_remote_depth(remote.depth);
   if (remote.depth < depth_)
@@ -770,27 +892,61 @@ RdmaTransport::Conn* RdmaTransport::Acquire(
                    " did not provide a valid v2 receive segment");
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-    return nullptr;
+    result.failure = AcquireFailure::kEndpoint;
+    return result;
   }
-  const size_t expected_slot = rdma::V2SlotSize(
-      static_cast<size_t>(std::max<uint64_t>(
-          conn_declared, rdma::kV2DataOffset)));
+  const size_t expected_slot = rdma::V2SlotSize(static_cast<size_t>(
+      std::max<uint64_t>(conn_declared, rdma::kV2DataOffset)));
   if (expected_slot == 0 ||
       conn->recv_segment.slot_size != expected_slot) {
     DFKV_LOG_ERROR("rdma: peer " + node +
                    " returned incompatible v2 receive-segment geometry");
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-    return nullptr;
+    result.failure = AcquireFailure::kEndpoint;
+    return result;
   }
   ::close(fd);
   if (!conn->ep.EnsurePoolMrs(pools, true)) {
     Destroy(conn, rdma::RailCompletion::kRailFailure);
-    return nullptr;
+    result.failure = AcquireFailure::kLocalRail;
+    return result;
   }
   conns_opened_.fetch_add(1, std::memory_order_relaxed);
   rail_conns_[ridx].fetch_add(1, std::memory_order_relaxed);
-  return conn;
+  result.conn = conn;
+  result.failure = AcquireFailure::kNone;
+  return result;
+}
+
+bool RdmaTransport::PrepareRetry(
+    int attempt, bool from_pool, std::optional<size_t> attempted_rail,
+    AcquireFailure failure, RailMask* excluded, bool* cross_rail_retry) {
+  if (attempt != 0) return false;
+  if (failure == AcquireFailure::kLocalRail && attempted_rail &&
+      *attempted_rail < devs_.size()) {
+    excluded->assign(devs_.size(), 0);
+    (*excluded)[*attempted_rail] = 1;
+    const int caller_node = numa_aware_ ? numa::CurrentNode() : -1;
+    const auto candidates =
+        topology_->CandidatesFor(caller_node, numa_aware_);
+    if (rdma::HasUnexcludedRail(candidates.allowed, candidates.fallback,
+                                *excluded)) {
+      cross_rail_retries_.fetch_add(1, std::memory_order_relaxed);
+      *cross_rail_retry = true;
+    } else {
+      // A one-enabled-rail topology may make one fresh same-rail attempt, but
+      // ordinary admission still enforces quarantine, cooldown, and credits.
+      // It is not a cross-rail retry, so leave its accounting flag clear.
+      excluded->assign(devs_.size(), 0);
+    }
+    return true;
+  }
+  if (failure == AcquireFailure::kEndpoint && from_pool) {
+    stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
+    return true;
+  }
+  return false;
 }
 
 bool RdmaTransport::RegisterMemory(void* base, size_t size) {
@@ -1111,6 +1267,23 @@ std::string RdmaTransport::MetricsText() const {
   s += "dfkv_rdma_client_stale_pool_retries_total " +
        std::to_string(stale_pool_retries_.load(std::memory_order_relaxed)) +
        "\n";
+  s += "# HELP dfkv_rdma_client_cross_rail_retries_total Logical operations retried with the failed client-local RDMA rail excluded and another topology-enabled rail available\n";
+  s += "# TYPE dfkv_rdma_client_cross_rail_retries_total counter\n";
+  s += "dfkv_rdma_client_cross_rail_retries_total " +
+       std::to_string(cross_rail_retries_.load(std::memory_order_relaxed)) +
+       "\n";
+  s += "# HELP dfkv_rdma_client_cross_rail_retry_successes_total Cross-rail retries completed successfully\n";
+  s += "# TYPE dfkv_rdma_client_cross_rail_retry_successes_total counter\n";
+  s += "dfkv_rdma_client_cross_rail_retry_successes_total " +
+       std::to_string(
+           cross_rail_retry_successes_.load(std::memory_order_relaxed)) +
+       "\n";
+  s += "# HELP dfkv_rdma_client_cross_rail_retry_exhausted_total Cross-rail retries whose second transport attempt failed\n";
+  s += "# TYPE dfkv_rdma_client_cross_rail_retry_exhausted_total counter\n";
+  s += "dfkv_rdma_client_cross_rail_retry_exhausted_total " +
+       std::to_string(
+           cross_rail_retry_exhausted_.load(std::memory_order_relaxed)) +
+       "\n";
   s += "# HELP dfkv_rdma_client_completion_timeouts_total Completion windows exhausting their absolute deadline\n";
   s += "# TYPE dfkv_rdma_client_completion_timeouts_total counter\n";
   s += "dfkv_rdma_client_completion_timeouts_total " +
@@ -1135,12 +1308,25 @@ std::string RdmaTransport::MetricsText() const {
 }
 
 void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
+  bool refresh_ok = false;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    // Refresh while still active and while pools_ is stable. A refresh failure
+    // is local MR evidence and must tear down before returning the lease.
+    refresh_ok = c->ep.EnsurePoolMrs(pools_, true);
+  }
+  if (!refresh_ok) {
+    Destroy(c, rdma::RailCompletion::kRailFailure);
+    return;
+  }
+
   if (c->credit_held) {
     const uint64_t now = rdma::RailPolicy::NowMicros();
     rail_policy_->Complete(c->lease, now - c->lease_started_us,
                            rdma::RailCompletion::kSuccess, now);
     c->credit_held = false;
   }
+
   bool reusable = false;
   {
     std::lock_guard<std::mutex> lk(mu_);
@@ -1148,12 +1334,7 @@ void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
                      ? pool_
                      : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
     auto& v = idle[node];
-    // A connection that was active during successful growth still owns the old
-    // generation. Refresh it only after its WRs complete, before it becomes
-    // idle; this is the endpoint lease that makes old-generation retirement
-    // safe without interrupting the operation that used it.
-    if (v.size() < pool_max_ && c->ep.EnsurePoolMrs(pools_, true) &&
-        c->lifecycle.MakeIdle()) {
+    if (v.size() < pool_max_ && c->lifecycle.MakeIdle()) {
       v.push_back(c);
       reusable = true;
     }
@@ -1179,17 +1360,48 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
   const Lane lane =
       op == WireOp::kCache || op == WireOp::kRange ? Lane::kData
                                                    : Lane::kControl;
+  const bool replay_safe = op != WireOp::kCache && op != WireOp::kRemove;
+  RailMask excluded(devs_.size(), 0);
+  bool cross_rail_retry = false;
+  CompletionFaultOperation completion_fault(
+      &test_completion_fault_calls_, op == WireOp::kRange);
   for (int attempt = 0; attempt < 2; ++attempt) {
-    if (attempt != 0)
-      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
-    if (out) out->clear();
-    bool from_pool = false;
-    Conn* conn = Acquire(node, lane, &from_pool, attempt > 0);
-    if (!conn) return Status::kIOError;
+    completion_fault.BeginAttempt(attempt);
+    std::string attempt_out;
+    uint64_t attempt_value_len = 0;
+    AcquireOptions options;
+    options.force_new = attempt != 0;
+    options.excluded = excluded;
+    AcquireResult acquired = Acquire(node, lane, options);
+    if (!acquired.conn) {
+      if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
+                       acquired.failure, &excluded, &cross_rail_retry)) {
+        continue;
+      }
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      return Status::kIOError;
+    }
+    Conn* conn = acquired.conn;
+    if (InjectLocalRailFailure(attempt)) {
+      const size_t failed_rail = conn->rail_index;
+      Destroy(conn, rdma::RailCompletion::kRailFailure);
+      if (PrepareRetry(attempt, acquired.from_pool, failed_rail,
+                       AcquireFailure::kLocalRail, &excluded,
+                       &cross_rail_retry))
+        continue;
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      return Status::kIOError;
+    }
     rdma::RcEndpoint& ep = conn->ep;
 
     bool ok = false;
     ibv_mr* transient_output_mr = nullptr;
+    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
+    bool request_posted = false;
     if (op == WireOp::kCache) {
       if (payload_len > conn->data_capacity()) {
         Release(node, lane, conn);
@@ -1202,58 +1414,54 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
                                      /*remote_write=*/false)
               : nullptr;
       transient_output_mr = payload_mr;
-      if (payload_len != 0 && !payload_mr) {
-        Release(node, lane, conn);
-        return Status::kIOError;
+      if (payload_len == 0 || payload_mr) {
+        conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
+        ok = ep.PostRecv(0) &&
+             ep.PostWriteImmScatter(
+                 0, kReqPrefix, payload, static_cast<size_t>(payload_len),
+                 payload_mr, conn->put_addr(0), conn->recv_segment.rkey, 0);
+        if (ok)
+          v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
       }
-      conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
-      ok = ep.PostRecv(0) &&
-           ep.PostWriteImmScatter(
-               0, kReqPrefix, payload, static_cast<size_t>(payload_len),
-               payload_mr, conn->put_addr(0), conn->recv_segment.rkey, 0);
-      if (ok)
-        v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
     } else if (op == WireOp::kRange) {
       if (!out || length > conn->data_capacity() ||
           length > std::numeric_limits<uint32_t>::max()) {
         Release(node, lane, conn);
         return Status::kInvalid;
       }
-      out->resize(static_cast<size_t>(length));
+      attempt_out.resize(static_cast<size_t>(length));
       std::vector<RdmaWriteTarget> targets;
       if (length != 0) {
-        transient_output_mr = ep.RegisterTransient(out->data(), out->size());
-        if (!transient_output_mr) {
-          Release(node, lane, conn);
-          return Status::kIOError;
+        transient_output_mr =
+            ep.RegisterTransient(attempt_out.data(), attempt_out.size());
+        if (transient_output_mr) {
+          targets.push_back(
+              {reinterpret_cast<uint64_t>(attempt_out.data()),
+               transient_output_mr->rkey, static_cast<uint32_t>(length)});
         }
-        targets.push_back(
-            {reinterpret_cast<uint64_t>(out->data()),
-             transient_output_mr->rkey, static_cast<uint32_t>(length)});
       }
-      size_t frame_len = 0;
-      ok = EncodeRdmaGetReq(ep.sbuf(0), ep.cap(), key, offset, length,
-                            targets, &frame_len) &&
-           ep.PostRecv(0) && ep.PostSend(0, frame_len);
-      if (ok)
-        v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
+      if (length == 0 || transient_output_mr) {
+        size_t frame_len = 0;
+        ok = EncodeRdmaGetReq(ep.sbuf(0), ep.cap(), key, offset, length,
+                              targets, &frame_len) &&
+             ep.PostRecv(0) && ep.PostSend(0, frame_len);
+        if (ok)
+          v2_get_writes_.fetch_add(1, std::memory_order_relaxed);
+      }
     } else {
       conn->Encode(ep.sbuf(0), op, key, offset, length, payload_len);
       ok = ep.PostRecv(0) &&
            ep.PostSend(0, kReqPrefix + static_cast<size_t>(payload_len));
     }
+    request_posted = ok;
 
     std::vector<uint32_t> reply_bytes;
     bool timed_out = false;
-    // Post/encode failures above carry no WC evidence and stay a local rail
-    // failure; a failed reap window is classified from its own evidence so a
-    // dead peer cannot poison a healthy local rail.
-    rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     if (ok) {
       ibv_wc_status wc_status = IBV_WC_SUCCESS;
       bool had_wcs = false;
       ok = ReapWindow(ep, 1, &reply_bytes, op_timeout_ms_, &timed_out,
-                      &wc_status, &had_wcs);
+                      &wc_status, &had_wcs, &completion_fault);
       if (!ok) completion = rdma::ClassifyCompletion(wc_status, had_wcs);
     }
     if (timed_out)
@@ -1265,48 +1473,67 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
       transient_output_mr = nullptr;
     }
 
-    if (!ok) {
-      Destroy(conn, completion);
-      if (!from_pool) return Status::kIOError;
-      continue;
-    }
-    if (recv_bytes < kRespPrefix) {
-      Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-      return Status::kIOError;
-    }
-    Status status;
+    Status status = Status::kIOError;
     uint64_t data_len = 0;
+    if (ok && recv_bytes < kRespPrefix) {
+      ok = false;
+      completion = rdma::RailCompletion::kEndpointFailure;
+    }
     const uint64_t response_bound =
         op == WireOp::kMembers ? rdma::kV2ControlResponseMax
                                : (op == WireOp::kRange ? length : 0);
-    if (!conn->Decode(ep.rbuf(0), &status, &data_len, response_bound,
-                      value_len)) {
-      Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-      return Status::kIOError;
+    if (ok && !conn->Decode(
+                  ep.rbuf(0), &status, &data_len, response_bound,
+                  value_len ? &attempt_value_len : nullptr)) {
+      ok = false;
+      completion = rdma::RailCompletion::kEndpointFailure;
     }
-    if (out) {
+    if (ok && out) {
       if (op == WireOp::kRange) {
-        if (status == Status::kOk && data_len <= out->size()) {
-          out->resize(static_cast<size_t>(data_len));
+        if (status == Status::kOk && data_len <= attempt_out.size()) {
+          attempt_out.resize(static_cast<size_t>(data_len));
         } else if (status != Status::kOk) {
-          out->clear();
+          attempt_out.clear();
         } else {
-          Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-          return Status::kIOError;
+          ok = false;
+          completion = rdma::RailCompletion::kEndpointFailure;
         }
+      } else if (data_len > rdma::kV2ControlResponseMax ||
+                 data_len > recv_bytes - kRespPrefix) {
+        ok = false;
+        completion = rdma::RailCompletion::kEndpointFailure;
       } else {
-        if (data_len > rdma::kV2ControlResponseMax ||
-            data_len > recv_bytes - kRespPrefix) {
-          Destroy(conn, rdma::RailCompletion::kEndpointFailure);
-          return Status::kIOError;
-        }
-        out->assign(ep.rbuf(0) + kRespPrefix,
-                    static_cast<size_t>(data_len));
+        attempt_out.assign(ep.rbuf(0) + kRespPrefix,
+                           static_cast<size_t>(data_len));
       }
     }
-    Release(node, lane, conn);
-    return status;
+    if (ok) {
+      if (out) *out = std::move(attempt_out);
+      if (value_len) *value_len = attempt_value_len;
+      Release(node, lane, conn);
+      if (cross_rail_retry)
+        cross_rail_retry_successes_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      return status;
+    }
+
+    const size_t failed_rail = conn->rail_index;
+    Destroy(conn, completion);
+    const AcquireFailure failure =
+        completion == rdma::RailCompletion::kRailFailure &&
+                (replay_safe || !request_posted)
+            ? AcquireFailure::kLocalRail
+            : AcquireFailure::kEndpoint;
+    if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     &excluded, &cross_rail_retry)) {
+      continue;
+    }
+    if (cross_rail_retry)
+      cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
+    return Status::kIOError;
   }
+  if (cross_rail_retry)
+    cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
   return Status::kIOError;
 }
 
@@ -1371,20 +1598,32 @@ std::vector<Status> RdmaTransport::CacheMany(
   }
   if (valid_count == 0) return result;
 
+  RailMask excluded(devs_.size(), 0);
+  bool cross_rail_retry = false;
   for (int attempt = 0; attempt < 2; ++attempt) {
-    if (attempt != 0)
-      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
     std::fill(result.begin(), result.end(), Status::kIOError);
     for (size_t i = 0; i < count; ++i)
       if (bad[i]) result[i] = Status::kInvalid;
-    bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0,
-                         std::min(valid_count, depth_));
-    if (!conn) return result;
+    AcquireOptions options;
+    options.force_new = attempt != 0;
+    options.requested_credits = std::min(valid_count, depth_);
+    options.excluded = excluded;
+    AcquireResult acquired = Acquire(node, Lane::kData, options);
+    if (!acquired.conn) {
+      if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
+                       acquired.failure, &excluded, &cross_rail_retry))
+        continue;
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      return result;
+    }
+    Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
-    bool conn_ok = true;
+    bool conn_ok = !InjectLocalRailFailure(attempt);
+    bool request_posted = false;
     // Failure attribution for Destroy: post/encode/register failures keep the
     // local-rail default; a failed reap window is classified from its WC
     // evidence; wire decode failures blame the peer.
@@ -1420,6 +1659,7 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         ++posted;
         v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+        request_posted = true;
       }
       std::vector<uint32_t> reply_bytes;
       bool timed_out = false;
@@ -1451,12 +1691,26 @@ std::vector<Status> RdmaTransport::CacheMany(
     }
     if (conn_ok) {
       Release(node, Lane::kData, conn);
+      if (cross_rail_retry)
+        cross_rail_retry_successes_.fetch_add(1,
+                                              std::memory_order_relaxed);
       return result;
     }
+    const size_t failed_rail = conn->rail_index;
     Destroy(conn, completion);
-    if (from_pool) continue;
+    const AcquireFailure failure =
+        completion == rdma::RailCompletion::kRailFailure && !request_posted
+            ? AcquireFailure::kLocalRail
+            : AcquireFailure::kEndpoint;
+    if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     &excluded, &cross_rail_retry))
+      continue;
+    if (cross_rail_retry)
+      cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
     return result;
   }
+  if (cross_rail_retry)
+    cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
   return result;
 }
 
@@ -1470,10 +1724,7 @@ std::vector<Status> RdmaTransport::RangeMany(
     uint64_t offset, uint64_t length, std::vector<std::string>* outputs,
     std::vector<uint64_t>* value_lens) {
   const size_t count = keys.size();
-  if (outputs == nullptr) {
-    if (value_lens) value_lens->clear();
-    return InvalidStatuses(count);
-  }
+  if (outputs == nullptr) return InvalidStatuses(count);
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) {
     outputs->clear();
@@ -1487,23 +1738,34 @@ std::vector<Status> RdmaTransport::RangeMany(
     if (value_lens) value_lens->clear();
     return InvalidStatuses(count);
   }
-  outputs->assign(count, std::string());
-  if (value_lens) value_lens->assign(count, 0);
 
+  RailMask excluded(devs_.size(), 0);
+  bool cross_rail_retry = false;
+  CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
   for (int attempt = 0; attempt < 2; ++attempt) {
-    if (attempt != 0)
-      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
+    completion_fault.BeginAttempt(attempt);
     std::fill(result.begin(), result.end(), Status::kIOError);
-    outputs->assign(count, std::string());
-    if (value_lens) value_lens->assign(count, 0);
-    bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0,
-                         std::min(count, depth_));
-    if (!conn) return result;
+    std::vector<std::string> attempt_outputs(count);
+    std::vector<uint64_t> attempt_value_lens(count, 0);
+    AcquireOptions options;
+    options.force_new = attempt != 0;
+    options.requested_credits = std::min(count, depth_);
+    options.excluded = excluded;
+    AcquireResult acquired = Acquire(node, Lane::kData, options);
+    if (!acquired.conn) {
+      if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
+                       acquired.failure, &excluded, &cross_rail_retry))
+        continue;
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      return result;
+    }
+    Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
-    bool conn_ok = true;
+    bool conn_ok = !InjectLocalRailFailure(attempt);
     // Failure attribution for Destroy: post/encode/register failures keep the
     // local-rail default; a failed reap window is classified from its WC
     // evidence; wire decode failures blame the peer.
@@ -1512,7 +1774,7 @@ std::vector<Status> RdmaTransport::RangeMany(
       const size_t width = std::min(window, count - base);
       std::vector<ibv_mr*> output_mrs(width, nullptr);
       for (size_t slot = 0; slot < width; ++slot) {
-        std::string& output = (*outputs)[base + slot];
+        std::string& output = attempt_outputs[base + slot];
         output.resize(static_cast<size_t>(length));
         std::vector<RdmaWriteTarget> targets;
         if (length != 0) {
@@ -1541,7 +1803,7 @@ std::vector<Status> RdmaTransport::RangeMany(
       bool had_wcs = false;
       if (conn_ok &&
           !ReapWindow(ep, width, &reply_bytes, BatchTimeout(), &timed_out,
-                      &wc_status, &had_wcs)) {
+                      &wc_status, &had_wcs, &completion_fault)) {
         conn_ok = false;
         completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
@@ -1565,8 +1827,8 @@ std::vector<Status> RdmaTransport::RangeMany(
           break;
         }
         result[base + slot] = status;
-        if (value_lens) (*value_lens)[base + slot] = value_len;
-        std::string& output = (*outputs)[base + slot];
+        attempt_value_lens[base + slot] = value_len;
+        std::string& output = attempt_outputs[base + slot];
         if (status != Status::kOk) {
           output.clear();
         } else if (data_len <= output.size()) {
@@ -1579,13 +1841,29 @@ std::vector<Status> RdmaTransport::RangeMany(
       }
     }
     if (conn_ok) {
+      *outputs = std::move(attempt_outputs);
+      if (value_lens) *value_lens = std::move(attempt_value_lens);
       Release(node, Lane::kData, conn);
+      if (cross_rail_retry)
+        cross_rail_retry_successes_.fetch_add(1,
+                                              std::memory_order_relaxed);
       return result;
     }
+    const size_t failed_rail = conn->rail_index;
     Destroy(conn, completion);
-    if (from_pool) continue;
+    const AcquireFailure failure =
+        completion == rdma::RailCompletion::kRailFailure
+            ? AcquireFailure::kLocalRail
+            : AcquireFailure::kEndpoint;
+    if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     &excluded, &cross_rail_retry))
+      continue;
+    if (cross_rail_retry)
+      cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
     return result;
   }
+  if (cross_rail_retry)
+    cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
   return result;
 }
 
@@ -1598,19 +1876,30 @@ std::vector<Status> RdmaTransport::ExistMany(
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) return result;
 
+  RailMask excluded(devs_.size(), 0);
+  bool cross_rail_retry = false;
   for (int attempt = 0; attempt < 2; ++attempt) {
-    if (attempt != 0)
-      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
     std::fill(result.begin(), result.end(), Status::kIOError);
     std::fill(exists->begin(), exists->end(), 0);
-    bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kControl, &from_pool, attempt > 0,
-                         std::min(count, depth_));
-    if (!conn) return result;
+    AcquireOptions options;
+    options.force_new = attempt != 0;
+    options.requested_credits = std::min(count, depth_);
+    options.excluded = excluded;
+    AcquireResult acquired = Acquire(node, Lane::kControl, options);
+    if (!acquired.conn) {
+      if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
+                       acquired.failure, &excluded, &cross_rail_retry))
+        continue;
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      return result;
+    }
+    Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
-    bool conn_ok = true;
+    bool conn_ok = !InjectLocalRailFailure(attempt);
     // Failure attribution for Destroy: post/encode/register failures keep the
     // local-rail default; a failed reap window is classified from its WC
     // evidence; wire decode failures blame the peer.
@@ -1650,12 +1939,26 @@ std::vector<Status> RdmaTransport::ExistMany(
     }
     if (conn_ok) {
       Release(node, Lane::kControl, conn);
+      if (cross_rail_retry)
+        cross_rail_retry_successes_.fetch_add(1,
+                                              std::memory_order_relaxed);
       return result;
     }
+    const size_t failed_rail = conn->rail_index;
     Destroy(conn, completion);
-    if (from_pool) continue;
+    const AcquireFailure failure =
+        completion == rdma::RailCompletion::kRailFailure
+            ? AcquireFailure::kLocalRail
+            : AcquireFailure::kEndpoint;
+    if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     &excluded, &cross_rail_retry))
+      continue;
+    if (cross_rail_retry)
+      cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
     return result;
   }
+  if (cross_rail_retry)
+    cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
   return result;
 }
 
@@ -1664,10 +1967,15 @@ std::vector<Status> RdmaTransport::RangeInto(
     const std::vector<RangeDst>& destinations,
     std::vector<uint64_t>* value_lens) {
   const size_t count = keys.size();
-  if (value_lens) value_lens->assign(count, 0);
-  if (destinations.size() != count) return InvalidStatuses(count);
+  if (destinations.size() != count) {
+    if (value_lens) value_lens->assign(count, 0);
+    return InvalidStatuses(count);
+  }
   std::vector<Status> result(count, Status::kIOError);
-  if (count == 0) return result;
+  if (count == 0) {
+    if (value_lens) value_lens->clear();
+    return result;
+  }
   std::vector<char> bad(count, 0);
   size_t valid_count = 0;
   for (size_t i = 0; i < count; ++i) {
@@ -1680,29 +1988,51 @@ std::vector<Status> RdmaTransport::RangeInto(
       ++valid_count;
     }
   }
-  if (valid_count == 0) return result;
+  if (valid_count == 0) {
+    if (value_lens) value_lens->assign(count, 0);
+    return result;
+  }
   rdma::OperationContext operation;
   if (!operation.Submit() || !operation.ClaimPoller()) return result;
   bool final_timeout = false;
+  RailMask excluded(devs_.size(), 0);
+  bool cross_rail_retry = false;
+  CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
 
   for (int attempt = 0; attempt < 2; ++attempt) {
-    if (attempt != 0)
-      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
+    completion_fault.BeginAttempt(attempt);
+    final_timeout = false;
     std::fill(result.begin(), result.end(), Status::kIOError);
-    for (size_t i = 0; i < count; ++i)
-      if (bad[i]) result[i] = Status::kInvalid;
-    if (value_lens) value_lens->assign(count, 0);
-    bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kData, &from_pool, attempt > 0,
-                         std::min(valid_count, depth_));
-    if (!conn) {
+    std::vector<std::vector<char>> attempt_outputs(count);
+    std::vector<uint64_t> attempt_data_lens(count, 0);
+    std::vector<uint64_t> attempt_value_lens(count, 0);
+    for (size_t i = 0; i < count; ++i) {
+      if (bad[i]) {
+        result[i] = Status::kInvalid;
+      } else {
+        attempt_outputs[i].resize(destinations[i].n);
+      }
+    }
+    AcquireOptions options;
+    options.force_new = attempt != 0;
+    options.requested_credits = std::min(valid_count, depth_);
+    options.excluded = excluded;
+    AcquireResult acquired = Acquire(node, Lane::kData, options);
+    if (!acquired.conn) {
+      if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
+                       acquired.failure, &excluded, &cross_rail_retry))
+        continue;
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
       operation.Complete(false);
       return result;
     }
+    Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
-    bool conn_ok = true;
+    bool conn_ok = !InjectLocalRailFailure(attempt);
     // Failure attribution for Destroy: post/encode/register failures keep the
     // local-rail default; a failed reap window is classified from its WC
     // evidence; wire decode failures blame the peer.
@@ -1715,9 +2045,10 @@ std::vector<Status> RdmaTransport::RangeInto(
         const size_t item_index = base + slot;
         if (bad[item_index]) continue;
         const RangeDst& destination = destinations[item_index];
+        std::vector<char>& output = attempt_outputs[item_index];
         if (destination.n != 0) {
           output_mrs[slot] =
-              ep.RegisterTransient(destination.payload, destination.n);
+              ep.RegisterTransient(output.data(), output.size());
           if (!output_mrs[slot]) {
             conn_ok = false;
             break;
@@ -1726,7 +2057,7 @@ std::vector<Status> RdmaTransport::RangeInto(
         std::vector<RdmaWriteTarget> targets;
         if (destination.n != 0) {
           targets.push_back(
-              {reinterpret_cast<uint64_t>(destination.payload),
+              {reinterpret_cast<uint64_t>(output.data()),
                output_mrs[slot]->rkey,
                static_cast<uint32_t>(destination.n)});
         }
@@ -1746,7 +2077,7 @@ std::vector<Status> RdmaTransport::RangeInto(
       bool had_wcs = false;
       if (conn_ok &&
           !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out, &wc_status, &had_wcs)) {
+                      &timed_out, &wc_status, &had_wcs, &completion_fault)) {
         conn_ok = false;
         completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
@@ -1769,20 +2100,42 @@ std::vector<Status> RdmaTransport::RangeInto(
           break;
         }
         result[item_index] = status;
-        if (value_lens) (*value_lens)[item_index] = value_len;
+        attempt_data_lens[item_index] = data_len;
+        attempt_value_lens[item_index] = value_len;
       }
     }
     if (conn_ok) {
+      for (size_t i = 0; i < count; ++i) {
+        if (result[i] == Status::kOk && attempt_data_lens[i] != 0) {
+          std::memcpy(destinations[i].payload, attempt_outputs[i].data(),
+                      static_cast<size_t>(attempt_data_lens[i]));
+        }
+      }
+      if (value_lens) *value_lens = std::move(attempt_value_lens);
       Release(node, Lane::kData, conn);
+      if (cross_rail_retry)
+        cross_rail_retry_successes_.fetch_add(1,
+                                              std::memory_order_relaxed);
       operation.Complete(true);
       return result;
     }
+    const size_t failed_rail = conn->rail_index;
     Destroy(conn, completion);
-    if (from_pool) continue;
+    const AcquireFailure failure =
+        completion == rdma::RailCompletion::kRailFailure
+            ? AcquireFailure::kLocalRail
+            : AcquireFailure::kEndpoint;
+    if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     &excluded, &cross_rail_retry))
+      continue;
+    if (cross_rail_retry)
+      cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
     if (final_timeout) operation.RequestCancel();
     operation.Complete(false);
     return result;
   }
+  if (cross_rail_retry)
+    cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
   if (final_timeout) operation.RequestCancel();
   operation.Complete(false);
   return result;
@@ -1832,22 +2185,31 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   }
   if (valid_count == 0) return result;
 
+  RailMask excluded(devs_.size(), 0);
+  bool cross_rail_retry = false;
   for (int attempt = 0; attempt < 2; ++attempt) {
-    if (attempt != 0)
-      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
-    for (size_t i = 0; i < count; ++i) {
-      if (bad[i]) {
-        result[i] = Status::kInvalid;
-      } else if (!completed[i]) {
-        result[i] = Status::kIOError;
-      }
+    // Completed items and their terminal statuses survive a fresh-rail
+    // attempt. Any incomplete item restarts below with new connection-local
+    // progress and transient registrations.
+    AcquireOptions options;
+    options.force_new = attempt != 0;
+    options.requested_credits = 1;
+    options.excluded = excluded;
+    AcquireResult acquired = Acquire(node, Lane::kSgData, options);
+    if (!acquired.conn) {
+      if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
+                       acquired.failure, &excluded, &cross_rail_retry))
+        continue;
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      return result;
     }
-    bool from_pool = false;
-    Conn* conn = Acquire(node, Lane::kSgData, &from_pool, attempt > 0, 1);
-    if (!conn) return result;
+    Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t seg_limit = std::max<size_t>(1, ep.max_sge() - 1);
-    bool conn_ok = true;
+    bool conn_ok = !InjectLocalRailFailure(attempt);
+    bool request_posted = false;
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
     const size_t remote_capacity = conn->data_capacity();
 
@@ -1915,6 +2277,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
           break;
         }
         v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+        request_posted = true;
         std::vector<uint32_t> reply_bytes;
         bool timed_out = false;
         ibv_wc_status wc_status = IBV_WC_SUCCESS;
@@ -1955,15 +2318,29 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     }
     if (conn_ok) {
       Release(node, Lane::kSgData, conn);
+      if (cross_rail_retry)
+        cross_rail_retry_successes_.fetch_add(1,
+                                              std::memory_order_relaxed);
       return result;
     }
+    const size_t failed_rail = conn->rail_index;
     Destroy(conn, completion);
     for (size_t i = 0; i < count; ++i) {
       if (!bad[i] && !completed[i]) result[i] = Status::kIOError;
     }
-    if (from_pool) continue;
+    const AcquireFailure failure =
+        completion == rdma::RailCompletion::kRailFailure && !request_posted
+            ? AcquireFailure::kLocalRail
+            : AcquireFailure::kEndpoint;
+    if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     &excluded, &cross_rail_retry))
+      continue;
+    if (cross_rail_retry)
+      cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
     return result;
   }
+  if (cross_rail_retry)
+    cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
   return result;
 }
 
@@ -2008,12 +2385,16 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     const std::vector<RangeDstMulti>& destinations,
     std::vector<size_t>* out_lengths) {
   const size_t count = keys.size();
-  if (out_lengths) out_lengths->assign(count, 0);
-  if (destinations.size() != count) return InvalidStatuses(count);
+  if (destinations.size() != count) {
+    if (out_lengths) out_lengths->assign(count, 0);
+    return InvalidStatuses(count);
+  }
   std::vector<Status> result(count, Status::kIOError);
-  if (count == 0) return result;
+  if (count == 0) {
+    if (out_lengths) out_lengths->clear();
+    return result;
+  }
   std::vector<char> bad(count, 0);
-  std::vector<char> completed(count, 0);
   std::vector<size_t> capacities(count, 0);
   size_t valid_count = 0;
   for (size_t i = 0; i < count; ++i) {
@@ -2038,30 +2419,64 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       ++valid_count;
     }
   }
+  if (valid_count == 0) {
+    if (out_lengths) out_lengths->assign(count, 0);
+    return result;
+  }
+  // Keep fully validated items across a rail retry, but fence every server DMA
+  // in operation-owned storage. Caller segments are published only after all
+  // remaining items complete on the final healthy connection.
+  std::vector<char> completed(count, 0);
+  std::vector<std::vector<char>> staged_outputs(count);
+  std::vector<size_t> staged_out_lengths(count, 0);
+  for (size_t i = 0; i < count; ++i) {
+    if (!bad[i]) staged_outputs[i].resize(capacities[i]);
+  }
   if (valid_count == 0) return result;
+  rdma::OperationContext operation;
+  if (!operation.Submit() || !operation.ClaimPoller()) return result;
+  bool final_timeout = false;
 
+  RailMask excluded(devs_.size(), 0);
+  bool cross_rail_retry = false;
+  CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
   for (int attempt = 0; attempt < 2; ++attempt) {
-    if (attempt != 0)
-      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
+    completion_fault.BeginAttempt(attempt);
+    final_timeout = false;
+    size_t remaining_count = 0;
     for (size_t i = 0; i < count; ++i) {
       if (bad[i]) {
         result[i] = Status::kInvalid;
       } else if (!completed[i]) {
         result[i] = Status::kIOError;
-        if (out_lengths) (*out_lengths)[i] = 0;
+        staged_out_lengths[i] = 0;
+        ++remaining_count;
       }
     }
-    bool from_pool = false;
-    Conn* conn = Acquire(
-        node, Lane::kSgData, &from_pool, attempt > 0,
-        std::min<size_t>(valid_count, depth_));
-    if (!conn) return result;
+    AcquireOptions options;
+    options.force_new = attempt != 0;
+    options.requested_credits = std::min<size_t>(remaining_count, depth_);
+    options.excluded = excluded;
+    AcquireResult acquired = Acquire(node, Lane::kSgData, options);
+    if (!acquired.conn) {
+      if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
+                       acquired.failure, &excluded, &cross_rail_retry))
+        continue;
+      if (cross_rail_retry)
+        cross_rail_retry_exhausted_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      operation.Complete(false);
+      return result;
+    }
+    Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t target_limit =
         std::max<size_t>(1, std::min(ep.max_sge() - 1,
                                     rdma::kV2MaxGetTargets));
-    const size_t operation_limit = ep.window();
-    bool conn_ok = operation_limit != 0;
+    const size_t operation_limit =
+        std::min(ep.window(), static_cast<size_t>(conn->lease.credits));
+    bool conn_ok =
+        operation_limit != 0 && !InjectLocalRailFailure(attempt);
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
 
     struct GetProgress {
@@ -2131,14 +2546,16 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
             const auto& payload =
                 destination.payloads[progress.segment_index++];
             if (payload.second == 0) continue;
-            ibv_mr* mr =
-                ep.RegisterTransient(payload.first, payload.second);
+            char* const target =
+                staged_outputs[progress.item].data() +
+                progress.logical_offset + window_capacity;
+            ibv_mr* mr = ep.RegisterTransient(target, payload.second);
             if (!mr) {
               conn_ok = false;
               break;
             }
             targets.push_back(
-                {reinterpret_cast<uint64_t>(payload.first), mr->rkey,
+                {reinterpret_cast<uint64_t>(target), mr->rkey,
                  static_cast<uint32_t>(payload.second)});
             mrs.push_back(mr);
             window_capacity += payload.second;
@@ -2189,17 +2606,20 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
           break;
         }
 
+        // One logical operation keeps its cancellation state across rail
+        // attempts; only a timeout on the terminal attempt requests cancel.
         std::vector<uint32_t> reply_bytes;
         bool timed_out = false;
         ibv_wc_status wc_status = IBV_WC_SUCCESS;
         bool had_wcs = false;
         if (!RunWindow(ep, frame_lengths, &reply_bytes, BatchTimeout(),
-                       &timed_out, &wc_status, &had_wcs)) {
+                       &timed_out, &wc_status, &had_wcs, &completion_fault)) {
           conn_ok = false;
           completion = rdma::ClassifyCompletion(wc_status, had_wcs);
         }
         if (timed_out)
           completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+        final_timeout = timed_out;
         if (!conn_ok) break;
         for (auto& mrs : round_mrs)
           for (ibv_mr* mr : mrs) ep.ReleaseTransient(mr);
@@ -2247,10 +2667,8 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
             }
             progress.finished = true;
             completed[progress.item] = 1;
-            if (out_lengths) {
-              (*out_lengths)[progress.item] =
-                  static_cast<size_t>(progress.response_value_len);
-            }
+            staged_out_lengths[progress.item] =
+                static_cast<size_t>(progress.response_value_len);
             --remaining;
           }
         }
@@ -2259,19 +2677,49 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     }
 
     if (conn_ok) {
+      for (size_t i = 0; i < count; ++i) {
+        if (result[i] != Status::kOk) continue;
+        size_t copied = 0;
+        for (const auto& payload : destinations[i].payloads) {
+          const size_t remaining = staged_out_lengths[i] - copied;
+          const size_t n = std::min(payload.second, remaining);
+          if (n != 0) {
+            std::memcpy(payload.first, staged_outputs[i].data() + copied, n);
+            copied += n;
+          }
+          if (copied == staged_out_lengths[i]) break;
+        }
+      }
+      if (out_lengths) *out_lengths = staged_out_lengths;
       Release(node, Lane::kSgData, conn);
+      if (cross_rail_retry)
+        cross_rail_retry_successes_.fetch_add(1,
+                                              std::memory_order_relaxed);
+      operation.Complete(true);
       return result;
     }
+    const size_t failed_rail = conn->rail_index;
     Destroy(conn, completion);
     for (size_t i = 0; i < count; ++i) {
-      if (!bad[i] && !completed[i]) {
-        result[i] = Status::kIOError;
-        if (out_lengths) (*out_lengths)[i] = 0;
-      }
+      if (!bad[i] && !completed[i]) result[i] = Status::kIOError;
     }
-    if (from_pool) continue;
+    const AcquireFailure failure =
+        completion == rdma::RailCompletion::kRailFailure
+            ? AcquireFailure::kLocalRail
+            : AcquireFailure::kEndpoint;
+    if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     &excluded, &cross_rail_retry))
+      continue;
+    if (cross_rail_retry)
+      cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
+    if (final_timeout) operation.RequestCancel();
+    operation.Complete(false);
     return result;
   }
+  if (cross_rail_retry)
+    cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
+  if (final_timeout) operation.RequestCancel();
+  operation.Complete(false);
   return result;
 }
 

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -14,6 +14,7 @@
 #include <condition_variable>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <limits>
 #include <mutex>
 #include <thread>
@@ -119,16 +120,41 @@ class RdmaTransport : public Transport {
 
  private:
   struct Conn;
-  // force_new skips the idle pool after a stale connection. Lanes separate
-  // payload, device-direct SG, and key-sized control traffic; each lane keeps
-  // the negotiated depth while owning an independent endpoint pool.
+  using RailMask = std::vector<uint8_t>;
+  enum class AcquireFailure : uint8_t {
+    kNone,
+    kAdmission,
+    kLocalRail,
+    kEndpoint,
+  };
+  struct AcquireOptions {
+    bool force_new = false;
+    size_t requested_credits = 1;
+    RailMask excluded;
+  };
+  struct AcquireResult {
+    Conn* conn = nullptr;
+    bool from_pool = false;
+    std::optional<size_t> attempted_rail;
+    AcquireFailure failure = AcquireFailure::kAdmission;
+  };
+  // Lanes separate payload, device-direct SG, and key-sized control traffic;
+  // each lane keeps the negotiated depth while owning an independent endpoint
+  // pool. Acquisition performs exactly one rail admission and one endpoint
+  // lookup/construction; the logical operation owns all retry decisions.
   enum class Lane { kData, kSgData, kControl };
-  Conn* Acquire(const std::string& node, Lane lane, bool* from_pool,
-                bool force_new = false, size_t requested_credits = 1);
+  AcquireResult Acquire(const std::string& node, Lane lane,
+                        const AcquireOptions& options);
+  // Schedules at most one fresh retry. cross_rail_retry is set only while the
+  // failed rail stays excluded and another topology-enabled rail exists.
+  bool PrepareRetry(int attempt, bool from_pool,
+                    std::optional<size_t> attempted_rail,
+                    AcquireFailure failure, RailMask* excluded,
+                    bool* cross_rail_retry);
   void Release(const std::string& node, Lane lane, Conn* c);
   void Destroy(Conn* c,
                rdma::RailCompletion completion =
-                   rdma::RailCompletion::kRailFailure);
+                   rdma::RailCompletion::kAdmission);
   bool EvictOneIdle();
   // Keep every idle QP alive while its client process is healthy. This lets a
   // short server-side idle reaper reclaim dead clients without forcing the
@@ -222,6 +248,12 @@ class RdmaTransport : public Transport {
   mutable std::atomic<uint64_t> v2_probe_attempts_{0};
   mutable std::atomic<uint64_t> v2_probe_failures_{0};
   std::atomic<uint64_t> stale_pool_retries_{0};
+  std::atomic<uint64_t> cross_rail_retries_{0};
+  std::atomic<uint64_t> cross_rail_retry_successes_{0};
+  std::atomic<uint64_t> cross_rail_retry_exhausted_{0};
+  // Deterministic test-only completion-fault targeting. Inert unless
+  // DFKV_RDMA_TEST_COMPLETION_FAULT is set.
+  std::atomic<uint64_t> test_completion_fault_calls_{0};
   std::atomic<uint64_t> completion_timeouts_{0};
   std::atomic<uint64_t> keepalive_attempts_{0};
   std::atomic<uint64_t> keepalive_successes_{0};

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -6,6 +6,9 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
 
 #include <string>
 #include <chrono>
@@ -21,21 +24,44 @@ using namespace dfkv;  // NOLINT
 namespace {
 class MetricsTransport final : public Transport {
  public:
+  enum class AttemptResult : uint8_t { kSuccess, kRailFailure };
+  struct ScriptedAttempt {
+    size_t rail;
+    AttemptResult result;
+    std::chrono::milliseconds delay{0};
+    size_t completed_items_before_failure = 0;
+  };
+
   bool pipeline = false;
-  std::mutex mu;
+  mutable std::mutex mu;
   std::map<std::string, std::string> values;
   std::vector<Status> exist_script;
+  std::vector<ScriptedAttempt> attempt_script;
+  std::vector<ScriptedAttempt> attempts;
+  std::vector<size_t> replay_item_counts;
   size_t exist_calls = 0;
   size_t range_calls = 0;
   size_t range_multi_calls = 0;
   size_t range_multi_misses = 0;
+  uint64_t cross_rail_retries = 0;
+  uint64_t cross_rail_retry_successes = 0;
+  uint64_t cross_rail_retry_exhausted = 0;
+
+  void Script(std::initializer_list<ScriptedAttempt> script) {
+    std::lock_guard<std::mutex> lock(mu);
+    attempt_script.assign(script);
+    attempts.clear();
+    replay_item_counts.clear();
+  }
 
   Status Cache(const std::string&, const BlockKey& key, const void* data,
                size_t len) override {
     std::lock_guard<std::mutex> lock(mu);
-    values[key.Filename()] =
-        std::string(static_cast<const char*>(data), len);
-    return Status::kOk;
+    const bool ok = RunAttemptsLocked(1, [&] {
+      values[key.Filename()] =
+          std::string(static_cast<const char*>(data), len);
+    });
+    return ok ? Status::kOk : Status::kIOError;
   }
   Status Range(const std::string&, const BlockKey& key, uint64_t offset,
                uint64_t length, std::string* out,
@@ -44,11 +70,13 @@ class MetricsTransport final : public Transport {
     ++range_calls;
     auto found = values.find(key.Filename());
     if (found == values.end()) return Status::kNotFound;
-    if (value_len) *value_len = found->second.size();
-    const size_t begin =
-        std::min<size_t>(static_cast<size_t>(offset), found->second.size());
-    *out = found->second.substr(begin, static_cast<size_t>(length));
-    return Status::kOk;
+    const bool ok = RunAttemptsLocked(1, [&] {
+      if (value_len) *value_len = found->second.size();
+      const size_t begin =
+          std::min<size_t>(static_cast<size_t>(offset), found->second.size());
+      *out = found->second.substr(begin, static_cast<size_t>(length));
+    });
+    return ok ? Status::kOk : Status::kIOError;
   }
   Status Lookup(const std::string&, const BlockKey& key,
                 uint64_t* value_len) override {
@@ -76,20 +104,145 @@ class MetricsTransport final : public Transport {
     return Status::kOk;
   }
   bool pipelined() const override { return pipeline; }
+
+  std::vector<Status> CacheFrom(
+      const std::string&, const std::vector<CacheSrc>& srcs) override {
+    std::lock_guard<std::mutex> lock(mu);
+    const bool ok = RunAttemptsLocked(srcs.size(), [&] {
+      for (const auto& src : srcs) {
+        values[src.key.Filename()] =
+            std::string(static_cast<const char*>(src.payload),
+                        src.payload_len);
+      }
+    });
+    return std::vector<Status>(
+        srcs.size(), ok ? Status::kOk : Status::kIOError);
+  }
+
+  std::vector<Status> RangeInto(
+      const std::string&, const std::vector<BlockKey>& keys,
+      const std::vector<RangeDst>& dsts,
+      std::vector<uint64_t>* value_lens) override {
+    std::lock_guard<std::mutex> lock(mu);
+    range_calls += keys.size();
+    if (value_lens) value_lens->assign(keys.size(), 0);
+    if (dsts.size() != keys.size()) return InvalidStatuses(keys.size());
+    std::vector<Status> result(keys.size(), Status::kNotFound);
+    const bool ok = RunAttemptsLocked(keys.size(), [&] {
+      for (size_t i = 0; i < keys.size(); ++i) {
+        auto found = values.find(keys[i].Filename());
+        if (found == values.end()) continue;
+        const size_t copied = std::min(dsts[i].n, found->second.size());
+        if (copied) std::memcpy(dsts[i].payload, found->second.data(), copied);
+        if (value_lens) (*value_lens)[i] = found->second.size();
+        result[i] = Status::kOk;
+      }
+    });
+    if (!ok) result.assign(keys.size(), Status::kIOError);
+    return result;
+  }
+
+  std::vector<Status> CacheFromMulti(
+      const std::string&, const std::vector<CacheSrcMulti>& srcs) override {
+    std::lock_guard<std::mutex> lock(mu);
+    const bool ok = RunAttemptsLocked(srcs.size(), [&] {
+      for (const auto& src : srcs) {
+        std::string value;
+        for (const auto& segment : src.payloads)
+          value.append(static_cast<const char*>(segment.first),
+                       segment.second);
+        values[src.key.Filename()] = std::move(value);
+      }
+    });
+    return std::vector<Status>(
+        srcs.size(), ok ? Status::kOk : Status::kIOError);
+  }
+
   std::vector<Status> RangeIntoMulti(
-      const std::string& node, const std::vector<BlockKey>& keys,
+      const std::string&, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
       std::vector<size_t>* out_lens) override {
+    std::lock_guard<std::mutex> lock(mu);
     ++range_multi_calls;
-    std::vector<Status> result =
-        Transport::RangeIntoMulti(node, keys, dsts, out_lens);
-    for (size_t i = 0; i < result.size() && range_multi_misses > 0; ++i) {
-      if (result[i] != Status::kOk) continue;
-      result[i] = Status::kNotFound;
-      if (out_lens && i < out_lens->size()) (*out_lens)[i] = 0;
-      --range_multi_misses;
+    if (out_lens) out_lens->assign(keys.size(), 0);
+    if (dsts.size() != keys.size()) return InvalidStatuses(keys.size());
+    std::vector<Status> result(keys.size(), Status::kNotFound);
+    const bool ok = RunAttemptsLocked(keys.size(), [&] {
+      for (size_t i = 0; i < keys.size(); ++i) {
+        auto found = values.find(keys[i].Filename());
+        if (found == values.end()) continue;
+        size_t offset = 0;
+        for (const auto& segment : dsts[i].payloads) {
+          const size_t copy =
+              std::min(segment.second, found->second.size() - offset);
+          if (copy)
+            std::memcpy(segment.first, found->second.data() + offset, copy);
+          offset += copy;
+          if (offset == found->second.size()) break;
+        }
+        if (out_lens) (*out_lens)[i] = found->second.size();
+        result[i] = Status::kOk;
+      }
+    });
+    if (!ok) {
+      result.assign(keys.size(), Status::kIOError);
+    } else {
+      for (size_t i = 0; i < result.size() && range_multi_misses > 0; ++i) {
+        if (result[i] != Status::kOk) continue;
+        result[i] = Status::kNotFound;
+        if (out_lens) (*out_lens)[i] = 0;
+        --range_multi_misses;
+      }
     }
     return result;
+  }
+
+  std::string MetricsText() const override {
+    std::lock_guard<std::mutex> lock(mu);
+    return
+        "# TYPE dfkv_rdma_client_cross_rail_retries_total counter\n"
+        "dfkv_rdma_client_cross_rail_retries_total " +
+        std::to_string(cross_rail_retries) +
+        "\n# TYPE dfkv_rdma_client_cross_rail_retry_successes_total counter\n"
+        "dfkv_rdma_client_cross_rail_retry_successes_total " +
+        std::to_string(cross_rail_retry_successes) +
+        "\n# TYPE dfkv_rdma_client_cross_rail_retry_exhausted_total counter\n"
+        "dfkv_rdma_client_cross_rail_retry_exhausted_total " +
+        std::to_string(cross_rail_retry_exhausted) + "\n";
+  }
+
+ private:
+  template <typename Success>
+  bool RunAttemptsLocked(size_t item_count, Success&& success) {
+    const std::vector<ScriptedAttempt> script =
+        attempt_script.empty()
+            ? std::vector<ScriptedAttempt>{{0, AttemptResult::kSuccess}}
+            : attempt_script;
+    size_t remaining_items = item_count;
+    bool cross_rail_retry = false;
+    for (size_t i = 0; i < script.size() && i < 2; ++i) {
+      if (script[i].delay.count() != 0)
+        std::this_thread::sleep_for(script[i].delay);
+      attempts.push_back(script[i]);
+      replay_item_counts.push_back(remaining_items);
+      if (script[i].result == AttemptResult::kSuccess) {
+        success();
+        if (cross_rail_retry) ++cross_rail_retry_successes;
+        return true;
+      }
+      remaining_items -=
+          std::min(remaining_items,
+                   script[i].completed_items_before_failure);
+      if (i == 0 && script.size() > 1) {
+        cross_rail_retry = script[1].rail != script[0].rail;
+        if (cross_rail_retry) ++cross_rail_retries;
+        continue;
+      }
+      if (cross_rail_retry) ++cross_rail_retry_exhausted;
+      return false;
+    }
+    if (cross_rail_retry) ++cross_rail_retry_exhausted;
+    return false;
   }
 };
 
@@ -101,6 +254,29 @@ uint64_t Metric(const std::string& snapshot, const std::string& family,
   EXPECT_NE(start, std::string::npos) << snapshot;
   if (start == std::string::npos) return 0;
   return std::stoull(snapshot.substr(start + prefix.size()));
+}
+uint64_t TransportCounter(const std::string& snapshot,
+                          const std::string& family) {
+  const std::string prefix = family + " ";
+  size_t start = snapshot.find(prefix);
+  while (start != std::string::npos &&
+         start != 0 && snapshot[start - 1] != '\n') {
+    start = snapshot.find(prefix, start + 1);
+  }
+  EXPECT_NE(start, std::string::npos) << snapshot;
+  if (start == std::string::npos) return 0;
+  EXPECT_EQ(snapshot.find(family + "{"), std::string::npos)
+      << family << " must remain an unlabeled process counter";
+  return std::stoull(snapshot.substr(start + prefix.size()));
+}
+double MetricDouble(const std::string& snapshot, const std::string& family,
+                    const std::string& op) {
+  const std::string prefix =
+      family + "{op=\"" + op + "\"} ";
+  const size_t start = snapshot.find(prefix);
+  EXPECT_NE(start, std::string::npos) << snapshot;
+  if (start == std::string::npos) return 0;
+  return std::stod(snapshot.substr(start + prefix.size()));
 }
 
 struct DedupEnv {
@@ -221,6 +397,239 @@ TEST(ClientOpMetrics, TcpAndPipelinedBatchesCountCallsNotFanoutKeys) {
     }
   }
 }
+TEST(ClientOpMetrics, CrossRailRetryCountsOneScalarPublicCall) {
+  using Result = MetricsTransport::AttemptResult;
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, "metrics/cross-rail-scalar",
+                  &transport);
+  const std::string value = "rail-retry-payload";
+  const auto failed_attempt_delay = std::chrono::milliseconds(35);
+  const auto successful_attempt_delay = std::chrono::milliseconds(5);
+
+  transport.Script(
+      {{0, Result::kRailFailure, failed_attempt_delay},
+       {1, Result::kSuccess, successful_attempt_delay}});
+  ASSERT_TRUE(client.Put("key", value.data(), value.size()));
+  ASSERT_EQ(transport.attempts.size(), 2u);
+  EXPECT_EQ(transport.attempts[0].rail, 0u);
+  EXPECT_EQ(transport.attempts[1].rail, 1u);
+  EXPECT_EQ(transport.replay_item_counts, (std::vector<size_t>{1, 1}));
+
+  transport.Script(
+      {{0, Result::kRailFailure, failed_attempt_delay},
+       {1, Result::kSuccess, successful_attempt_delay}});
+  std::string output(value.size(), '\0');
+  ASSERT_TRUE(client.Get("key", output.data(), output.size()));
+  EXPECT_EQ(output, value);
+  ASSERT_EQ(transport.attempts.size(), 2u);
+  EXPECT_EQ(transport.attempts[0].rail, 0u);
+  EXPECT_EQ(transport.attempts[1].rail, 1u);
+  EXPECT_EQ(transport.replay_item_counts, (std::vector<size_t>{1, 1}));
+
+  const std::string snapshot = client.MetricsSnapshot();
+  for (const char* op : {"put", "get"}) {
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_requests_total", op), 1u);
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_keys_total", op), 1u);
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_hits_total", op), 1u);
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_bytes_total", op),
+              value.size());
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_latency_seconds_count", op),
+              1u);
+    EXPECT_GE(MetricDouble(
+                  snapshot, "dfkv_client_op_latency_seconds_sum", op),
+              std::chrono::duration<double>(failed_attempt_delay +
+                                            successful_attempt_delay)
+                      .count() *
+                  0.9)
+        << "one public latency sample must enclose both transport attempts";
+    EXPECT_LT(MetricDouble(
+                  snapshot, "dfkv_client_op_latency_seconds_sum", op),
+              2.0)
+        << "scripted retry latency unexpectedly exceeded the deadlock guard";
+  }
+  EXPECT_EQ(TransportCounter(
+                snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
+            2u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_successes_total"),
+            2u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+            0u);
+}
+
+TEST(ClientOpMetrics, SameRailFallbackDoesNotCountAsCrossRailRetry) {
+  using Result = MetricsTransport::AttemptResult;
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, "metrics/same-rail-fallback",
+                  &transport);
+  const std::string value = "same-rail-payload";
+
+  transport.Script(
+      {{0, Result::kRailFailure}, {0, Result::kSuccess}});
+  ASSERT_TRUE(client.Put("key", value.data(), value.size()));
+  ASSERT_EQ(transport.attempts.size(), 2u);
+  EXPECT_EQ(transport.attempts[0].rail, 0u);
+  EXPECT_EQ(transport.attempts[1].rail, 0u);
+
+  const std::string snapshot = client.MetricsSnapshot();
+  EXPECT_EQ(TransportCounter(
+                snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
+            0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_successes_total"),
+            0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+            0u);
+}
+
+TEST(ClientOpMetrics, CrossRailRetryPreservesCompletedMultiWindowSgItems) {
+  using Result = MetricsTransport::AttemptResult;
+  constexpr size_t kItems = 9;  // 2 * depth(4) + 1
+  constexpr size_t kSegmentBytes = 4;
+  constexpr size_t kCompletedBeforeFailure = 4;
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, "metrics/cross-rail-sg", &transport);
+
+  std::vector<std::array<std::string, 3>> segments(kItems);
+  std::vector<std::string> expected(kItems);
+  std::vector<KvPutItemSg> puts;
+  puts.reserve(kItems);
+  for (size_t i = 0; i < kItems; ++i) {
+    for (size_t segment = 0; segment < 3; ++segment) {
+      segments[i][segment] =
+          std::string(kSegmentBytes,
+                      static_cast<char>('A' + i * 3 + segment));
+      expected[i] += segments[i][segment];
+    }
+    puts.push_back(
+        {"key-" + std::to_string(i),
+         {segments[i][0].data(), segments[i][1].data(),
+          segments[i][2].data()},
+         {kSegmentBytes, kSegmentBytes, kSegmentBytes}});
+  }
+
+  transport.Script(
+      {{0, Result::kRailFailure, {}, kCompletedBeforeFailure},
+       {1, Result::kSuccess}});
+  EXPECT_EQ(client.BatchPutSg(puts), std::vector<bool>(kItems, true));
+  EXPECT_EQ(transport.replay_item_counts,
+            (std::vector<size_t>{kItems,
+                                 kItems - kCompletedBeforeFailure}));
+
+  std::vector<std::array<std::array<char, kSegmentBytes>, 3>> output(kItems);
+  std::vector<KvGetItemSg> gets;
+  gets.reserve(kItems);
+  for (size_t i = 0; i < kItems; ++i) {
+    gets.push_back(
+        {puts[i].key,
+         {output[i][0].data(), output[i][1].data(), output[i][2].data()},
+         {kSegmentBytes, kSegmentBytes, kSegmentBytes}});
+  }
+  transport.Script(
+      {{0, Result::kRailFailure, {}, kCompletedBeforeFailure},
+       {1, Result::kSuccess}});
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg(gets, &lengths),
+            std::vector<bool>(kItems, true));
+  EXPECT_EQ(lengths, std::vector<size_t>(kItems, 3 * kSegmentBytes));
+  EXPECT_EQ(transport.replay_item_counts,
+            (std::vector<size_t>{kItems,
+                                 kItems - kCompletedBeforeFailure}));
+  for (size_t i = 0; i < kItems; ++i) {
+    std::string actual;
+    for (const auto& segment : output[i])
+      actual.append(segment.data(), segment.size());
+    EXPECT_EQ(actual, expected[i]) << i;
+  }
+
+  const std::string snapshot = client.MetricsSnapshot();
+  for (const char* op : {"put", "get"}) {
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_requests_total", op), 1u);
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_keys_total", op), kItems);
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_hits_total", op), kItems);
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_bytes_total", op),
+              kItems * 3 * kSegmentBytes);
+    EXPECT_EQ(Metric(snapshot, "dfkv_client_op_latency_seconds_count", op),
+              1u);
+  }
+  EXPECT_EQ(TransportCounter(
+                snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
+            2u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_successes_total"),
+            2u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+            0u);
+}
+
+TEST(ClientOpMetrics, ExhaustedCrossRailRetryCountsOneFailure) {
+  using Result = MetricsTransport::AttemptResult;
+  constexpr size_t kItems = 9;
+  constexpr size_t kSegmentBytes = 4;
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, "metrics/cross-rail-exhausted",
+                  &transport);
+
+  std::vector<std::array<std::array<char, kSegmentBytes>, 3>> output(kItems);
+  for (auto& item : output)
+    for (auto& segment : item) segment.fill(static_cast<char>(0x5a));
+  std::vector<KvGetItemSg> gets;
+  gets.reserve(kItems);
+  for (size_t i = 0; i < kItems; ++i) {
+    gets.push_back(
+        {"key-" + std::to_string(i),
+         {output[i][0].data(), output[i][1].data(), output[i][2].data()},
+         {kSegmentBytes, kSegmentBytes, kSegmentBytes}});
+  }
+
+  transport.Script(
+      {{0, Result::kRailFailure}, {1, Result::kRailFailure}});
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg(gets, &lengths),
+            std::vector<bool>(kItems, false));
+  EXPECT_EQ(lengths, std::vector<size_t>(kItems, 0));
+  ASSERT_EQ(transport.attempts.size(), 2u);
+  EXPECT_EQ(transport.attempts[0].rail, 0u);
+  EXPECT_EQ(transport.attempts[1].rail, 1u);
+  EXPECT_EQ(transport.replay_item_counts,
+            (std::vector<size_t>{kItems, kItems}));
+  for (const auto& item : output)
+    for (const auto& segment : item)
+      for (char byte : segment) EXPECT_EQ(byte, static_cast<char>(0x5a));
+
+  const std::string snapshot = client.MetricsSnapshot();
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_requests_total", "get"), 1u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_keys_total", "get"), kItems);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_hits_total", "get"), 0u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_bytes_total", "get"), 0u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_latency_seconds_count", "get"),
+            1u);
+  EXPECT_EQ(TransportCounter(
+                snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
+            1u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_successes_total"),
+            0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+            1u);
+}
+
 
 TEST(ClientOpMetrics, RendezvousHitsAreCountedAndRemoveCannotServeStale) {
   const std::string key_namespace = "metrics/dedup";

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -11,6 +11,8 @@
 #include "cache/rdma_server.h"
 #include "common/config_dump.h"
 #include "transport/rdma_transport.h"
+#include "transport/rail_select.h"
+#include "transport/rdma_topology.h"
 #include "transport/rdma_protocol.h"
 #include "transport/rdma_verbs.h"
 
@@ -19,11 +21,17 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <condition_variable>
+#include <algorithm>
+#include <cctype>
+#include <array>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <limits>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -107,6 +115,9 @@ struct RdmaNode {
   std::unique_ptr<KvNodeServer> srv;
   std::unique_ptr<RdmaServer> rsrv;
   std::string addr;  // bootstrap "ip:port" for the client member list
+  mutable std::mutex observation_mu;
+  std::map<std::string, size_t> cache_direct_calls;
+  std::map<std::string, size_t> range_direct_calls;
 
   explicit RdmaNode(const std::string& tag, size_t max_msg = kMaxMsg) {
     ConfigureTestRecvSegment();
@@ -127,11 +138,19 @@ struct RdmaNode {
         [this](const BlockKey& key, uint64_t off, uint64_t len,
                char* io_buf, size_t cap, const char** out_data,
                size_t* out_len, size_t* value_len) {
+          {
+            std::lock_guard<std::mutex> lock(observation_mu);
+            ++range_direct_calls[key.Filename()];
+          }
           return srv->RangeDirectForKey(
               key, off, len, io_buf, cap, out_data, out_len, value_len);
         });
     rsrv->set_cache_direct_handler(
         [this](const BlockKey& key, char* data, size_t len, size_t cap) {
+          {
+            std::lock_guard<std::mutex> lock(observation_mu);
+            ++cache_direct_calls[key.Filename()];
+          }
           return srv->CacheDirectForKey(key, data, len, cap);
         });
     EXPECT_EQ(rsrv->Start(0), Status::kOk);
@@ -141,6 +160,16 @@ struct RdmaNode {
     if (rsrv) rsrv->Stop();
     if (srv) srv->Stop();
     fs::remove_all(dir);
+  }
+  size_t CacheDirectCalls(const BlockKey& key) const {
+    std::lock_guard<std::mutex> lock(observation_mu);
+    const auto found = cache_direct_calls.find(key.Filename());
+    return found == cache_direct_calls.end() ? 0 : found->second;
+  }
+  size_t RangeDirectCalls(const BlockKey& key) const {
+    std::lock_guard<std::mutex> lock(observation_mu);
+    const auto found = range_direct_calls.find(key.Filename());
+    return found == range_direct_calls.end() ? 0 : found->second;
   }
 };
 
@@ -154,6 +183,95 @@ long CounterVal(const std::string& text, const std::string& name) {
   auto sp = text.find(' ', p);
   if (sp == std::string::npos) return -1;
   try { return std::stol(text.substr(sp + 1)); } catch (...) { return -1; }
+}
+long DeviceCounterVal(const std::string& text, const std::string& name,
+                      const std::string& device) {
+  const std::string prefix = name + "{dev=\"" + device + "\"} ";
+  const auto pos = text.find(prefix);
+  if (pos == std::string::npos) return -1;
+  try {
+    return std::stol(text.substr(pos + prefix.size()));
+  } catch (...) {
+    return -1;
+  }
+}
+// Rail-policy configuration is process-global. Keep every two-HCA test on one
+// suite-safe value: 32 concurrent callers may each reserve the depth-four
+// maximum, even if locality initially selects the same rail for all of them.
+constexpr char kRealHcaRailCredits[] = "128";
+
+std::vector<std::string> ConfiguredTwoTestRails() {
+  const char* configured = std::getenv("DFKV_RDMA_DEV");
+  if (!configured || !*configured) return {};
+  std::vector<std::string> rails;
+  std::string value(configured);
+  for (size_t start = 0; start <= value.size();) {
+    const size_t comma = value.find(',', start);
+    const size_t end = comma == std::string::npos ? value.size() : comma;
+    std::string rail = value.substr(start, end - start);
+    rail.erase(std::remove_if(rail.begin(), rail.end(),
+                              [](unsigned char c) { return std::isspace(c); }),
+               rail.end());
+    if (!rail.empty()) rails.push_back(std::move(rail));
+    if (comma == std::string::npos) break;
+    start = comma + 1;
+  }
+  return rails.size() == 2 ? rails : std::vector<std::string>{};
+}
+bool HaveConfiguredActiveRails(const std::vector<std::string>& rails) {
+  if (rails.size() != 2 || rails[0] == rails[1]) return false;
+  const auto discovered = rdma::RdmaTopology::Discover(
+      rails, rdma::RdmaDiscoveryPolicy::kActiveOnly);
+  return discovered.status == rdma::RdmaDiscoveryStatus::kOk &&
+         discovered.devices.size() == rails.size();
+}
+
+void ExpectReleasedRailResources(const std::string& before,
+                                 const std::string& after,
+                                 const std::vector<std::string>& rails) {
+  for (const auto& rail : rails) {
+    EXPECT_EQ(DeviceCounterVal(after, "dfkv_rdma_client_rail_inflight", rail),
+              0)
+        << rail;
+    EXPECT_EQ(
+        DeviceCounterVal(after, "dfkv_rdma_client_rail_credits_available",
+                         rail),
+        DeviceCounterVal(before, "dfkv_rdma_client_rail_credits_available",
+                         rail))
+        << rail;
+  }
+  EXPECT_EQ(CounterVal(after, "dfkv_rdma_client_transient_user_mr_active"),
+            CounterVal(before,
+                       "dfkv_rdma_client_transient_user_mr_active"));
+}
+void ExpectTwoDistinctRailAttempts(
+    const std::string& before, const std::string& after,
+    const std::vector<std::string>& rails, long expected_local_failures) {
+  ASSERT_EQ(rails.size(), 2u);
+  long selections = 0;
+  long errors = 0;
+  long endpoint_errors = 0;
+  for (const auto& rail : rails) {
+    const long selected =
+        DeviceCounterVal(after, "dfkv_rdma_client_rail_selections_total",
+                         rail) -
+        DeviceCounterVal(before, "dfkv_rdma_client_rail_selections_total",
+                         rail);
+    EXPECT_EQ(selected, 1) << rail;
+    selections += selected;
+    errors += DeviceCounterVal(after, "dfkv_rdma_client_rail_errors_total",
+                               rail) -
+              DeviceCounterVal(before, "dfkv_rdma_client_rail_errors_total",
+                               rail);
+    endpoint_errors +=
+        DeviceCounterVal(after, "dfkv_rdma_client_endpoint_errors_total",
+                         rail) -
+        DeviceCounterVal(before, "dfkv_rdma_client_endpoint_errors_total",
+                         rail);
+  }
+  EXPECT_EQ(selections, 2);
+  EXPECT_EQ(errors, expected_local_failures);
+  EXPECT_EQ(endpoint_errors, 0);
 }
 
 struct FakePoolRail {
@@ -357,6 +475,194 @@ TEST(RdmaServerStartup, ExplicitResolutionFailureNeverShrinksTopology) {
   EXPECT_EQ(RdmaServerTestPeer::AnchorCount(server), 0u);
   EXPECT_EQ(RdmaServerTestPeer::RailStatsCount(server), 0u);
   EXPECT_EQ(RdmaServerTestPeer::RegisteredRailCount(server), 0u);
+}
+
+TEST(RdmaSafety, LocalRailFailureQuarantinesButPeerFailureDoesNot) {
+  rdma::RailPolicyConfig config;
+  config.credits_per_rail = 2;
+  config.error_threshold = 1;
+  config.quarantine_us = 1000;
+  config.latency_weight = 1;
+  config.error_penalty_us = 100;
+  rdma::RailPolicy policy(2, config);
+
+  auto local = policy.TryAcquire(2, 100);
+  ASSERT_TRUE(local);
+  ASSERT_EQ(local->rail, 0u);
+  policy.Complete(*local, 10, rdma::RailCompletion::kRailFailure, 200);
+  auto stats = policy.Snapshot(200);
+  ASSERT_EQ(stats.size(), 2u);
+  EXPECT_EQ(stats[0].errors, 1u);
+  EXPECT_EQ(stats[0].endpoint_errors, 0u);
+  EXPECT_EQ(stats[0].consecutive_errors, 1u);
+  EXPECT_EQ(stats[0].quarantines, 1u);
+  EXPECT_TRUE(stats[0].quarantined);
+  EXPECT_EQ(stats[0].inflight, 0u);
+  EXPECT_EQ(stats[0].credits, 2u);
+
+  auto endpoint = policy.TryAcquire(2, 200);
+  ASSERT_TRUE(endpoint);
+  ASSERT_EQ(endpoint->rail, 1u);
+  policy.Complete(*endpoint, 10, rdma::RailCompletion::kEndpointFailure, 210);
+  stats = policy.Snapshot(210);
+  EXPECT_EQ(stats[1].errors, 0u);
+  EXPECT_EQ(stats[1].endpoint_errors, 1u);
+  EXPECT_EQ(stats[1].consecutive_errors, 0u);
+  EXPECT_EQ(stats[1].quarantines, 0u);
+  EXPECT_FALSE(stats[1].quarantined);
+  EXPECT_EQ(stats[1].inflight, 0u);
+  EXPECT_EQ(stats[1].credits, 2u);
+}
+
+TEST(RdmaSafety, OperationExclusionAppliesToPreferredAndFallbackRails) {
+  rdma::RailPolicy policy(
+      3, rdma::RailPolicyConfig{/*credits_per_rail=*/2,
+                                /*error_threshold=*/3,
+                                /*quarantine_us=*/1000,
+                                /*latency_weight=*/1,
+                                /*error_penalty_us=*/100});
+  const std::vector<uint8_t> preferred{1, 1, 0};
+  const std::vector<uint8_t> fallback{0, 0, 1};
+
+  auto preferred_retry = rdma::AcquireWithFallback(
+      policy, 1, 0, preferred, fallback, /*excluded=*/{1, 0, 0});
+  ASSERT_TRUE(preferred_retry);
+  EXPECT_EQ(preferred_retry->rail, 1u);
+  policy.Complete(*preferred_retry, 1, rdma::RailCompletion::kSuccess, 100);
+
+  auto fallback_retry = rdma::AcquireWithFallback(
+      policy, 1, 0, preferred, fallback, /*excluded=*/{1, 1, 0});
+  ASSERT_TRUE(fallback_retry);
+  EXPECT_EQ(fallback_retry->rail, 2u);
+  policy.Complete(*fallback_retry, 1, rdma::RailCompletion::kSuccess, 101);
+
+  EXPECT_TRUE(rdma::HasUnexcludedRail(preferred, fallback, {1, 1, 0}));
+  EXPECT_FALSE(rdma::HasUnexcludedRail({1}, {}, {1}));
+  EXPECT_FALSE(
+      rdma::AcquireWithFallback(policy, 1, 0, {1, 0, 0}, {}, {1, 0, 0}))
+      << "admission must not silently bypass an operation-local exclusion";
+}
+TEST(RdmaSafety, QuarantinedRailAllowsOneProbeAndRecoversOnlyOnSuccess) {
+
+  rdma::RailPolicyConfig config;
+  config.credits_per_rail = 64;
+  config.error_threshold = 1;
+  config.quarantine_us = 1000;
+  config.latency_weight = 1;
+  config.error_penalty_us = 100;
+  rdma::RailPolicy policy(2, config);
+
+  auto failed = policy.TryAcquire(1, 100);
+  ASSERT_TRUE(failed);
+  ASSERT_EQ(failed->rail, 0u);
+  policy.Complete(*failed, 10, rdma::RailCompletion::kRailFailure, 200);
+  auto before_cooldown = policy.TryAcquire(1, 1199);
+  ASSERT_TRUE(before_cooldown);
+  EXPECT_EQ(before_cooldown->rail, 1u);
+  policy.Complete(*before_cooldown, 10, rdma::RailCompletion::kSuccess, 1199);
+
+  constexpr size_t kCallers = 32;
+  std::mutex gate_mu;
+  std::condition_variable ready_cv;
+  std::condition_variable start_cv;
+  std::condition_variable completed_cv;
+  size_t ready = 0;
+  size_t completed = 0;
+  bool start = false;
+  std::vector<std::optional<rdma::RailLease>> leases(kCallers);
+  std::vector<std::thread> callers;
+  callers.reserve(kCallers);
+  for (size_t i = 0; i < kCallers; ++i) {
+    callers.emplace_back([&, i] {
+      std::unique_lock<std::mutex> lock(gate_mu);
+      ++ready;
+      ready_cv.notify_one();
+      start_cv.wait(lock, [&] { return start; });
+      lock.unlock();
+      leases[i] = policy.TryAcquire(1, 1200);
+      lock.lock();
+      ++completed;
+      completed_cv.notify_one();
+    });
+  }
+  bool all_ready = false;
+  {
+    std::unique_lock<std::mutex> lock(gate_mu);
+    all_ready = ready_cv.wait_for(lock, std::chrono::seconds(2),
+                                  [&] { return ready == kCallers; });
+    start = true;
+  }
+  start_cv.notify_all();
+  EXPECT_TRUE(all_ready) << "callers did not reach the start barrier";
+  {
+    std::unique_lock<std::mutex> lock(gate_mu);
+    EXPECT_TRUE(completed_cv.wait_for(lock, std::chrono::seconds(2),
+                                      [&] { return completed == kCallers; }))
+        << "rail-policy callers deadlocked";
+  }
+  for (auto& caller : callers) caller.join();
+
+  size_t probe_index = kCallers;
+  size_t rail0_leases = 0;
+  for (size_t i = 0; i < leases.size(); ++i) {
+    ASSERT_TRUE(leases[i]) << i;
+    if (leases[i]->rail == 0) {
+      ++rail0_leases;
+      probe_index = i;
+    } else {
+      EXPECT_EQ(leases[i]->rail, 1u);
+    }
+  }
+  ASSERT_EQ(rail0_leases, 1u);
+  auto stats = policy.Snapshot(1200);
+  EXPECT_TRUE(stats[0].quarantined);
+  EXPECT_TRUE(stats[0].recovery_probe);
+  EXPECT_EQ(stats[0].recoveries, 0u);
+
+  for (size_t i = 0; i < leases.size(); ++i) {
+    if (i == probe_index) continue;
+    policy.Complete(*leases[i], 10, rdma::RailCompletion::kSuccess, 1201);
+  }
+  policy.Complete(*leases[probe_index], 10,
+                  rdma::RailCompletion::kEndpointFailure, 1201);
+  stats = policy.Snapshot(1201);
+  EXPECT_TRUE(stats[0].quarantined);
+  EXPECT_FALSE(stats[0].recovery_probe);
+  EXPECT_EQ(stats[0].recoveries, 0u);
+  EXPECT_EQ(stats[0].endpoint_errors, 1u);
+
+  auto failed_probe = policy.TryAcquire(1, 1202);
+  ASSERT_TRUE(failed_probe);
+  ASSERT_EQ(failed_probe->rail, 0u);
+  policy.Complete(*failed_probe, 10, rdma::RailCompletion::kRailFailure, 1202);
+  stats = policy.Snapshot(1202);
+  EXPECT_EQ(stats[0].quarantines, 2u);
+  EXPECT_TRUE(stats[0].quarantined);
+  EXPECT_FALSE(stats[0].recovery_probe);
+
+  auto other_success = policy.TryAcquire(1, 2201);
+  ASSERT_TRUE(other_success);
+  ASSERT_EQ(other_success->rail, 1u);
+  policy.Complete(*other_success, 10, rdma::RailCompletion::kSuccess, 2201);
+  stats = policy.Snapshot(2201);
+  EXPECT_EQ(stats[0].recoveries, 0u)
+      << "success on another rail must not recover the quarantined rail";
+
+  auto successful_probe = policy.TryAcquire(1, 2202);
+  ASSERT_TRUE(successful_probe);
+  ASSERT_EQ(successful_probe->rail, 0u);
+  policy.Complete(*successful_probe, 10, rdma::RailCompletion::kSuccess, 2203);
+  stats = policy.Snapshot(2203);
+  EXPECT_EQ(stats[0].recoveries, 1u);
+  EXPECT_EQ(stats[0].consecutive_errors, 0u);
+  EXPECT_FALSE(stats[0].quarantined);
+  EXPECT_FALSE(stats[0].recovery_probe);
+
+  auto admitted_after_recovery = policy.TryAcquire(1, 2204);
+  ASSERT_TRUE(admitted_after_recovery);
+  EXPECT_EQ(admitted_after_recovery->rail, 0u);
+  policy.Complete(*admitted_after_recovery, 10,
+                  rdma::RailCompletion::kSuccess, 2205);
 }
 
 TEST(RdmaSafety, CompletionDeadlineUsesOneAbsoluteBudget) {
@@ -2202,4 +2508,509 @@ TEST(RdmaLoopback, DefaultDeclarationKeepsGlobalCap) {
   std::string got(v.size(), '\0');
   ASSERT_TRUE(c.Get("full-size", got.data(), got.size()));
   EXPECT_EQ(got, v);
+}
+
+TEST(RdmaLoopback, ClientLocalRailFailureRetriesFreshPutAndGet) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv local_failure_fault(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+  RdmaNode node("cross-rail-scalar");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  const std::string value(64 * 1024, 'p');
+
+  std::string before = transport.MetricsText();
+  const long stale_before =
+      CounterVal(before, "dfkv_rdma_client_stale_pool_retries_total");
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", "1");
+    ASSERT_TRUE(client.Put("fresh-put", value.data(), value.size()));
+  }
+  std::string after = transport.MetricsText();
+  ExpectTwoDistinctRailAttempts(before, after, rails, 1);
+  ExpectReleasedRailResources(before, after, rails);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_endpoint_cache_hits_total") -
+          CounterVal(before, "dfkv_rdma_endpoint_cache_hits_total"),
+      0)
+      << "the first local failure must be exercised on a fresh endpoint";
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_endpoint_cache_misses_total") -
+          CounterVal(before, "dfkv_rdma_endpoint_cache_misses_total"),
+      2);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_exhausted_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+      0);
+  EXPECT_EQ(CounterVal(after,
+                       "dfkv_rdma_client_stale_pool_retries_total"),
+            stale_before);
+
+  // Attempt 2 of the PUT left a healthy idle QP on its rail. Admission chooses
+  // a rail from current NUMA locality and health before consulting that rail's
+  // pool, so the GET may start either pooled or fresh. Its injected local
+  // failure must still retire that endpoint and retry on the other local rail.
+  before = after;
+  const long get_stale_before =
+      CounterVal(before, "dfkv_rdma_client_stale_pool_retries_total");
+  std::string output(value.size(), '\0');
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1");
+    ASSERT_TRUE(client.Get("fresh-put", output.data(), output.size()));
+  }
+  EXPECT_EQ(output, value);
+  after = transport.MetricsText();
+  ExpectTwoDistinctRailAttempts(before, after, rails, 1);
+  ExpectReleasedRailResources(before, after, rails);
+  const long get_endpoint_misses =
+      CounterVal(after, "dfkv_rdma_endpoint_cache_misses_total") -
+      CounterVal(before, "dfkv_rdma_endpoint_cache_misses_total");
+  EXPECT_GE(get_endpoint_misses, 1);
+  EXPECT_LE(get_endpoint_misses, 2)
+      << "two rail attempts may require at most one fresh endpoint per rail";
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      1);
+  EXPECT_EQ(CounterVal(after,
+                       "dfkv_rdma_client_stale_pool_retries_total"),
+            get_stale_before)
+      << "a local-rail failure is not a stale-endpoint retry";
+}
+
+TEST(RdmaLoopback, SingleEnabledRailFallbackIsNotCrossRailRetry) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv local_failure_fault(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+  RdmaNode node("same-rail-fallback");
+  RdmaTransport transport(kMaxMsg, rails[0]);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  const std::string value(64 * 1024, 's');
+
+  const std::string before = transport.MetricsText();
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", "1");
+    ASSERT_TRUE(client.Put("same-rail", value.data(), value.size()));
+  }
+  const std::string after = transport.MetricsText();
+  EXPECT_EQ(
+      DeviceCounterVal(after, "dfkv_rdma_client_rail_selections_total",
+                       rails[0]) -
+          DeviceCounterVal(before,
+                           "dfkv_rdma_client_rail_selections_total",
+                           rails[0]),
+      2);
+  EXPECT_EQ(DeviceCounterVal(after, "dfkv_rdma_client_rail_errors_total",
+                             rails[0]) -
+                DeviceCounterVal(before,
+                                 "dfkv_rdma_client_rail_errors_total",
+                                 rails[0]),
+            1);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
+      0);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      0);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_exhausted_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+      0);
+  ExpectReleasedRailResources(before, after, {rails[0]});
+}
+
+TEST(RdmaLoopback,
+     ClientCompletionFailurePreservesCompletedMultiWindowSgItems) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv local_failure_fault(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+  // PUT uses the pre-post local-failure seam, so its retry may safely replay
+  // every item. GET advances both items in rounds: item 0 completes in round 2
+  // and completion window 3 faults only the still-incomplete item.
+  RdmaNode node("cross-rail-sg");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+
+  constexpr size_t kItems = 2;
+  constexpr size_t kSegmentBytes = 31;
+  const size_t max_sg = transport.MaxSgPayloadSegs();
+  ASSERT_GE(max_sg, 2u);
+  std::vector<std::vector<std::string>> segments(kItems);
+  segments[0].resize(max_sg + 1);
+  segments[1].resize(3 * max_sg + 1);
+  std::vector<std::string> expected(kItems);
+  std::vector<KvPutItemSg> puts;
+  puts.reserve(kItems);
+  std::vector<BlockKey> block_keys;
+  block_keys.reserve(kItems);
+  for (size_t i = 0; i < kItems; ++i) {
+    std::vector<const void*> pointers;
+    std::vector<size_t> sizes;
+    for (size_t segment = 0; segment < segments[i].size(); ++segment) {
+      // BatchGetAutoSg groups by total capacity. Make both totals equal so the
+      // two- and four-window items share one RangeIntoMulti logical call;
+      // segment count, rather than byte count, still determines the windows.
+      const size_t segment_bytes =
+          i == 0 && segment == 0
+              ? (2 * max_sg + 1) * kSegmentBytes
+              : kSegmentBytes;
+      segments[i][segment] =
+          std::string(segment_bytes,
+                      static_cast<char>('A' + i * 13 + segment % 13));
+      expected[i] += segments[i][segment];
+      pointers.push_back(segments[i][segment].data());
+      sizes.push_back(segments[i][segment].size());
+    }
+    const std::string key = "sg-" + std::to_string(i);
+    puts.push_back({key, std::move(pointers), std::move(sizes)});
+    block_keys.push_back(ToBlockKey(SelfHdr(), key));
+  }
+
+  std::string before = transport.MetricsText();
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", "1");
+    EXPECT_EQ(client.BatchPutSg(puts), std::vector<bool>(kItems, true));
+  }
+  std::string after = transport.MetricsText();
+  ExpectTwoDistinctRailAttempts(before, after, rails, 1);
+  ExpectReleasedRailResources(before, after, rails);
+  EXPECT_EQ(node.CacheDirectCalls(block_keys[0]), 1u)
+      << "pre-post failure must not duplicate the first PUT item";
+  EXPECT_EQ(node.CacheDirectCalls(block_keys[1]), 1u)
+      << "pre-post failure must not duplicate the second PUT item";
+
+  std::vector<std::vector<std::string>> output(kItems);
+  std::vector<KvGetItemSg> gets;
+  gets.reserve(kItems);
+  std::vector<size_t> expected_lengths;
+  expected_lengths.reserve(kItems);
+  for (size_t i = 0; i < kItems; ++i) {
+    std::vector<void*> pointers;
+    std::vector<size_t> capacities;
+    size_t total = 0;
+    output[i].resize(segments[i].size());
+    for (size_t segment = 0; segment < segments[i].size(); ++segment) {
+      output[i][segment].assign(segments[i][segment].size(), '\0');
+      pointers.push_back(output[i][segment].data());
+      capacities.push_back(output[i][segment].size());
+      total += output[i][segment].size();
+    }
+    gets.push_back(
+        {puts[i].key, std::move(pointers), std::move(capacities)});
+    expected_lengths.push_back(total);
+  }
+  ASSERT_EQ(expected_lengths[0], expected_lengths[1])
+      << "SG retry items must remain in one transport group";
+
+  before = after;
+  std::vector<size_t> lengths;
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:3");
+    EXPECT_EQ(client.BatchGetAutoSg(gets, &lengths),
+              std::vector<bool>(kItems, true));
+  }
+  EXPECT_EQ(lengths, expected_lengths);
+  after = transport.MetricsText();
+  ExpectTwoDistinctRailAttempts(before, after, rails, 1);
+  ExpectReleasedRailResources(before, after, rails);
+  EXPECT_EQ(node.RangeDirectCalls(block_keys[0]), 1u)
+      << "the completed GET item must not restart on the fresh rail";
+  EXPECT_EQ(node.RangeDirectCalls(block_keys[1]), 2u)
+      << "only the incomplete GET item must restart from window zero";
+  for (size_t i = 0; i < kItems; ++i) {
+    std::string actual;
+    for (const auto& segment : output[i]) actual += segment;
+    EXPECT_EQ(actual, expected[i]) << i;
+  }
+  EXPECT_EQ(CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total"),
+            2);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      2);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+      0);
+  EXPECT_EQ(CounterVal(after,
+                       "dfkv_rdma_client_stale_pool_retries_total"),
+            0);
+}
+
+TEST(RdmaLoopback, ConcurrentOperationsRemainIsolatedAcrossLocalRailRetry) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv local_failure_fault(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+  ScopedEnv ambient_completion_fault("DFKV_RDMA_TEST_COMPLETION_FAULT",
+                                     nullptr);
+  RdmaNode node("cross-rail-concurrent");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  KVClient client({{"n", node.addr}}, "test/cross-rail-concurrent",
+                  &transport);
+
+  constexpr size_t kCallers = 32;
+  constexpr auto kConcurrencyDeadline = std::chrono::seconds(30);
+  constexpr size_t kValueBytes = 64 * 1024;
+  std::vector<std::string> values(kCallers);
+  for (size_t i = 0; i < kCallers; ++i) {
+    values[i].resize(kValueBytes);
+    for (size_t byte = 0; byte < kValueBytes; ++byte)
+      values[i][byte] =
+          static_cast<char>((i * 31 + byte * 17) & 0xff);
+  }
+  std::vector<std::string> outputs(
+      kCallers, std::string(kValueBytes, '\0'));
+  for (size_t i = 0; i < kCallers; ++i) {
+    ASSERT_TRUE(client.Put("concurrent-" + std::to_string(i),
+                           values[i].data(), values[i].size()))
+        << i;
+  }
+  std::vector<char> get_ok(kCallers, 0);
+  std::mutex gate_mu;
+  std::condition_variable ready_cv;
+  std::condition_variable start_cv;
+  std::condition_variable completed_cv;
+  size_t ready = 0;
+  size_t completed = 0;
+  bool start = false;
+  const auto deadline =
+      std::chrono::steady_clock::now() + kConcurrencyDeadline;
+  std::vector<std::thread> callers;
+  callers.reserve(kCallers);
+  const std::string before = transport.MetricsText();
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1");
+    for (size_t i = 0; i < kCallers; ++i) {
+      callers.emplace_back([&, i] {
+        std::unique_lock<std::mutex> lock(gate_mu);
+        ++ready;
+        ready_cv.notify_one();
+        if (!start_cv.wait_until(lock, deadline, [&] { return start; })) {
+          ++completed;
+          completed_cv.notify_one();
+          return;
+        }
+        lock.unlock();
+        get_ok[i] =
+            client.Get("concurrent-" + std::to_string(i), outputs[i].data(),
+                       outputs[i].size())
+                ? 1
+                : 0;
+        lock.lock();
+        ++completed;
+        completed_cv.notify_one();
+      });
+    }
+    bool all_ready = false;
+    {
+      std::unique_lock<std::mutex> lock(gate_mu);
+      all_ready =
+          ready_cv.wait_until(lock, deadline, [&] { return ready == kCallers; });
+      start = true;
+    }
+    start_cv.notify_all();
+    EXPECT_TRUE(all_ready) << "callers did not reach the start barrier";
+    {
+      std::unique_lock<std::mutex> lock(gate_mu);
+      EXPECT_TRUE(completed_cv.wait_until(
+          lock, deadline, [&] { return completed == kCallers; }))
+          << "concurrent RDMA calls deadlocked";
+    }
+    for (auto& caller : callers) caller.join();
+  }
+  EXPECT_EQ(get_ok, std::vector<char>(kCallers, 1));
+
+  const std::string after = transport.MetricsText();
+  long selection_delta = 0;
+  long error_delta = 0;
+  for (const auto& rail : rails) {
+    selection_delta +=
+        DeviceCounterVal(after, "dfkv_rdma_client_rail_selections_total",
+                         rail) -
+        DeviceCounterVal(before, "dfkv_rdma_client_rail_selections_total",
+                         rail);
+    error_delta +=
+        DeviceCounterVal(after, "dfkv_rdma_client_rail_errors_total", rail) -
+        DeviceCounterVal(before, "dfkv_rdma_client_rail_errors_total", rail);
+  }
+  EXPECT_EQ(selection_delta, static_cast<long>(kCallers + 1))
+      << "exactly one logical call must have two rail attempts";
+  EXPECT_EQ(error_delta, 1);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_exhausted_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+      0);
+  ExpectReleasedRailResources(before, after, rails);
+
+  for (size_t i = 0; i < kCallers; ++i)
+    EXPECT_EQ(outputs[i], values[i]) << i;
+  ExpectReleasedRailResources(after, transport.MetricsText(), rails);
+}
+
+TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv local_failure_fault(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+  ScopedEnv ambient_completion_fault("DFKV_RDMA_TEST_COMPLETION_FAULT",
+                                     nullptr);
+  RdmaNode node("cross-rail-exhausted");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  const std::string key_namespace = "test/cross-rail-exhausted";
+  KVClient client({{"n", node.addr}}, key_namespace, &transport);
+  const std::string value(64 * 1024, 'x');
+
+  std::string before = transport.MetricsText();
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", "1,2");
+    EXPECT_FALSE(client.Put("failed-put", value.data(), value.size()));
+  }
+  std::string after = transport.MetricsText();
+  ExpectTwoDistinctRailAttempts(before, after, rails, 2);
+  ExpectReleasedRailResources(before, after, rails);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      0);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_exhausted_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+      1);
+  std::vector<char> exists;
+  // Both PUT failures are injected before posting, so retry exhaustion cannot
+  // leave an ambiguous server-side commit.
+  EXPECT_EQ(transport.ExistMany(
+                node.addr, {ToBlockKey(key_namespace, "failed-put")}, &exists),
+            std::vector<Status>({Status::kNotFound}));
+  EXPECT_EQ(exists, std::vector<char>({0}));
+
+  // Seed a readable value with both fault seams disabled, then fail both local
+  // attempts of a fresh public GET. Neither failed attempt may mutate its
+  // caller destination.
+  KVClient writer({{"n", node.addr}}, key_namespace, &transport);
+  ASSERT_TRUE(writer.Put("failed-get", value.data(), value.size()));
+  KVClient reader({{"n", node.addr}}, key_namespace, &transport);
+  std::string output(value.size(), static_cast<char>(0x5a));
+  before = transport.MetricsText();
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT",
+                    "1:1:1,1:2:1");
+    EXPECT_FALSE(reader.Get("failed-get", output.data(), output.size()));
+  }
+  after = transport.MetricsText();
+  ExpectTwoDistinctRailAttempts(before, after, rails, 2);
+  ExpectReleasedRailResources(before, after, rails);
+  EXPECT_EQ(output,
+            std::string(value.size(), static_cast<char>(0x5a)));
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      0);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_exhausted_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+      1);
+  EXPECT_EQ(CounterVal(after,
+                       "dfkv_rdma_client_stale_pool_retries_total"),
+            CounterVal(before,
+                       "dfkv_rdma_client_stale_pool_retries_total"));
+
+  // Drive another synchronous control completion before checking the sentinel
+  // again; failed QP teardown must fence every old DMA before retry/return.
+  EXPECT_EQ(transport.ExistMany(
+                node.addr, {ToBlockKey(key_namespace, "failed-get")}, &exists),
+            std::vector<Status>({Status::kOk}));
+  EXPECT_EQ(output,
+            std::string(value.size(), static_cast<char>(0x5a)));
 }


### PR DESCRIPTION
## Summary
- quarantine client-local RDMA rails after classified local failures and retry read operations once on a distinct healthy rail
- stage GET output per attempt so failed DMA never mutates caller buffers; do not replay ambiguous PUT completions
- add per-rail and cross-rail metrics, docs, deterministic concurrency/SG/exhaustion coverage

## Verification
- local: 717/717 CTest pass
- xb01-gpu-200b-0064: 5/5 real two-HCA RDMA recovery tests pass on ib7s400p0+ib7s400p1
- client metric tests: 4/4 pass
- production rollout unchanged