### PR TITLE
feat(rdma): add heterogeneous peer-aware rail selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,39 +49,38 @@ TCP/RDMA → `dfkv_server` → optional RAM hot tier → DiskCacheGroup over N N
 Distributed = client-side consistent hashing; no replication (regenerable KV →
 node loss = miss → recompute). Full architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-**Membership** is managed by the MDS tier (`dfkv_mds` + etcd). Nodes register
-with the MDS on startup and send periodic heartbeats; etcd leases (TTL 30 s)
-are the liveness signal. Native clients use the single immutable
-`dfkv_client_options_v2` constructor: set either static `members` or
-`mds_endpoints` + `mds_group`. MDS mode polls the directory and rebuilds the
-weighted consistent-hash ring whenever its epoch advances. Two-layer offline
-detection: **layer-2** — etcd lease expiry → MDS view changes → client epoch →
-ring rebuild (authoritative removal after the 30 s lease TTL plus etcd, MDS RPC,
-and client-polling delay; this is not a 30 s upper bound); **layer-1** —
-`PeerHealth` fast avoidance short-circuits transport failures to misses during
-a cooldown. There is no post-open membership mutation API in v2. For rings still running v1.x
+**Membership and peer topology** are managed by the MDS tier (`dfkv_mds` +
+etcd). Nodes register and heartbeat; etcd leases (TTL 30 s) are the liveness
+signal. Native clients use the immutable `dfkv_client_options_v2` constructor:
+set either static `members` or `mds_endpoints` + `mds_group`. Modern discovery
+uses `kListTopology`. Its existing optional `HLT1` membership extension carries
+each member's placement eligibility plus repeated
+`{device name, port_state, phys_state, query_ok}` rail health; no second rail
+protocol is used. Clients independently deduplicate placement changes with
+`MembersEpoch` and peer-topology changes with `MembersTopologyEpoch`. The latter
+is canonical over stable member-id/device-name order and includes the member's
+address/placement binding, eligibility, and all rail health fields, so a rail
+transition is forwarded to the transport even when the Ketama ring is
+unchanged. Two-layer offline detection remains: etcd lease expiry updates the
+placement view, while `PeerHealth` quickly avoids endpoint IO failures. There
+is no post-open membership mutation API in v2. For rings still running v1.x
 nodes/clients, `DFKV_MDS_ACCEPT_LEGACY=1` enables a dual-protocol shim on the
-MDS control plane (ring-level isolation still applies) — see
-`docs/DEPLOY.md` §2b.
+MDS control plane (ring-level isolation still applies) — see `docs/DEPLOY.md`
+§2b.
 
-**RDMA server rail admission** is deliberately asymmetric. With no device
-list, automatic discovery remains `ACTIVE`-only. An explicit
-`dfkv_server --rdma-dev` list instead defines a fixed topology in configured
-first-occurrence order: a present but `DOWN` rail is still opened, initialized
-(anchor plus every required MR), and monitored. A missing/unopenable device,
-port- or GID-query failure, or any anchor/MR initialization failure aborts startup.
-The daemon may start with an initialized `DOWN` rail, but the whole node stays
-out of the placement ring until **every initialized/resolved rail**, including
-the auto-discovered rail when no list is configured, is `ACTIVE`/`LinkUp` for
-the recovery sample streak. The default is three successful sampling
-opportunities. At the nominal 10 s registrar cadence this usually takes about
-20–30 s depending on phase, plus registrar connection/RPC delays, and can take
-longer while MDS is unreachable; it is not a wall-clock upper bound. The node
-then rejoins without a restart. This fail-closed policy trades the node's entire
-cache capacity while any one resolved rail is unhealthy for immutable,
-index-aligned multi-rail topology. Startup
-cardinalities and current health are described in
-[`docs/DEPLOY.md`](docs/DEPLOY.md) and
+**RDMA server rail admission** separates immutable startup resources from
+runtime eligibility. With no device list, discovery remains `ACTIVE`-only. An
+explicit `dfkv_server --rdma-dev` list defines fixed first-occurrence order: a
+present `DOWN` rail is still opened, initialized (anchor plus every required
+MR), and monitored. Missing/unopenable devices, port/GID-query failure, or any
+anchor/MR initialization failure abort startup; startup never shrinks the
+configured topology. After initialization, the node is placement-eligible when
+**at least one** initialized rail is healthy. Losing one of several rails is
+`PARTIAL` and keeps serving; losing the final healthy rail makes the node
+`DEGRADED` immediately. Recovery from zero to nonzero healthy rails retains the
+`DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` gate (default 3), then rejoins without a
+restart as `PARTIAL` or `ACTIVE`. Startup cardinalities, current health, and
+bounded metrics are described in [`docs/DEPLOY.md`](docs/DEPLOY.md) and
 [`docs/METRICS.md`](docs/METRICS.md).
 
 **Client registration** (who is using dfkv): cache *consumers* (inference
@@ -220,21 +219,18 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
 - **Connection pooling + keep-alive** (TCP_NODELAY): ~250× lower latency vs dial-per-call.
 - **Batch APIs** with concurrent fan-out across nodes and local NVMe disks.
 - **Connect/IO timeouts + stale-connection retry**: a hung node fails fast, never hangs.
-- **Observability** ([docs/METRICS.md](docs/METRICS.md)): opt-in embedded Prometheus
-  `/metrics` on `dfkv_server` and `dfkv_mds` (`--metrics-port`); sampled op-latency
-  histogram, eviction/error/per-disk/RDMA counters server-side; client-side counters
-  (peer health, IO errors, per-rail quarantine/recovery,
-  `dfkv_rdma_client_cross_rail_retries_total`,
-  `dfkv_rdma_client_cross_rail_retry_successes_total`, and
-  `dfkv_rdma_client_cross_rail_retry_exhausted_total`) via
-  `dfkv_stats_snapshot` + a plugin poller. Client RDMA families exist only
-  when the RDMA transport is in use and that snapshot is exported; absence from
-  a TCP-only process is expected. Server `dfkv_server_ring_eligible` and
-  `dfkv_server_ib_device_healthy` families are emitted only by an RDMA-enabled
-  binary running an RDMA listener. Their absence from a TCP-only binary or an
-  RDMA build without a listener must not be coerced to zero by dashboards or
-  alerts. **Opt-in and
-  off the datapath** — no `--metrics-port` ⇒ no metrics listener, behavior unchanged.
+- **Observability** ([docs/METRICS.md](docs/METRICS.md)): opt-in embedded
+  Prometheus endpoints plus client snapshots. New unlabeled client process
+  counters are `dfkv_rdma_client_peer_topology_updates_total`,
+  `dfkv_rdma_client_no_compatible_rail_total`, and
+  `dfkv_rdma_client_stale_generation_reaps_total`; bounded retry counters remain
+  `dfkv_rdma_client_cross_rail_{retries,retry_successes,retry_exhausted}_total`.
+  Server partial health is exposed by `dfkv_server_rdma_rails_configured`,
+  `dfkv_rdma_rails_initialized`, `dfkv_server_rdma_rails_active`,
+  `dfkv_server_ib_device_healthy{device}`, and
+  `dfkv_server_ring_eligible`. RDMA families exist only when the corresponding
+  RDMA listener/transport is active; TCP-only absence is not zero and must not
+  be coerced to unhealthy. No metrics port means no HTTP listener.
   The three connectors (vLLM / LMCache / SGLang HiCache) can also **push** fleet
   metrics (ops/keys/bytes, op latency, per-peer latency) over OTLP to a central
   Collector → Grafana — opt-in via `DFKV_METRICS_ENABLED=1`, **zero-dependency stdlib
@@ -255,15 +251,19 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
   share + each node's **self-reported version/config** — engine, capacity, RAM tier,
   RDMA dev — carried on register/heartbeat, so fleet-wide version/config audit is one
   command, no per-node ssh) and `dfkvctl stat --all` (per-node metrics + aggregate) via MDS.
-- **RDMA transport v2** (gated `-DDFKV_WITH_RDMA=ON`, native libibverbs RC):
-  with no device override each host chooses its first `ACTIVE` local HCA and
-  sends an empty device selector to its peer. An explicit comma whitelist opts
-  into multi-rail round-robin and therefore must name the intended fabric on
-  both hosts. Device names are limited to 18 bytes in the wire dev frame —
-  longer names fail fast instead of silently truncating (7837f0b). QPs bootstrap over a tiny TCP channel, so the data fabric needs no
-  IP. A v2 capability probe is mandatory; protocol, QP, receive-segment, or
-  registration mismatch rejects the connection. Unset `DFKV_RDMA` selects TCP;
-  once RDMA is requested it never switches transports.
+- **Peer-aware heterogeneous RDMA rails** (gated `-DDFKV_WITH_RDMA=ON`,
+  native libibverbs RC): with no device override each host chooses its first
+  `ACTIVE` local HCA. `DFKV_RDMA_DEV` fixes stable local device indices.
+  `DFKV_RDMA_RAIL_TIERS` optionally groups that list as priority tiers using
+  `a|b;c` syntax (leftmost Tier 0, `|` peers within a tier, `;` separates
+  tiers); every name must exist in `DFKV_RDMA_DEV`. When absent, all configured
+  devices form one homogeneous tier. For each endpoint, selection intersects
+  local enabled rails with the peer's HLT1 healthy rails and uses only the
+  highest nonempty tier. A configured-tier client fails closed with
+  `Status::kNoCompatibleRail` when peer topology is missing/incomplete or the
+  intersection is empty. QPs bootstrap over TCP, so the data fabric needs no
+  IP. A v2 capability probe is mandatory; once RDMA is requested it never
+  switches transports.
 - **One-sided zero-copy data plane**: control descriptors/status use small 4-KiB
   SEND/RECV buffers. PUT payloads RDMA-WRITE into leases from one process-wide,
   pre-registered receive segment; GET payloads RDMA-WRITE directly into the
@@ -274,33 +274,33 @@ docs/       ARCHITECTURE.md (layers · storage engines · RAM hot tier · wire p
   depth-flat (the per-connection serve loop is in-order; benchmarked GET ~1.24 GB/s at
   depth 1 == 32). The throughput levers are **multi-connection fan-out**
   (`batch_concurrency`) and **fewer/larger keys**. See `docs/datapath-perf-notes.md`.
-- **NUMA-aware rail selection** (`DFKV_RDMA_NUMA=1`): with an explicit
-  multi-rail whitelist, prefers an `ACTIVE` rail local to the calling thread,
-  then round-robins the listed healthy rails; when every NUMA-local rail is
-  inadmissible, it degrades to the full enabled rail set instead of refusing
-  traffic (5ef39f1). Server threads follow their QP's
-  rail NUMA node; the single shared receive segment is registered on each
-  selected rail but is not separately NUMA-allocated per rail. Off by default;
-  vendor-neutral (sysfs + `sched_getcpu`, no libnuma/CUDA).
-- **Client-local rail recovery**: local device/verbs evidence (`Open`, local QP
-  transition, MR registration/refresh, post/CQ API failure, or a locally
-  classified WC) is `kRailFailure`; peer/bootstrap/protocol failure, remote/RNR/
-  retry/flush WC, silent completion timeout, resource admission, cancellation,
-  and invalid input are not. A first-attempt `kRailFailure` retires the failed
-  endpoint and synchronously tears down its QP/MRs before one fresh retry. The
-  retry excludes that rail from both NUMA-preferred and fallback selection, so
-  it uses a distinct topology-enabled local rail whenever one exists. There are
-  at most two physical attempts. A one-rail topology may instead make the one
-  fresh retry on that same rail, but it never reuses the failed QP or bypasses
-  quarantine, cooldown, credits, or the single recovery-probe gate.
-- **Bounded at-least-once replay**: a rail retry replays the existing whole
-  logical PUT/GET/batch/SG operation after teardown; it does not promise
-  exactly-once PUT execution when a remote commit preceded a lost completion.
-  This is client-only recovery and is separate from server node/ring health
-  (`DFKV_RDMA_HEALTH_FILE` and `dfkv_server_ring_eligible`). It changes neither
-  the RDMA wire protocol nor server behavior, so upgraded clients remain
-  compatible with mixed-version servers that already speak the same RDMA v2
-  protocol.
+- **Tier-bounded NUMA and congestion selection** (`DFKV_RDMA_NUMA=1`):
+  NUMA locality, per-rail credits, latency, quarantine, and recovery select only
+  inside the highest compatible tier. A healthy Tier-0 rail with exhausted
+  credits waits under the existing bounded backpressure contract; congestion
+  never overflows traffic into Tier 1. Lower tiers are considered only when the
+  peer-health intersection makes every higher tier unavailable. Server threads
+  follow their QP rail NUMA node; the shared receive segment is registered on
+  each selected rail but is not separately NUMA-allocated per rail.
+- **Generation-fenced endpoint recovery**: each public operation captures one
+  peer-topology generation for both of its possible physical attempts.
+  Connections record that generation. A stale-generation pool entry is never
+  reused or returned to a pool; it is retired through the existing single-owner
+  teardown lifecycle. A first-attempt client-local `kRailFailure` retires its
+  endpoint before at most one fresh retry, excluding the failed rail when
+  another compatible rail is available. The operation never widens beyond two
+  physical attempts.
+- **Replay contract**: replay-safe GET/batch/SG paths retain byte-exact completed
+  items/windows and retry only unfinished work. A PUT may cross rails only when
+  failure is known to precede request submission. Once a PUT may have been
+  submitted, its outcome is ambiguous and it is returned without cross-rail
+  replay; dfkv does not promise exactly-once execution or broaden the existing
+  ambiguous-write policy. `kNoCompatibleRail` is client-local and peer-health
+  neutral: it neither cools the peer nor counts as a served peer response.
+  A current MDS can expose a legacy member's absent HLT1; configured tiers then
+  fail closed, while no-tier clients retain homogeneous behavior. A legacy MDS
+  does not understand `kListTopology`: modern polls fail and preserve the
+  last-good ring, so rollout is MDS-first rather than silent fallback.
 - **SGLang HiCache pool-aware v2 interface** (`batch_set_v2`/`batch_get_v2` +
   PoolTransfer) for multi-pool models (Mamba/SWA/DeepSeek-V4).
 - **Packaging**: CPack (deb/rpm/tgz) + Dockerfile; **graceful shutdown**; leveled logging.
@@ -321,7 +321,7 @@ fabric selection and capacity explicit.
 | `DFKV_DISK_HASH_WEIGHT` | `10` | Flattens the intra-server disk ring share from ±20 % to ±3 % so the hottest disk stops gating the whole node (+5–6 % cold read, ~2× lower p99). **Re-routes existing keys** (cache miss + refill) — flip together with a restart/upgrade window. |
 | `--rdma-depth` | `4` (default) | Handshake window is `min(client, server)`. Single-connection PUT/GET bandwidth is depth-flat once connected, but production connector batches require both sides to expose the same bounded window; a 1-vs-4 mismatch caused burst PUT failures and a 29.8% hot-round regression on GLM-5.2. Depth 4 with the default 4 MiB declaration leases about 16 MiB per data QP, so a 16 GiB receive segment admits about 1024 QPs. Increase only for a measured latency-bound path and budget `depth × slot_size` per pooled QP. |
 | `DFKV_RDMA_IDLE_MS` | `30000` for frequently replaced clients; otherwise default `600000` | Server dead-client reaper. A short interval bounds leaked receive-segment leases, but live clients must set `DFKV_RDMA_KEEPALIVE_MS` below this value or their next GET pays stale-QP recovery. |
-| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | With an RDMA listener, the server gates placement on every initialized/resolved IB rail, including the auto-discovered rail. Any query failure or non-ACTIVE/LinkUp rail removes the node immediately; three successful sampling opportunities re-admit it. At the nominal 10 s registrar cadence this is usually about 20–30 s depending on phase, plus registrar connection/RPC delays, and can be longer while MDS is unreachable; it is not an upper bound. |
+| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | Any healthy initialized rail keeps placement eligible; a partial loss stays online. Loss of the final healthy rail removes the node immediately. Only recovery from zero to nonzero waits the consecutive sample gate, then rejoins as `PARTIAL` or `ACTIVE`. |
 | `DFKV_RDMA_HEALTH_FILE` | unset | Diagnostic-only health input (`device port_state phys_state`, one per initialized/resolved rail, including an auto-discovered rail) for controlled fault injection. Production MUST leave this unset so health comes from sysfs. |
 | `--ram-tier` / `--ram-tier-bytes` / `--ram-tier-shards` | on / sized to the node / `16` for ≥100 GiB arenas | Large arenas contend on the shard locks under mixed load (+40 % mixed R/W at 16 shards on a 128 GiB arena); small (≤16 GiB) arenas are fine at the default 8. |
 | `--store-engine` | `slab` | Index rebuilds on restart; removes file-per-block hazards. |
@@ -332,11 +332,12 @@ fabric selection and capacity explicit.
 
 | Knob | Recommended | Why |
 |---|---|---|
-| `DFKV_RDMA_DEV` | leave unset for one local HCA; use the same fabric whitelist on both hosts for multi-rail | Unset lets each endpoint select its own first `ACTIVE` local HCA, so local names may differ. A comma list explicitly enables multi-rail and is sent to the peer; every listed name must exist and be on the intended interoperable fabric at both ends. |
+| `DFKV_RDMA_DEV` | leave unset for one local HCA; set each host's actual stable local whitelist for multi-rail | The local list may differ in cardinality on GPU and CPU hosts. Peer-aware selection uses exact shared names from HLT1; configured tiers require an explicit list. |
+| `DFKV_RDMA_RAIL_TIERS` | unset for homogeneous hosts; e.g. `mlx5_0|mlx5_1;mlx5_2` for heterogeneous hosts | Every name must be present in `DFKV_RDMA_DEV`; leftmost is highest priority. GPU and CPU hosts may expose different subsets, but interoperating rail names must describe the same fabric. The client uses the highest tier in `local enabled ∩ peer healthy`; missing/incomplete peer HLT1 fails closed only when tiers are configured. Credits, NUMA, latency, and quarantine never cause tier overflow. |
 | `DFKV_RDMA_DEPTH` | `4` (default) | Keep client/server defaults aligned for connector batch correctness. Throughput scaling comes from multiple pooled connections, not raising one QP's depth; lowering depth reduces receive-segment consumption only after validating the real engine workload. |
 | `DFKV_RDMA_RAIL_ERROR_THRESHOLD` | `3` (default) | Consecutive client-local rail failures required to quarantine that rail; endpoint/peer failures do not contribute. |
 | `DFKV_RDMA_RAIL_COOLDOWN_MS` | `5000` (default) | Quarantine duration. No admission occurs during cooldown; afterward exactly one real operation is admitted as the recovery probe. Probe success clears the rail state, local failure starts another cooldown, and endpoint failure proves neither recovery nor a new local fault. |
-| local-rail attempts | fixed at `2` (not configurable) | One initial attempt plus at most one fresh retry after `kRailFailure`; a distinct enabled local rail is mandatory when present. A one-rail topology may retry fresh on the same rail without bypassing quarantine. |
+| local-rail attempts | fixed at `2` (not configurable) | One initial attempt plus at most one fresh retry. GET retries only unfinished work. PUT crosses rails only before request post; ambiguous post-submit failure is returned without replay. Both attempts retain one captured peer generation. |
 | `DFKV_RDMA_KEEPALIVE_MS` | `15000` (default); `0` = off | Sends lightweight membership probes over every idle pooled QP. Live clients keep their QPs and avoid first-GET reconnect tails; exited clients send no probes and remain reclaimable. Keep the interval strictly below the server reap interval. |
 | `DFKV_RDMA_POOL_MAX` | `16` (default) | Maximum idle QPs retained per server and per lane, across all rails. It is not a process-wide connection cap. Raise only when connection-open metrics grow on repeated steady-state rounds; each retained QP leases `depth × align4K(4096 + declared_max_block)` from the server receive segment. |
 | `DFKV_RDMA_ENDPOINT_CACHE_MAX` | autoscaled (floor `256`, process-wide) | Hard cap on live client RDMA endpoints across all `RdmaTransport` instances. Unset, the cap follows the adopted ring: `nodes x (2 x rails + 1) x 1.25`, raised (never shrunk) on every membership adoption, so large rings cannot starve admission into 10 s `kResourceExhausted` timeouts. Setting this env (or any budget env) pins the whole budget and disables autoscaling. Under pressure, the requesting transport applies a SIEVE second-chance scan to its idle data/SG/control endpoints, destroys one cold QP, then retries admission. A hot cache hit sets only one visited bit; no LRU mutation occurs on the datapath. |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -17,8 +17,8 @@ dfkv 把**控制面**与**数据面**解耦：
 
 - **控制面 = TCP + 两边 SEND/RECV**：bootstrap TCP 只交换设备/QP/receive-segment 描述；RDMA QP 的 request descriptor 有界，response buffer 显式预留 `18-byte prefix + 32 KiB`，使 32-KiB `Members` 在 control lane 完整返回；更大响应直接失败、不截断。
 - **payload = one-sided RDMA**：v2 PUT 用 `RDMA_WRITE_WITH_IMM` 直落 server 共享 receive-segment slot，GET 由 server `RDMA_WRITE` 到 client 提交的 `{addr,rkey,len}`。数据 fabric 无需 IP。
-- **设备发现**：留空时自动发现策略保持 `ACTIVE`-only（两端各选本地首个 port 1 `ACTIVE` HCA）；显式逗号白名单定义固定 topology，按配置首次出现顺序去重，且 server 会接纳**存在但启动时 DOWN** 的设备完成 anchor/MR 初始化并持续监控。多 fabric 节点仍须过滤到两端同名且互通的 fabric。
-- **失败策略**：未设 `DFKV_RDMA` 时选择 TCP；一旦选择 RDMA，显式设备缺失、open/port/GID query 失败，或任一 configured rail 的 anchor、共享 receive-segment MR、RAM/user MR 初始化失败，均拒绝启动而不缩小 topology。present DOWN 本身不拒绝启动，但整个节点保持 ring-ineligible，直至全部 initialized/resolved rail（包括未配置列表时自动发现的 rail）通过恢复采样门；无需重启。
+- **设备发现与拓扑**：留空时自动发现保持 `ACTIVE`-only（两端各选本地首个 port 1 `ACTIVE` HCA）；显式逗号白名单定义固定 topology，按首次出现顺序去重，server 会接纳**存在但启动时 DOWN** 的设备完成 anchor/MR 初始化并持续监控。运行期至少一条 initialized rail 健康即可承载 placement；最后一条健康 rail 丢失立即退环，0→非 0 恢复仍通过连续采样门。
+- **失败策略**：未设 `DFKV_RDMA` 时选择 TCP；一旦选择 RDMA，显式设备缺失、open/port/GID query 失败，或任一 configured rail 的 anchor、共享 receive-segment MR、RAM/user MR 初始化失败，均拒绝启动而不缩小 topology。client 配置 `DFKV_RDMA_RAIL_TIERS` 后还要求 MDS 返回完整 HLT1 peer topology；缺失/不完整或无兼容健康轨以 client-local `kNoCompatibleRail` fail closed，不切 TCP、不惩罚 peer。
 
 发现：默认走 **MDS 动态发现**（etcd + dfkv_mds，见 §2b）；静态成员表仍作为遗留/单节点备用路径（见 §4-legacy）。无副本（一致性哈希单属主，节点挂 = 该分片 miss → 重算）。
 
@@ -178,10 +178,10 @@ Environment=DFKV_RDMA_RECV_SEGMENT_SIZE=17179869184
 # 8×400G 轨全轨白名单 + NUMA：B200 生产 host 一台带 8 个 HCA 轨。
 # 显式白名单是固定 topology：保留首次出现顺序；present DOWN rail 仍必须完成
 # anchor/共享 segment/所有配置 MR 初始化，随后由 health monitor 等待 LinkUp。
-# server/client 两端白名单到**同名互通**一组轨；client 的 `DFKV_RDMA_NUMA=1`
-# 后每 rank 优先本 NUMA 轨，本地轨全不可准入时降级重试全部 enabled rail
-# （rail_select.h/rdma_transport.cc）。`--rdma-dev` 直传 RDMA server，胜过同名
-# env；client 侧 `DFKV_RDMA_DEV` 另行注入（CONNECTORS §1.2）。
+# client 侧另行注入本机 `DFKV_RDMA_DEV`；GPU/CPU host 可有不同列表。
+# 若设置 `DFKV_RDMA_RAIL_TIERS`，名称须来自该 local list，peer HLT1 用同名健康
+# 交集决定最高可用 tier。NUMA/credits/latency 只在 tier 内选择，拥塞不降 tier。
+# `--rdma-dev` 只配置 server，胜过同名 env（CONNECTORS §1.2）。
 Environment=DFKV_RDMA_NUMA=1
 # v2.0.0 监听器加固（PR#240）：首帧 30s absolute deadline 断 slow-dribble,
 # metrics 端口连接数上限 64（防连接占用打满）,
@@ -295,74 +295,74 @@ journalctl -u dfkv -n 10 --no-pager
 > [METRICS.md](METRICS.md) 的 registrar heartbeat 指标。
 > RDMA startup 日志
 > `rdma topology startup: configured=N initialized=N ACTIVE=M inactive=...`
-> 分别给出 `configured`（显式列表按首次出现去重；自动发现时为 0）、
-> `initialized`（自动发现或显式配置后 resolved、且 anchor 和启动所需 MR 全部
-> 完成的 rail）及启动瞬间 verbs port `IBV_PORT_ACTIVE` rail 数。显式部署必须
-> 看到 `configured == initialized`；`ACTIVE` 可以较小，此时启动成功但
-> `dfkv_server_ring_eligible=0`。运行期 rail 总数/顺序 immutable，健康门覆盖
-> **全部 initialized/resolved rail**，包括 auto 模式选出的 rail；当前
-> ACTIVE+LinkUp 健康数应从 `sum(dfkv_server_ib_device_healthy)` 读取，不能把
-> 启动 `ACTIVE` 快照当成当前状态。这两个 `dfkv_server_*` IB health family
-> 仅在 RDMA-enabled binary 实际启动 RDMA listener 时输出；TCP-only binary
-> 或未启动 RDMA listener 的进程缺少它们是预期行为，告警不得把缺失补成 0。
-> server 的 bootstrap 监听 `0.0.0.0`，靠防火墙限制在内网。优雅关闭已修（`systemctl stop` 约 1s 退出）。
-> **多轨与 NUMA**：两端自动发现留空时仍只选首个 ACTIVE HCA。server 的显式
-> `--rdma-dev` 是固定 anchor 白名单：按首次出现顺序去重并固定索引；client 的
-> `DFKV_RDMA_DEV` 是独立的数据面选择，仍须指向当前可用且与 server 同名互通的
-> rail。server 对每个 provider metadata 完整（包括 GID query 成功）的 configured
-> rail 建立 anchor、共享 receive-segment MR 及所有已配置 MR，**不会因为启动时
-> DOWN 就删轨或重排**。任一 rail missing/open/port/GID query/anchor/MR 失败都
-> fail-fast，不以子集启动。设备名在 peer
-> 显式选轨 frame 中上限 18 字节；超长 server anchor 只能作为 default anchor
-> 访问，生产两端显式白名单不得使用。生产多 fabric 主机仍须在两端过滤到
-> **同名且互通**设备。client 以 `DFKV_RDMA_RAIL_CREDITS` 的 per-rail credit、
-> 归一化 inflight、延迟和本地 rail 错误分数选轨（分数相同时按固定发现顺序
-> 选择）。`DFKV_RDMA_NUMA=1` 在每次 Acquire 读取 caller NUMA；白名单内存在
-> local rail 时严格优先 local mask。caller NUMA 未知或没有 local rail 时回退
-> 全部白名单；全部 local rail 都不可准入（被隔离或 credit 耗尽）时也会降级为
-> 全 enabled rail 重试一次——local 是严格偏好而不是可用性闸门。receive
-> segment 仍是单块 process-wide 分配，不是 per-NUMA/per-rail 分片。
+> 分别给出显式 configured、完成 anchor/启动 MR 的固定 initialized 集合、以及
+> 启动瞬间 ACTIVE 快照。显式部署必须 `configured == initialized`；missing/open/
+> port/GID/anchor/MR 任一失败仍拒绝启动。运行期不可用 rail 不会被删除或重排。
+> 当前总数和健康数看 `dfkv_server_rdma_rails_configured`、
+> `dfkv_rdma_rails_initialized`、`dfkv_server_rdma_rails_active` 和
+> `dfkv_server_ib_device_healthy{device}`，不能把启动 `ACTIVE` 当现状。这些
+> family 仅在 RDMA listener 存在时输出；TCP-only 进程缺失是预期行为。
 >
-> **boot-degraded 与容量取舍**：present DOWN rail 完成初始化后留在固定
-> topology 和 metrics label 集合中；任一 initialized/resolved rail（包括 auto
-> 模式选出的 rail）当前不是 ACTIVE/LinkUp，节点就以 `DEGRADED` 注册并整体退出
-> placement ring。其余健康 rail 不承接该节点的部分流量，因此代价是临时损失
-> 该节点**全部** cache capacity/vnode share，而不是只损失一条 rail 的带宽。
-> 恢复门默认要求三个连续成功的本地健康采样机会。按 registrar 名义 10 s 节拍，
-> LinkUp 后通常约 20–30 s（取决于采样相位）完成三次，但还要叠加 registrar
-> 建连/RPC 及 MDS 对外可见延迟；MDS 不可达时采样/发布可更久，因此这不是
-> wall-clock 上界。门满足后同一进程自动 rejoin，**LinkUp 后无需 restart**。
+> **partial health**：至少一条 initialized rail 健康即允许 placement。9→8 等
+> 部分掉轨保持 ring eligible，并报告 `PARTIAL`；最后一条健康轨丢失时立即
+> `DEGRADED`/退环。0→1 恢复保持
+> `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES`（默认 3）连续成功采样门，通过后以
+> `PARTIAL` 或 `ACTIVE` 原进程回环，无需重启。该门只防恢复抖动，不延迟从非零
+> 到零的摘除。
 >
-> **client-local 失败域与有界重放**：本地 device open、QP transition、
-> MR register/refresh、post/CQ verbs API 失败，以及被分类为 local 的 WC
-> （`LOC_*`、`FATAL`、`GENERAL`）才是 `kRailFailure`。TCP bootstrap、peer
-> 不可达、probe/协商/protocol/receive-segment/decode 失败，remote/retry/RNR/
-> response-timeout/flush WC，以及没有 local-error WC 的 completion deadline
-> 是 endpoint 失败；resource/rail-credit admission、cancel 和 invalid input
-> 也不是 rail 健康证据。后两类不会增加 rail consecutive errors 或错误恢复
-> rail，endpoint 失败仍由 `PeerHealth` 处理。
+> **peer-aware tiers**：server `--rdma-dev` 和 client `DFKV_RDMA_DEV` 都固定
+> 本机设备索引。client 的 `DFKV_RDMA_RAIL_TIERS` 用 `a|b;c` 表示优先级：
+> `|` 是同 tier，`;` 从 Tier 0 向低优先级分隔；空 tier/name、重复 rail 或任何
+> 不在 `DFKV_RDMA_DEV` 的名称都使 client 初始化失败。未配置 tiers 时全部 local
+> devices 是一个 homogeneous tier。MDS `kListTopology` 返回 Members 基础记录的
+> 地址/placement binding，并复用 `HLT1` 扩展承载 eligibility 与
+> `{device,port_state,phys_state,query_ok}`；不另建 rail 协议。client 选择稳定的
+> `local enabled ∩ peer healthy ∩ highest available tier`。NUMA、credits、
+> latency、quarantine/cooldown 只在该 tier 内排序/等待；**健康 Tier-0 credit
+> 紧张必须等待，拥塞绝不溢出 Tier 1**。只有 peer health 使高 tier 完全不可用，
+> 才会使用下一 tier。
 >
-> 首次 `kRailFailure` 后，client 必须先 retire endpoint，并同步完成 QP/CQ/MR
-> teardown，才会建立 fresh endpoint 做**至多一次**重试；物理尝试总数固定为
-> 2，不可配置。第二次选择从 NUMA preferred 和 fallback 两个集合同时排除故障
-> rail，只要 topology 中存在另一条 enabled rail 就必须换轨；不能因为另一轨
-> credit 耗尽、正在 quarantine 或 cooldown 就回到原轨。单轨部署没有另一条
-> topology-enabled rail 时可做一次 fresh 同轨重试，但绝不复用故障 QP，也不
-> 绕过 quarantine/cooldown/backpressure。
+> GPU/CPU 异构示例（名称仅为示例，生产须用两端实际同 fabric 名）：
+> ```bash
+> # GPU host: two preferred rails plus one lower-bandwidth fallback
+> export DFKV_RDMA_DEV=mlx5_0,mlx5_1,mlx5_2
+> export DFKV_RDMA_RAIL_TIERS='mlx5_0|mlx5_1;mlx5_2'
 >
-> 该重试会从头重放现有整个 logical PUT/GET/batch/SG operation，语义仍是
-> **at-least-once**：若 PUT 已在远端 commit 而本地 completion 丢失，同一覆盖
-> 写可能执行两次，不提供 exactly-once 或 concurrent-writer isolation。它与
-> pooled stale-QP 的既有 fresh-endpoint retry 分开计数。实现完全在 client，
-> 与 server 的 `DFKV_RDMA_HEALTH_FILE`、`dfkv_server_ring_eligible` 整节点
-> 退环/恢复机制无关；**不修改 RDMA wire protocol 或 server 行为**，因此升级
-> client 与仍支持同一 RDMA v2 protocol 的混合版本 server 兼容。
+> # CPU host: one preferred rail plus the shared fallback
+> export DFKV_RDMA_DEV=mlx5_0,mlx5_2
+> export DFKV_RDMA_RAIL_TIERS='mlx5_0;mlx5_2'
+> ```
+> GPU↔GPU 可在 `mlx5_0|mlx5_1` 内选择；GPU↔CPU 的最高共同健康 tier 是
+> `mlx5_0`，仅它健康性消失后才考虑 `mlx5_2`。设备名不匹配不是“异构映射”，
+> 而是无交集。
 >
-> **client-local quarantine 恢复**：默认连续 3 次 `kRailFailure` 后隔离该
-> rail 5000 ms。cooldown 前不准入；到期仅一个真实 operation 获得 recovery
-> probe，其他 caller 继续跳过。probe success 清除 consecutive errors/
-> quarantine 并记录 recovery；probe local failure 重启完整 cooldown；probe
-> endpoint failure 只释放 probe ownership，既不证明恢复也不增加 local fault。
+> **HLT1 / mixed version**：`MembersTopologyEpoch` 以稳定 member-id/device-name
+> 顺序 canonicalize 地址/placement binding、eligibility 和每轨 health 字段；
+> client 用 placement epoch 独立去重 Ketama ring，同时始终把新的 topology
+> generation 送给 transport。旧 MDS 不识别 `kListTopology`：modern poll 会失败并
+> 保留 last-good ring，不会静默降回 `kListMembers`；因此 rollout 先升级 MDS。
+> 当前 MDS 中的旧 member 没有 HLT1，topology 标记 incomplete。未配置 tiers 的
+> homogeneous client 可继续服务这类 member；配置 tiers 时返回
+> `Status::kNoCompatibleRail`。静态 member 列表也没有 HLT1，不能与 configured
+> tiers 搭配。旧 client 对新 MDS 仍可使用既有 placement API，但没有 peer-aware
+> tier 能力。
+>
+> **generation fence 与错误语义**：每个 logical operation 在开始时捕获一个
+> peer generation，两次物理尝试都使用它。Conn 记录 peer generation；旧代 pool
+> entry 不再复用/回池，只由既有 single-owner lifecycle teardown，防止 topology
+> 变化后跨代 QP 复活。`kNoCompatibleRail` 是 client-local、从不编码上 wire，
+> 不计 served response、IO error 或 peer cooldown。
+>
+> 物理尝试总数仍固定至多 2。已完成的 GET/batch/SG item/window 保留 byte-exact
+> 结果，第二次只提交未完成工作。PUT 只有在确认 request 尚未 post 时才可换轨；
+> post 后 failure 的远端 commit 状态不明确，必须原样失败，**不得跨轨 replay**。
+> 这不扩大 pooled stale-QP 的既有 fresh retry，也不承诺 exactly-once 或
+> concurrent-writer isolation。
+>
+> client-local rail quarantine 仍由本地 Open/QP/MR/post/CQ 和 local WC 证据
+> 驱动；peer/bootstrap/protocol、remote/RNR/timeout、admission、
+> `kNoCompatibleRail` 均不增加 local rail error。cooldown 到期仍只准入一个真实
+> recovery probe。
 >
 > **v2 segment 预算**：`slot=align4K(4096 + max_raw_payload)`；
 > `segment >= Σ(live + client-pool-idle data/control QP × depth × slot)`。lease
@@ -472,10 +472,11 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 | `DFKV_RDMA_BATCH_OP_TIMEOUT_MS` | 0=跟随 RDMA_OP | client：multi-item Cache/Range/Exist、SG 窗口总期限 |
 | `DFKV_RDMA_POOL_MAX` | `16` | client：每 server、每 lane、跨所有 rail 的 idle QP 保留上限，不是进程总连接上限；只在稳定负载仍反复建连时上调 |
 | `DFKV_RDMA_RAIL_CREDITS` | 默认 `64`, 硬上限 4096 | client：每 rail QP 信用数（inflight 上限），>server depth 会回退 |
+| `DFKV_RDMA_RAIL_TIERS` | unset = `DFKV_RDMA_DEV` 全部同一 homogeneous tier | client：`a|b;c`；所有名必须在 `DFKV_RDMA_DEV`。从最高非空 `local enabled ∩ peer healthy` tier 选轨；configured tiers 遇 absent/incomplete HLT1 或空交集返回 `kNoCompatibleRail` |
 | `DFKV_RDMA_RAIL_BACKPRESSURE_MS` | `10` | client：Acquire 失败重试 backoff |
 | `DFKV_RDMA_RAIL_COOLDOWN_MS` | `5000` | client-local rail quarantine 冷却期；冷却期间不准入，期满仅允许 1 个真实 operation 作为 recovery probe |
 | `DFKV_RDMA_RAIL_ERROR_THRESHOLD` | `3` | client：连续 `kRailFailure` 达到该值才 quarantine；peer/endpoint、admission、timeout（无 local-error WC）、cancel 和 invalid input 不计入 |
-| client-local rail attempts | 固定 `2`（不可配置） | client：初次尝试加至多一次 fresh retry；存在另一条 topology-enabled rail 时必须换轨，单轨才可 fresh 同轨且不得绕过 quarantine |
+| client-local rail attempts | 固定 `2`（不可配置） | GET/batch/SG 第二次只重试未完成 item/window；PUT 仅在确认 request 未 post 时可换轨，post 后 ambiguous failure 不 replay |
 | `DFKV_RDMA_RAIL_LATENCY_WEIGHT` | — | client：rail selection 的延迟 EWMA 权重 |
 | `DFKV_RDMA_RAIL_ERROR_PENALTY_US` | — | client：rail selection 的错误分数惩罚微秒 |
 | `DFKV_RDMA_IDLE_MS` | — | server：idle QP 重回收周期 |
@@ -550,8 +551,8 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 | `DFKV_READ_SHARD_KEYS` | `16` | client 每个 read shard 的目标 key 数；server 不读取 |
 | `DFKV_MDS_IO_TIMEOUT_S` | `60` | MDS 控制面帧读写超时（MDS 进程该） |
 | `DFKV_MDS_ETCD_PROBE_MS` | `30000` | MDS 与 etcd 存活探测窗（MDS 进程该） |
-| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | 仅有 RDMA listener 时生效。健康门检查固定的全部 initialized/resolved rail（包括 auto-discovered rail）；任一 query 失败或非 ACTIVE/LinkUp 立即退整节点。恢复要求连续三个成功采样机会，不是固定时长：启动先采样一次，后续在 registrar 建连后、每次 MDS 注册/心跳 RPC 发送前采样。heartbeat 名义间隔 10 s，通常约 20–30 s（取决于相位），另加建连/RPC/发布延迟；MDS 不可达时可能更久，无 wall-clock 上界 |
-| `DFKV_RDMA_HEALTH_FILE` | 未设置（生产必须未设置） | 仅用于受控故障注入；每行 `device port_state phys_state`，缺失任一 initialized/resolved 设备（包括 auto-discovered rail）按 query 失败处理。生产从 sysfs 读取 |
+| `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES` | `3` | 仅 RDMA listener 生效。任一 initialized rail 健康即可 placement；部分掉轨保持 `PARTIAL`。最后一条健康 rail 丢失立即 `DEGRADED`；0→非 0 恢复要求连续成功样本，通过后 `PARTIAL`/`ACTIVE` 回环 |
+| `DFKV_RDMA_HEALTH_FILE` | 未设置（生产必须未设置） | 仅受控故障注入；逐 initialized device 提供 `device port_state phys_state`，生产从 sysfs 读取 |
 | `DFKV_TENANT_QUOTAS_COUNT` | — | tenant 配额文件预期条数（容量校验） |
 
 #### 未收录的常见误配 → 详见 CONNECTORS.md §1.7
@@ -566,11 +567,13 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 ### 4a. MDS 动态发现（推荐）
 
 节点通过 `--mds` + `--group` + `--id` + `--advertise` 向 MDS 自注册。客户端在
-调用 `dfkv_open_v2` 前，把 endpoints、group、poll interval 和可选客户端注册身份
-一次性写入 `dfkv_client_options_v2`；构造成功后自动轮询 MDS。epoch
-（placement 内容 hash）变化时自动重建加权 Ketama 环。增减节点只需启停
-`dfkv_server`，无需修改已运行客户端的配置。
-
+`dfkv_open_v2` 构造时一次性提供 endpoints/group/poll interval。现代客户端请求
+`kListTopology`：placement 仍用原成员字段和 `MembersEpoch` 独立去重；已有
+`HLT1` 扩展承载 eligibility 与逐设备健康，`MembersTopologyEpoch` 变化时即使
+Ketama placement 不变也调用 transport 的 peer-topology 更新。当前 MDS 中的旧
+member 因缺少 HLT1 而产生 incomplete topology：未配置 tiers 时 homogeneous
+兼容，配置 `DFKV_RDMA_RAIL_TIERS` 时 fail closed。旧 MDS 不支持
+`kListTopology`，modern poll 失败并保留 last-good ring；rollout 必须 MDS-first。
 两层离线检测：
 - **层 2（权威）**：etcd lease 到期（TTL 30s）→ 下次 MDS poll（默认 3s）→
   placement-content epoch 推进 → 环重建。小幅缩容通常约 TTL+一次 poll；

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -21,13 +21,12 @@
 还要求本地 startup 完成以及（配置 MDS 时）首次注册成功。首次注册 latch 后，
 瞬时 heartbeat 丢失不会清 readiness；用下述 heartbeat 指标单独告警。未配置
 MDS 的 node 仅等待本地 startup 和动态 storage health。
-IB ring eligibility is intentionally independent of these HTTP checks. Only an
-RDMA-enabled binary with an active RDMA listener constructs the health monitor
-and emits `dfkv_server_ring_eligible` /
-`dfkv_server_ib_device_healthy`; their absence from a TCP-only binary or an
-RDMA build without a listener is expected. When present, an initialized server
-with a `DOWN` rail can keep `/healthz` and `/readyz` at 200 while
-`dfkv_server_ring_eligible=0` excludes the whole node from placement.
+IB placement eligibility is independent of these HTTP checks. Only an
+RDMA-enabled binary with an active listener emits the server rail families.
+At least one healthy initialized rail keeps the node eligible: a partial loss
+reports fewer active rails but `/healthz`, `/readyz`, and placement remain
+online. Losing the final healthy rail makes `dfkv_server_ring_eligible=0`
+immediately; 0→nonzero recovery waits the configured sample streak.
 `dfkv_mds` 的语义不同：`/healthz` 是纯进程 liveness，**不 probe etcd**——
 否则一次秒级 etcd 抖动会让 kubelet 同时重启全部 MDS 副本，CrashLoop 比抖动
 更久并引发 lease 集体过期。`/readyz` 保留 etcd 依赖检查，但经 TTL-debounced
@@ -123,45 +122,38 @@ Tenant 标签**只**来自启动时有界配置文件中的 16-hex hash；默认
 此时 cache `/readyz` 保持 200，恢复后续租。`rate(dfkv_tcp_rejected_connections_total[5m]) > 0`
 触发时同步看 `dfkv_open_connections / dfkv_tcp_max_connections`。
 
-IB rail 告警必须按**节点**聚合：
-`min by (instance) (dfkv_server_ib_device_healthy) == 0` 或
-`dfkv_server_ring_eligible == 0` 表示该节点的**全部** cache capacity 已从
-placement ring 移除，不能把其余健康 rail 当成部分容量仍可路由。这两个查询在
-TCP-only server 或未启动 RDMA listener 的 RDMA build 上不会返回序列，这是预期
-行为；不得用 `or vector(0)` 等方式把缺失补成 unhealthy。若要告警“应有但缺失”，
-必须用明确标识 RDMA-listener 部署的 scrape inventory，例如：
-```promql
-(up{job="dfkv-server-rdma"} == 1)
-  unless on(job, instance) dfkv_server_ring_eligible{job="dfkv-server-rdma"}
-```
-不能对混合 TCP/RDMA job 全局使用 `absent()`。
+IB rail 告警先看 active cardinality，再看 eligibility：
+`dfkv_server_rdma_rails_active < dfkv_rdma_rails_initialized` 表示 `PARTIAL`
+带宽；只要 active ≥1，节点仍在 placement。`dfkv_server_ring_eligible == 0`
+表示最后健康 rail 已丢失、该节点全部 cache capacity 已摘除。逐轨定位用
+`dfkv_server_ib_device_healthy{device}`。这些查询在 TCP-only server 或未启动
+RDMA listener 的 RDMA build 上不会返回序列，这是预期行为；不得用
+`or vector(0)` 把缺失补成 unhealthy。告警“应有但缺失”必须关联明确的
+RDMA-listener scrape inventory。
 
-默认 `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES=3`。健康门覆盖全部
-initialized/resolved rail，包括未配置设备列表时 auto-discovered 的 rail；任一
-query 失败或 non-ACTIVE/LinkUp 样本立即清零 streak 并退环。恢复要求三个连续
-成功的本地健康采样机会，而不是固定时长。启动时先采样一次，后续在 registrar
-成功建立连接后、每次注册/心跳 RPC 发送前采样（heartbeat 名义间隔 10 s），MDS
-只在 RPC 成功后看到新状态。因此 LinkUp 后通常约 20–30 s（取决于采样相位）
-完成三个样本，还要叠加 registrar 建连/RPC 与发布延迟；MDS 不可达时可能更久。
-这不是 wall-clock 上界。**无需重启**；重启反而丢弃已初始化 topology 并重新
-承担全部 anchor/MR 启动成本。
+默认 `DFKV_RDMA_HEALTH_RECOVERY_SAMPLES=3`。从非零健康轨降到零立即清 eligibility；
+从零恢复到非零才要求连续成功的本地健康采样机会。通过后，全部轨健康为
+`ACTIVE`，部分健康为 `PARTIAL`。heartbeat 名义间隔 10 s 时三次机会通常约
+20–30 s（取决于相位），还要叠加 registrar/MDS 发布延迟；这不是上界，也无需
+重启。部分掉轨 9→8 不走该恢复门，因为节点从未失去最后健康轨。
 
 四种 rail 口径不能混用：
 
 | 口径 | 权威来源 | 解释 |
 |---|---|---|
-| configured | startup log `configured=N` | 显式列表按首次出现去重后的意图；auto 模式为 0 |
-| initialized/resolved | startup log `initialized=N`；成功启动后 `dfkv_rdma_recv_segment_registered_rails` | 自动发现或显式配置后已完成 anchor、共享 segment 和全部启动 MR 的固定 topology；auto 模式包含选出的 rail |
-| startup-ACTIVE | startup log `ACTIVE=N` / `inactive=...` | 仅启动瞬间的 verbs port-state 快照，不会随恢复改写 |
-| current healthy | `sum by (instance) (dfkv_server_ib_device_healthy)`；最终门为 `dfkv_server_ring_eligible` | 固定 initialized/resolved 集合中当前 ACTIVE+LinkUp 数；仅 RDMA listener 存在时输出 |
+| configured input / monitored topology | startup log `configured=N`; `dfkv_server_rdma_rails_configured` | log 值是显式列表去重数（auto 为 0）；gauge 是 health monitor 的固定 resolved rail 数（auto 含选出的 rail） |
+| initialized/resolved | startup log `initialized=N`; `dfkv_rdma_rails_initialized`; `dfkv_rdma_recv_segment_registered_rails` | 完成 anchor、共享 segment 和全部启动 MR 的固定 topology，auto 含选出的 rail |
+| startup-ACTIVE | startup log `ACTIVE=N` / `inactive=...` | 仅启动瞬间快照 |
+| current healthy | `dfkv_server_rdma_rails_active`; `sum(dfkv_server_ib_device_healthy)` | 当前 ACTIVE+LinkUp 数；至少 1 即可 placement |
 
 仅在 **RDMA-enabled binary 实际启动 RDMA listener** 时额外输出（折叠进同一
 `/metrics`）；TCP-only binary 或未启动 RDMA listener 时下列 family 不存在：
 
 | 指标 | 类型 | 含义 |
 |---|---|---|
-| `dfkv_server_ring_eligible` | gauge | **当前**全部 initialized/resolved IB rail（包括 auto-discovered rail）是否满足恢复门；任一设备 query 失败或不是 ACTIVE/LinkUp 时为 0，整个节点（不是单 rail 容量）退出 placement ring，但进程、`/healthz`、`/readyz` 保持在线 |
-| `dfkv_server_ib_device_healthy{device}` | gauge | 各 initialized/resolved RDMA 设备 port 1 的**当前**状态是否同时为 ACTIVE 与 LinkUp；`device` 集合与顺序在启动后固定，包含 auto-discovered rail，也包含显式配置的启动时 DOWN rail |
+| `dfkv_server_ring_eligible` | gauge | 当前是否有至少一条通过门控的 initialized healthy rail；最后一条丢失立即为 0，0→非 0 需 recovery streak |
+| `dfkv_server_rdma_rails_configured` / `dfkv_rdma_rails_initialized` / `dfkv_server_rdma_rails_active` | gauge | health monitor 固定 resolved 数 / 成功 anchor 初始化数 / 当前健康数；auto 模式均包含选出的 rail，无 `device` label |
+| `dfkv_server_ib_device_healthy{device}` | gauge | 每个固定 initialized device 当前是否 `query_ok && ACTIVE && LinkUp`；部分为 0 不再等价于整节点退环 |
 | `dfkv_rdma_completions_total` / `dfkv_rdma_completion_errors_total` | counter | RDMA 请求完成 / 错误完成 |
 | `dfkv_rdma_active_conns` | gauge | 当前服务中的 RDMA 连接 |
 | `dfkv_rdma_v2_conns_opened_total` | counter | server 累计打开的 v2 连接 |
@@ -177,20 +169,14 @@ query 失败或 non-ACTIVE/LinkUp 样本立即清零 streak 并退环。恢复�
 | `dfkv_rdma_rail_put_writes_total{dev}` / `dfkv_rdma_rail_put_bytes_total{dev}` | counter | 每 rail 收到的 PUT one-sided writes / payload bytes |
 | `dfkv_rdma_rail_get_writes_total{dev}` / `dfkv_rdma_rail_get_bytes_total{dev}` | counter | 每 rail 发出的 GET one-sided writes / payload bytes |
 
-> **v2 上线判据**：启动日志
-> `rdma topology startup: configured=N initialized=N ACTIVE=M inactive=...`
-> 精确区分显式 configured、自动发现或显式配置后完成 anchor/MR 的
-> initialized/resolved，以及启动瞬间 verbs port `IBV_PORT_ACTIVE` 快照；
-> 自动发现的 `configured=0` 但 initialized 集合包含选出的 rail，显式 topology
-> 则必须
-> `configured == initialized == dfkv_rdma_recv_segment_registered_rails`，而
-> `ACTIVE` 可以更小。RDMA listener 运行期用固定 initialized/resolved 集合
-> `dfkv_server_ib_device_healthy{device}` 统计 current ACTIVE+LinkUp healthy，
-> 并以 `dfkv_server_ring_eligible` 判断整节点是否可放置。随后确认
-> client/server 两侧连接总数增长、PUT/GET write counter 随负载增长、
-> `dfkv_rdma_v2_ready=1` 且 `dfkv_rdma_recv_segment_free_bytes` 有容量余量。
-> 启动失败或连接拒绝时检查缺失/open/port/GID query 错误、每轨
-> anchor/MR/segment 注册日志、segment 容量和两端协议版本。
+> **v2 上线判据**：显式 topology 必须
+> `configured == initialized == dfkv_rdma_recv_segment_registered_rails`。
+> 启动 `ACTIVE` 只是快照；运行期以
+> `dfkv_server_rdma_rails_active` 和逐设备 healthy 为准。active≥1 时
+> `dfkv_server_ring_eligible=1`；`active < initialized` 是 `PARTIAL`，不是整节点
+> 故障。active=0 必须立即退环，恢复到非零在 sample streak 后重新 eligible。
+> 随后确认 client/server QP 与 PUT/GET write counter 增长、
+> `dfkv_rdma_v2_ready=1` 且 receive-segment free bytes 有余量。
 
 读侧 convoy 合并与直读晋升（`DFKV_READ_COALESCE=1` 时才有增量；恒零 = 开关没生效）：
 | `dfkv_read_coalesce_leaders_total` | counter | 经 coalescer 登记并完成的读（同步 leader + io_uring flight 各计一次；>0 = 合并路径确实在环内） |
@@ -270,7 +256,7 @@ TTL-debounced etcd probe 判定（`DFKV_MDS_PROBE_CACHE_MS`，默认 2500 ms 内
 | `dfkv_mds_group_version_skew{group}` | 去重版本数，**>1 = 版本漂移** |
 | `dfkv_mds_group_clients{group}` | 当前注册的 inference connector/consumer 实例数；client lease 到期后自动下降 |
 
-对应 CLI：`dfkvctl topology --mds <eps> --group <g>` 展示全部在线节点、逐设备 IB 状态及 ACTIVE/DEGRADED ring 状态；`dfkvctl stats --mds <eps> --group <g>` 只统计 health-eligible placement view（每节点表格+汇总行，数据一跳来自 MDS 不触节点）/ `--all`（kListGroups 枚举全部环）。深钻仍用 `dfkvctl stat --all`（逐节点全量 /metrics）。
+对应 CLI：`dfkvctl topology --mds <eps> --group <g>` 通过 `kListTopology` 展示全部在线节点和 HLT1 逐设备健康。HLT1 是 Members 的已有可选扩展（placement eligibility + repeated device name/port_state/phys_state/query_ok），不是独立 rail protocol。`MembersTopologyEpoch` 对 member id/device name 稳定排序并包含地址/placement binding 与全部 health 字段；因此 rail health 变化不必重建 Ketama 环，仍会更新 transport。`dfkvctl stats` 只聚合 eligible placement；`PARTIAL` 节点仍在其中，只有零 active 的 `DEGRADED` 节点进入 degraded 计数。
 
 原有计数：
 | 指标 | 类型 | 含义 |
@@ -347,14 +333,17 @@ C 客户端快照还含传输级指标（RDMA 构建）：
 | `dfkv_rdma_client_oversize_rejects_total` | counter | 分配、注册或发帖前因超过声明上限而拒绝的操作 |
 | `dfkv_rdma_client_v2_probe_attempts_total` / `dfkv_rdma_client_v2_probe_failures_total` | counter | 必选 v2 bootstrap probe 尝试 / 失败 |
 | `dfkv_rdma_client_stale_pool_retries_total` | counter | pooled QP 失败后改用 fresh connection 的重试 |
-| `dfkv_rdma_client_cross_rail_retries_total` | counter | 无 label 的 process counter；client-local `kRailFailure` 后启动的 logical-operation replay；一次调用最多加 1，不按 batch window 计数。存在另一条 topology-enabled rail 时 retry 必须换轨 |
-| `dfkv_rdma_client_cross_rail_retry_successes_total` | counter | 无 label 的 process counter；上述 retry 最终成功的 logical operation 数 |
-| `dfkv_rdma_client_cross_rail_retry_exhausted_total` | counter | 无 label 的 process counter；已启动上述 retry、但第二次物理尝试仍失败的 logical operation 数 |
+| `dfkv_rdma_client_cross_rail_retries_total` | counter | 无 label；client-local `kRailFailure` 后真正启动的 cross-rail logical retry。GET 可重试未完成 work；PUT 只有 request 未 post 才计入 |
+| `dfkv_rdma_client_cross_rail_retry_successes_total` | counter | 无 label；上述 retry 最终成功的 logical operation 数 |
+| `dfkv_rdma_client_cross_rail_retry_exhausted_total` | counter | 无 label；上述 retry 的第二次物理尝试仍失败 |
 | `dfkv_rdma_client_completion_timeouts_total` | counter | 消耗完一次绝对 completion-window deadline 的窗口；部分完成不重置预算 |
 | `dfkv_rdma_client_resource_budget_raises_total` | counter | 预算自适应放大次数（随 ring 采纳，只增不减；任一预算 env 显式设置时恒为 0） |
 | `dfkv_rdma_client_admission_failures_total` | counter | 本进程预算饥饿导致的操作失败（返回 kResourceExhausted，对端从未被拨号、不进冷却）；应恒为 0，>0 说明预算仍小于扇出需求 |
 | `dfkv_rdma_client_depth_refunds_total` | counter | 服务端 clamp depth 后按协商值退还 WR/注册字节预算的连接数（首连按上限探测，后续按学习值建连） |
 | `dfkv_rdma_client_topology_nodes` | gauge | 最近一次喂给预算自适应的 ring 规模（0=从未提示或自适应关闭） |
+| `dfkv_rdma_client_peer_topology_updates_total` | counter | 无 label；接纳的新 peer immutable topology generation 数；同 generation 重复通知不增加 |
+| `dfkv_rdma_client_no_compatible_rail_total` | counter | 无 label；configured tiers 因 absent/incomplete peer topology 或最高可用交集为空而返回 `kNoCompatibleRail` 的次数；不计 peer health failure |
+| `dfkv_rdma_client_stale_generation_reaps_total` | counter | 无 label；因 Conn 的 peer generation 落后而拒绝 take/repool/keepalive、并经 single-owner lifecycle 回收的 endpoint 数 |
 | `dfkv_rdma_client_keepalive_attempts_total` / `dfkv_rdma_client_keepalive_successes_total` / `dfkv_rdma_client_keepalive_failures_total` | counter | idle pooled QP 的保活尝试 / 成功 / 失败并退役连接；仅 `DFKV_RDMA_KEEPALIVE_MS>0` 时增长 |
 | `dfkv_rdma_client_rail_conns_total{dev}` / `dfkv_rdma_client_rail_selections_total{dev}` | counter | 每 rail 新连接 / 准入分布 |
 | `dfkv_rdma_client_rail_inflight{dev}` / `dfkv_rdma_client_rail_credits_available{dev}` | gauge | 当前已租 / 可用 request credits |
@@ -376,40 +365,37 @@ TCP 构建或 TCP fallback 的 C 快照 family（同样由插件镜像）：
 | `dfkv_transport_pool_backoff_endpoints` | gauge | 当前阻止连接增长的 endpoint 数 |
 | `dfkv_transport_pool_backoff_events_total` / `dfkv_transport_pool_backoff_suppressed_total` | counter | 进入 backoff / backoff 中被 fast-fail 的 acquire |
 
-RDMA client transport family 只在 RDMA build/runtime 使用相应传输并由 client
-stats snapshot/connector poller 导出时可见；TCP-only 进程缺失这些 family 是预期
-行为，不能补 0 解释为 rail 故障。所有 `{dev}` 序列数固定为进程启动时发现的 rail
-数，NUMA `reason` 只有上述两个枚举，不会按任意 endpoint 扩张。endpoint
-cooldown/恢复由上表 `dfkv_client_peer_marked_bad_total` /
-`dfkv_client_peer_recovered_total` 汇总，逐 peer error 序列在 `PeerHealth` 内硬限
-4096 条。因此 rail 故障、endpoint 故障和两种 quarantine 可以分别告警，单个坏
-node 不再表现为共享 HCA 故障。
+RDMA client transport family 只在 RDMA runtime 使用相应传输并由 client snapshot/
+connector poller 导出时可见；TCP-only 进程缺失是预期行为。所有新 peer-topology
+family 均是无 label process counter，避免 peer 地址造成无界时序；`{dev}` 仍只
+来自进程启动时的固定 local rail 集合。`kNoCompatibleRail` 是本地兼容性结果，
+不增加 `dfkv_client_ops_served_total`、`dfkv_client_io_errors_total`、
+`dfkv_client_peer_marked_bad_total` 或 cooldown。endpoint 和 local-rail health
+仍按各自既有 family 分开告警。
 
 **retry 语义与告警**：
 
-- 三个 `cross_rail` counter 只统计 `kRailFailure` 后的 replay；pooled endpoint
-  staleness 仍只计 `dfkv_rdma_client_stale_pool_retries_total`，peer/endpoint、
-  admission、cancel、invalid input 不计。每个公开调用物理尝试最多 2 次；第二次
-  使用 fresh endpoint，且在任何另一条 enabled local rail 存在时必须换轨。单轨
-  topology 才允许 fresh 同轨 retry，且不得绕过 quarantine/cooldown。
-- retry 前同步 retire 故障 endpoint 并 teardown QP/CQ/MR，然后从 item 0 重放
-  整个 logical PUT/GET/batch/SG operation。语义为 at-least-once；remote PUT
-  commit 后 completion 丢失时可能覆盖写两次，不保证 exactly-once。公开
-  `dfkv_client_op_{requests,keys}_total` 不随物理尝试翻倍，hit/bytes 只按最终
-  logical result 计，latency 包含两次尝试。
-- `rate(dfkv_rdma_client_cross_rail_retry_exhausted_total[5m]) > 0` 任何增长都
-  需要处置；它表示一次换轨（或单轨 fresh）机会仍未恢复 logical operation。
-  任一 `dfkv_rdma_client_rail_quarantined{dev} == 1` 持续超过两个默认 cooldown
-  （10 s；若修改 `DFKV_RDMA_RAIL_COOLDOWN_MS` 则使用其两倍）也应告警。
-- workload drain 后 `dfkv_rdma_client_rail_inflight{dev} != 0`，或
-  `dfkv_rdma_client_transient_user_mr_active` 未回到 drain 前基线，按资源泄漏
-  告警。`dfkv_rdma_client_rail_recovery_probe{dev}` 应在 probe 完成后归零。
+- `cross_rail` counter 只统计 client-local `kRailFailure` 后真正启动的跨轨 retry；
+  pooled endpoint staleness仍由 `stale_pool_retries_total` 单独计数。每个 logical
+  operation 捕获一个 peer generation，物理尝试最多 2 次。
+- GET/batch/SG 保留已完成 item/window 的 byte-exact staged 结果，fresh 第二次只
+  提交未完成集合。PUT 仅在明确 request 尚未 post 时允许换轨；post 后 completion
+  不明的 PUT 不 cross-rail replay，避免扩大 ambiguous write 语义。
+- Conn 绑定 peer generation；pool 中旧代 endpoint 永不复用或回池，并通过既有
+  single-owner lifecycle 销毁。topology update 不在别的线程直接双重 teardown。
+- `Status::kNoCompatibleRail` 是 client-local（不上 wire）、peer-health neutral：
+  不增加 served、IO error、marked-bad 或 cooldown。configured tiers 遇 absent/
+  incomplete HLT1 或空健康交集时返回它；未配置 tiers 的 legacy homogeneous 模式
+  不需要完整 peer topology。
+- `rate(dfkv_rdma_client_cross_rail_retry_exhausted_total[5m]) > 0` 或持续
+  `rail_quarantined{dev} == 1` 需要处置。workload drain 后 inflight 或 transient
+  MR 不归零按资源泄漏告警。
 
-这是 **client-only** rail recovery，与 server 的
-`dfkv_server_ib_device_healthy` / `dfkv_server_ring_eligible` 整节点 placement
-健康门完全分离；`DFKV_RDMA_HEALTH_FILE` 只影响 server health monitor。该能力
-不改变 RDMA wire protocol 或 server 行为，升级 client 与仍支持同一 RDMA v2
-protocol 的混合版本 server 兼容。
+该能力不新增 rail wire protocol：MDS 复用 Members HLT1，transport 数据面仍是
+RDMA v2。新 client + 当前 MDS + legacy member 在未配置 tiers 时保持
+homogeneous 兼容；configured tiers 对该 member fail closed。legacy MDS 不识别
+`kListTopology`，modern poll 失败并保留 last-good ring，rollout 必须 MDS-first，
+不能把这类 poll failure 解释为 homogeneous fallback。
 
 ### 3.4 连接器车队指标（三连接器 OTLP **push**，opt-in）
 §3.3 是进程本地 Prometheus **pull**。vLLM、LMCache、SGLang HiCache 还可把

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -1627,6 +1627,9 @@ std::string RdmaServer::MetricsText() const {
     CompletionErrors());
   m(s, "dfkv_rdma_active_conns", "gauge",
     "RDMA connections currently serving", ActiveConns());
+  m(s, "dfkv_rdma_rails_initialized", "gauge",
+    "RDMA rails with successfully initialized server anchors",
+    InitializedRailCount());
   m(s, "dfkv_rdma_v2_conns_opened_total", "counter",
     "RDMA v2 connections opened", V2Conns());
   m(s, "dfkv_rdma_v2_put_writes_total", "counter",

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -84,6 +84,11 @@ class RdmaServer {
   // Explicit-mode failures retain the complete requested order; diagnostic
   // probe evidence never replaces this with a partially discovered topology.
   const std::vector<std::string>& DeviceNames() const { return anchor_devs_; }
+  // Fixed topology and successfully materialized anchors. Explicit startup is
+  // fail-closed, so a running server has one initialized anchor per configured
+  // rail; keeping both counts exposes startup/lifecycle truth independently.
+  size_t ConfiguredRailCount() const { return anchor_devs_.size(); }
+  size_t InitializedRailCount() const { return anchors_.size(); }
 
   // Observability (used by tests): number of Serve threads not yet reaped.
   // Bounded under churn now that finished connections are joined as new ones

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -250,6 +250,48 @@ void KVClient::AdoptRing(ConHash ring, std::map<std::string, std::string> addr) 
   if (count > 0) ring_cv_.notify_all();
 }
 
+void KVClient::PublishPeerTopologies(
+    const std::vector<MemberInfo>& topology, uint64_t generation) {
+  std::set<std::string> current;
+  for (const auto& member : topology)
+    current.insert(member.ip + ":" + std::to_string(member.port));
+
+  std::set<std::string> omitted;
+  {
+    std::lock_guard<std::mutex> lock(ring_mu_);
+    omitted = published_peer_addrs_;
+    for (const auto& [name, address] : addr_) {
+      (void)name;
+      omitted.insert(address);
+    }
+    for (const auto& address : current) omitted.erase(address);
+    published_peer_addrs_ = current;
+  }
+
+  for (const auto& member : topology) {
+    PeerTopology peer;
+    peer.peer_addr = member.ip + ":" + std::to_string(member.port);
+    peer.generation = generation;
+    peer.complete = member.has_health;
+    peer.rails.reserve(member.health.ib_devices.size());
+    for (const auto& device : member.health.ib_devices)
+      peer.rails.push_back(PeerRailTopology{device.name, device.healthy()});
+    std::sort(peer.rails.begin(), peer.rails.end(),
+              [](const PeerRailTopology& a, const PeerRailTopology& b) {
+                return a.name < b.name;
+              });
+    t_->OnPeerTopology(peer);
+  }
+
+  for (const auto& address : omitted) {
+    PeerTopology peer;
+    peer.peer_addr = address;
+    peer.generation = generation;
+    peer.complete = false;
+    t_->OnPeerTopology(peer);
+  }
+}
+
 void KVClient::SetMembers(std::vector<std::pair<std::string, std::string>> members) {
   ConHash ring;
   std::map<std::string, std::string> addr;
@@ -265,6 +307,7 @@ void KVClient::SetMembers(const std::vector<MemberInfo>& members) {
   ConHash ring;
   std::map<std::string, std::string> addr;
   for (const auto& m : members) {
+    if (!m.RingEligible()) continue;
     ring.AddNode(m.id, m.weight < 1 ? 1 : static_cast<int>(m.weight));
     addr[m.id] = m.ip + ":" + std::to_string(m.port);
   }
@@ -275,9 +318,36 @@ void KVClient::SetMembers(const std::vector<MemberInfo>& members) {
 void KVClient::StartMdsDiscovery(std::vector<std::string> mds_eps,
                                  const std::string& group, int poll_ms) {
   StopMdsDiscovery();
+  struct PlacementEpochState {
+    bool have_epoch = false;
+    uint64_t epoch = 0;
+  };
+  auto placement_state = std::make_shared<PlacementEpochState>();
   poller_ = std::make_unique<MdsMemberPoller>(
       std::move(mds_eps), group,
-      [this](const std::vector<MemberInfo>& ms) { SetMembers(ms); }, poll_ms);
+      [this, placement_state](const std::vector<MemberInfo>& topology,
+                              uint64_t topology_epoch,
+                              bool placement_admitted) {
+        // Topology is a replace-all stream independent of placement. Degraded
+        // members remain here even though SetMembers excludes them. Omitted
+        // peers still held by a guard-rejected ring are explicitly invalidated.
+        PublishPeerTopologies(topology, topology_epoch);
+
+        if (!placement_admitted) return;
+        std::vector<MemberInfo> placement;
+        placement.reserve(topology.size());
+        for (const auto& member : topology) {
+          if (member.RingEligible()) placement.push_back(member);
+        }
+        const uint64_t placement_epoch = MembersEpoch(placement);
+        if (placement_state->have_epoch &&
+            placement_state->epoch == placement_epoch)
+          return;
+        placement_state->epoch = placement_epoch;
+        placement_state->have_epoch = true;
+        SetMembers(placement);
+      },
+      poll_ms);
   poller_->Start();
 }
 
@@ -349,10 +419,11 @@ void KVClient::ProbeLoop() {
       // A non-IO reply also means the peer is reachable: clear its data-path
       // cooldown here (off the data path) so recovery never depends on a data
       // request re-dialing a peer that is still inside its backed-off cooldown.
-      // kResourceExhausted never dialed the peer at all: its wall time is a
-      // local budget wait (up to RESOURCE_ACQUIRE_MS) that would poison the
-      // latency EWMA, and it proves nothing about peer reachability.
-      if (st != Status::kIOError && st != Status::kResourceExhausted) {
+      // kResourceExhausted and kNoCompatibleRail never dialed the peer at all:
+      // their wall time is local resource/topology selection and would poison
+      // the latency EWMA; neither proves anything about peer reachability.
+      if (st != Status::kIOError && st != Status::kResourceExhausted &&
+          st != Status::kNoCompatibleRail) {
         peer_lat_.Observe(a, sec);
         health_.MarkProbeAlive(a);
       }

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <string>
 #include <thread>
 #include <utility>
@@ -199,6 +200,11 @@ class KVClient {
   // (added/removed node ids) vs the previously-adopted view. Shared by both
   // SetMembers overloads so static and MDS-discovery paths log identically.
   void AdoptRing(ConHash ring, std::map<std::string, std::string> addr);
+  // Publish one replace-all topology response. Peers omitted by the response
+  // receive incomplete snapshots at its generation while they are still held
+  // by the ring, so a guard-rejected placement shrink cannot retain stale rails.
+  void PublishPeerTopologies(const std::vector<MemberInfo>& topology,
+                             uint64_t generation);
   // Scalar transport bodies. Public scalar methods add exactly one metric;
   // TCP batch fan-out calls these bodies so it cannot double-count each key.
   bool PutDirect(const std::string& key, const void* value, size_t n);
@@ -231,6 +237,9 @@ class KVClient {
   mutable std::mutex ring_mu_;  // guards ring_ + addr_
   ConHash ring_;
   std::map<std::string, std::string> addr_;  // name -> ip:port
+  // Addresses in the preceding replace-all topology response. Together with
+  // addr_, this finds omitted published or still-ring-held peers.
+  std::set<std::string> published_peer_addrs_;
   std::condition_variable ring_cv_;  // notified when AdoptRing sets a non-empty ring
   std::string key_namespace_;
   uint64_t namespace_hash_ = 0;

--- a/src/common/membership.h
+++ b/src/common/membership.h
@@ -341,6 +341,69 @@ inline uint64_t MembersEpoch(std::vector<MemberInfo> ms) {
   }
   return h;
 }
+// Canonical generation for the complete peer topology carried by HLT1. Unlike
+// MembersEpoch, this intentionally changes for rail-health-only updates so
+// transports can retire connections selected from an obsolete peer view
+// without rebuilding the placement ring. Member and device ordering from etcd
+// and sysfs is not stable, so both are sorted before hashing. The placement
+// fields bind a topology generation to the exact transport address/ring view it
+// describes; has_health distinguishes a legacy/incomplete report from a
+// complete report containing zero rails.
+inline uint64_t MembersTopologyEpoch(std::vector<MemberInfo> ms) {
+  std::sort(ms.begin(), ms.end(), [](const MemberInfo& a, const MemberInfo& b) {
+    if (a.id != b.id) return a.id < b.id;
+    if (a.ip != b.ip) return a.ip < b.ip;
+    if (a.port != b.port) return a.port < b.port;
+    return a.weight < b.weight;
+  });
+  uint64_t h = 1469598103934665603ull;
+  auto mix = [&h](const void* p, size_t n) {
+    const unsigned char* b = static_cast<const unsigned char*>(p);
+    for (size_t i = 0; i < n; ++i) {
+      h ^= b[i];
+      h *= 1099511628211ull;
+    }
+  };
+  auto mix_string = [&mix](const std::string& s) {
+    const uint32_t n = static_cast<uint32_t>(s.size());
+    mix(&n, sizeof(n));
+    mix(s.data(), s.size());
+  };
+  const uint32_t member_count = static_cast<uint32_t>(ms.size());
+  mix(&member_count, sizeof(member_count));
+  for (auto& m : ms) {
+    mix_string(m.id);
+    mix_string(m.ip);
+    mix(&m.port, sizeof(m.port));
+    mix(&m.weight, sizeof(m.weight));
+    const uint8_t eligible = m.RingEligible() ? 1 : 0;
+    const uint8_t has_health = m.has_health ? 1 : 0;
+    mix(&eligible, sizeof(eligible));
+    mix(&has_health, sizeof(has_health));
+    if (!m.has_health) continue;
+
+    std::sort(m.health.ib_devices.begin(), m.health.ib_devices.end(),
+              [](const IbDeviceHealth& a, const IbDeviceHealth& b) {
+                if (a.name != b.name) return a.name < b.name;
+                if (a.port_state != b.port_state)
+                  return a.port_state < b.port_state;
+                if (a.phys_state != b.phys_state)
+                  return a.phys_state < b.phys_state;
+                return a.query_ok < b.query_ok;
+              });
+    const uint32_t rail_count =
+        static_cast<uint32_t>(m.health.ib_devices.size());
+    mix(&rail_count, sizeof(rail_count));
+    for (const auto& d : m.health.ib_devices) {
+      mix_string(d.name);
+      mix(&d.port_state, sizeof(d.port_state));
+      mix(&d.phys_state, sizeof(d.phys_state));
+      const uint8_t query_ok = d.query_ok ? 1 : 0;
+      mix(&query_ok, sizeof(query_ok));
+    }
+  }
+  return h;
+}
 
 }  // namespace dfkv
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -20,7 +20,11 @@ enum class Status {
   // Peer health must treat it as neither a served response nor a peer IO
   // failure: cooling down a peer for a local admission stall poisons every
   // key routed to it (see .issue/0812-004).
-  kResourceExhausted
+  kResourceExhausted,
+  // Client-local only and peer-health-neutral. The selected peer topology has
+  // no healthy device-name intersection with this client's configured rails.
+  // This is decided before taking credits, process budget, or dialing a peer.
+  kNoCompatibleRail
 };
 
 inline const char* StatusName(Status s) {
@@ -32,6 +36,7 @@ inline const char* StatusName(Status s) {
     case Status::kIOError: return "IOError";
     case Status::kInvalid: return "Invalid";
     case Status::kResourceExhausted: return "ResourceExhausted";
+    case Status::kNoCompatibleRail: return "NoCompatibleRail";
   }
   return "?";
 }

--- a/src/mds/mds_member_poller.cc
+++ b/src/mds/mds_member_poller.cc
@@ -40,11 +40,22 @@ int ShrinkGuardPct() {
 }
 }  // namespace
 
-MdsMemberPoller::MdsMemberPoller(std::vector<std::string> mds_eps, std::string group,
-                                 OnChange cb, int poll_ms, int io_timeout_ms)
+MdsMemberPoller::MdsMemberPoller(std::vector<std::string> mds_eps,
+                                 std::string group, OnChange cb, int poll_ms,
+                                 int io_timeout_ms)
     : eps_(std::move(mds_eps)),
       group_(std::move(group)),
       cb_(std::move(cb)),
+      poll_ms_(poll_ms),
+      io_ms_(io_timeout_ms),
+      guard_(kViewsToAccept, ShrinkGuardPct()) {}
+
+MdsMemberPoller::MdsMemberPoller(std::vector<std::string> mds_eps,
+                                 std::string group, OnTopologyChange cb,
+                                 int poll_ms, int io_timeout_ms)
+    : eps_(std::move(mds_eps)),
+      group_(std::move(group)),
+      topology_cb_(std::move(cb)),
       poll_ms_(poll_ms),
       io_ms_(io_timeout_ms),
       guard_(kViewsToAccept, ShrinkGuardPct()) {}
@@ -58,53 +69,107 @@ uint64_t MdsMemberPoller::NowMs() const {
 }
 
 bool MdsMemberPoller::Query(std::vector<MemberInfo>* out, uint64_t* epoch) {
-  uint64_t now = NowMs();
-  std::string ep = eps_.Pick(now);
+  const uint64_t now = NowMs();
+  const std::string ep = eps_.Pick(now);
   if (ep.empty()) return false;
-  int fd = net::Dial(ep, io_ms_, io_ms_);
-  if (fd < 0) { eps_.MarkFailed(ep, now); return false; }
-  char pre[kReqPrefix];
-  EncodeReq(pre, WireOp::kListMembers, BlockKey{}, 0, 0, group_.size());
-  bool ok = net::WriteAll(fd, pre, kReqPrefix) &&
-            (group_.empty() || net::WriteAll(fd, group_.data(), group_.size()));
+
+  auto request = [&](WireOp op, Status* status, std::string* data) {
+    const int fd = net::Dial(ep, io_ms_, io_ms_);
+    if (fd < 0) return false;
+
+    char pre[kReqPrefix];
+    EncodeReq(pre, op, BlockKey{}, 0, 0, group_.size());
+    bool ok =
+        net::WriteAll(fd, pre, kReqPrefix) &&
+        (group_.empty() ||
+         net::WriteAll(fd, group_.data(), group_.size()));
+    uint64_t data_len = 0;
+    if (ok) {
+      char response[kRespPrefix];
+      ok = net::ReadAll(fd, response, kRespPrefix) &&
+           DecodeResp(response, status, &data_len,
+                      wire_limits::kMdsMaxRespData);
+    }
+    if (ok && *status == Status::kOk) {
+      data->resize(data_len);
+      ok = data_len == 0 || net::ReadAll(fd, &(*data)[0], data_len);
+    }
+    ::close(fd);
+    return ok;
+  };
+
+  Status status = Status::kInvalid;
   std::string data;
-  if (ok) {
-    char rp[kRespPrefix];
-    Status st = Status::kInvalid;
-    uint64_t dlen = 0;
-    ok = net::ReadAll(fd, rp, kRespPrefix) && DecodeResp(rp, &st, &dlen, wire_limits::kMdsMaxRespData) &&
-         st == Status::kOk;
-    if (ok) { data.resize(dlen); ok = (dlen == 0) || net::ReadAll(fd, &data[0], dlen); }
+  bool legacy_members = false;
+  bool ok = request(WireOp::kListTopology, &status, &data);
+  if (ok && status == Status::kInvalid) {
+    // kListTopology was appended after the legacy placement RPC. An old MDS
+    // reports an unknown operation as kInvalid; retry that same selected
+    // endpoint with kListMembers. No transport/framing failure reaches this
+    // branch, so an unhealthy modern endpoint still participates in failover.
+    data.clear();
+    ok = request(WireOp::kListMembers, &status, &data);
+    legacy_members = ok && status == Status::kOk;
   }
-  ::close(fd);
-  if (!ok) { eps_.MarkFailed(ep, now); return false; }
+  if (!ok || status != Status::kOk ||
+      !DecodeMembers(data.data(), data.size(), out, epoch)) {
+    eps_.MarkFailed(ep, now);
+    return false;
+  }
+  if (legacy_members) {
+    // ListMembers is a placement view and may omit degraded peers, so it can
+    // never prove complete rail topology even if a transitional MDS happens to
+    // append HLT1. Preserve legacy placement while making explicit-tier
+    // transports fail closed. Its wire epoch belongs to the placement view;
+    // publish the canonical topology generation expected by modern consumers.
+    for (auto& member : *out) {
+      member.health = MemberHealth{};
+      member.has_health = false;
+    }
+    *epoch = MembersTopologyEpoch(*out);
+  }
   eps_.MarkOk(ep);
-  return DecodeMembers(data.data(), data.size(), out, epoch);
+  return true;
 }
 
 bool MdsMemberPoller::PollOnce() {
-  std::vector<MemberInfo> ms;
-  uint64_t epoch = 0;
-  if (!Query(&ms, &epoch)) return false;  // failed RPC never clears the ring
+  std::vector<MemberInfo> topology;
+  uint64_t topology_epoch = 0;
+  if (!Query(&topology, &topology_epoch))
+    return false;  // failed RPC never clears the ring
 
-  // Adoption guard (MemberViewGuard): a *successful* response that is empty
-  // OR deviates from the trusted reference past the suspicion bar is almost
-  // always etcd-outage recovery (mass lease expiry / staggered
-  // re-registration), not a genuine membership swing; adopting it remaps the
-  // whole cluster into a miss storm and remaps AGAIN when the members
-  // stabilize. Suspicious views must reappear as the SAME value for
-  // kViewsToAccept polls.
-  // Rejecting must not advance the placement-content epoch — eventual adoption
-  // of that same content would otherwise be suppressed by epoch dedup below.
-  if (!guard_.Admit(ms.size()))
-    return true;  // keep the last ring; do NOT invoke on_change
-
-  if (!have_epoch_ || epoch != last_epoch_) {
-    last_epoch_ = epoch;
-    have_epoch_ = true;
-    if (!ms.empty()) ever_adopted_ = true;
-    cb_(ms);
+  std::vector<MemberInfo> placement;
+  placement.reserve(topology.size());
+  for (const auto& member : topology) {
+    if (member.RingEligible()) placement.push_back(member);
   }
+  const uint64_t placement_epoch = MembersEpoch(placement);
+
+  // The placement guard still judges the eligible view, exactly as it did when
+  // kListMembers filtered degraded members on the server. A rejected placement
+  // never advances its epoch, so a persistent view can be adopted later.
+  // Topology generations are independent: HLT1 changes must reach the modern
+  // callback immediately even while the corresponding placement is held.
+  const bool placement_admitted = guard_.Admit(placement.size());
+  const bool topology_changed =
+      !have_topology_epoch_ || topology_epoch != last_topology_epoch_;
+  if (topology_changed) {
+    last_topology_epoch_ = topology_epoch;
+    have_topology_epoch_ = true;
+  }
+
+  bool placement_changed = false;
+  if (placement_admitted &&
+      (!have_placement_epoch_ || placement_epoch != last_placement_epoch_)) {
+    last_placement_epoch_ = placement_epoch;
+    have_placement_epoch_ = true;
+    placement_changed = true;
+    if (!placement.empty()) ever_adopted_ = true;
+  }
+
+  if (topology_cb_ && (topology_changed || placement_changed))
+    topology_cb_(topology, topology_epoch, placement_admitted);
+  if (cb_ && placement_changed) cb_(placement);
   return true;
 }
 
@@ -119,7 +184,7 @@ void MdsMemberPoller::ReportHealth(bool query_ok) {
     }
     return;
   }
-  // Query failed: no MDS endpoint answered ListMembers (unreachable or RPC
+  // Query failed: no MDS endpoint answered ListTopology (unreachable or RPC
   // error). The ring is intentionally NOT cleared, but if it was never
   // populated the client routes every op to an empty ring and silently returns
   // ok=0 — the exact trap where a mistyped mds_endpoint looks like a write/data

--- a/src/mds/mds_member_poller.h
+++ b/src/mds/mds_member_poller.h
@@ -19,9 +19,10 @@ namespace dfkv {
 // are taken against a trusted REFERENCE size, not the last adopted hop: the
 // reference only follows a view size that has repeated views_to_accept_
 // consecutive polls (or a persisted suspicious view, below), never a one-off
-// hop. Three suspicious cases share one hysteresis: a successful ListMembers
-// that is (a) empty, or (b) a shrink dropping more than shrink_pct% of the
-// reference, or (c) growth ballooning past +shrink_pct% of it. (a)/(b) are
+// hop. Three suspicious cases share one hysteresis: a successful topology's
+// eligible view that is (a) empty, or (b) a shrink dropping more than
+// shrink_pct% of the reference, or (c) growth ballooning past
+// +shrink_pct% of it. (a)/(b) are
 // almost always etcd-outage recovery (mass lease expiry, e.g. NOSPACE)
 // rather than a genuine teardown, and (c) is that same outage unwinding as
 // members re-register on their own schedule. Suspicious views must reappear
@@ -129,14 +130,23 @@ class MemberViewGuard {
   uint64_t rejected_growth_ = 0;
 };
 
-// Client-side discovery: periodically polls the MDS for a group's member view
-// and invokes on_change(members) whenever its placement-content epoch changes.
+// Client-side discovery: periodically polls the MDS for a group's complete
+// topology. The legacy callback remains placement-only. The modern callback
+// receives every topology generation plus whether the placement guard admits
+// the corresponding eligible-member view; its consumer can forward topology
+// immediately while independently deduplicating ring adoption.
 // Endpoint selection + failover via MdsEndpoints. One background thread.
 class MdsMemberPoller {
  public:
   using OnChange = std::function<void(const std::vector<MemberInfo>&)>;
-  MdsMemberPoller(std::vector<std::string> mds_eps, std::string group, OnChange cb,
-                  int poll_ms = 3000, int io_timeout_ms = 2000);
+  using OnTopologyChange =
+      std::function<void(const std::vector<MemberInfo>&, uint64_t, bool)>;
+  MdsMemberPoller(std::vector<std::string> mds_eps, std::string group,
+                  OnChange cb, int poll_ms = 3000,
+                  int io_timeout_ms = 2000);
+  MdsMemberPoller(std::vector<std::string> mds_eps, std::string group,
+                  OnTopologyChange cb, int poll_ms = 3000,
+                  int io_timeout_ms = 2000);
   ~MdsMemberPoller();
 
   void Start();
@@ -167,10 +177,13 @@ class MdsMemberPoller {
   MdsEndpoints eps_;
   std::string group_;
   OnChange cb_;
+  OnTopologyChange topology_cb_;
   int poll_ms_;
   int io_ms_;
-  uint64_t last_epoch_ = 0;
-  bool have_epoch_ = false;
+  uint64_t last_topology_epoch_ = 0;
+  uint64_t last_placement_epoch_ = 0;
+  bool have_topology_epoch_ = false;
+  bool have_placement_epoch_ = false;
   // MDS reachability diagnostics (ReportHealth). Without these a bad mds
   // endpoint fails 100% silently — the exact trap where "ok=0" writes look like
   // a data/write bug instead of "the ring was never populated".

--- a/src/mds/mds_server.cc
+++ b/src/mds/mds_server.cc
@@ -346,12 +346,16 @@ Status MdsServer::ListMembers(const std::string& group, std::string* out,
         (include_degraded || one[0].RingEligible()))
       members.push_back(one[0]);
   }
-  // Epoch = content hash of the member set, NOT etcd's global revision: the
-  // revision bumps on every cluster write (including unrelated groups), which
-  // would make clients rebuild their ring needlessly. The hash changes iff THIS
-  // group's membership content changes.
+  // Placement and topology have separate canonical generations. The legacy
+  // kListMembers view is filtered to eligible members and keeps its placement
+  // epoch. kListTopology includes degraded members and uses the HLT1-sensitive
+  // generation, so rail-only changes reach modern clients without inventing a
+  // second wire extension.
   metrics_.members_last_list.store(members.size(), std::memory_order_relaxed);
-  *out = EncodeMembers(members, MembersEpoch(members));
+  const uint64_t epoch = include_degraded
+                             ? MembersTopologyEpoch(members)
+                             : MembersEpoch(members);
+  *out = EncodeMembers(members, epoch);
   return Status::kOk;
 }
 

--- a/src/tools/dfkvctl_main.cc
+++ b/src/tools/dfkvctl_main.cc
@@ -136,6 +136,15 @@ static std::string IbHealthSummary(const MemberInfo& member) {
   }
   return out.empty() ? "none" : out;
 }
+static const char* MemberStatus(const MemberInfo& member) {
+  if (!member.RingEligible()) return "DEGRADED";
+  if (!member.has_health) return "ACTIVE";
+  size_t active = 0;
+  for (const auto& device : member.health.ib_devices)
+    if (device.healthy()) ++active;
+  if (active == 0) return "DEGRADED";
+  return active == member.health.ib_devices.size() ? "ACTIVE" : "PARTIAL";
+}
 
 // Extract the value of `key=` from a "k=v,k=v" info string, or "" if absent.
 static std::string InfoField(const std::string& info, const std::string& key) {
@@ -310,7 +319,7 @@ static int CmdRing(const std::string& mds, const std::string& group,
     // cap, ...). "-" = node predates info reporting (itself a version signal).
     std::printf("%-16s %-22s %-9s %6u %8zu %6.1f%% %-30s %s\n",
                 m.id.c_str(), addr.c_str(),
-                m.RingEligible() ? "ACTIVE" : "DEGRADED", m.weight, v, share,
+                MemberStatus(m), m.weight, v, share,
                 IbHealthSummary(m).c_str(),
                 m.info.empty() ? "-" : m.info.c_str());
   }

--- a/src/transport/rail_select.h
+++ b/src/transport/rail_select.h
@@ -10,7 +10,12 @@
 #include <limits>
 #include <mutex>
 #include <optional>
+#include <memory>
 #include <vector>
+#include <string>
+#include <unordered_map>
+
+#include "transport/transport.h"
 
 namespace dfkv {
 namespace rdma {
@@ -30,6 +35,185 @@ inline size_t PickRail(const std::vector<int>& dev_node, int caller_node,
   if (local.empty()) return rr_tick % n;        // no NUMA-local rail -> all
   return local[rr_tick % local.size()];
 }
+
+// Parse DFKV_RDMA_RAIL_TIERS. A missing value synthesizes one homogeneous tier
+// containing every configured local device. An explicit value is a strict
+// semicolon-separated tier list whose alternatives use '|': "a|b;c". Empty
+// names/tiers, duplicates, and names outside DFKV_RDMA_DEV are rejected.
+inline bool ParseRailTiers(const std::string& spec,
+                           const std::vector<std::string>& local_devices,
+                           std::vector<std::vector<uint8_t>>* tiers,
+                           std::string* error) {
+  if (!tiers) return false;
+  tiers->clear();
+  if (error) error->clear();
+  if (spec.empty()) {
+    tiers->push_back(std::vector<uint8_t>(local_devices.size(), 1));
+    return true;
+  }
+  std::vector<uint8_t> seen(local_devices.size(), 0);
+  size_t tier_begin = 0;
+  while (tier_begin <= spec.size()) {
+    const size_t tier_end = spec.find(';', tier_begin);
+    const size_t end =
+        tier_end == std::string::npos ? spec.size() : tier_end;
+    if (end == tier_begin) {
+      if (error) *error = "DFKV_RDMA_RAIL_TIERS contains an empty tier";
+      tiers->clear();
+      return false;
+    }
+    std::vector<uint8_t> mask(local_devices.size(), 0);
+    size_t name_begin = tier_begin;
+    while (name_begin <= end) {
+      const size_t separator = spec.find('|', name_begin);
+      const size_t name_end =
+          separator == std::string::npos || separator > end ? end : separator;
+      if (name_end == name_begin) {
+        if (error) *error = "DFKV_RDMA_RAIL_TIERS contains an empty rail name";
+        tiers->clear();
+        return false;
+      }
+      const std::string name = spec.substr(name_begin, name_end - name_begin);
+      const auto found =
+          std::find(local_devices.begin(), local_devices.end(), name);
+      if (found == local_devices.end()) {
+        if (error)
+          *error = "DFKV_RDMA_RAIL_TIERS rail '" + name +
+                   "' is not present in DFKV_RDMA_DEV";
+        tiers->clear();
+        return false;
+      }
+      const size_t index =
+          static_cast<size_t>(std::distance(local_devices.begin(), found));
+      if (seen[index]) {
+        if (error)
+          *error = "DFKV_RDMA_RAIL_TIERS repeats rail '" + name + "'";
+        tiers->clear();
+        return false;
+      }
+      seen[index] = 1;
+      mask[index] = 1;
+      if (name_end == end) break;
+      name_begin = name_end + 1;
+    }
+    tiers->push_back(std::move(mask));
+    if (tier_end == std::string::npos) break;
+    tier_begin = tier_end + 1;
+  }
+  return true;
+}
+
+// Return the first (highest-priority) tier with at least one peer-healthy local
+// rail. The returned mask contains only that tier's intersection, preventing
+// credits, latency, NUMA, or quarantine from spilling into a lower tier.
+inline std::vector<uint8_t> HighestCompatibleTier(
+    const std::vector<std::vector<uint8_t>>& tiers,
+    const std::vector<uint8_t>& peer_healthy) {
+  for (const auto& tier : tiers) {
+    std::vector<uint8_t> compatible(
+        std::max(tier.size(), peer_healthy.size()), 0);
+    bool any = false;
+    for (size_t i = 0; i < compatible.size(); ++i) {
+      compatible[i] =
+          i < tier.size() && tier[i] != 0 && i < peer_healthy.size() &&
+          peer_healthy[i] != 0;
+      any = any || compatible[i] != 0;
+    }
+    if (any) return compatible;
+  }
+  return {};
+}
+
+struct PeerRailSnapshot {
+  uint64_t generation = 0;
+  bool complete = false;
+  // Peer health by stable local device index. `compatible` is the highest tier
+  // for an all-enabled local topology; transports recompute from peer_healthy
+  // when runtime local eligibility removes rails.
+  std::vector<uint8_t> peer_healthy;
+  std::vector<uint8_t> compatible;
+};
+
+// Thread-safe immutable snapshot publication keyed by peer address. Explicit
+// heterogeneous tiers fail closed until a complete HLT1 topology arrives.
+// Without explicit tiers, absent/incomplete topology preserves the legacy
+// homogeneous all-local behavior.
+class PeerTopologyStore {
+ public:
+  PeerTopologyStore(std::vector<std::string> local_devices,
+                    std::vector<std::vector<uint8_t>> tiers,
+                    bool require_complete)
+      : local_devices_(std::move(local_devices)),
+        tiers_(std::move(tiers)),
+        require_complete_(require_complete) {
+    auto fallback = std::make_shared<PeerRailSnapshot>();
+    fallback->complete = !require_complete_;
+    if (!require_complete_) {
+      fallback->peer_healthy.assign(local_devices_.size(), 1);
+      fallback->compatible.assign(local_devices_.size(), 1);
+    }
+    fallback_ = std::move(fallback);
+  }
+
+  bool Update(const PeerTopology& topology) {
+    if (topology.peer_addr.empty()) return false;
+    auto next = std::make_shared<PeerRailSnapshot>();
+    next->generation = topology.generation;
+    next->complete = topology.complete;
+    if (topology.complete) {
+      std::vector<uint8_t> healthy(local_devices_.size(), 0);
+      for (const auto& rail : topology.rails) {
+        if (!rail.healthy) continue;
+        const auto found =
+            std::find(local_devices_.begin(), local_devices_.end(), rail.name);
+        if (found != local_devices_.end()) {
+          healthy[static_cast<size_t>(
+              std::distance(local_devices_.begin(), found))] = 1;
+        }
+      }
+      next->peer_healthy = healthy;
+      next->compatible = HighestCompatibleTier(tiers_, healthy);
+    } else if (!require_complete_) {
+      next->peer_healthy.assign(local_devices_.size(), 1);
+      next->compatible.assign(local_devices_.size(), 1);
+    }
+    std::lock_guard<std::mutex> lock(mu_);
+    const auto found = snapshots_.find(topology.peer_addr);
+    // generation is a canonical FNV topology token, not a numeric sequence.
+    // MdsMemberPoller publishes callbacks in order; compare equality only to
+    // deduplicate the same immutable snapshot. Ordering it with < or > would
+    // reject arbitrary valid topology changes.
+    if (found != snapshots_.end() &&
+        topology.generation == found->second->generation)
+      return false;
+    snapshots_[topology.peer_addr] = std::move(next);
+    return true;
+  }
+
+  std::shared_ptr<const PeerRailSnapshot> Snapshot(
+      const std::string& peer_addr) const {
+    std::lock_guard<std::mutex> lock(mu_);
+    const auto found = snapshots_.find(peer_addr);
+    return found == snapshots_.end() ? fallback_ : found->second;
+  }
+
+  bool IsCurrent(const std::string& peer_addr, uint64_t generation) const {
+    std::lock_guard<std::mutex> lock(mu_);
+    const auto found = snapshots_.find(peer_addr);
+    return (found == snapshots_.end() ? fallback_->generation
+                                      : found->second->generation) ==
+           generation;
+  }
+
+ private:
+  std::vector<std::string> local_devices_;
+  std::vector<std::vector<uint8_t>> tiers_;
+  bool require_complete_;
+  std::shared_ptr<const PeerRailSnapshot> fallback_;
+  mutable std::mutex mu_;
+  std::unordered_map<std::string,
+                     std::shared_ptr<const PeerRailSnapshot>> snapshots_;
+};
 
 struct RailPolicyConfig {
   uint32_t credits_per_rail = 64;
@@ -302,6 +486,60 @@ inline bool HasUnexcludedRail(const std::vector<uint8_t>& preferred,
     if (enabled && !(i < excluded.size() && excluded[i] != 0)) return true;
   }
   return false;
+}
+
+inline std::vector<uint8_t> IntersectRailMasks(
+    const std::vector<uint8_t>& left, const std::vector<uint8_t>& right) {
+  std::vector<uint8_t> out(std::max(left.size(), right.size()), 0);
+  for (size_t i = 0; i < out.size(); ++i)
+    out[i] = i < left.size() && left[i] != 0 && i < right.size() &&
+             right[i] != 0;
+  return out;
+}
+
+
+inline std::vector<uint8_t> UnionRailMasks(
+    const std::vector<uint8_t>& left, const std::vector<uint8_t>& right) {
+  std::vector<uint8_t> out(std::max(left.size(), right.size()), 0);
+  for (size_t i = 0; i < out.size(); ++i)
+    out[i] = (i < left.size() && left[i] != 0) ||
+             (i < right.size() && right[i] != 0);
+  return out;
+}
+inline bool HasRail(const std::vector<uint8_t>& mask) {
+  return std::any_of(mask.begin(), mask.end(),
+                     [](uint8_t enabled) { return enabled != 0; });
+}
+
+// Apply locality only within an already selected highest compatible tier.
+// Credit pressure waits on that tier; `fallback` is a NUMA fallback mask, never
+// a lower heterogeneous tier.
+inline std::optional<RailLease> AcquireHighestTier(
+    RailPolicy& policy, uint32_t requested, uint64_t timeout_us,
+    const std::vector<uint8_t>& highest_tier,
+    const std::vector<uint8_t>& preferred,
+    const std::vector<uint8_t>& fallback,
+    const std::vector<uint8_t>& excluded = {}) {
+  std::vector<uint8_t> local = IntersectRailMasks(highest_tier, preferred);
+  std::vector<uint8_t> nonlocal =
+      IntersectRailMasks(highest_tier, fallback);
+  if (!HasRail(local)) {
+    local = std::move(nonlocal);
+    nonlocal.clear();
+  }
+  if (!HasRail(local)) return std::nullopt;
+  const uint64_t now = RailPolicy::NowMicros();
+  if (auto lease = policy.TryAcquire(requested, now, local, excluded))
+    return lease;
+  if (HasRail(nonlocal)) {
+    if (auto lease = policy.TryAcquire(requested, now, nonlocal, excluded))
+      return lease;
+  }
+  const bool local_available = HasUnexcludedRail(local, {}, excluded);
+  return policy.Acquire(requested, timeout_us,
+                        local_available || !HasRail(nonlocal) ? local
+                                                             : nonlocal,
+                        excluded);
 }
 
 // Bounded admission that prefers one candidate mask and degrades to a fallback

--- a/src/transport/rdma_health.cc
+++ b/src/transport/rdma_health.cc
@@ -72,19 +72,20 @@ RdmaHealthMonitor::RdmaHealthMonitor(ProbeFn probe,
       recovery_samples_(std::max<uint32_t>(1, recovery_samples)) {}
 
 MemberHealth RdmaHealthMonitor::Sample() {
-  std::vector<IbDeviceHealth> devices = probe_ ? probe_() : std::vector<IbDeviceHealth>{};
-  const bool all_healthy = !devices.empty() &&
-      std::all_of(devices.begin(), devices.end(),
+  std::vector<IbDeviceHealth> devices =
+      probe_ ? probe_() : std::vector<IbDeviceHealth>{};
+  const bool any_healthy =
+      std::any_of(devices.begin(), devices.end(),
                   [](const IbDeviceHealth& d) { return d.healthy(); });
   std::lock_guard<std::mutex> lock(mu_);
   const bool was_eligible = last_.ring_eligible;
-  if (!all_healthy) {
-    healthy_streak_ = 0;
+  if (!any_healthy) {
+    active_streak_ = 0;
     last_.ring_eligible = false;
   } else if (!sampled_ || last_.ring_eligible) {
-    healthy_streak_ = recovery_samples_;
+    active_streak_ = recovery_samples_;
     last_.ring_eligible = true;
-  } else if (++healthy_streak_ >= recovery_samples_) {
+  } else if (++active_streak_ >= recovery_samples_) {
     last_.ring_eligible = true;
   }
   last_.ib_devices = std::move(devices);
@@ -104,11 +105,22 @@ MemberHealth RdmaHealthMonitor::Last() const {
 
 std::string RdmaHealthMonitor::MetricsText() const {
   const MemberHealth health = Last();
+  const size_t active = static_cast<size_t>(std::count_if(
+      health.ib_devices.begin(), health.ib_devices.end(),
+      [](const IbDeviceHealth& device) { return device.healthy(); }));
   std::string out =
       "# HELP dfkv_server_ring_eligible Whether IB health permits placement ring membership\n"
       "# TYPE dfkv_server_ring_eligible gauge\n"
       "dfkv_server_ring_eligible " +
       std::string(health.ring_eligible ? "1\n" : "0\n") +
+      "# HELP dfkv_server_rdma_rails_configured RDMA rails in the server's fixed configured topology\n"
+      "# TYPE dfkv_server_rdma_rails_configured gauge\n"
+      "dfkv_server_rdma_rails_configured " +
+      std::to_string(health.ib_devices.size()) + "\n"
+      "# HELP dfkv_server_rdma_rails_active Configured RDMA rails currently healthy\n"
+      "# TYPE dfkv_server_rdma_rails_active gauge\n"
+      "dfkv_server_rdma_rails_active " +
+      std::to_string(active) + "\n"
       "# HELP dfkv_server_ib_device_healthy Whether an IB device port is ACTIVE and LinkUp\n"
       "# TYPE dfkv_server_ib_device_healthy gauge\n";
   for (const auto& device : health.ib_devices) {

--- a/src/transport/rdma_health.h
+++ b/src/transport/rdma_health.h
@@ -20,6 +20,9 @@ class RdmaHealthMonitor {
   using ProbeFn = std::function<std::vector<IbDeviceHealth>()>;
 
   explicit RdmaHealthMonitor(ProbeFn probe, uint32_t recovery_samples = 3);
+  // Runtime placement needs at least one healthy initialized rail. Loss of the
+  // final rail is immediate; recovery from zero requires recovery_samples
+  // consecutive samples with at least one healthy rail.
 
   MemberHealth Sample();
   MemberHealth Last() const;
@@ -30,7 +33,7 @@ class RdmaHealthMonitor {
   uint32_t recovery_samples_;
   mutable std::mutex mu_;
   MemberHealth last_;
-  uint32_t healthy_streak_ = 0;
+  uint32_t active_streak_ = 0;
   bool sampled_ = false;
 };
 

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -140,19 +140,20 @@ std::vector<std::string> ParseDeviceList(const std::string& list) {
   return devices;
 }
 
-std::string JoinDevices(const std::vector<std::string>& devices) {
+std::string JoinDevices(const std::vector<std::string>& devices,
+                        const char* separator = ",") {
   std::string out;
   for (const auto& device : devices) {
-    if (!out.empty()) out += ",";
+    if (!out.empty()) out += separator;
     out += device;
   }
   return out;
 }
 
-// Test-only deterministic completion faults for replay-safe read operations.
+// Test-only deterministic completion faults for data operations.
 // The env value is a comma-separated list of
 // "<logical-call>:<attempt>:<completion-window>" specs, all one-based.
-// Eligible logical read calls are numbered only while the env is set. Each
+// Eligible logical calls are numbered only while the env is set. Each
 // operation owns its injection state and passes it explicitly to data-path
 // reaps, so pooled connection maintenance cannot consume a target window.
 // A matching successfully reaped window is surfaced once as
@@ -325,13 +326,12 @@ std::shared_ptr<rdma::ResourceBudget> ProcessResourceBudget(
   return budget;
 }
 
-// Admission (budget) starvation never dialed the peer, so it must not be
-// reported as the peer's kIOError: PeerHealth would cool the node down and
-// blanket-fail every key routed to it (the 0812-004 amplification). Flip only
-// the slots still carrying the kIOError default; kInvalid verdicts stand.
-void MarkAdmissionFailure(std::vector<Status>* result) {
+// Client-local failures that occur before dialing the peer must remain neutral
+// to PeerHealth. Flip only slots still carrying the kIOError default;
+// deterministic kInvalid verdicts stand.
+void MarkClientLocalFailure(std::vector<Status>* result, Status status) {
   for (auto& s : *result)
-    if (s == Status::kIOError) s = Status::kResourceExhausted;
+    if (s == Status::kIOError) s = status;
 }
 
 }  // namespace
@@ -340,6 +340,7 @@ struct RdmaTransport::Conn {
   rdma::RcEndpoint ep;
   rdma::RecvSegmentInfo recv_segment;
   size_t rail_index = 0;
+  uint64_t peer_generation = 0;
   rdma::RailLease lease;
   uint64_t lease_started_us = 0;
   bool credit_held = false;
@@ -413,6 +414,25 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
   if (auto_device_ && discovered.size() > 1) discovered.resize(1);
   devs_.reserve(discovered.size());
   for (const auto& device : discovered) devs_.push_back(device.name);
+  const char* tiers_env = std::getenv("DFKV_RDMA_RAIL_TIERS");
+  const std::string tiers_spec = tiers_env ? tiers_env : "";
+  peer_topology_required_ = !tiers_spec.empty();
+  if (peer_topology_required_ && filter.empty()) {
+    const std::string error =
+        "DFKV_RDMA_RAIL_TIERS requires an explicit DFKV_RDMA_DEV list";
+    DFKV_LOG_ERROR(error);
+    throw std::runtime_error(error);
+  }
+  std::string tiers_error;
+  if (!rdma::ParseRailTiers(tiers_spec, devs_, &rail_tiers_, &tiers_error)) {
+    DFKV_LOG_ERROR(tiers_error);
+    throw std::runtime_error(tiers_error);
+  }
+  peer_topologies_ = std::make_unique<rdma::PeerTopologyStore>(
+      devs_, rail_tiers_, peer_topology_required_);
+  config_dump::RecordResolved(
+      "DFKV_RDMA_RAIL_TIERS",
+      peer_topology_required_ ? tiers_spec : JoinDevices(devs_, "|"));
   topology_ =
       std::make_unique<rdma::RdmaTopology>(std::move(discovered));
   numa_aware_ = numa::Enabled();
@@ -648,8 +668,12 @@ void RdmaTransport::KeepaliveLoop() {
       collect(control_pool_, Lane::kControl);
     }
     for (const auto& entry : idle) {
-      if (keepalive_stop_.load(std::memory_order_relaxed) ||
-          !KeepaliveConn(entry.conn)) {
+      if (!peer_topologies_->IsCurrent(entry.node,
+                                       entry.conn->peer_generation)) {
+        stale_generation_reaps_.fetch_add(1, std::memory_order_relaxed);
+        Destroy(entry.conn, rdma::RailCompletion::kAdmission);
+      } else if (keepalive_stop_.load(std::memory_order_relaxed) ||
+                 !KeepaliveConn(entry.conn)) {
         Destroy(entry.conn, rdma::RailCompletion::kEndpointFailure);
       } else {
         Release(entry.node, entry.lane, entry.conn);
@@ -737,6 +761,40 @@ void RdmaTransport::OnTopologyHint(size_t nodes) {
   }
 }
 
+void RdmaTransport::OnPeerTopology(const PeerTopology& topology) {
+  std::vector<Conn*> stale;
+  {
+    // Publish and detach under the same pool lock. Acquire's generation check
+    // uses this lock too, so no idle endpoint can cross the update linearization
+    // point and become active with the retired generation.
+    std::lock_guard<std::mutex> lock(mu_);
+    if (!peer_topologies_->Update(topology)) return;
+    const auto reap = [&](auto& pools) {
+      const auto found = pools.find(topology.peer_addr);
+      if (found == pools.end()) return;
+      auto& connections = found->second;
+      for (auto it = connections.begin(); it != connections.end();) {
+        Conn* conn = *it;
+        if (conn->peer_generation == topology.generation ||
+            !conn->lifecycle.RequestRetire()) {
+          ++it;
+          continue;
+        }
+        stale.push_back(conn);
+        it = connections.erase(it);
+      }
+      if (connections.empty()) pools.erase(found);
+    };
+    reap(pool_);
+    reap(sg_pool_);
+    reap(control_pool_);
+  }
+  peer_topology_updates_.fetch_add(1, std::memory_order_relaxed);
+  for (Conn* conn : stale)
+    Destroy(conn, rdma::RailCompletion::kAdmission);
+  stale_generation_reaps_.fetch_add(stale.size(), std::memory_order_relaxed);
+}
+
 uint16_t RdmaTransport::LearnedDepth(const std::string& node, Lane lane) {
   const uint16_t full = static_cast<uint16_t>(std::min<size_t>(depth_, 256));
   std::lock_guard<std::mutex> lk(depth_mu_);
@@ -778,13 +836,21 @@ bool RdmaTransport::ProbeV2(const std::string& node) const {
 
 RdmaTransport::AcquireResult RdmaTransport::Acquire(
     const std::string& node, Lane lane, const AcquireOptions& options) {
+  AcquireResult result;
+  const auto peer_snapshot =
+      options.peer ? options.peer : peer_topologies_->Snapshot(node);
+  if (!peer_snapshot || !rdma::HasRail(peer_snapshot->peer_healthy)) {
+    no_compatible_rail_.fetch_add(1, std::memory_order_relaxed);
+    result.failure = AcquireFailure::kNoCompatibleRail;
+    result.status = Status::kNoCompatibleRail;
+    return result;
+  }
   const uint32_t requested = static_cast<uint32_t>(
       std::min<size_t>(options.requested_credits,
                        std::numeric_limits<uint32_t>::max()));
-  // Selection is global across configured rails: first constrain candidates to
-  // the caller's local NUMA rails when that topology exists, then choose least
-  // normalized inflight with latency/error penalties. The operation-local
-  // exclusion applies to both the preferred and fallback topology masks.
+  // NUMA preference, credits, latency, and quarantine are applied only inside
+  // the highest tier in the captured peer generation that still intersects
+  // the runtime-enabled local topology.
   const int caller_node = numa_aware_ ? numa::CurrentNode() : -1;
   const auto candidates =
       topology_->CandidatesFor(caller_node, numa_aware_);
@@ -793,12 +859,25 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   } else if (candidates.locality == rdma::RailLocality::kNoLocal) {
     numa_no_local_fallbacks_.fetch_add(1, std::memory_order_relaxed);
   }
-  auto lease = rdma::AcquireWithFallback(
-      *rail_policy_, requested, rail_backpressure_us_, candidates.allowed,
-      candidates.fallback, options.excluded);
-  if (!lease) return {};
-
-  AcquireResult result;
+  const auto local_enabled =
+      rdma::UnionRailMasks(candidates.allowed, candidates.fallback);
+  const auto highest_tier = rdma::HighestCompatibleTier(
+      rail_tiers_,
+      rdma::IntersectRailMasks(peer_snapshot->peer_healthy, local_enabled));
+  if (!rdma::HasRail(highest_tier)) {
+    no_compatible_rail_.fetch_add(1, std::memory_order_relaxed);
+    result.failure = AcquireFailure::kNoCompatibleRail;
+    result.status = Status::kNoCompatibleRail;
+    return result;
+  }
+  auto lease = rdma::AcquireHighestTier(
+      *rail_policy_, requested, rail_backpressure_us_, highest_tier,
+      candidates.allowed, candidates.fallback, options.excluded);
+  if (!lease) {
+    result.failure = AcquireFailure::kAdmission;
+    result.status = Status::kResourceExhausted;
+    return result;
+  }
   result.attempted_rail = lease->rail;
   const size_t ridx = lease->rail;
   const uint64_t lease_started = rdma::RailPolicy::NowMicros();
@@ -809,10 +888,13 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
       };
 
   std::vector<std::pair<void*, size_t>> pools;
+  std::vector<Conn*> stale;
   Conn* pooled = nullptr;
   {
     std::lock_guard<std::mutex> lk(mu_);
     pools = pools_;
+    const uint64_t current_generation =
+        peer_topologies_->Snapshot(node)->generation;
     if (!options.force_new) {
       auto& idle = lane == Lane::kData
                        ? pool_
@@ -821,9 +903,19 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
       if (it != idle.end()) {
         auto& pool_candidates = it->second;
         for (size_t i = pool_candidates.size(); i > 0; --i) {
-          if (pool_candidates[i - 1]->rail_index == ridx &&
-              pool_candidates[i - 1]->lifecycle.Activate()) {
-            pooled = pool_candidates[i - 1];
+          Conn* candidate = pool_candidates[i - 1];
+          if (candidate->peer_generation != current_generation) {
+            if (candidate->lifecycle.RequestRetire()) {
+              stale.push_back(candidate);
+              pool_candidates.erase(pool_candidates.begin() +
+                                    static_cast<std::ptrdiff_t>(i - 1));
+            }
+            continue;
+          }
+          if (candidate->peer_generation == peer_snapshot->generation &&
+              candidate->rail_index == ridx &&
+              candidate->lifecycle.Activate()) {
+            pooled = candidate;
             pool_candidates.erase(
                 pool_candidates.begin() + static_cast<std::ptrdiff_t>(i - 1));
             break;
@@ -832,6 +924,9 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
       }
     }
   }
+  for (Conn* conn : stale)
+    Destroy(conn, rdma::RailCompletion::kAdmission);
+  stale_generation_reaps_.fetch_add(stale.size(), std::memory_order_relaxed);
   if (pooled) {
     pooled->lease = *lease;
     pooled->lease_started_us = lease_started;
@@ -891,6 +986,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     }
     complete_unowned_lease(rdma::RailCompletion::kAdmission);
     result.failure = AcquireFailure::kAdmission;
+    result.status = Status::kResourceExhausted;
     return result;
   }
 
@@ -913,6 +1009,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
   auto* conn = new Conn();
   conn->rail_index = ridx;
+  conn->peer_generation = peer_snapshot->generation;
   conn->lease = *lease;
   conn->lease_started_us = lease_started;
   conn->credit_held = true;
@@ -934,20 +1031,20 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   char devbuf[rdma::kDevNameBytes];
   rdma::EncodeDevFrame(auto_device_ ? std::string() : dev, conn_declared,
                        devbuf, rdma::kDevProtoV2);
-  char mine[rdma::kQpInfoBytes], peer[rdma::kQpInfoBytes];
+  char mine[rdma::kQpInfoBytes], remote_qp_bytes[rdma::kQpInfoBytes];
   rdma::QpInfo my = conn->ep.Local();
   my.depth = static_cast<uint16_t>(std::min<size_t>(conn_depth, 256));
   my.protocol_version = rdma::kDevProtoV2;
   rdma::SerializeQpInfo(my, mine);
   if (!net::WriteAll(fd, devbuf, rdma::kDevNameBytes) ||
       !net::WriteAll(fd, mine, rdma::kQpInfoBytes) ||
-      !net::ReadAll(fd, peer, rdma::kQpInfoBytes)) {
+      !net::ReadAll(fd, remote_qp_bytes, rdma::kQpInfoBytes)) {
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
     result.failure = AcquireFailure::kEndpoint;
     return result;
   }
-  const rdma::QpInfo remote = rdma::ParseQpInfo(peer);
+  const rdma::QpInfo remote = rdma::ParseQpInfo(remote_qp_bytes);
   if (remote.protocol_version != rdma::kDevProtoV2 || remote.depth == 0) {
     DFKV_LOG_ERROR("rdma: peer " + node +
                    " returned an invalid v2 QP negotiation");
@@ -1025,8 +1122,12 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
 
 bool RdmaTransport::PrepareRetry(
     int attempt, bool from_pool, std::optional<size_t> attempted_rail,
-    AcquireFailure failure, RailMask* excluded, bool* cross_rail_retry) {
-  if (attempt != 0) return false;
+    AcquireFailure failure, ReplaySafety replay_safety, bool request_posted,
+    const std::shared_ptr<const rdma::PeerRailSnapshot>& peer,
+    RailMask* excluded, bool* cross_rail_retry) {
+  if (attempt != 0 || failure == AcquireFailure::kNoCompatibleRail ||
+      (replay_safety == ReplaySafety::kUnsafeAfterPost && request_posted))
+    return false;
   if (failure == AcquireFailure::kLocalRail && attempted_rail &&
       *attempted_rail < devs_.size()) {
     excluded->assign(devs_.size(), 0);
@@ -1034,14 +1135,21 @@ bool RdmaTransport::PrepareRetry(
     const int caller_node = numa_aware_ ? numa::CurrentNode() : -1;
     const auto candidates =
         topology_->CandidatesFor(caller_node, numa_aware_);
-    if (rdma::HasUnexcludedRail(candidates.allowed, candidates.fallback,
-                                *excluded)) {
+    const auto local_enabled =
+        rdma::UnionRailMasks(candidates.allowed, candidates.fallback);
+    const auto highest_tier = rdma::HighestCompatibleTier(
+        rail_tiers_,
+        rdma::IntersectRailMasks(peer->peer_healthy, local_enabled));
+    const auto preferred =
+        rdma::IntersectRailMasks(highest_tier, candidates.allowed);
+    const auto fallback =
+        rdma::IntersectRailMasks(highest_tier, candidates.fallback);
+    if (rdma::HasUnexcludedRail(preferred, fallback, *excluded)) {
       cross_rail_retries_.fetch_add(1, std::memory_order_relaxed);
       *cross_rail_retry = true;
     } else {
-      // A one-enabled-rail topology may make one fresh same-rail attempt, but
-      // ordinary admission still enforces quarantine, cooldown, and credits.
-      // It is not a cross-rail retry, so leave its accounting flag clear.
+      // A one-compatible-rail topology may make one fresh same-rail attempt,
+      // while ordinary admission still enforces quarantine and credits.
       excluded->assign(devs_.size(), 0);
     }
     return true;
@@ -1425,6 +1533,21 @@ std::string RdmaTransport::MetricsText() const {
   s += "dfkv_rdma_client_keepalive_failures_total " +
        std::to_string(keepalive_failures_.load(std::memory_order_relaxed)) +
        "\n";
+  s += "# HELP dfkv_rdma_client_peer_topology_updates_total Published peer topology generations\n";
+  s += "# TYPE dfkv_rdma_client_peer_topology_updates_total counter\n";
+  s += "dfkv_rdma_client_peer_topology_updates_total " +
+       std::to_string(
+           peer_topology_updates_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_no_compatible_rail_total Operations rejected before admission because no peer-compatible rail exists\n";
+  s += "# TYPE dfkv_rdma_client_no_compatible_rail_total counter\n";
+  s += "dfkv_rdma_client_no_compatible_rail_total " +
+       std::to_string(no_compatible_rail_.load(std::memory_order_relaxed)) +
+       "\n";
+  s += "# HELP dfkv_rdma_client_stale_generation_reaps_total Connections retired instead of reuse after a peer topology generation change\n";
+  s += "# TYPE dfkv_rdma_client_stale_generation_reaps_total counter\n";
+  s += "dfkv_rdma_client_stale_generation_reaps_total " +
+       std::to_string(
+           stale_generation_reaps_.load(std::memory_order_relaxed)) + "\n";
   return s;
 }
 
@@ -1449,17 +1572,24 @@ void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
   }
 
   bool reusable = false;
+  bool generation_current = false;
   {
     std::lock_guard<std::mutex> lk(mu_);
-    auto& idle = lane == Lane::kData
-                     ? pool_
-                     : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
-    auto& v = idle[node];
-    if (v.size() < pool_max_ && c->lifecycle.MakeIdle()) {
-      v.push_back(c);
-      reusable = true;
+    generation_current =
+        peer_topologies_->IsCurrent(node, c->peer_generation);
+    if (generation_current) {
+      auto& idle = lane == Lane::kData
+                       ? pool_
+                       : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
+      auto& v = idle[node];
+      if (v.size() < pool_max_ && c->lifecycle.MakeIdle()) {
+        v.push_back(c);
+        reusable = true;
+      }
     }
   }
+  if (!reusable && !generation_current)
+    stale_generation_reaps_.fetch_add(1, std::memory_order_relaxed);
   if (!reusable) Destroy(c);
 }
 
@@ -1481,11 +1611,17 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
   const Lane lane =
       op == WireOp::kCache || op == WireOp::kRange ? Lane::kData
                                                    : Lane::kControl;
-  const bool replay_safe = op != WireOp::kCache && op != WireOp::kRemove;
+  const bool local_rail_replay_safe =
+      op != WireOp::kCache && op != WireOp::kRemove;
+  const ReplaySafety replay_safety =
+      op == WireOp::kCache ? ReplaySafety::kUnsafeAfterPost
+                           : ReplaySafety::kReplaySafe;
+  const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
   CompletionFaultOperation completion_fault(
-      &test_completion_fault_calls_, op == WireOp::kRange);
+      &test_completion_fault_calls_,
+      op == WireOp::kCache || op == WireOp::kRange);
   for (int attempt = 0; attempt < 2; ++attempt) {
     completion_fault.BeginAttempt(attempt);
     std::string attempt_out;
@@ -1493,26 +1629,26 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
     AcquireOptions options;
     options.force_new = attempt != 0;
     options.excluded = excluded;
+    options.peer = peer;
     AcquireResult acquired = Acquire(node, lane, options);
     if (!acquired.conn) {
       if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
-                       acquired.failure, &excluded, &cross_rail_retry)) {
+                       acquired.failure, replay_safety, false, peer, &excluded,
+                       &cross_rail_retry)) {
         continue;
       }
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
                                               std::memory_order_relaxed);
-      return acquired.failure == AcquireFailure::kAdmission
-                 ? Status::kResourceExhausted
-                 : Status::kIOError;
+      return acquired.status;
     }
     Conn* conn = acquired.conn;
     if (InjectLocalRailFailure(attempt)) {
       const size_t failed_rail = conn->rail_index;
       Destroy(conn, rdma::RailCompletion::kRailFailure);
       if (PrepareRetry(attempt, acquired.from_pool, failed_rail,
-                       AcquireFailure::kLocalRail, &excluded,
-                       &cross_rail_retry))
+                       AcquireFailure::kLocalRail, replay_safety, false, peer,
+                       &excluded, &cross_rail_retry))
         continue;
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
@@ -1644,11 +1780,12 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
     Destroy(conn, completion);
     const AcquireFailure failure =
         completion == rdma::RailCompletion::kRailFailure &&
-                (replay_safe || !request_posted)
+                (local_rail_replay_safe || !request_posted)
             ? AcquireFailure::kLocalRail
             : AcquireFailure::kEndpoint;
     if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
-                     &excluded, &cross_rail_retry)) {
+                     replay_safety, request_posted, peer, &excluded,
+                     &cross_rail_retry)) {
       continue;
     }
     if (cross_rail_retry)
@@ -1721,9 +1858,12 @@ std::vector<Status> RdmaTransport::CacheMany(
   }
   if (valid_count == 0) return result;
 
+  const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
+  CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
   for (int attempt = 0; attempt < 2; ++attempt) {
+    completion_fault.BeginAttempt(attempt);
     std::fill(result.begin(), result.end(), Status::kIOError);
     for (size_t i = 0; i < count; ++i)
       if (bad[i]) result[i] = Status::kInvalid;
@@ -1731,16 +1871,19 @@ std::vector<Status> RdmaTransport::CacheMany(
     options.force_new = attempt != 0;
     options.requested_credits = std::min(valid_count, depth_);
     options.excluded = excluded;
+    options.peer = peer;
     AcquireResult acquired = Acquire(node, Lane::kData, options);
     if (!acquired.conn) {
       if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
-                       acquired.failure, &excluded, &cross_rail_retry))
+                       acquired.failure, ReplaySafety::kUnsafeAfterPost, false,
+                       peer, &excluded, &cross_rail_retry))
         continue;
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
                                               std::memory_order_relaxed);
-      if (acquired.failure == AcquireFailure::kAdmission)
-        MarkAdmissionFailure(&result);
+      if (acquired.failure == AcquireFailure::kAdmission ||
+          acquired.failure == AcquireFailure::kNoCompatibleRail)
+        MarkClientLocalFailure(&result, acquired.status);
       return result;
     }
     Conn* conn = acquired.conn;
@@ -1792,7 +1935,7 @@ std::vector<Status> RdmaTransport::CacheMany(
       bool had_wcs = false;
       if (conn_ok &&
           !ReapPosted(ep, posted, width, &reply_bytes, BatchTimeout(),
-                      &timed_out, &wc_status, &had_wcs)) {
+                      &timed_out, &wc_status, &had_wcs, &completion_fault)) {
         conn_ok = false;
         completion = rdma::ClassifyCompletion(wc_status, had_wcs);
       }
@@ -1828,6 +1971,7 @@ std::vector<Status> RdmaTransport::CacheMany(
             ? AcquireFailure::kLocalRail
             : AcquireFailure::kEndpoint;
     if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     ReplaySafety::kUnsafeAfterPost, request_posted, peer,
                      &excluded, &cross_rail_retry))
       continue;
     if (cross_rail_retry)
@@ -1864,6 +2008,7 @@ std::vector<Status> RdmaTransport::RangeMany(
     return InvalidStatuses(count);
   }
 
+  const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
   CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
@@ -1876,16 +2021,19 @@ std::vector<Status> RdmaTransport::RangeMany(
     options.force_new = attempt != 0;
     options.requested_credits = std::min(count, depth_);
     options.excluded = excluded;
+    options.peer = peer;
     AcquireResult acquired = Acquire(node, Lane::kData, options);
     if (!acquired.conn) {
       if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
-                       acquired.failure, &excluded, &cross_rail_retry))
+                       acquired.failure, ReplaySafety::kReplaySafe, false,
+                       peer, &excluded, &cross_rail_retry))
         continue;
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
                                               std::memory_order_relaxed);
-      if (acquired.failure == AcquireFailure::kAdmission)
-        MarkAdmissionFailure(&result);
+      if (acquired.failure == AcquireFailure::kAdmission ||
+          acquired.failure == AcquireFailure::kNoCompatibleRail)
+        MarkClientLocalFailure(&result, acquired.status);
       return result;
     }
     Conn* conn = acquired.conn;
@@ -1983,7 +2131,8 @@ std::vector<Status> RdmaTransport::RangeMany(
             ? AcquireFailure::kLocalRail
             : AcquireFailure::kEndpoint;
     if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
-                     &excluded, &cross_rail_retry))
+                     ReplaySafety::kReplaySafe, false, peer, &excluded,
+                     &cross_rail_retry))
       continue;
     if (cross_rail_retry)
       cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
@@ -2003,6 +2152,7 @@ std::vector<Status> RdmaTransport::ExistMany(
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) return result;
 
+  const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
   for (int attempt = 0; attempt < 2; ++attempt) {
@@ -2012,16 +2162,19 @@ std::vector<Status> RdmaTransport::ExistMany(
     options.force_new = attempt != 0;
     options.requested_credits = std::min(count, depth_);
     options.excluded = excluded;
+    options.peer = peer;
     AcquireResult acquired = Acquire(node, Lane::kControl, options);
     if (!acquired.conn) {
       if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
-                       acquired.failure, &excluded, &cross_rail_retry))
+                       acquired.failure, ReplaySafety::kReplaySafe, false,
+                       peer, &excluded, &cross_rail_retry))
         continue;
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
                                               std::memory_order_relaxed);
-      if (acquired.failure == AcquireFailure::kAdmission)
-        MarkAdmissionFailure(&result);
+      if (acquired.failure == AcquireFailure::kAdmission ||
+          acquired.failure == AcquireFailure::kNoCompatibleRail)
+        MarkClientLocalFailure(&result, acquired.status);
       return result;
     }
     Conn* conn = acquired.conn;
@@ -2080,7 +2233,8 @@ std::vector<Status> RdmaTransport::ExistMany(
             ? AcquireFailure::kLocalRail
             : AcquireFailure::kEndpoint;
     if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
-                     &excluded, &cross_rail_retry))
+                     ReplaySafety::kReplaySafe, false, peer, &excluded,
+                     &cross_rail_retry))
       continue;
     if (cross_rail_retry)
       cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
@@ -2124,6 +2278,7 @@ std::vector<Status> RdmaTransport::RangeInto(
   rdma::OperationContext operation;
   if (!operation.Submit() || !operation.ClaimPoller()) return result;
   bool final_timeout = false;
+  const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
   CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
@@ -2146,16 +2301,19 @@ std::vector<Status> RdmaTransport::RangeInto(
     options.force_new = attempt != 0;
     options.requested_credits = std::min(valid_count, depth_);
     options.excluded = excluded;
+    options.peer = peer;
     AcquireResult acquired = Acquire(node, Lane::kData, options);
     if (!acquired.conn) {
       if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
-                       acquired.failure, &excluded, &cross_rail_retry))
+                       acquired.failure, ReplaySafety::kReplaySafe, false,
+                       peer, &excluded, &cross_rail_retry))
         continue;
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
                                               std::memory_order_relaxed);
-      if (acquired.failure == AcquireFailure::kAdmission)
-        MarkAdmissionFailure(&result);
+      if (acquired.failure == AcquireFailure::kAdmission ||
+          acquired.failure == AcquireFailure::kNoCompatibleRail)
+        MarkClientLocalFailure(&result, acquired.status);
       operation.Complete(false);
       return result;
     }
@@ -2257,7 +2415,8 @@ std::vector<Status> RdmaTransport::RangeInto(
             ? AcquireFailure::kLocalRail
             : AcquireFailure::kEndpoint;
     if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
-                     &excluded, &cross_rail_retry))
+                     ReplaySafety::kReplaySafe, false, peer, &excluded,
+                     &cross_rail_retry))
       continue;
     if (cross_rail_retry)
       cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
@@ -2316,26 +2475,31 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   }
   if (valid_count == 0) return result;
 
+  const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
+  CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
   for (int attempt = 0; attempt < 2; ++attempt) {
-    // Completed items and their terminal statuses survive a fresh-rail
-    // attempt. Any incomplete item restarts below with new connection-local
-    // progress and transient registrations.
+    // A fresh attempt is possible only before any request is posted;
+    // validation results survive while connection-local progress restarts.
+    completion_fault.BeginAttempt(attempt);
     AcquireOptions options;
     options.force_new = attempt != 0;
     options.requested_credits = 1;
     options.excluded = excluded;
+    options.peer = peer;
     AcquireResult acquired = Acquire(node, Lane::kSgData, options);
     if (!acquired.conn) {
       if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
-                       acquired.failure, &excluded, &cross_rail_retry))
+                       acquired.failure, ReplaySafety::kUnsafeAfterPost, false,
+                       peer, &excluded, &cross_rail_retry))
         continue;
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
                                               std::memory_order_relaxed);
-      if (acquired.failure == AcquireFailure::kAdmission)
-        MarkAdmissionFailure(&result);
+      if (acquired.failure == AcquireFailure::kAdmission ||
+          acquired.failure == AcquireFailure::kNoCompatibleRail)
+        MarkClientLocalFailure(&result, acquired.status);
       return result;
     }
     Conn* conn = acquired.conn;
@@ -2416,7 +2580,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
         ibv_wc_status wc_status = IBV_WC_SUCCESS;
         bool had_wcs = false;
         if (!ReapPosted(ep, 1, 1, &reply_bytes, BatchTimeout(), &timed_out,
-                        &wc_status, &had_wcs)) {
+                        &wc_status, &had_wcs, &completion_fault)) {
           conn_ok = false;
           completion = rdma::ClassifyCompletion(wc_status, had_wcs);
         }
@@ -2466,6 +2630,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
             ? AcquireFailure::kLocalRail
             : AcquireFailure::kEndpoint;
     if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
+                     ReplaySafety::kUnsafeAfterPost, request_posted, peer,
                      &excluded, &cross_rail_retry))
       continue;
     if (cross_rail_retry)
@@ -2570,6 +2735,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
   if (!operation.Submit() || !operation.ClaimPoller()) return result;
   bool final_timeout = false;
 
+  const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
   CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
@@ -2590,16 +2756,19 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     options.force_new = attempt != 0;
     options.requested_credits = std::min<size_t>(remaining_count, depth_);
     options.excluded = excluded;
+    options.peer = peer;
     AcquireResult acquired = Acquire(node, Lane::kSgData, options);
     if (!acquired.conn) {
       if (PrepareRetry(attempt, acquired.from_pool, acquired.attempted_rail,
-                       acquired.failure, &excluded, &cross_rail_retry))
+                       acquired.failure, ReplaySafety::kReplaySafe, false,
+                       peer, &excluded, &cross_rail_retry))
         continue;
       if (cross_rail_retry)
         cross_rail_retry_exhausted_.fetch_add(1,
                                               std::memory_order_relaxed);
-      if (acquired.failure == AcquireFailure::kAdmission)
-        MarkAdmissionFailure(&result);
+      if (acquired.failure == AcquireFailure::kAdmission ||
+          acquired.failure == AcquireFailure::kNoCompatibleRail)
+        MarkClientLocalFailure(&result, acquired.status);
       operation.Complete(false);
       return result;
     }
@@ -2843,7 +3012,8 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
             ? AcquireFailure::kLocalRail
             : AcquireFailure::kEndpoint;
     if (PrepareRetry(attempt, acquired.from_pool, failed_rail, failure,
-                     &excluded, &cross_rail_retry))
+                     ReplaySafety::kReplaySafe, false, peer, &excluded,
+                     &cross_rail_retry))
       continue;
     if (cross_rail_retry)
       cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -96,6 +96,7 @@ class RdmaTransport : public Transport {
   // any budget env explicitly (DFKV_RDMA_ENDPOINT_CACHE_MAX / QP_BUDGET /
   // WR_BUDGET / REGISTERED_BYTES_BUDGET): explicit config is a contract.
   void OnTopologyHint(size_t nodes) override;
+  void OnPeerTopology(const PeerTopology& topology) override;
 
   bool pipelined() const override { return true; }
   size_t MaxSgPayloadSegs() const override { return sg_payload_segs_; }
@@ -131,20 +132,27 @@ class RdmaTransport : public Transport {
   using RailMask = std::vector<uint8_t>;
   enum class AcquireFailure : uint8_t {
     kNone,
+    kNoCompatibleRail,
     kAdmission,
     kLocalRail,
     kEndpoint,
+  };
+  enum class ReplaySafety : uint8_t {
+    kReplaySafe,
+    kUnsafeAfterPost,
   };
   struct AcquireOptions {
     bool force_new = false;
     size_t requested_credits = 1;
     RailMask excluded;
+    std::shared_ptr<const rdma::PeerRailSnapshot> peer;
   };
   struct AcquireResult {
     Conn* conn = nullptr;
     bool from_pool = false;
     std::optional<size_t> attempted_rail;
     AcquireFailure failure = AcquireFailure::kAdmission;
+    Status status = Status::kIOError;
   };
   // Lanes separate payload, device-direct SG, and key-sized control traffic;
   // each lane keeps the negotiated depth while owning an independent endpoint
@@ -153,12 +161,15 @@ class RdmaTransport : public Transport {
   enum class Lane { kData, kSgData, kControl };
   AcquireResult Acquire(const std::string& node, Lane lane,
                         const AcquireOptions& options);
-  // Schedules at most one fresh retry. cross_rail_retry is set only while the
-  // failed rail stays excluded and another topology-enabled rail exists.
-  bool PrepareRetry(int attempt, bool from_pool,
-                    std::optional<size_t> attempted_rail,
-                    AcquireFailure failure, RailMask* excluded,
-                    bool* cross_rail_retry);
+  // Schedules at most one fresh retry. Operations that may commit remotely
+  // are retryable only until their first request is posted. cross_rail_retry
+  // is set only while the failed rail stays excluded and another
+  // topology-enabled rail exists.
+  bool PrepareRetry(
+      int attempt, bool from_pool, std::optional<size_t> attempted_rail,
+      AcquireFailure failure, ReplaySafety replay_safety, bool request_posted,
+      const std::shared_ptr<const rdma::PeerRailSnapshot>& peer,
+      RailMask* excluded, bool* cross_rail_retry);
   void Release(const std::string& node, Lane lane, Conn* c);
   void Destroy(Conn* c,
                rdma::RailCompletion completion =
@@ -265,6 +276,9 @@ class RdmaTransport : public Transport {
   std::atomic<uint64_t> depth_refunds_{0};
   std::unique_ptr<rdma::RdmaTopology> topology_;
   std::vector<std::string> devs_;  // stable discovered ACTIVE rail order
+  std::vector<std::vector<uint8_t>> rail_tiers_;
+  bool peer_topology_required_ = false;
+  std::unique_ptr<rdma::PeerTopologyStore> peer_topologies_;
   bool auto_device_ = true;
   bool numa_aware_ = false;
   // Global least-inflight rail admission with per-rail credits, failure
@@ -283,6 +297,9 @@ class RdmaTransport : public Transport {
   std::atomic<uint64_t> cross_rail_retries_{0};
   std::atomic<uint64_t> cross_rail_retry_successes_{0};
   std::atomic<uint64_t> cross_rail_retry_exhausted_{0};
+  std::atomic<uint64_t> peer_topology_updates_{0};
+  std::atomic<uint64_t> no_compatible_rail_{0};
+  std::atomic<uint64_t> stale_generation_reaps_{0};
   // Deterministic test-only completion-fault targeting. Inert unless
   // DFKV_RDMA_TEST_COMPLETION_FAULT is set.
   std::atomic<uint64_t> test_completion_fault_calls_{0};

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -71,6 +71,23 @@ struct EndpointPoolOptions {
   uint64_t acquire_timeout_ms = 10000;
 };
 
+// One peer rail advertised by the membership topology. Device names are the
+// shared placement binding between hosts; health is the peer's runtime view.
+struct PeerRailTopology {
+  std::string name;
+  bool healthy = false;
+};
+
+// Complete peer-specific topology update. generation is the canonical
+// membership topology epoch, not a transport-local counter. Transports must
+// treat snapshots as immutable so one logical operation cannot mix epochs.
+struct PeerTopology {
+  std::string peer_addr;
+  uint64_t generation = 0;
+  bool complete = false;
+  std::vector<PeerRailTopology> rails;
+};
+
 
 class Transport {
  public:
@@ -134,6 +151,13 @@ class Transport {
   // Called on every membership adoption; implementations must tolerate
   // repeated and concurrent calls. Default: stateless transports ignore it.
   virtual void OnTopologyHint(size_t nodes) { (void)nodes; }
+
+  // Peer-aware rail topology is independent of the scalar ring-size budget
+  // hint. Stateful transports publish an immutable per-address snapshot;
+  // transports without heterogeneous path selection ignore it.
+  virtual void OnPeerTopology(const PeerTopology& topology) {
+    (void)topology;
+  }
 
   // True if CacheMany/RangeMany pipeline requests on one connection (RDMA). When
   // false (TCP), the client parallelizes batches across items with its own

--- a/src/transport/wire_legacy.h
+++ b/src/transport/wire_legacy.h
@@ -79,9 +79,10 @@ inline uint8_t LegacyStatusByte(Status st) {
     case Status::kQuotaExceeded: return 3;  // v2-only; folds into legacy kIOError
     case Status::kIOError: return 3;
     case Status::kInvalid: return 4;
-    // Client-local admission starvation; unreachable on any server encode
-    // path, folded like kIOError for switch exhaustiveness.
+    // Client-local admission/topology failures; unreachable on any server
+    // encode path, folded like kIOError for switch exhaustiveness.
     case Status::kResourceExhausted: return 3;
+    case Status::kNoCompatibleRail: return 3;
   }
   return 4;
 }

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <sys/mman.h>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 using namespace dfkv;  // NOLINT
@@ -24,7 +25,11 @@ using namespace dfkv;  // NOLINT
 namespace {
 class MetricsTransport final : public Transport {
  public:
-  enum class AttemptResult : uint8_t { kSuccess, kRailFailure };
+  enum class AttemptResult : uint8_t {
+    kSuccess,
+    kRailFailure,
+    kAmbiguousPostSubmitFailure,
+  };
   struct ScriptedAttempt {
     size_t rail;
     AttemptResult result;
@@ -39,6 +44,9 @@ class MetricsTransport final : public Transport {
   std::vector<ScriptedAttempt> attempt_script;
   std::vector<ScriptedAttempt> attempts;
   std::vector<size_t> replay_item_counts;
+  std::vector<std::vector<size_t>> attempt_item_indices;
+  std::vector<size_t> range_multi_item_calls;
+  size_t remote_put_commits = 0;
   size_t exist_calls = 0;
   size_t range_calls = 0;
   size_t range_multi_calls = 0;
@@ -52,12 +60,15 @@ class MetricsTransport final : public Transport {
     attempt_script.assign(script);
     attempts.clear();
     replay_item_counts.clear();
+    attempt_item_indices.clear();
+    range_multi_item_calls.clear();
   }
 
   Status Cache(const std::string&, const BlockKey& key, const void* data,
                size_t len) override {
     std::lock_guard<std::mutex> lock(mu);
     const bool ok = RunAttemptsLocked(1, [&] {
+      ++remote_put_commits;
       values[key.Filename()] =
           std::string(static_cast<const char*>(data), len);
     });
@@ -109,6 +120,7 @@ class MetricsTransport final : public Transport {
       const std::string&, const std::vector<CacheSrc>& srcs) override {
     std::lock_guard<std::mutex> lock(mu);
     const bool ok = RunAttemptsLocked(srcs.size(), [&] {
+      remote_put_commits += srcs.size();
       for (const auto& src : srcs) {
         values[src.key.Filename()] =
             std::string(static_cast<const char*>(src.payload),
@@ -146,6 +158,7 @@ class MetricsTransport final : public Transport {
       const std::string&, const std::vector<CacheSrcMulti>& srcs) override {
     std::lock_guard<std::mutex> lock(mu);
     const bool ok = RunAttemptsLocked(srcs.size(), [&] {
+      remote_put_commits += srcs.size();
       for (const auto& src : srcs) {
         std::string value;
         for (const auto& segment : src.payloads)
@@ -167,8 +180,11 @@ class MetricsTransport final : public Transport {
     if (out_lens) out_lens->assign(keys.size(), 0);
     if (dsts.size() != keys.size()) return InvalidStatuses(keys.size());
     std::vector<Status> result(keys.size(), Status::kNotFound);
-    const bool ok = RunAttemptsLocked(keys.size(), [&] {
-      for (size_t i = 0; i < keys.size(); ++i) {
+    range_multi_item_calls.assign(keys.size(), 0);
+    const bool ok = RunAttemptsLocked(
+        keys.size(), [&](size_t begin, size_t end) {
+      for (size_t i = begin; i < end; ++i) {
+        ++range_multi_item_calls[i];
         auto found = values.find(keys[i].Filename());
         if (found == values.end()) continue;
         size_t offset = 0;
@@ -218,21 +234,44 @@ class MetricsTransport final : public Transport {
         attempt_script.empty()
             ? std::vector<ScriptedAttempt>{{0, AttemptResult::kSuccess}}
             : attempt_script;
-    size_t remaining_items = item_count;
+    size_t completed_items = 0;
     bool cross_rail_retry = false;
     for (size_t i = 0; i < script.size() && i < 2; ++i) {
       if (script[i].delay.count() != 0)
         std::this_thread::sleep_for(script[i].delay);
       attempts.push_back(script[i]);
-      replay_item_counts.push_back(remaining_items);
+      replay_item_counts.push_back(item_count - completed_items);
+      std::vector<size_t> attempted_items;
+      attempted_items.reserve(item_count - completed_items);
+      for (size_t item = completed_items; item < item_count; ++item)
+        attempted_items.push_back(item);
+      attempt_item_indices.push_back(std::move(attempted_items));
       if (script[i].result == AttemptResult::kSuccess) {
-        success();
+        if constexpr (std::is_invocable_v<Success, size_t, size_t>)
+          success(completed_items, item_count);
+        else
+          success();
         if (cross_rail_retry) ++cross_rail_retry_successes;
         return true;
       }
-      remaining_items -=
-          std::min(remaining_items,
+      if (script[i].result == AttemptResult::kAmbiguousPostSubmitFailure) {
+        // The peer may already have committed this PUT. The production
+        // contract returns the ambiguous failure without replaying it on a
+        // different rail.
+        if constexpr (std::is_invocable_v<Success, size_t, size_t>)
+          success(completed_items, item_count);
+        else
+          success();
+        return false;
+      }
+      const size_t newly_completed =
+          std::min(item_count - completed_items,
                    script[i].completed_items_before_failure);
+      if constexpr (std::is_invocable_v<Success, size_t, size_t>) {
+        if (newly_completed != 0)
+          success(completed_items, completed_items + newly_completed);
+      }
+      completed_items += newly_completed;
       if (i == 0 && script.size() > 1) {
         cross_rail_retry = script[1].rail != script[0].rail;
         if (cross_rail_retry) ++cross_rail_retries;
@@ -490,7 +529,124 @@ TEST(ClientOpMetrics, SameRailFallbackDoesNotCountAsCrossRailRetry) {
             0u);
 }
 
-TEST(ClientOpMetrics, CrossRailRetryPreservesCompletedMultiWindowSgItems) {
+TEST(ClientOpMetrics, AmbiguousPostSubmitPutIsNotCrossRailReplayed) {
+  using Result = MetricsTransport::AttemptResult;
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, "metrics/ambiguous-put", &transport);
+  const std::string value("committed\0payload", 17);
+
+  transport.Script(
+      {{0, Result::kAmbiguousPostSubmitFailure},
+       {1, Result::kSuccess}});
+  EXPECT_FALSE(client.Put("key", value.data(), value.size()));
+  ASSERT_EQ(transport.attempts.size(), 1u);
+  EXPECT_EQ(transport.attempts[0].rail, 0u);
+  EXPECT_EQ(transport.remote_put_commits, 1u)
+      << "the ambiguous first attempt may already have committed exactly once";
+
+  const std::string snapshot = client.MetricsSnapshot();
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_requests_total", "put"), 1u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_hits_total", "put"), 0u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_bytes_total", "put"), 0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
+            0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_successes_total"),
+            0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot,
+                "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+            0u);
+}
+
+TEST(ClientOpMetrics, AmbiguousPostSubmitPipelinedBatchPutIsNotReplayed) {
+  using Result = MetricsTransport::AttemptResult;
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, "metrics/ambiguous-batch-put",
+                  &transport);
+  const std::vector<std::string> values{
+      std::string("first\0value", 11),
+      std::string("second\0value", 12),
+      std::string("third\0value", 11),
+  };
+  std::vector<KvPutItem> puts;
+  for (size_t i = 0; i < values.size(); ++i) {
+    puts.push_back({"key-" + std::to_string(i), values[i].data(),
+                    values[i].size()});
+  }
+
+  transport.Script(
+      {{0, Result::kAmbiguousPostSubmitFailure},
+       {1, Result::kSuccess}});
+  EXPECT_EQ(client.BatchPut(puts), std::vector<bool>(puts.size(), false));
+  ASSERT_EQ(transport.attempts.size(), 1u);
+  EXPECT_EQ(transport.attempts[0].rail, 0u);
+  EXPECT_EQ(transport.replay_item_counts,
+            std::vector<size_t>({puts.size()}));
+  EXPECT_EQ(transport.remote_put_commits, puts.size());
+  for (size_t i = 0; i < puts.size(); ++i) {
+    EXPECT_EQ(transport.values[ToBlockKey(
+                                   "metrics/ambiguous-batch-put", puts[i].key)
+                                   .Filename()],
+              values[i]);
+  }
+
+  const std::string snapshot = client.MetricsSnapshot();
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_requests_total", "put"), 1u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_keys_total", "put"),
+            puts.size());
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_hits_total", "put"), 0u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_bytes_total", "put"), 0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
+            0u);
+}
+
+TEST(ClientOpMetrics, AmbiguousPostSubmitSgBatchPutIsNotReplayed) {
+  using Result = MetricsTransport::AttemptResult;
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"n", "test:1"}}, "metrics/ambiguous-sg-put",
+                  &transport);
+  const std::array<std::string, 3> segments{
+      std::string("first\0", 6),
+      std::string("second\0", 7),
+      std::string("third\0", 6),
+  };
+  std::vector<KvPutItemSg> puts{
+      {"sg-key",
+       {segments[0].data(), segments[1].data(), segments[2].data()},
+       {segments[0].size(), segments[1].size(), segments[2].size()}},
+  };
+
+  transport.Script(
+      {{0, Result::kAmbiguousPostSubmitFailure},
+       {1, Result::kSuccess}});
+  EXPECT_EQ(client.BatchPutSg(puts), std::vector<bool>({false}));
+  ASSERT_EQ(transport.attempts.size(), 1u);
+  EXPECT_EQ(transport.attempts[0].rail, 0u);
+  EXPECT_EQ(transport.replay_item_counts, std::vector<size_t>({1}));
+  EXPECT_EQ(transport.remote_put_commits, 1u);
+  EXPECT_EQ(transport.values[ToBlockKey("metrics/ambiguous-sg-put", "sg-key")
+                                 .Filename()],
+            segments[0] + segments[1] + segments[2]);
+
+  const std::string snapshot = client.MetricsSnapshot();
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_requests_total", "put"), 1u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_keys_total", "put"), 1u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_hits_total", "put"), 0u);
+  EXPECT_EQ(Metric(snapshot, "dfkv_client_op_bytes_total", "put"), 0u);
+  EXPECT_EQ(TransportCounter(
+                snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
+            0u);
+}
+
+TEST(ClientOpMetrics,
+     ByteExactGetUsesAtMostTwoAttemptsAndDoesNotReplayCompletedItems) {
   using Result = MetricsTransport::AttemptResult;
   constexpr size_t kItems = 9;  // 2 * depth(4) + 1
   constexpr size_t kSegmentBytes = 4;
@@ -505,9 +661,11 @@ TEST(ClientOpMetrics, CrossRailRetryPreservesCompletedMultiWindowSgItems) {
   puts.reserve(kItems);
   for (size_t i = 0; i < kItems; ++i) {
     for (size_t segment = 0; segment < 3; ++segment) {
-      segments[i][segment] =
-          std::string(kSegmentBytes,
-                      static_cast<char>('A' + i * 3 + segment));
+      segments[i][segment].resize(kSegmentBytes);
+      for (size_t byte = 0; byte < kSegmentBytes; ++byte) {
+        segments[i][segment][byte] = static_cast<char>(
+            (i * 37 + segment * 11 + byte * 53) & 0xff);
+      }
       expected[i] += segments[i][segment];
     }
     puts.push_back(
@@ -517,13 +675,10 @@ TEST(ClientOpMetrics, CrossRailRetryPreservesCompletedMultiWindowSgItems) {
          {kSegmentBytes, kSegmentBytes, kSegmentBytes}});
   }
 
-  transport.Script(
-      {{0, Result::kRailFailure, {}, kCompletedBeforeFailure},
-       {1, Result::kSuccess}});
+  transport.Script({{0, Result::kSuccess}});
   EXPECT_EQ(client.BatchPutSg(puts), std::vector<bool>(kItems, true));
-  EXPECT_EQ(transport.replay_item_counts,
-            (std::vector<size_t>{kItems,
-                                 kItems - kCompletedBeforeFailure}));
+  EXPECT_EQ(transport.replay_item_counts, (std::vector<size_t>{kItems}));
+  ASSERT_EQ(transport.attempts.size(), 1u);
 
   std::vector<std::array<std::array<char, kSegmentBytes>, 3>> output(kItems);
   std::vector<KvGetItemSg> gets;
@@ -544,6 +699,16 @@ TEST(ClientOpMetrics, CrossRailRetryPreservesCompletedMultiWindowSgItems) {
   EXPECT_EQ(transport.replay_item_counts,
             (std::vector<size_t>{kItems,
                                  kItems - kCompletedBeforeFailure}));
+  ASSERT_EQ(transport.attempts.size(), 2u);
+  ASSERT_EQ(transport.attempt_item_indices.size(), 2u);
+  EXPECT_EQ(transport.attempt_item_indices[0],
+            (std::vector<size_t>{0, 1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_EQ(transport.attempt_item_indices[1],
+            (std::vector<size_t>{4, 5, 6, 7, 8}))
+      << "items completed by attempt one must never be replayed";
+  EXPECT_EQ(transport.range_multi_item_calls,
+            std::vector<size_t>(kItems, 1u))
+      << "every byte-exact item must be fetched exactly once across attempts";
   for (size_t i = 0; i < kItems; ++i) {
     std::string actual;
     for (const auto& segment : output[i])
@@ -563,11 +728,11 @@ TEST(ClientOpMetrics, CrossRailRetryPreservesCompletedMultiWindowSgItems) {
   }
   EXPECT_EQ(TransportCounter(
                 snapshot, "dfkv_rdma_client_cross_rail_retries_total"),
-            2u);
+            1u);
   EXPECT_EQ(TransportCounter(
                 snapshot,
                 "dfkv_rdma_client_cross_rail_retry_successes_total"),
-            2u);
+            1u);
   EXPECT_EQ(TransportCounter(
                 snapshot,
                 "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
@@ -596,7 +761,9 @@ TEST(ClientOpMetrics, ExhaustedCrossRailRetryCountsOneFailure) {
   }
 
   transport.Script(
-      {{0, Result::kRailFailure}, {1, Result::kRailFailure}});
+      {{0, Result::kRailFailure},
+       {1, Result::kRailFailure},
+       {2, Result::kSuccess}});
   std::vector<size_t> lengths;
   EXPECT_EQ(client.BatchGetAutoSg(gets, &lengths),
             std::vector<bool>(kItems, false));

--- a/test/client/dynamic_members_test.cc
+++ b/test/client/dynamic_members_test.cc
@@ -2,12 +2,27 @@
 // runtime so adding a node re-routes new keys without recreating the client.
 #include "client/kv_client.h"
 #include "cache/kv_node_server.h"
+#include "common/membership.h"
+#include "mds/mds_member_poller.h"
+#include "transport/rail_select.h"
+#include "transport/wire.h"
+#include "utils/net_util.h"
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace fs = std::filesystem;
 using namespace dfkv;  // NOLINT
@@ -24,6 +39,173 @@ std::unique_ptr<Node> Start(const std::string& tag) {
   n->addr = "127.0.0.1:" + std::to_string(n->srv->port());
   return n;
 }
+
+// A local MDS with a mutable topology response. The client's background poller
+// is synchronized through the recording transport below, so the test never
+// sleeps or depends on lease timing.
+class ScriptedTopologyMds {
+ public:
+  explicit ScriptedTopologyMds(std::vector<MemberInfo> members)
+      : members_(std::move(members)) {
+    lfd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    ::bind(lfd_, reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
+    ::listen(lfd_, 8);
+    socklen_t sl = sizeof(sa);
+    ::getsockname(lfd_, reinterpret_cast<sockaddr*>(&sa), &sl);
+    port_ = ntohs(sa.sin_port);
+    thread_ = std::thread([this] { Serve(); });
+  }
+
+  ~ScriptedTopologyMds() {
+    ::shutdown(lfd_, SHUT_RDWR);
+    ::close(lfd_);
+    if (thread_.joinable()) thread_.join();
+  }
+
+  std::string endpoint() const {
+    return "127.0.0.1:" + std::to_string(port_);
+  }
+
+  void SetMembers(std::vector<MemberInfo> members) {
+    std::lock_guard<std::mutex> lock(mu_);
+    members_ = std::move(members);
+  }
+
+  bool only_topology_requests() const {
+    return only_topology_requests_.load();
+  }
+
+ private:
+  void Serve() {
+    for (;;) {
+      const int fd = ::accept(lfd_, nullptr, nullptr);
+      if (fd < 0) return;
+      char prefix[kReqPrefix];
+      ReqFields request{};
+      bool ok = net::ReadAll(fd, prefix, sizeof(prefix)) &&
+                DecodeReq(prefix, &request);
+      if (ok && request.payload_len != 0) {
+        std::string payload(request.payload_len, '\0');
+        ok = net::ReadAll(fd, &payload[0], payload.size());
+      }
+      if (ok) {
+        if (request.op != static_cast<uint8_t>(WireOp::kListTopology))
+          only_topology_requests_.store(false);
+        std::vector<MemberInfo> members;
+        {
+          std::lock_guard<std::mutex> lock(mu_);
+          members = members_;
+        }
+        const std::string data =
+            EncodeMembers(members, MembersTopologyEpoch(members));
+        char response[kRespPrefix];
+        EncodeResp(response, Status::kOk, data.size());
+        ok = net::WriteAll(fd, response, sizeof(response)) &&
+             (data.empty() ||
+              net::WriteAll(fd, data.data(), data.size()));
+      }
+      (void)ok;
+      ::close(fd);
+    }
+  }
+
+  mutable std::mutex mu_;
+  std::vector<MemberInfo> members_;
+  std::atomic<bool> only_topology_requests_{true};
+  int lfd_ = -1;
+  int port_ = 0;
+  std::thread thread_;
+};
+
+// Emulates an MDS predating kListTopology. It either returns the legacy
+// unknown-op response (kInvalid) or drops that request, and records whether the
+// client correctly limits fallback to the former.
+class LegacyMembersMds {
+ public:
+  LegacyMembersMds(std::vector<MemberInfo> members, bool drop_topology)
+      : members_(std::move(members)), drop_topology_(drop_topology) {
+    lfd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    ::bind(lfd_, reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
+    ::listen(lfd_, 8);
+    socklen_t sl = sizeof(sa);
+    ::getsockname(lfd_, reinterpret_cast<sockaddr*>(&sa), &sl);
+    port_ = ntohs(sa.sin_port);
+    thread_ = std::thread([this] { Serve(); });
+  }
+
+  ~LegacyMembersMds() {
+    ::shutdown(lfd_, SHUT_RDWR);
+    ::close(lfd_);
+    if (thread_.joinable()) thread_.join();
+  }
+
+  std::string endpoint() const {
+    return "127.0.0.1:" + std::to_string(port_);
+  }
+
+  std::vector<WireOp> requests() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return requests_;
+  }
+
+ private:
+  void Serve() {
+    for (;;) {
+      const int fd = ::accept(lfd_, nullptr, nullptr);
+      if (fd < 0) return;
+
+      char prefix[kReqPrefix];
+      ReqFields request{};
+      bool ok = net::ReadAll(fd, prefix, sizeof(prefix)) &&
+                DecodeReq(prefix, &request);
+      if (ok && request.payload_len != 0) {
+        std::string payload(request.payload_len, '\0');
+        ok = net::ReadAll(fd, &payload[0], payload.size());
+      }
+      if (!ok) {
+        ::close(fd);
+        continue;
+      }
+
+      const WireOp op = static_cast<WireOp>(request.op);
+      {
+        std::lock_guard<std::mutex> lock(mu_);
+        requests_.push_back(op);
+      }
+      if (op == WireOp::kListTopology && drop_topology_) {
+        ::close(fd);
+        continue;
+      }
+
+      Status status = Status::kInvalid;
+      std::string data;
+      if (op == WireOp::kListMembers) {
+        status = Status::kOk;
+        data = EncodeMembers(members_, MembersEpoch(members_));
+      }
+      char response[kRespPrefix];
+      EncodeResp(response, status, data.size());
+      ok = net::WriteAll(fd, response, sizeof(response)) &&
+           (data.empty() || net::WriteAll(fd, data.data(), data.size()));
+      (void)ok;
+      ::close(fd);
+    }
+  }
+
+  const std::vector<MemberInfo> members_;
+  const bool drop_topology_;
+  mutable std::mutex mu_;
+  std::vector<WireOp> requests_;
+  int lfd_ = -1;
+  int port_ = 0;
+  std::thread thread_;
+};
 }  // namespace
 
 TEST(DynamicMembers, AddingNodeReroutesNewKeys) {
@@ -96,10 +278,54 @@ TEST(DynamicMembers, SetMembersLogsAddRemoveDelta) {
 // later SetMembers (0812-004: a fixed budget starved a 55-node ring).
 namespace {
 struct HintRecordingTransport : dfkv::Transport {
+  void OnTopologyHint(size_t nodes) override {
+    std::lock_guard<std::mutex> lock(mu);
+    hints.push_back(nodes);
+    cv.notify_all();
+  }
+  void OnPeerTopology(const PeerTopology& topology) override {
+    topology_store.Update(topology);
+    std::lock_guard<std::mutex> lock(mu);
+    peer_topologies.push_back(topology);
+    cv.notify_all();
+  }
+  bool WaitForPeerTopologies(size_t count) {
+    std::unique_lock<std::mutex> lock(mu);
+    return cv.wait_for(lock, std::chrono::seconds(5), [&] {
+      return peer_topologies.size() >= count;
+    });
+  }
+  bool WaitForHints(size_t count) {
+    std::unique_lock<std::mutex> lock(mu);
+    return cv.wait_for(lock, std::chrono::seconds(5),
+                       [&] { return hints.size() >= count; });
+  }
+  std::vector<size_t> Hints() const {
+    std::lock_guard<std::mutex> lock(mu);
+    return hints;
+  }
+  std::vector<PeerTopology> PeerTopologies() const {
+    std::lock_guard<std::mutex> lock(mu);
+    return peer_topologies;
+  }
+  std::vector<std::string> CachePeers() const {
+    std::lock_guard<std::mutex> lock(mu);
+    return cache_peers;
+  }
+  std::shared_ptr<const rdma::PeerRailSnapshot> PeerSnapshot(
+      const std::string& address) const {
+    return topology_store.Snapshot(address);
+  }
+  mutable std::mutex mu;
+  std::condition_variable cv;
   std::vector<size_t> hints;
-  void OnTopologyHint(size_t nodes) override { hints.push_back(nodes); }
-  Status Cache(const std::string&, const dfkv::BlockKey&, const void*,
+  std::vector<PeerTopology> peer_topologies;
+  std::vector<std::string> cache_peers;
+  rdma::PeerTopologyStore topology_store{{"ib0"}, {{0}}, true};
+  Status Cache(const std::string& peer, const dfkv::BlockKey&, const void*,
                size_t) override {
+    std::lock_guard<std::mutex> lock(mu);
+    cache_peers.push_back(peer);
     return Status::kOk;
   }
   Status Range(const std::string&, const dfkv::BlockKey&, uint64_t, uint64_t,
@@ -136,4 +362,177 @@ TEST(DynamicMembers, AdoptionsFeedTransportTopologyHint) {
   // An empty adoption routes nowhere and must not hint a zero-sized ring.
   c.SetMembers(P{});
   EXPECT_EQ(t.hints.size(), 2u);
+}
+
+TEST(DynamicMembers, LegacyMdsFallbackAdoptsIncompleteTopology) {
+  using P = std::vector<std::pair<std::string, std::string>>;
+  const MemberInfo peer{"legacy-n1", "127.0.0.1", 28101, 1};
+  LegacyMembersMds mds({peer}, false);
+  HintRecordingTransport transport;
+  KVClient client(P{}, Hdr(), &transport);
+  client.StartMdsDiscovery({mds.endpoint()}, "legacy-topology-test", 60000);
+
+  const bool got_topology = transport.WaitForPeerTopologies(1);
+  const bool got_ring = client.WaitForRing(5000);
+  client.StopMdsDiscovery();
+
+  ASSERT_TRUE(got_topology);
+  ASSERT_TRUE(got_ring);
+  const std::vector<WireOp> requests = mds.requests();
+  ASSERT_EQ(requests.size(), 2u);
+  EXPECT_EQ(requests[0], WireOp::kListTopology);
+  EXPECT_EQ(requests[1], WireOp::kListMembers);
+
+  // Homogeneous transports still receive placement, while tier-aware
+  // transports retain the incomplete signal and fail closed during selection.
+  const std::vector<size_t> hints = transport.Hints();
+  ASSERT_EQ(hints.size(), 1u);
+  EXPECT_EQ(hints[0], 1u);
+  const std::vector<PeerTopology> topologies = transport.PeerTopologies();
+  ASSERT_EQ(topologies.size(), 1u);
+  EXPECT_EQ(topologies[0].peer_addr, "127.0.0.1:28101");
+  EXPECT_EQ(topologies[0].generation,
+            MembersTopologyEpoch(std::vector<MemberInfo>{peer}));
+  EXPECT_FALSE(topologies[0].complete);
+  EXPECT_TRUE(topologies[0].rails.empty());
+}
+
+TEST(DynamicMembers, TransportFailureDoesNotTriggerLegacyFallback) {
+  const MemberInfo peer{"legacy-n1", "127.0.0.1", 28101, 1};
+  LegacyMembersMds mds({peer}, true);
+  bool adopted = false;
+  MdsMemberPoller poller(
+      {mds.endpoint()}, "legacy-topology-test",
+      MdsMemberPoller::OnChange(
+          [&](const std::vector<MemberInfo>&) { adopted = true; }),
+      60000, 1000);
+
+  EXPECT_FALSE(poller.PollOnce());
+  EXPECT_FALSE(adopted);
+  const std::vector<WireOp> requests = mds.requests();
+  ASSERT_EQ(requests.size(), 1u);
+  EXPECT_EQ(requests[0], WireOp::kListTopology);
+}
+
+TEST(DynamicMembers, RailHealthChangePropagatesWithoutPlacementChurn) {
+  using P = std::vector<std::pair<std::string, std::string>>;
+  MemberInfo peer{"n1", "127.0.0.1", 28001, 1};
+  peer.has_health = true;
+  peer.health.ring_eligible = true;
+  peer.health.ib_devices = {
+      {"ib0", 4, 5, true}, {"ib1", 4, 5, true}};
+  ScriptedTopologyMds mds({peer});
+  HintRecordingTransport transport;
+  KVClient client(P{}, Hdr(), &transport);
+  client.StartMdsDiscovery({mds.endpoint()}, "topology-test", 10);
+
+  ASSERT_TRUE(transport.WaitForPeerTopologies(1));
+  const std::vector<PeerTopology> initial = transport.PeerTopologies();
+  ASSERT_EQ(initial.size(), 1u);
+  EXPECT_EQ(initial[0].peer_addr, "127.0.0.1:28001");
+  EXPECT_TRUE(initial[0].complete);
+  EXPECT_EQ(initial[0].generation,
+            MembersTopologyEpoch(std::vector<MemberInfo>{peer}));
+  ASSERT_EQ(initial[0].rails.size(), 2u);
+  EXPECT_EQ(initial[0].rails[0].name, "ib0");
+  EXPECT_TRUE(initial[0].rails[0].healthy);
+  EXPECT_EQ(initial[0].rails[1].name, "ib1");
+  EXPECT_TRUE(initial[0].rails[1].healthy);
+
+  // This changes HLT1 and the topology generation, but not placement:
+  // n1 remains eligible at the same address and weight.
+  peer.health.ib_devices[1] = {"ib1", 2, 2, true};
+  mds.SetMembers({peer});
+  ASSERT_TRUE(transport.WaitForPeerTopologies(2));
+  client.StopMdsDiscovery();
+
+  const std::vector<PeerTopology> changed = transport.PeerTopologies();
+  ASSERT_EQ(changed.size(), 2u);
+  EXPECT_EQ(changed[1].peer_addr, initial[0].peer_addr);
+  EXPECT_NE(changed[1].generation, initial[0].generation);
+  EXPECT_EQ(changed[1].generation,
+            MembersTopologyEpoch(std::vector<MemberInfo>{peer}));
+  ASSERT_EQ(changed[1].rails.size(), 2u);
+  EXPECT_TRUE(changed[1].rails[0].healthy);
+  EXPECT_FALSE(changed[1].rails[1].healthy);
+
+  // Placement was adopted once. The partial rail transition was independently
+  // forwarded to the transport without another ring adoption/scale hint.
+  const std::vector<size_t> hints = transport.Hints();
+  ASSERT_EQ(hints.size(), 1u);
+  EXPECT_EQ(hints[0], 1u);
+  EXPECT_TRUE(client.WaitForRing(0));
+  EXPECT_TRUE(mds.only_topology_requests());
+}
+
+TEST(DynamicMembers, GuardRejectedShrinkInvalidatesOmittedRoutablePeers) {
+  using P = std::vector<std::pair<std::string, std::string>>;
+  std::vector<MemberInfo> peers;
+  for (int i = 0; i < 3; ++i) {
+    MemberInfo peer{"n" + std::to_string(i), "127.0.0.1",
+                    static_cast<uint32_t>(28201 + i), 1};
+    peer.has_health = true;
+    peer.health.ring_eligible = true;
+    peer.health.ib_devices = {{"ib0", 4, 5, true}};
+    peers.push_back(peer);
+  }
+  ScriptedTopologyMds mds(peers);
+  HintRecordingTransport transport;
+  KVClient client(P{}, Hdr(), &transport);
+  // Leave a full second between polls so this test observes the first
+  // guard-rejected shrink before the persistence threshold can adopt it.
+  client.StartMdsDiscovery({mds.endpoint()}, "guarded-shrink-test", 1000);
+
+  ASSERT_TRUE(transport.WaitForPeerTopologies(3));
+  ASSERT_TRUE(client.WaitForRing(5000));
+  ASSERT_TRUE(transport.WaitForHints(1));
+  ASSERT_EQ(transport.Hints(), std::vector<size_t>({3u}));
+  const uint64_t initial_generation =
+      MembersTopologyEpoch(std::vector<MemberInfo>{peers});
+
+  mds.SetMembers({peers[0]});
+  ASSERT_TRUE(transport.WaitForPeerTopologies(6));
+  client.StopMdsDiscovery();
+
+  const uint64_t shrink_generation =
+      MembersTopologyEpoch(std::vector<MemberInfo>{peers[0]});
+  ASSERT_NE(shrink_generation, initial_generation);
+  const std::vector<PeerTopology> updates = transport.PeerTopologies();
+  ASSERT_EQ(updates.size(), 6u);
+  EXPECT_EQ(updates[3].peer_addr, "127.0.0.1:28201");
+  EXPECT_EQ(updates[3].generation, shrink_generation);
+  EXPECT_TRUE(updates[3].complete);
+  for (size_t i = 4; i < 6; ++i) {
+    EXPECT_EQ(updates[i].generation, shrink_generation);
+    EXPECT_FALSE(updates[i].complete);
+    EXPECT_TRUE(updates[i].rails.empty());
+  }
+  EXPECT_NE(updates[4].peer_addr, updates[5].peer_addr);
+  EXPECT_TRUE((updates[4].peer_addr == "127.0.0.1:28202" ||
+               updates[4].peer_addr == "127.0.0.1:28203"));
+  EXPECT_TRUE((updates[5].peer_addr == "127.0.0.1:28202" ||
+               updates[5].peer_addr == "127.0.0.1:28203"));
+
+  // No second placement hint: the guard retained all three routes. The
+  // replace-all invalidations have already made explicitly configured tiers
+  // fail closed for the omitted peers.
+  const auto omitted_two = transport.PeerSnapshot("127.0.0.1:28202");
+  const auto omitted_three = transport.PeerSnapshot("127.0.0.1:28203");
+  EXPECT_EQ(omitted_two->generation, shrink_generation);
+  EXPECT_FALSE(omitted_two->complete);
+  EXPECT_TRUE(omitted_two->compatible.empty());
+  EXPECT_EQ(omitted_three->generation, shrink_generation);
+  EXPECT_FALSE(omitted_three->complete);
+  EXPECT_TRUE(omitted_three->compatible.empty());
+  ASSERT_EQ(transport.Hints(), std::vector<size_t>({3u}));
+  const char value = 'v';
+  for (int i = 0; i < 1000; ++i)
+    ASSERT_TRUE(client.Put("held-" + std::to_string(i), &value, 1));
+  const std::vector<std::string> routed = transport.CachePeers();
+  EXPECT_NE(std::find(routed.begin(), routed.end(), "127.0.0.1:28201"),
+            routed.end());
+  EXPECT_NE(std::find(routed.begin(), routed.end(), "127.0.0.1:28202"),
+            routed.end());
+  EXPECT_NE(std::find(routed.begin(), routed.end(), "127.0.0.1:28203"),
+            routed.end());
 }

--- a/test/client/kv_client_health_test.cc
+++ b/test/client/kv_client_health_test.cc
@@ -32,6 +32,17 @@ struct CountingTransport : Transport {
     return node == dead ? Status::kIOError : Status::kOk;
   }
 };
+
+uint64_t MetricValue(const std::string& text, const std::string& family) {
+  const std::string prefix = family + " ";
+  size_t pos = text.find(prefix);
+  while (pos != std::string::npos && pos != 0 && text[pos - 1] != '\n')
+    pos = text.find(prefix, pos + 1);
+  EXPECT_NE(pos, std::string::npos) << text;
+  return pos == std::string::npos
+             ? 0
+             : std::stoull(text.substr(pos + prefix.size()));
+}
 }  // namespace
 
 TEST(KvClientHealth, DeadPeerShortCircuitsAfterFirstFailure) {
@@ -81,6 +92,19 @@ struct StarvedTransport : CountingTransport {
     return Status::kResourceExhausted;
   }
 };
+
+struct NoCompatibleTransport : CountingTransport {
+  Status Range(const std::string& node, const BlockKey&, uint64_t, uint64_t,
+               std::string*, uint64_t*) override {
+    { std::lock_guard<std::mutex> lk(mu); range_calls[node]++; }
+    return Status::kNoCompatibleRail;
+  }
+  Status Cache(const std::string& node, const BlockKey&, const void*,
+               size_t) override {
+    { std::lock_guard<std::mutex> lk(mu); cache_calls[node]++; }
+    return Status::kNoCompatibleRail;
+  }
+};
 }  // namespace
 
 TEST(KvClientHealth, ResourceExhaustedDoesNotCoolThePeer) {
@@ -97,4 +121,31 @@ TEST(KvClientHealth, ResourceExhaustedDoesNotCoolThePeer) {
   std::lock_guard<std::mutex> lk(t.mu);
   EXPECT_EQ(t.range_calls["10.0.0.9:3"], 2);
   EXPECT_EQ(t.cache_calls["10.0.0.9:3"], 2);
+}
+
+TEST(KvClientHealth, NoCompatibleRailIsPeerNeutral) {
+  NoCompatibleTransport t;
+  const std::string peer = "10.0.0.9:4";
+  KVClient c({{"n", peer}}, Hdr(), &t);
+  char out[64] = {};
+  const std::string value(64, 'x');
+
+  EXPECT_FALSE(c.Get("k1", out, sizeof(out)));
+  EXPECT_FALSE(c.Get("k2", out, sizeof(out)));
+  EXPECT_FALSE(c.Put("k1", value.data(), value.size()));
+  EXPECT_FALSE(c.Put("k2", value.data(), value.size()));
+
+  {
+    std::lock_guard<std::mutex> lk(t.mu);
+    EXPECT_EQ(t.range_calls[peer], 2)
+        << "a local compatibility miss must not cool the peer";
+    EXPECT_EQ(t.cache_calls[peer], 2)
+        << "a local compatibility miss must not short-circuit later keys";
+  }
+  const std::string metrics = c.MetricsSnapshot();
+  EXPECT_EQ(MetricValue(metrics, "dfkv_client_ops_served_total"), 0u);
+  EXPECT_EQ(MetricValue(metrics, "dfkv_client_io_errors_total"), 0u);
+  EXPECT_EQ(MetricValue(metrics, "dfkv_client_unhealthy_skips_total"), 0u);
+  EXPECT_EQ(MetricValue(metrics, "dfkv_client_peer_marked_bad_total"), 0u);
+  EXPECT_EQ(MetricValue(metrics, "dfkv_client_busy_suppressed_total"), 0u);
 }

--- a/test/mds/mds_server_test.cc
+++ b/test/mds/mds_server_test.cc
@@ -37,6 +37,13 @@ bool DoReq(int port, WireOp op, const std::string& payload, Status* st, std::str
   ::close(fd);
   return ok;
 }
+
+const MemberInfo* FindMember(const std::vector<MemberInfo>& members,
+                             const std::string& id) {
+  for (const auto& member : members)
+    if (member.id == id) return &member;
+  return nullptr;
+}
 }  // namespace
 
 TEST(MdsServer, RegisterThenListRoundTripsThroughEtcd) {
@@ -658,46 +665,125 @@ TEST(MdsServer, ZeroFirstReqMsKeepsOldDribbleBehavior) {
   ::unsetenv("DFKV_MDS_IO_TIMEOUT_S");
 }
 
-TEST(MdsServer, DegradedMemberIsExcludedFromRingButVisibleInTopology) {
+TEST(MdsServer, PlacementAndTopologyTrackRailHealthIndependently) {
   const char* ep = EtcdEp();
   if (!ep) GTEST_SKIP() << "set DFKV_TEST_ETCD=host:port";
   MdsServer mds(ep);
   ASSERT_EQ(mds.Start(0), Status::kOk);
   const std::string group =
       "itest-health-" + std::to_string(mds.port());
-  MemberInfo active{"active", "10.1.1.1", 28000, 1};
-  active.has_health = true;
-  active.health.ib_devices = {{"ib0", 4, 5, true}};
-  MemberInfo degraded{"degraded", "10.1.1.2", 28000, 1};
-  degraded.has_health = true;
-  degraded.health.ring_eligible = false;
-  degraded.health.ib_devices = {{"ib1", 2, 2, true}};
+
+  // Keep a legacy member beside the HLT1 member. The optional per-member
+  // extension must remain decodable in a mixed-version view.
+  MemberInfo legacy{"legacy", "10.1.1.1", 28000, 1};
+  MemberInfo peer{"peer", "10.1.1.2", 28000, 1};
+  peer.has_health = true;
+  peer.health.ring_eligible = true;
+  peer.health.ib_devices = {
+      {"ib0", 4, 5, true}, {"ib1", 4, 5, true}};
   Status st;
   std::string data;
   ASSERT_TRUE(DoReq(mds.port(), WireOp::kRegister,
-                    EncodeMemberReq(group, active), &st, &data));
+                    EncodeMemberReq(group, legacy), &st, &data));
   ASSERT_EQ(st, Status::kOk);
   ASSERT_TRUE(DoReq(mds.port(), WireOp::kRegister,
-                    EncodeMemberReq(group, degraded), &st, &data));
+                    EncodeMemberReq(group, peer), &st, &data));
   ASSERT_EQ(st, Status::kOk);
 
   std::vector<MemberInfo> members;
-  uint64_t epoch = 0;
+  uint64_t placement_epoch = 0;
   ASSERT_TRUE(DoReq(mds.port(), WireOp::kListMembers, group, &st, &data));
   ASSERT_EQ(st, Status::kOk);
-  ASSERT_TRUE(DecodeMembers(data.data(), data.size(), &members, &epoch));
+  ASSERT_TRUE(
+      DecodeMembers(data.data(), data.size(), &members, &placement_epoch));
+  ASSERT_EQ(members.size(), 2u);
+
+  uint64_t topology_epoch = 0;
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kListTopology, group, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(
+      DecodeMembers(data.data(), data.size(), &members, &topology_epoch));
+  ASSERT_EQ(members.size(), 2u);
+  const MemberInfo* visible_peer = FindMember(members, "peer");
+  ASSERT_NE(visible_peer, nullptr);
+  ASSERT_TRUE(visible_peer->has_health);
+  ASSERT_EQ(visible_peer->health.ib_devices.size(), 2u);
+  EXPECT_EQ(visible_peer->health.ib_devices[0].name, "ib0");
+  EXPECT_TRUE(visible_peer->health.ib_devices[0].healthy());
+  EXPECT_EQ(visible_peer->health.ib_devices[1].name, "ib1");
+  EXPECT_TRUE(visible_peer->health.ib_devices[1].healthy());
+  const MemberInfo* visible_legacy = FindMember(members, "legacy");
+  ASSERT_NE(visible_legacy, nullptr);
+  EXPECT_FALSE(visible_legacy->has_health);
+
+  // Canonical topology generations are independent of the member's HLT1 rail
+  // serialization order.
+  const uint64_t initial_topology_epoch = topology_epoch;
+  peer.health.ib_devices = {
+      {"ib1", 4, 5, true}, {"ib0", 4, 5, true}};
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kHeartbeat,
+                    EncodeMemberReq(group, peer), &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kListTopology, group, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(
+      DecodeMembers(data.data(), data.size(), &members, &topology_epoch));
+  EXPECT_EQ(topology_epoch, initial_topology_epoch);
+
+  // One failed rail is a topology-only change: the peer remains in placement,
+  // the placement epoch stays stable, and the canonical topology epoch moves.
+  const uint64_t initial_placement_epoch = placement_epoch;
+  peer.health.ib_devices = {
+      {"ib0", 4, 5, true}, {"ib1", 2, 2, true}};
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kHeartbeat,
+                    EncodeMemberReq(group, peer), &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kListMembers, group, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(
+      DecodeMembers(data.data(), data.size(), &members, &placement_epoch));
+  ASSERT_EQ(members.size(), 2u);
+  EXPECT_EQ(placement_epoch, initial_placement_epoch);
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kListTopology, group, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(
+      DecodeMembers(data.data(), data.size(), &members, &topology_epoch));
+  EXPECT_NE(topology_epoch, initial_topology_epoch);
+  visible_peer = FindMember(members, "peer");
+  ASSERT_NE(visible_peer, nullptr);
+  ASSERT_EQ(visible_peer->health.ib_devices.size(), 2u);
+  EXPECT_TRUE(visible_peer->health.ib_devices[0].healthy());
+  EXPECT_FALSE(visible_peer->health.ib_devices[1].healthy());
+
+  // Losing the last active rail removes the peer from placement immediately,
+  // while kListTopology continues to expose its full degraded HLT1 state.
+  const uint64_t partial_topology_epoch = topology_epoch;
+  peer.health.ring_eligible = false;
+  peer.health.ib_devices[0] = {"ib0", 1, 2, true};
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kHeartbeat,
+                    EncodeMemberReq(group, peer), &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(DoReq(mds.port(), WireOp::kListMembers, group, &st, &data));
+  ASSERT_EQ(st, Status::kOk);
+  ASSERT_TRUE(
+      DecodeMembers(data.data(), data.size(), &members, &placement_epoch));
   ASSERT_EQ(members.size(), 1u);
-  EXPECT_EQ(members[0].id, "active");
+  EXPECT_EQ(members[0].id, "legacy");
+  EXPECT_NE(placement_epoch, initial_placement_epoch);
 
   ASSERT_TRUE(DoReq(mds.port(), WireOp::kListTopology, group, &st, &data));
   ASSERT_EQ(st, Status::kOk);
-  ASSERT_TRUE(DecodeMembers(data.data(), data.size(), &members, &epoch));
+  ASSERT_TRUE(
+      DecodeMembers(data.data(), data.size(), &members, &topology_epoch));
+  EXPECT_NE(topology_epoch, partial_topology_epoch);
   ASSERT_EQ(members.size(), 2u);
-  EXPECT_TRUE(members[0].has_health);
-  bool saw_degraded = false;
-  for (const auto& member : members)
-    if (member.id == "degraded") saw_degraded = !member.RingEligible();
-  EXPECT_TRUE(saw_degraded);
+  visible_peer = FindMember(members, "peer");
+  ASSERT_NE(visible_peer, nullptr);
+  EXPECT_FALSE(visible_peer->RingEligible());
+  ASSERT_EQ(visible_peer->health.ib_devices.size(), 2u);
+  EXPECT_FALSE(visible_peer->health.ib_devices[0].healthy());
+  EXPECT_FALSE(visible_peer->health.ib_devices[1].healthy());
+
   bool etcd_reachable = false;
   const std::string metrics = mds.GroupMetricsText(&etcd_reachable);
   EXPECT_TRUE(etcd_reachable);

--- a/test/transport/rdma_health_test.cc
+++ b/test/transport/rdma_health_test.cc
@@ -16,7 +16,7 @@ IbDeviceHealth Device(const char* name, uint8_t port, uint8_t phys,
 
 }  // namespace
 
-TEST(RdmaHealth, AnyUnhealthyDeviceRemovesNodeImmediately) {
+TEST(RdmaHealth, AnyHealthyDeviceKeepsNodeEligible) {
   std::deque<std::vector<IbDeviceHealth>> samples{
       {Device("ib0", 4, 5), Device("ib1", 4, 5)},
       {Device("ib0", 4, 5), Device("ib1", 2, 2)}};
@@ -26,10 +26,29 @@ TEST(RdmaHealth, AnyUnhealthyDeviceRemovesNodeImmediately) {
     return sample;
   });
   EXPECT_TRUE(monitor.Sample().ring_eligible);
-  const MemberHealth degraded = monitor.Sample();
-  EXPECT_FALSE(degraded.ring_eligible);
-  ASSERT_EQ(degraded.ib_devices.size(), 2u);
-  EXPECT_FALSE(degraded.ib_devices[1].healthy());
+  const MemberHealth partially_degraded = monitor.Sample();
+  EXPECT_TRUE(partially_degraded.ring_eligible);
+  ASSERT_EQ(partially_degraded.ib_devices.size(), 2u);
+  EXPECT_TRUE(partially_degraded.ib_devices[0].healthy());
+  EXPECT_FALSE(partially_degraded.ib_devices[1].healthy());
+  const std::string metrics = monitor.MetricsText();
+  EXPECT_NE(metrics.find("dfkv_server_rdma_rails_configured 2"),
+            std::string::npos);
+  EXPECT_NE(metrics.find("dfkv_server_rdma_rails_active 1"),
+            std::string::npos);
+}
+
+TEST(RdmaHealth, ZeroActiveDevicesRemovesNodeImmediately) {
+  std::deque<std::vector<IbDeviceHealth>> samples{
+      {Device("ib0", 4, 5), Device("ib1", 2, 2)},
+      {Device("ib0", 1, 2), Device("ib1", 2, 2)}};
+  rdma::RdmaHealthMonitor monitor([&] {
+    auto sample = samples.front();
+    samples.pop_front();
+    return sample;
+  });
+  EXPECT_TRUE(monitor.Sample().ring_eligible);
+  EXPECT_FALSE(monitor.Sample().ring_eligible);
 }
 
 TEST(RdmaHealth, RecoveryRequiresConsecutiveHealthySamples) {
@@ -45,6 +64,21 @@ TEST(RdmaHealth, RecoveryRequiresConsecutiveHealthySamples) {
   EXPECT_FALSE(monitor.Sample().ring_eligible);
   EXPECT_FALSE(monitor.Sample().ring_eligible);
   EXPECT_FALSE(monitor.Sample().ring_eligible);
+  EXPECT_FALSE(monitor.Sample().ring_eligible);
+  EXPECT_FALSE(monitor.Sample().ring_eligible);
+  EXPECT_TRUE(monitor.Sample().ring_eligible);
+}
+
+TEST(RdmaHealth, SingleRailUsesTheSameRemovalAndRecoveryLifecycle) {
+  std::deque<std::vector<IbDeviceHealth>> samples{
+      {Device("ib0", 4, 5)}, {Device("ib0", 1, 2)},
+      {Device("ib0", 4, 5)}, {Device("ib0", 4, 5)}};
+  rdma::RdmaHealthMonitor monitor([&] {
+    auto sample = samples.front();
+    samples.pop_front();
+    return sample;
+  }, 2);
+  EXPECT_TRUE(monitor.Sample().ring_eligible);
   EXPECT_FALSE(monitor.Sample().ring_eligible);
   EXPECT_FALSE(monitor.Sample().ring_eligible);
   EXPECT_TRUE(monitor.Sample().ring_eligible);

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -20,6 +20,7 @@
 #include <sys/mman.h>  // shm_unlink (node-dedup test)
 #include <unistd.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <algorithm>
@@ -542,6 +543,287 @@ TEST(RdmaSafety, OperationExclusionAppliesToPreferredAndFallbackRails) {
       rdma::AcquireWithFallback(policy, 1, 0, {1, 0, 0}, {}, {1, 0, 0}))
       << "admission must not silently bypass an operation-local exclusion";
 }
+
+TEST(RdmaPeerRails, NineRailGpuPeerUsesOnlyPrimaryTier) {
+  const std::vector<std::string> devices{
+      "gpu0", "gpu1", "gpu2", "gpu3", "gpu4",
+      "gpu5", "gpu6", "gpu7", "cpu0"};
+  std::vector<std::vector<uint8_t>> tiers;
+  std::string error;
+  ASSERT_TRUE(rdma::ParseRailTiers(
+      "gpu0|gpu1|gpu2|gpu3|gpu4|gpu5|gpu6|gpu7;cpu0", devices,
+      &tiers, &error))
+      << error;
+  ASSERT_EQ(tiers.size(), 2u);
+  EXPECT_EQ(tiers[0],
+            (std::vector<uint8_t>{1, 1, 1, 1, 1, 1, 1, 1, 0}));
+  EXPECT_EQ(tiers[1],
+            (std::vector<uint8_t>{0, 0, 0, 0, 0, 0, 0, 0, 1}));
+
+  rdma::PeerTopologyStore store(devices, tiers, /*require_complete=*/true);
+  PeerTopology topology{
+      "gpu-peer", 41, true,
+      {{"gpu0", true}, {"gpu1", true}, {"gpu2", true},
+       {"gpu3", true}, {"gpu4", true}, {"gpu5", true},
+       {"gpu6", true}, {"gpu7", true}, {"cpu0", true}}};
+  ASSERT_TRUE(store.Update(topology));
+  const auto snapshot = store.Snapshot("gpu-peer");
+  ASSERT_TRUE(snapshot->complete);
+  EXPECT_EQ(snapshot->generation, 41u);
+  EXPECT_EQ(snapshot->compatible,
+            (std::vector<uint8_t>{1, 1, 1, 1, 1, 1, 1, 1, 0}));
+
+  rdma::RailPolicy policy(9);
+  auto lease = rdma::AcquireHighestTier(
+      policy, 1, 0, snapshot->compatible, snapshot->compatible, {});
+  ASSERT_TRUE(lease);
+  EXPECT_LT(lease->rail, 8u);
+  policy.Complete(*lease, 1, rdma::RailCompletion::kSuccess, 101);
+  EXPECT_EQ(policy.Snapshot(101)[8].selections, 0u);
+}
+
+TEST(RdmaPeerRails, CpuPeerUsesItsFirstSharedRailWithoutRejection) {
+  const std::vector<std::string> devices{
+      "gpu0", "gpu1", "gpu2", "gpu3", "gpu4",
+      "gpu5", "gpu6", "gpu7", "cpu0"};
+  std::vector<std::vector<uint8_t>> tiers;
+  ASSERT_TRUE(rdma::ParseRailTiers(
+      "gpu0|gpu1|gpu2|gpu3|gpu4|gpu5|gpu6|gpu7;cpu0", devices,
+      &tiers, nullptr));
+  rdma::PeerTopologyStore store(devices, tiers, /*require_complete=*/true);
+  ASSERT_TRUE(store.Update(
+      PeerTopology{"cpu-peer", 7, true, {{"cpu0", true}}}));
+  const auto snapshot = store.Snapshot("cpu-peer");
+  ASSERT_EQ(snapshot->compatible,
+            (std::vector<uint8_t>{0, 0, 0, 0, 0, 0, 0, 0, 1}));
+
+  rdma::RailPolicy policy(9);
+  auto lease = rdma::AcquireHighestTier(
+      policy, 1, 0, snapshot->compatible,
+      /*preferred=*/{1, 0, 0, 0, 0, 0, 0, 0, 0},
+      /*fallback=*/{1, 1, 1, 1, 1, 1, 1, 1, 1});
+  ASSERT_TRUE(lease);
+  EXPECT_EQ(lease->rail, 8u);
+  policy.Complete(*lease, 1, rdma::RailCompletion::kSuccess, 101);
+  const auto stats = policy.Snapshot(101);
+  EXPECT_EQ(stats[8].selections, 1u);
+  EXPECT_EQ(stats[8].errors, 0u);
+  EXPECT_EQ(stats[8].endpoint_errors, 0u);
+}
+
+TEST(RdmaPeerRails, PrimaryFailureUses200GFallbackAndRecoveryIsStable) {
+  const std::vector<std::string> devices{"gpu400_0", "gpu400_1", "ib200"};
+  std::vector<std::vector<uint8_t>> tiers;
+  ASSERT_TRUE(rdma::ParseRailTiers("gpu400_0|gpu400_1;ib200", devices, &tiers,
+                                   nullptr));
+  rdma::PeerTopologyStore store(devices, tiers, /*require_complete=*/true);
+
+  ASSERT_TRUE(store.Update(PeerTopology{
+      "peer", 10, true,
+      {{"ib200", true}, {"gpu400_1", true}, {"gpu400_0", false}}}));
+  const auto partial = store.Snapshot("peer");
+  EXPECT_EQ(partial->compatible, (std::vector<uint8_t>{0, 1, 0}));
+
+  ASSERT_TRUE(store.Update(PeerTopology{
+      "peer", 11, true,
+      {{"gpu400_0", false}, {"gpu400_1", false}, {"ib200", true}}}));
+  const auto fallback = store.Snapshot("peer");
+  EXPECT_EQ(fallback->compatible, (std::vector<uint8_t>{0, 0, 1}));
+  EXPECT_EQ(partial->compatible, (std::vector<uint8_t>{0, 1, 0}))
+      << "published snapshots must remain immutable";
+
+  ASSERT_TRUE(store.Update(PeerTopology{
+      "peer", 12, true,
+      {{"gpu400_0", true}, {"gpu400_1", false}, {"ib200", true}}}));
+  const auto recovered = store.Snapshot("peer");
+  EXPECT_EQ(recovered->compatible, (std::vector<uint8_t>{1, 0, 0}));
+  EXPECT_FALSE(store.Update(PeerTopology{
+      "peer", 12, true,
+      {{"gpu400_0", false}, {"gpu400_1", false}, {"ib200", true}}}))
+      << "duplicate generations must not perturb stable recovery";
+  EXPECT_EQ(store.Snapshot("peer")->compatible,
+            (std::vector<uint8_t>{1, 0, 0}));
+}
+
+TEST(RdmaPeerRails, NoIntersectionIsPeerNeutralAndLocallyObservable) {
+  const std::vector<std::string> devices{"gpu0", "cpu0"};
+  std::vector<std::vector<uint8_t>> tiers;
+  ASSERT_TRUE(
+      rdma::ParseRailTiers("gpu0;cpu0", devices, &tiers, nullptr));
+  rdma::PeerTopologyStore store(devices, tiers, /*require_complete=*/true);
+  ASSERT_TRUE(store.Update(
+      PeerTopology{"peer", 3, true, {{"remote-only", true}}}));
+  EXPECT_TRUE(store.Snapshot("peer")->compatible.empty());
+  EXPECT_STREQ(StatusName(Status::kNoCompatibleRail), "NoCompatibleRail");
+
+  rdma::RailPolicy policy(2, rdma::RailPolicyConfig{
+                                 /*credits_per_rail=*/1,
+                                 /*error_threshold=*/1,
+                                 /*quarantine_us=*/1000,
+                                 /*latency_weight=*/1,
+                                 /*error_penalty_us=*/100});
+  const auto stats = policy.Snapshot(100);
+  ASSERT_EQ(stats.size(), 2u);
+  for (const auto& rail : stats) {
+    EXPECT_EQ(rail.selections, 0u);
+    EXPECT_EQ(rail.errors, 0u);
+    EXPECT_EQ(rail.endpoint_errors, 0u);
+    EXPECT_EQ(rail.quarantines, 0u);
+    EXPECT_FALSE(rail.quarantined);
+  }
+}
+
+TEST(RdmaPeerRails, OperationGenerationFencesOlderSnapshots) {
+  const std::vector<std::string> devices{"gpu0", "cpu0"};
+  std::vector<std::vector<uint8_t>> tiers;
+  ASSERT_TRUE(
+      rdma::ParseRailTiers("gpu0;cpu0", devices, &tiers, nullptr));
+  rdma::PeerTopologyStore store(devices, tiers, /*require_complete=*/true);
+  ASSERT_TRUE(store.Update(
+      PeerTopology{"peer", 100, true, {{"gpu0", true}}}));
+  const auto operation = store.Snapshot("peer");
+  ASSERT_EQ(operation->generation, 100u);
+
+  ASSERT_TRUE(store.Update(
+      PeerTopology{"peer", 101, true, {{"cpu0", true}}}));
+  EXPECT_FALSE(store.IsCurrent("peer", operation->generation));
+  EXPECT_EQ(operation->generation, 100u);
+  EXPECT_EQ(operation->compatible, (std::vector<uint8_t>{1, 0}));
+  const auto current = store.Snapshot("peer");
+  EXPECT_EQ(current->generation, 101u);
+  EXPECT_EQ(current->compatible, (std::vector<uint8_t>{0, 1}));
+}
+
+TEST(RdmaPeerRails, PrimaryCreditPressureNeverOverflowsToLowerTier) {
+  const std::vector<std::vector<uint8_t>> tiers{{1, 0}, {0, 1}};
+  const auto compatible =
+      rdma::HighestCompatibleTier(tiers, /*peer_healthy=*/{1, 1});
+  ASSERT_EQ(compatible, (std::vector<uint8_t>{1, 0}));
+  rdma::RailPolicy policy(
+      2, rdma::RailPolicyConfig{/*credits_per_rail=*/1,
+                                /*error_threshold=*/3,
+                                /*quarantine_us=*/1000,
+                                /*latency_weight=*/1,
+                                /*error_penalty_us=*/100});
+
+  auto primary = rdma::AcquireHighestTier(
+      policy, 1, 0, compatible, /*preferred=*/{1, 0},
+      /*fallback=*/{0, 1});
+  ASSERT_TRUE(primary);
+  ASSERT_EQ(primary->rail, 0u);
+  EXPECT_FALSE(rdma::AcquireHighestTier(
+      policy, 1, 0, compatible, /*preferred=*/{1, 0},
+      /*fallback=*/{0, 1}))
+      << "healthy Tier-0 pressure must wait or time out, never use Tier-1";
+  const auto pressured = policy.Snapshot(101);
+  EXPECT_GT(pressured[0].credits_exhausted, 0u);
+  EXPECT_EQ(pressured[1].selections, 0u);
+  policy.Complete(*primary, 1, rdma::RailCompletion::kSuccess, 102);
+}
+
+TEST(RdmaPeerRails, MixedVersionPolicyFailsClosedOnlyForExplicitTiers) {
+  const std::vector<std::string> devices{"gpu0", "cpu0"};
+  std::vector<std::vector<uint8_t>> explicit_tiers;
+  ASSERT_TRUE(rdma::ParseRailTiers("gpu0;cpu0", devices, &explicit_tiers,
+                                   nullptr));
+  rdma::PeerTopologyStore strict_store(
+      devices, explicit_tiers, /*require_complete=*/true);
+  EXPECT_FALSE(strict_store.Snapshot("legacy-peer")->complete);
+  EXPECT_TRUE(strict_store.Snapshot("legacy-peer")->compatible.empty());
+  ASSERT_TRUE(strict_store.Update(
+      PeerTopology{"legacy-peer", 1, false, {}}));
+  EXPECT_TRUE(strict_store.Snapshot("legacy-peer")->compatible.empty());
+
+  std::vector<std::vector<uint8_t>> homogeneous;
+  ASSERT_TRUE(rdma::ParseRailTiers("", devices, &homogeneous, nullptr));
+  rdma::PeerTopologyStore legacy_store(
+      devices, homogeneous, /*require_complete=*/false);
+  EXPECT_TRUE(legacy_store.Snapshot("legacy-peer")->complete);
+  EXPECT_EQ(legacy_store.Snapshot("legacy-peer")->compatible,
+            (std::vector<uint8_t>{1, 1}));
+  ASSERT_TRUE(legacy_store.Update(
+      PeerTopology{"legacy-peer", 1, false, {}}));
+  EXPECT_EQ(legacy_store.Snapshot("legacy-peer")->compatible,
+            (std::vector<uint8_t>{1, 1}));
+
+  std::string error;
+  EXPECT_FALSE(rdma::ParseRailTiers("gpu0;missing", devices, &homogeneous,
+                                    &error));
+  EXPECT_FALSE(error.empty());
+}
+
+TEST(RdmaPeerRails, ConcurrentPublicationAcquisitionAndSnapshotTeardown) {
+  const std::vector<std::string> devices{"gpu0", "gpu1", "cpu0"};
+  std::vector<std::vector<uint8_t>> tiers;
+  ASSERT_TRUE(rdma::ParseRailTiers("gpu0|gpu1;cpu0", devices, &tiers,
+                                   nullptr));
+  auto store = std::make_unique<rdma::PeerTopologyStore>(
+      devices, tiers, /*require_complete=*/true);
+  ASSERT_TRUE(store->Update(PeerTopology{
+      "peer", 2, true,
+      {{"gpu0", true}, {"gpu1", false}, {"cpu0", true}}}));
+  rdma::RailPolicy policy(3);
+
+  std::atomic<bool> start{false};
+  std::atomic<uint64_t> violations{0};
+  std::vector<std::thread> threads;
+  for (uint64_t writer = 0; writer < 2; ++writer) {
+    threads.emplace_back([&, writer] {
+      while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+      for (uint64_t i = 0; i < 1000; ++i) {
+        const uint64_t generation = 10 + writer * 1000 + i;
+        const bool even = generation % 2 == 0;
+        store->Update(PeerTopology{
+            "peer", generation, true,
+            {{"gpu0", even}, {"gpu1", !even}, {"cpu0", true}}});
+      }
+    });
+  }
+  for (size_t reader = 0; reader < 4; ++reader) {
+    threads.emplace_back([&] {
+      while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+      for (size_t i = 0; i < 2000; ++i) {
+        const auto snapshot = store->Snapshot("peer");
+        const bool even = snapshot->generation % 2 == 0;
+        const std::vector<uint8_t> expected =
+            even ? std::vector<uint8_t>{1, 0, 0}
+                 : std::vector<uint8_t>{0, 1, 0};
+        auto lease =
+            policy.TryAcquire(1, snapshot->generation, snapshot->compatible);
+        if (!snapshot->complete || snapshot->compatible != expected || !lease ||
+            lease->rail >= snapshot->compatible.size() ||
+            snapshot->compatible[lease->rail] == 0) {
+          violations.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (lease) {
+          policy.Complete(*lease, 1, rdma::RailCompletion::kSuccess,
+                          snapshot->generation);
+        }
+      }
+    });
+  }
+  start.store(true, std::memory_order_release);
+  for (auto& thread : threads) thread.join();
+  EXPECT_EQ(violations.load(std::memory_order_relaxed), 0u);
+  for (const auto& rail : policy.Snapshot(3000))
+    EXPECT_EQ(rail.inflight, 0u);
+
+  const auto retained = store->Snapshot("peer");
+  std::atomic<bool> inspect{false};
+  std::thread reader([retained, &inspect, &violations] {
+    while (!inspect.load(std::memory_order_acquire))
+      std::this_thread::yield();
+    for (size_t i = 0; i < 10000; ++i) {
+      if (!retained->complete || retained->compatible.empty())
+        violations.fetch_add(1, std::memory_order_relaxed);
+    }
+  });
+  inspect.store(true, std::memory_order_release);
+  store.reset();
+  reader.join();
+  EXPECT_EQ(violations.load(std::memory_order_relaxed), 0u);
+}
+
 TEST(RdmaSafety, QuarantinedRailAllowsOneProbeAndRecoversOnlyOnSuccess) {
 
   rdma::RailPolicyConfig config;
@@ -2508,6 +2790,158 @@ TEST(RdmaLoopback, DefaultDeclarationKeepsGlobalCap) {
   std::string got(v.size(), '\0');
   ASSERT_TRUE(c.Get("full-size", got.data(), got.size()));
   EXPECT_EQ(got, v);
+}
+
+TEST(RdmaLoopback,
+     PooledPostSubmitFailureDoesNotReplayPutAndGetRemainsReplaySafe) {
+  ScopedEnv configured_device("DFKV_RDMA_DEV", nullptr);
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv ambient_completion_fault("DFKV_RDMA_TEST_COMPLETION_FAULT",
+                                     nullptr);
+  ScopedEnv ambient_local_failure(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  RdmaNode node("pooled-post-submit");
+  const std::string value("pooled\0put-value", 16);
+
+  const auto expect_single_pooled_put_attempt =
+      [](const std::string& before, const std::string& after,
+         long expected_posts) {
+        EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_hits_total") -
+                      CounterVal(before,
+                                 "dfkv_rdma_endpoint_cache_hits_total"),
+                  1);
+        EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_misses_total") -
+                      CounterVal(before,
+                                 "dfkv_rdma_endpoint_cache_misses_total"),
+                  0);
+        EXPECT_EQ(
+            CounterVal(after, "dfkv_rdma_client_v2_put_writes_total") -
+                CounterVal(before, "dfkv_rdma_client_v2_put_writes_total"),
+            expected_posts);
+        EXPECT_EQ(
+            CounterVal(after,
+                       "dfkv_rdma_client_stale_pool_retries_total") -
+                CounterVal(before,
+                           "dfkv_rdma_client_stale_pool_retries_total"),
+            0);
+        EXPECT_EQ(
+            CounterVal(after,
+                       "dfkv_rdma_client_cross_rail_retries_total") -
+                CounterVal(before,
+                           "dfkv_rdma_client_cross_rail_retries_total"),
+            0);
+      };
+
+  {
+    RdmaTransport transport(kMaxMsg);
+    const BlockKey warm_key =
+        ToBlockKey(SelfHdr(), "pooled-scalar-warm");
+    const BlockKey failed_key =
+        ToBlockKey(SelfHdr(), "pooled-scalar-failed");
+    ASSERT_EQ(transport.Cache(node.addr, warm_key, value.data(), value.size()),
+              Status::kOk);
+    const std::string before = transport.MetricsText();
+    {
+      ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1");
+      EXPECT_EQ(
+          transport.Cache(node.addr, failed_key, value.data(), value.size()),
+          Status::kIOError);
+    }
+    const std::string after = transport.MetricsText();
+    expect_single_pooled_put_attempt(before, after, 1);
+    EXPECT_EQ(node.CacheDirectCalls(failed_key), 1u);
+  }
+
+  {
+    RdmaTransport transport(kMaxMsg);
+    const BlockKey warm_key =
+        ToBlockKey(SelfHdr(), "pooled-batch-warm");
+    const std::vector<BlockKey> failed_keys{
+        ToBlockKey(SelfHdr(), "pooled-batch-failed-0"),
+        ToBlockKey(SelfHdr(), "pooled-batch-failed-1"),
+    };
+    ASSERT_EQ(transport.CacheFrom(
+                  node.addr, {{warm_key, value.data(), value.size()}}),
+              std::vector<Status>({Status::kOk}));
+    const std::vector<CacheSrc> sources{
+        {failed_keys[0], value.data(), value.size()},
+        {failed_keys[1], value.data(), value.size()},
+    };
+    const std::string before = transport.MetricsText();
+    {
+      ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1");
+      EXPECT_EQ(transport.CacheFrom(node.addr, sources),
+                std::vector<Status>(sources.size(), Status::kIOError));
+    }
+    const std::string after = transport.MetricsText();
+    expect_single_pooled_put_attempt(before, after, sources.size());
+    for (const BlockKey& key : failed_keys) {
+      EXPECT_EQ(node.CacheDirectCalls(key), 1u);
+    }
+  }
+
+  {
+    RdmaTransport transport(kMaxMsg);
+    const BlockKey warm_key =
+        ToBlockKey(SelfHdr(), "pooled-sg-warm");
+    const BlockKey failed_key =
+        ToBlockKey(SelfHdr(), "pooled-sg-failed");
+    const std::array<std::string, 2> segments{
+        std::string("first\0segment", 13),
+        std::string("second\0segment", 14),
+    };
+    CacheSrcMulti warm;
+    warm.key = warm_key;
+    warm.payloads = {{value.data(), value.size()}};
+    ASSERT_EQ(transport.CacheFromMulti(node.addr, {warm}),
+              std::vector<Status>({Status::kOk}));
+    CacheSrcMulti source;
+    source.key = failed_key;
+    source.payloads = {
+        {segments[0].data(), segments[0].size()},
+        {segments[1].data(), segments[1].size()},
+    };
+    const std::string before = transport.MetricsText();
+    {
+      ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1");
+      EXPECT_EQ(transport.CacheFromMulti(node.addr, {source}),
+                std::vector<Status>({Status::kIOError}));
+    }
+    const std::string after = transport.MetricsText();
+    expect_single_pooled_put_attempt(before, after, 1);
+    EXPECT_EQ(node.CacheDirectCalls(failed_key), 1u);
+  }
+
+  {
+    RdmaTransport transport(kMaxMsg);
+    const BlockKey key = ToBlockKey(SelfHdr(), "pooled-get-retry");
+    ASSERT_EQ(transport.Cache(node.addr, key, value.data(), value.size()),
+              Status::kOk);
+    const std::string before = transport.MetricsText();
+    std::string output;
+    {
+      ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1");
+      EXPECT_EQ(transport.Range(node.addr, key, 0, value.size(), &output,
+                                nullptr),
+                Status::kOk);
+    }
+    EXPECT_EQ(output, value);
+    const std::string after = transport.MetricsText();
+    EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_hits_total") -
+                  CounterVal(before, "dfkv_rdma_endpoint_cache_hits_total"),
+              1);
+    EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_misses_total") -
+                  CounterVal(before,
+                             "dfkv_rdma_endpoint_cache_misses_total"),
+              1);
+    EXPECT_EQ(
+        CounterVal(after, "dfkv_rdma_client_v2_get_writes_total") -
+            CounterVal(before, "dfkv_rdma_client_v2_get_writes_total"),
+        2);
+    EXPECT_EQ(node.RangeDirectCalls(key), 2u);
+  }
 }
 
 TEST(RdmaLoopback, ClientLocalRailFailureRetriesFreshPutAndGet) {


### PR DESCRIPTION
## Summary
- propagate per-peer RDMA rail topology independently from placement
- select highest compatible healthy rail tier with generation-fenced pooling
- keep partially healthy servers in-ring and expose rail health/metrics
- prevent ambiguous post-submit PUT replay across pooled endpoints or rails

## Verification
- local: 744/744 CTest completed (environment-gated tests skipped)
- local TSan: DynamicMembers/RailSelect/RdmaHealth/ClientOpMetrics pass
- xb01-gpu-200b-0064 real HCA: 5/5 focused retry/replay tests pass
- isolated 9-rail GPU + 1-rail CPU mixed ring: 1 MiB and 16 MiB PUT/GET byte-exact, zero errors in bounded runs
- scripted health: 9->8 and 9->1 rails preserve placement; single-rail CPU exits and rejoins after 3 healthy samples
- receive segment: 3.75 GiB immediate -> 4 GiB after 30s idle reaper

No environment outside xb01-gpu-200b-0064 was changed.