### PR TITLE
feat(rdma): isolate unhealthy remote peer rails

### DIFF
--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -252,20 +252,30 @@ void KVClient::AdoptRing(ConHash ring, std::map<std::string, std::string> addr) 
 
 void KVClient::PublishPeerTopologies(
     const std::vector<MemberInfo>& topology, uint64_t generation) {
-  std::set<std::string> current;
+  std::map<std::string, std::string> current;
   for (const auto& member : topology)
-    current.insert(member.ip + ":" + std::to_string(member.port));
+    current[member.id] = member.ip + ":" + std::to_string(member.port);
 
-  std::set<std::string> omitted;
+  std::set<std::pair<std::string, std::string>> retired;
   {
     std::lock_guard<std::mutex> lock(ring_mu_);
-    omitted = published_peer_addrs_;
-    for (const auto& [name, address] : addr_) {
-      (void)name;
-      omitted.insert(address);
-    }
-    for (const auto& address : current) omitted.erase(address);
-    published_peer_addrs_ = current;
+    for (const auto& peer : published_peers_) retired.insert(peer);
+    for (const auto& peer : addr_) retired.insert(peer);
+    for (const auto& peer : current) retired.erase(peer);
+    published_peers_ = current;
+  }
+
+  // Retire old address/identity bindings before publishing replacements. In
+  // particular, replacing an id at the same address must not let the old
+  // retirement tear down the newly-published binding.
+  for (const auto& [peer_id, address] : retired) {
+    PeerTopology peer;
+    peer.peer_addr = address;
+    peer.generation = generation;
+    peer.complete = false;
+    peer.peer_id = peer_id;
+    peer.present = false;
+    t_->OnPeerTopology(peer);
   }
 
   for (const auto& member : topology) {
@@ -280,16 +290,18 @@ void KVClient::PublishPeerTopologies(
               [](const PeerRailTopology& a, const PeerRailTopology& b) {
                 return a.name < b.name;
               });
+    peer.peer_id = member.id;
+    peer.present = true;
     t_->OnPeerTopology(peer);
   }
 
-  for (const auto& address : omitted) {
-    PeerTopology peer;
-    peer.peer_addr = address;
-    peer.generation = generation;
-    peer.complete = false;
-    t_->OnPeerTopology(peer);
+  std::vector<std::string> live_peer_ids;
+  live_peer_ids.reserve(current.size());
+  for (const auto& [peer_id, address] : current) {
+    (void)address;
+    live_peer_ids.push_back(peer_id);
   }
+  t_->OnPeerIdentities(live_peer_ids);
 }
 
 void KVClient::SetMembers(std::vector<std::pair<std::string, std::string>> members) {

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -200,9 +200,11 @@ class KVClient {
   // (added/removed node ids) vs the previously-adopted view. Shared by both
   // SetMembers overloads so static and MDS-discovery paths log identically.
   void AdoptRing(ConHash ring, std::map<std::string, std::string> addr);
-  // Publish one replace-all topology response. Peers omitted by the response
-  // receive incomplete snapshots at its generation while they are still held
-  // by the ring, so a guard-rejected placement shrink cannot retain stale rails.
+  // Publish one replace-all topology response. Stable MDS ids are retained
+  // separately from routing addresses; superseded addresses are explicitly
+  // retired, and the complete live-id set is reconciled after publication.
+  // Peers omitted while still held by a guard-rejected ring are retired from
+  // topology state, so strict selection falls back closed without stale rails.
   void PublishPeerTopologies(const std::vector<MemberInfo>& topology,
                              uint64_t generation);
   // Scalar transport bodies. Public scalar methods add exactly one metric;
@@ -237,9 +239,10 @@ class KVClient {
   mutable std::mutex ring_mu_;  // guards ring_ + addr_
   ConHash ring_;
   std::map<std::string, std::string> addr_;  // name -> ip:port
-  // Addresses in the preceding replace-all topology response. Together with
-  // addr_, this finds omitted published or still-ring-held peers.
-  std::set<std::string> published_peer_addrs_;
+  // Stable identity -> routing address from the preceding replace-all topology
+  // response. Together with addr_, this finds removed identities and old
+  // addresses still held by a guard-rejected ring.
+  std::map<std::string, std::string> published_peers_;
   std::condition_variable ring_cv_;  // notified when AdoptRing sets a non-empty ring
   std::string key_namespace_;
   uint64_t namespace_hash_ = 0;

--- a/src/transport/rail_select.h
+++ b/src/transport/rail_select.h
@@ -125,7 +125,13 @@ inline std::vector<uint8_t> HighestCompatibleTier(
 }
 
 struct PeerRailSnapshot {
+  // Stable MDS identity. Address remains the lookup/routing key, but identity
+  // survives health-only generations and address changes.
+  std::string peer_id;
   uint64_t generation = 0;
+  // Transport-local publication/incarnation token. Unlike generation, this
+  // orders accepted store publications and changes across remove/re-add.
+  uint64_t publication = 0;
   bool complete = false;
   // Peer health by stable local device index. `compatible` is the highest tier
   // for an all-enabled local topology; transports recompute from peer_healthy
@@ -134,10 +140,10 @@ struct PeerRailSnapshot {
   std::vector<uint8_t> compatible;
 };
 
-// Thread-safe immutable snapshot publication keyed by peer address. Explicit
-// heterogeneous tiers fail closed until a complete HLT1 topology arrives.
-// Without explicit tiers, absent/incomplete topology preserves the legacy
-// homogeneous all-local behavior.
+// Thread-safe immutable snapshot publication keyed by peer address and carrying
+// the stable MDS identity. Explicit heterogeneous tiers fail closed until a
+// complete HLT1 topology arrives. Without explicit tiers, absent/incomplete
+// topology preserves the legacy homogeneous all-local behavior.
 class PeerTopologyStore {
  public:
   PeerTopologyStore(std::vector<std::string> local_devices,
@@ -157,7 +163,17 @@ class PeerTopologyStore {
 
   bool Update(const PeerTopology& topology) {
     if (topology.peer_addr.empty()) return false;
+    if (!topology.present) {
+      std::lock_guard<std::mutex> lock(mu_);
+      const auto found = snapshots_.find(topology.peer_addr);
+      if (found == snapshots_.end()) return true;
+      if (found->second->peer_id != topology.peer_id) return false;
+      snapshots_.erase(found);
+      return true;
+    }
+
     auto next = std::make_shared<PeerRailSnapshot>();
+    next->peer_id = topology.peer_id;
     next->generation = topology.generation;
     next->complete = topology.complete;
     if (topology.complete) {
@@ -177,15 +193,31 @@ class PeerTopologyStore {
       next->peer_healthy.assign(local_devices_.size(), 1);
       next->compatible.assign(local_devices_.size(), 1);
     }
+
     std::lock_guard<std::mutex> lock(mu_);
     const auto found = snapshots_.find(topology.peer_addr);
     // generation is a canonical FNV topology token, not a numeric sequence.
     // MdsMemberPoller publishes callbacks in order; compare equality only to
-    // deduplicate the same immutable snapshot. Ordering it with < or > would
-    // reject arbitrary valid topology changes.
+    // deduplicate the same immutable identity snapshot. Ordering it with < or >
+    // would reject arbitrary valid topology changes.
     if (found != snapshots_.end() &&
-        topology.generation == found->second->generation)
+        topology.generation == found->second->generation &&
+        topology.peer_id == found->second->peer_id)
       return false;
+    next->publication = ++last_publication_;
+
+    // An address may change while the MDS identity remains stable. Retire only
+    // the superseded address entry; immutable snapshots already captured by an
+    // in-flight operation remain valid.
+    if (!topology.peer_id.empty()) {
+      for (auto it = snapshots_.begin(); it != snapshots_.end();) {
+        if (it->first != topology.peer_addr &&
+            it->second->peer_id == topology.peer_id)
+          it = snapshots_.erase(it);
+        else
+          ++it;
+      }
+    }
     snapshots_[topology.peer_addr] = std::move(next);
     return true;
   }
@@ -197,12 +229,22 @@ class PeerTopologyStore {
     return found == snapshots_.end() ? fallback_ : found->second;
   }
 
-  bool IsCurrent(const std::string& peer_addr, uint64_t generation) const {
+  bool IsCurrent(const std::string& peer_addr, uint64_t publication) const {
     std::lock_guard<std::mutex> lock(mu_);
     const auto found = snapshots_.find(peer_addr);
-    return (found == snapshots_.end() ? fallback_->generation
-                                      : found->second->generation) ==
-           generation;
+    return (found == snapshots_.end() ? fallback_->publication
+                                      : found->second->publication) ==
+           publication;
+  }
+
+  bool IsCurrent(const std::string& peer_addr, const std::string& peer_id,
+                 uint64_t publication) const {
+    std::lock_guard<std::mutex> lock(mu_);
+    const auto found = snapshots_.find(peer_addr);
+    const auto& snapshot =
+        found == snapshots_.end() ? fallback_ : found->second;
+    return snapshot->peer_id == peer_id &&
+           snapshot->publication == publication;
   }
 
  private:
@@ -210,6 +252,7 @@ class PeerTopologyStore {
   std::vector<std::vector<uint8_t>> tiers_;
   bool require_complete_;
   std::shared_ptr<const PeerRailSnapshot> fallback_;
+  uint64_t last_publication_ = 0;
   mutable std::mutex mu_;
   std::unordered_map<std::string,
                      std::shared_ptr<const PeerRailSnapshot>> snapshots_;

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -151,14 +151,15 @@ std::string JoinDevices(const std::vector<std::string>& devices,
 }
 
 // Test-only deterministic completion faults for data operations.
-// The env value is a comma-separated list of
+// DFKV_RDMA_TEST_COMPLETION_FAULT injects local IBV_WC_GENERAL_ERR evidence;
+// DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT injects remote
+// IBV_WC_REM_ACCESS_ERR evidence. Their value is a comma-separated list of
 // "<logical-call>:<attempt>:<completion-window>" specs, all one-based.
-// Eligible logical calls are numbered only while the env is set. Each
-// operation owns its injection state and passes it explicitly to data-path
-// reaps, so pooled connection maintenance cannot consume a target window.
-// A matching successfully reaped window is surfaced once as
-// IBV_WC_GENERAL_ERR through
-// the production ReapPosted/ClassifyCompletion path.
+// Eligible logical calls are numbered only while one of the env vars is set.
+// Each operation owns its injection state and passes it explicitly to
+// data-path reaps, so pooled connection maintenance cannot consume a target
+// window. A matching successfully reaped window is surfaced once through the
+// production ReapPosted/ClassifyCompletion path.
 struct CompletionFaultTarget {
   uint64_t call = 0;
   uint64_t attempt = 0;
@@ -170,7 +171,13 @@ class CompletionFaultOperation {
   explicit CompletionFaultOperation(std::atomic<uint64_t>* calls,
                                     bool enabled = true) {
     if (!enabled) return;
-    const char* cursor = std::getenv("DFKV_RDMA_TEST_COMPLETION_FAULT");
+    const char* cursor =
+        std::getenv("DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT");
+    if (cursor && *cursor) {
+      status_ = IBV_WC_REM_ACCESS_ERR;
+    } else {
+      cursor = std::getenv("DFKV_RDMA_TEST_COMPLETION_FAULT");
+    }
     if (!cursor || !*cursor) return;
     std::vector<CompletionFaultTarget> parsed;
     for (;;) {
@@ -214,10 +221,12 @@ class CompletionFaultOperation {
     }
     return false;
   }
+  ibv_wc_status status() const { return status_; }
 
  private:
   std::vector<CompletionFaultTarget> targets_;
   uint64_t attempt_ = 0;
+  ibv_wc_status status_ = IBV_WC_GENERAL_ERR;
   uint64_t window_ = 0;
 };
 
@@ -284,7 +293,7 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
     }
   }
   if (completion_fault && completion_fault->InjectAfterCompletedWindow()) {
-    if (worst_status) *worst_status = IBV_WC_GENERAL_ERR;
+    if (worst_status) *worst_status = completion_fault->status();
     if (had_completions) *had_completions = true;
     return false;
   }
@@ -340,7 +349,11 @@ struct RdmaTransport::Conn {
   rdma::RcEndpoint ep;
   rdma::RecvSegmentInfo recv_segment;
   size_t rail_index = 0;
-  uint64_t peer_generation = 0;
+  uint64_t peer_publication = 0;
+  std::string peer_id;
+  uint64_t remote_lease_generation = 0;
+  bool remote_lease_held = false;
+  bool remote_recovery_probe = false;
   rdma::RailLease lease;
   uint64_t lease_started_us = 0;
   bool credit_held = false;
@@ -430,6 +443,19 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
   }
   peer_topologies_ = std::make_unique<rdma::PeerTopologyStore>(
       devs_, rail_tiers_, peer_topology_required_);
+  const int remote_base_cooldown_ms = EnvBoundedInt(
+      "DFKV_RDMA_REMOTE_RAIL_COOLDOWN_MS", 2000, 30000);
+  const int remote_max_cooldown_ms = std::max(
+      remote_base_cooldown_ms,
+      EnvBoundedInt("DFKV_RDMA_REMOTE_RAIL_MAX_COOLDOWN_MS", 30000, 30000));
+  remote_rail_health_ = std::make_unique<RemoteRailHealth>(
+      RemoteRailHealthConfig{
+          static_cast<uint64_t>(remote_base_cooldown_ms) * 1000,
+          static_cast<uint64_t>(remote_max_cooldown_ms) * 1000});
+  config_dump::RecordResolved("DFKV_RDMA_REMOTE_RAIL_COOLDOWN_MS",
+                              std::to_string(remote_base_cooldown_ms));
+  config_dump::RecordResolved("DFKV_RDMA_REMOTE_RAIL_MAX_COOLDOWN_MS",
+                              std::to_string(remote_max_cooldown_ms));
   config_dump::RecordResolved(
       "DFKV_RDMA_RAIL_TIERS",
       peer_topology_required_ ? tiers_spec : JoinDevices(devs_, "|"));
@@ -606,12 +632,15 @@ RdmaTransport::~RdmaTransport() {
   for (Conn* conn : idle) Destroy(conn);
 }
 
-bool RdmaTransport::KeepaliveConn(Conn* conn) {
-  if (!conn) return false;
+bool RdmaTransport::KeepaliveConn(Conn* conn,
+                                  rdma::RailCompletion* failure) {
+  if (!conn || !failure) return false;
+  *failure = rdma::RailCompletion::kAdmission;
   keepalive_attempts_.fetch_add(1, std::memory_order_relaxed);
   rdma::RcEndpoint& ep = conn->ep;
   conn->Encode(ep.sbuf(0), WireOp::kMembers, BlockKey{}, 0, 0, 0);
   if (!ep.PostRecv(0) || !ep.PostSend(0, kReqPrefix)) {
+    *failure = rdma::RailCompletion::kRailFailure;
     keepalive_failures_.fetch_add(1, std::memory_order_relaxed);
     return false;
   }
@@ -622,8 +651,13 @@ bool RdmaTransport::KeepaliveConn(Conn* conn) {
   const int timeout_ms =
       op_timeout_ms_ < 0 ? 100 : std::min(op_timeout_ms_, 100);
   if (!ReapWindow(ep, 1, &reply_bytes, timeout_ms, &timed_out, &wc_status,
-                  &had_wcs) ||
-      reply_bytes.empty() || reply_bytes[0] < kRespPrefix) {
+                  &had_wcs)) {
+    *failure = rdma::ClassifyCompletion(wc_status, had_wcs);
+    keepalive_failures_.fetch_add(1, std::memory_order_relaxed);
+    return false;
+  }
+  if (reply_bytes.empty() || reply_bytes[0] < kRespPrefix) {
+    *failure = rdma::RailCompletion::kEndpointFailure;
     keepalive_failures_.fetch_add(1, std::memory_order_relaxed);
     return false;
   }
@@ -631,8 +665,12 @@ bool RdmaTransport::KeepaliveConn(Conn* conn) {
   uint64_t data_len = 0;
   if (!conn->Decode(ep.rbuf(0), &status, &data_len,
                     rdma::kV2ControlResponseMax) ||
-      status != Status::kOk ||
       data_len > reply_bytes[0] - kRespPrefix) {
+    *failure = rdma::RailCompletion::kEndpointFailure;
+    keepalive_failures_.fetch_add(1, std::memory_order_relaxed);
+    return false;
+  }
+  if (status != Status::kOk) {
     keepalive_failures_.fetch_add(1, std::memory_order_relaxed);
     return false;
   }
@@ -668,29 +706,117 @@ void RdmaTransport::KeepaliveLoop() {
       collect(control_pool_, Lane::kControl);
     }
     for (const auto& entry : idle) {
-      if (!peer_topologies_->IsCurrent(entry.node,
-                                       entry.conn->peer_generation)) {
-        stale_generation_reaps_.fetch_add(1, std::memory_order_relaxed);
+      if (!peer_topologies_->IsCurrent(entry.node, entry.conn->peer_id,
+                                       entry.conn->peer_publication)) {
+        stale_publication_reaps_.fetch_add(1, std::memory_order_relaxed);
         Destroy(entry.conn, rdma::RailCompletion::kAdmission);
-      } else if (keepalive_stop_.load(std::memory_order_relaxed) ||
-                 !KeepaliveConn(entry.conn)) {
-        Destroy(entry.conn, rdma::RailCompletion::kEndpointFailure);
-      } else {
-        Release(entry.node, entry.lane, entry.conn);
+        continue;
       }
+      if (keepalive_stop_.load(std::memory_order_relaxed)) {
+        Destroy(entry.conn, rdma::RailCompletion::kAdmission);
+        continue;
+      }
+      if (!entry.conn->peer_id.empty()) {
+        const auto remote = remote_rail_health_->TryAcquire(
+            entry.conn->peer_id, entry.conn->rail_index,
+            rdma::RailPolicy::NowMicros());
+        if (!remote) {
+          Destroy(entry.conn, rdma::RailCompletion::kAdmission);
+          continue;
+        }
+        entry.conn->remote_lease_generation = remote->generation;
+        entry.conn->remote_lease_held = true;
+        entry.conn->remote_recovery_probe = remote->recovery_probe;
+      }
+      rdma::RailCompletion failure = rdma::RailCompletion::kAdmission;
+      if (!KeepaliveConn(entry.conn, &failure))
+        Destroy(entry.conn, failure);
+      else
+        Release(entry.node, entry.lane, entry.conn);
     }
     wait_lock.lock();
   }
 }
 
+void RdmaTransport::RetireIdlePeerRail(const std::string& peer_id,
+                                       size_t local_rail) {
+  if (peer_id.empty()) return;
+  std::vector<Conn*> retired;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    const auto reap = [&](auto& pools) {
+      for (auto map_it = pools.begin(); map_it != pools.end();) {
+        auto& connections = map_it->second;
+        for (auto it = connections.begin(); it != connections.end();) {
+          Conn* conn = *it;
+          if (conn->peer_id != peer_id || conn->rail_index != local_rail ||
+              !conn->lifecycle.RequestRetire()) {
+            ++it;
+            continue;
+          }
+          retired.push_back(conn);
+          it = connections.erase(it);
+        }
+        if (connections.empty())
+          map_it = pools.erase(map_it);
+        else
+          ++map_it;
+      }
+    };
+    reap(pool_);
+    reap(sg_pool_);
+    reap(control_pool_);
+  }
+  for (Conn* conn : retired)
+    Destroy(conn, rdma::RailCompletion::kAdmission);
+}
+
+void RdmaTransport::CompleteRemote(const std::string& peer_id,
+                                   size_t local_rail, uint64_t generation,
+                                   RemoteRailOutcome outcome) {
+  if (peer_id.empty() || generation == 0) return;
+  const uint64_t now = rdma::RailPolicy::NowMicros();
+  const RemoteRailCompletion completion = remote_rail_health_->Complete(
+      peer_id, local_rail, generation, outcome, now);
+  const std::string dev =
+      local_rail < devs_.size() && !devs_[local_rail].empty()
+          ? devs_[local_rail]
+          : "default";
+  if (completion.transition == RemoteRailTransition::kCooled) {
+    DFKV_LOG_WARN(
+        "rdma: remote endpoint rail cooled peer_id=" + peer_id +
+        " dev=" + dev + " cooldown_ms=" +
+        std::to_string(completion.cooldown_until_us > now
+                           ? (completion.cooldown_until_us - now) / 1000
+                           : 0));
+    RetireIdlePeerRail(peer_id, local_rail);
+  } else if (completion.transition == RemoteRailTransition::kRecovered) {
+    DFKV_LOG_INFO("rdma: remote endpoint rail recovered peer_id=" + peer_id +
+                  " dev=" + dev);
+  }
+}
+
+void RdmaTransport::CompleteRemoteLease(Conn* c,
+                                        RemoteRailOutcome outcome) {
+  if (!c || !c->remote_lease_held) return;
+  c->remote_lease_held = false;
+  CompleteRemote(c->peer_id, c->rail_index, c->remote_lease_generation,
+                 outcome);
+}
+
 void RdmaTransport::Destroy(Conn* c, rdma::RailCompletion completion) {
   if (!c) return;
+
   c->lifecycle.BeginDrain();
   const bool credit_held = c->credit_held;
   const rdma::RailLease lease = c->lease;
   const uint64_t lease_started_us = c->lease_started_us;
   const bool release_budget = c->budget_held;
   const rdma::ResourceRequest budget_request = c->budget_request;
+  CompleteRemoteLease(
+      c, completion == rdma::RailCompletion::kEndpointFailure
+             ? RemoteRailOutcome::kEndpointFailure
+             : RemoteRailOutcome::kAbandon);
 
   // The endpoint owns the QP, CQs, and all transient/pool MRs. Destroy it
   // synchronously before returning either rail credits or process resources,
@@ -764,19 +890,23 @@ void RdmaTransport::OnTopologyHint(size_t nodes) {
 void RdmaTransport::OnPeerTopology(const PeerTopology& topology) {
   std::vector<Conn*> stale;
   {
-    // Publish and detach under the same pool lock. Acquire's generation check
-    // uses this lock too, so no idle endpoint can cross the update linearization
-    // point and become active with the retired generation.
+    // Publish and detach under the same pool lock. Acquire's publication check
+    // uses this lock too, so no idle endpoint can cross the update
+    // linearization point and become active with the retired incarnation.
     std::lock_guard<std::mutex> lock(mu_);
     if (!peer_topologies_->Update(topology)) return;
+    const auto current_snapshot =
+        peer_topologies_->Snapshot(topology.peer_addr);
     const auto reap = [&](auto& pools) {
       const auto found = pools.find(topology.peer_addr);
       if (found == pools.end()) return;
       auto& connections = found->second;
       for (auto it = connections.begin(); it != connections.end();) {
         Conn* conn = *it;
-        if (conn->peer_generation == topology.generation ||
-            !conn->lifecycle.RequestRetire()) {
+        const bool current =
+            topology.present && conn->peer_id == current_snapshot->peer_id &&
+            conn->peer_publication == current_snapshot->publication;
+        if (current || !conn->lifecycle.RequestRetire()) {
           ++it;
           continue;
         }
@@ -792,7 +922,12 @@ void RdmaTransport::OnPeerTopology(const PeerTopology& topology) {
   peer_topology_updates_.fetch_add(1, std::memory_order_relaxed);
   for (Conn* conn : stale)
     Destroy(conn, rdma::RailCompletion::kAdmission);
-  stale_generation_reaps_.fetch_add(stale.size(), std::memory_order_relaxed);
+  stale_publication_reaps_.fetch_add(stale.size(), std::memory_order_relaxed);
+}
+
+void RdmaTransport::OnPeerIdentities(
+    const std::vector<std::string>& live_peer_ids) {
+  remote_rail_health_->Reconcile(live_peer_ids);
 }
 
 uint16_t RdmaTransport::LearnedDepth(const std::string& node, Lane lane) {
@@ -848,9 +983,9 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   const uint32_t requested = static_cast<uint32_t>(
       std::min<size_t>(options.requested_credits,
                        std::numeric_limits<uint32_t>::max()));
-  // NUMA preference, credits, latency, and quarantine are applied only inside
-  // the highest tier in the captured peer generation that still intersects
-  // the runtime-enabled local topology.
+  // NUMA preference, credits, latency, and local quarantine are applied only
+  // inside the highest tier in the captured immutable peer snapshot that
+  // intersects runtime-enabled local topology and remote endpoint health.
   const int caller_node = numa_aware_ ? numa::CurrentNode() : -1;
   const auto candidates =
       topology_->CandidatesFor(caller_node, numa_aware_);
@@ -861,28 +996,61 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
   const auto local_enabled =
       rdma::UnionRailMasks(candidates.allowed, candidates.fallback);
-  const auto highest_tier = rdma::HighestCompatibleTier(
-      rail_tiers_,
-      rdma::IntersectRailMasks(peer_snapshot->peer_healthy, local_enabled));
-  if (!rdma::HasRail(highest_tier)) {
+  const auto topology_compatible =
+      rdma::IntersectRailMasks(peer_snapshot->peer_healthy, local_enabled);
+  RailMask admission_excluded = options.excluded;
+  admission_excluded.resize(devs_.size(), 0);
+  std::optional<rdma::RailLease> lease;
+  std::optional<RemoteRailLease> remote_lease;
+  uint64_t lease_started = 0;
+  size_t ridx = 0;
+  for (size_t selection_attempt = 0; selection_attempt < devs_.size();
+       ++selection_attempt) {
+    const uint64_t now = rdma::RailPolicy::NowMicros();
+    const auto remote_compatible =
+        peer_snapshot->peer_id.empty()
+            ? topology_compatible
+            : remote_rail_health_->AllowedMask(
+                  peer_snapshot->peer_id, topology_compatible, now);
+    const auto highest_tier =
+        rdma::HighestCompatibleTier(rail_tiers_, remote_compatible);
+    if (!rdma::HasRail(highest_tier)) break;
+    lease = rdma::AcquireHighestTier(
+        *rail_policy_, requested, rail_backpressure_us_, highest_tier,
+        candidates.allowed, candidates.fallback, admission_excluded);
+    if (!lease) {
+      result.failure = AcquireFailure::kAdmission;
+      result.status = Status::kResourceExhausted;
+      return result;
+    }
+    ridx = lease->rail;
+    result.attempted_rail = ridx;
+    lease_started = rdma::RailPolicy::NowMicros();
+    if (peer_snapshot->peer_id.empty()) break;
+    remote_lease = remote_rail_health_->TryAcquire(
+        peer_snapshot->peer_id, ridx, lease_started);
+    if (remote_lease) break;
+    const uint64_t denied_at = rdma::RailPolicy::NowMicros();
+    rail_policy_->Complete(*lease, denied_at - lease_started,
+                           rdma::RailCompletion::kAdmission, denied_at);
+    admission_excluded[ridx] = 1;
+    lease.reset();
+  }
+  if (!lease) {
     no_compatible_rail_.fetch_add(1, std::memory_order_relaxed);
     result.failure = AcquireFailure::kNoCompatibleRail;
     result.status = Status::kNoCompatibleRail;
     return result;
   }
-  auto lease = rdma::AcquireHighestTier(
-      *rail_policy_, requested, rail_backpressure_us_, highest_tier,
-      candidates.allowed, candidates.fallback, options.excluded);
-  if (!lease) {
-    result.failure = AcquireFailure::kAdmission;
-    result.status = Status::kResourceExhausted;
-    return result;
-  }
-  result.attempted_rail = lease->rail;
-  const size_t ridx = lease->rail;
-  const uint64_t lease_started = rdma::RailPolicy::NowMicros();
   const auto complete_unowned_lease =
       [&](rdma::RailCompletion completion) {
+        if (remote_lease) {
+          CompleteRemote(
+              peer_snapshot->peer_id, ridx, remote_lease->generation,
+              completion == rdma::RailCompletion::kEndpointFailure
+                  ? RemoteRailOutcome::kEndpointFailure
+                  : RemoteRailOutcome::kAbandon);
+        }
         const uint64_t now = rdma::RailPolicy::NowMicros();
         rail_policy_->Complete(*lease, now - lease_started, completion, now);
       };
@@ -890,12 +1058,15 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   std::vector<std::pair<void*, size_t>> pools;
   std::vector<Conn*> stale;
   Conn* pooled = nullptr;
+  bool snapshot_current = false;
   {
     std::lock_guard<std::mutex> lk(mu_);
     pools = pools_;
-    const uint64_t current_generation =
-        peer_topologies_->Snapshot(node)->generation;
-    if (!options.force_new) {
+    const auto current_peer = peer_topologies_->Snapshot(node);
+    snapshot_current =
+        current_peer && current_peer->peer_id == peer_snapshot->peer_id &&
+        current_peer->publication == peer_snapshot->publication;
+    if (snapshot_current && !options.force_new) {
       auto& idle = lane == Lane::kData
                        ? pool_
                        : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
@@ -904,7 +1075,9 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
         auto& pool_candidates = it->second;
         for (size_t i = pool_candidates.size(); i > 0; --i) {
           Conn* candidate = pool_candidates[i - 1];
-          if (candidate->peer_generation != current_generation) {
+          if (!current_peer ||
+              candidate->peer_id != current_peer->peer_id ||
+              candidate->peer_publication != current_peer->publication) {
             if (candidate->lifecycle.RequestRetire()) {
               stale.push_back(candidate);
               pool_candidates.erase(pool_candidates.begin() +
@@ -912,7 +1085,8 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
             }
             continue;
           }
-          if (candidate->peer_generation == peer_snapshot->generation &&
+          if (candidate->peer_id == peer_snapshot->peer_id &&
+              candidate->peer_publication == peer_snapshot->publication &&
               candidate->rail_index == ridx &&
               candidate->lifecycle.Activate()) {
             pooled = candidate;
@@ -926,12 +1100,22 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
   for (Conn* conn : stale)
     Destroy(conn, rdma::RailCompletion::kAdmission);
-  stale_generation_reaps_.fetch_add(stale.size(), std::memory_order_relaxed);
+  stale_publication_reaps_.fetch_add(stale.size(), std::memory_order_relaxed);
+  if (!snapshot_current) {
+    complete_unowned_lease(rdma::RailCompletion::kAdmission);
+    result.failure = AcquireFailure::kAdmission;
+    return result;
+  }
   if (pooled) {
     pooled->lease = *lease;
     pooled->lease_started_us = lease_started;
     pooled->credit_held = true;
     pooled->visited = true;
+    pooled->remote_lease_generation =
+        remote_lease ? remote_lease->generation : 0;
+    pooled->remote_lease_held = remote_lease.has_value();
+    pooled->remote_recovery_probe =
+        remote_lease && remote_lease->recovery_probe;
     result.from_pool = true;
     if (!pooled->ep.EnsurePoolMrs(pools, true)) {
       Destroy(pooled, rdma::RailCompletion::kRailFailure);
@@ -1009,7 +1193,13 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
   auto* conn = new Conn();
   conn->rail_index = ridx;
-  conn->peer_generation = peer_snapshot->generation;
+  conn->peer_publication = peer_snapshot->publication;
+  conn->peer_id = peer_snapshot->peer_id;
+  conn->remote_lease_generation =
+      remote_lease ? remote_lease->generation : 0;
+  conn->remote_lease_held = remote_lease.has_value();
+  conn->remote_recovery_probe =
+      remote_lease && remote_lease->recovery_probe;
   conn->lease = *lease;
   conn->lease_started_us = lease_started;
   conn->credit_held = true;
@@ -1113,6 +1303,18 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     result.failure = AcquireFailure::kLocalRail;
     return result;
   }
+  bool publication_current = false;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    publication_current = peer_topologies_->IsCurrent(
+        node, conn->peer_id, conn->peer_publication);
+  }
+  if (!publication_current) {
+    stale_publication_reaps_.fetch_add(1, std::memory_order_relaxed);
+    Destroy(conn, rdma::RailCompletion::kAdmission);
+    result.failure = AcquireFailure::kAdmission;
+    return result;
+  }
   conns_opened_.fetch_add(1, std::memory_order_relaxed);
   rail_conns_[ridx].fetch_add(1, std::memory_order_relaxed);
   result.conn = conn;
@@ -1137,9 +1339,14 @@ bool RdmaTransport::PrepareRetry(
         topology_->CandidatesFor(caller_node, numa_aware_);
     const auto local_enabled =
         rdma::UnionRailMasks(candidates.allowed, candidates.fallback);
-    const auto highest_tier = rdma::HighestCompatibleTier(
-        rail_tiers_,
-        rdma::IntersectRailMasks(peer->peer_healthy, local_enabled));
+    auto compatible =
+        rdma::IntersectRailMasks(peer->peer_healthy, local_enabled);
+    if (!peer->peer_id.empty()) {
+      compatible = remote_rail_health_->AllowedMask(
+          peer->peer_id, compatible, rdma::RailPolicy::NowMicros());
+    }
+    const auto highest_tier =
+        rdma::HighestCompatibleTier(rail_tiers_, compatible);
     const auto preferred =
         rdma::IntersectRailMasks(highest_tier, candidates.allowed);
     const auto fallback =
@@ -1154,8 +1361,33 @@ bool RdmaTransport::PrepareRetry(
     }
     return true;
   }
-  if (failure == AcquireFailure::kEndpoint && from_pool) {
-    stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
+  if (failure == AcquireFailure::kEndpoint && attempted_rail &&
+      *attempted_rail < devs_.size()) {
+    excluded->assign(devs_.size(), 0);
+    (*excluded)[*attempted_rail] = 1;
+    const int caller_node = numa_aware_ ? numa::CurrentNode() : -1;
+    const auto candidates =
+        topology_->CandidatesFor(caller_node, numa_aware_);
+    const auto local_enabled =
+        rdma::UnionRailMasks(candidates.allowed, candidates.fallback);
+    auto compatible =
+        rdma::IntersectRailMasks(peer->peer_healthy, local_enabled);
+    if (!peer->peer_id.empty()) {
+      compatible = remote_rail_health_->AllowedMask(
+          peer->peer_id, compatible, rdma::RailPolicy::NowMicros());
+    }
+    const auto highest_tier =
+        rdma::HighestCompatibleTier(rail_tiers_, compatible);
+    const auto preferred =
+        rdma::IntersectRailMasks(highest_tier, candidates.allowed);
+    const auto fallback =
+        rdma::IntersectRailMasks(highest_tier, candidates.fallback);
+    if (!rdma::HasUnexcludedRail(preferred, fallback, *excluded))
+      return false;
+    if (from_pool)
+      stale_pool_retries_.fetch_add(1, std::memory_order_relaxed);
+    cross_rail_retries_.fetch_add(1, std::memory_order_relaxed);
+    *cross_rail_retry = true;
     return true;
   }
   return false;
@@ -1496,7 +1728,7 @@ std::string RdmaTransport::MetricsText() const {
   s += "dfkv_rdma_client_stale_pool_retries_total " +
        std::to_string(stale_pool_retries_.load(std::memory_order_relaxed)) +
        "\n";
-  s += "# HELP dfkv_rdma_client_cross_rail_retries_total Logical operations retried with the failed client-local RDMA rail excluded and another topology-enabled rail available\n";
+  s += "# HELP dfkv_rdma_client_cross_rail_retries_total Logical operations retried with the failed local or remote endpoint rail excluded and another compatible healthy rail available\n";
   s += "# TYPE dfkv_rdma_client_cross_rail_retries_total counter\n";
   s += "dfkv_rdma_client_cross_rail_retries_total " +
        std::to_string(cross_rail_retries_.load(std::memory_order_relaxed)) +
@@ -1533,7 +1765,7 @@ std::string RdmaTransport::MetricsText() const {
   s += "dfkv_rdma_client_keepalive_failures_total " +
        std::to_string(keepalive_failures_.load(std::memory_order_relaxed)) +
        "\n";
-  s += "# HELP dfkv_rdma_client_peer_topology_updates_total Published peer topology generations\n";
+  s += "# HELP dfkv_rdma_client_peer_topology_updates_total Published peer topology snapshots\n";
   s += "# TYPE dfkv_rdma_client_peer_topology_updates_total counter\n";
   s += "dfkv_rdma_client_peer_topology_updates_total " +
        std::to_string(
@@ -1543,15 +1775,18 @@ std::string RdmaTransport::MetricsText() const {
   s += "dfkv_rdma_client_no_compatible_rail_total " +
        std::to_string(no_compatible_rail_.load(std::memory_order_relaxed)) +
        "\n";
-  s += "# HELP dfkv_rdma_client_stale_generation_reaps_total Connections retired instead of reuse after a peer topology generation change\n";
+  s += "# HELP dfkv_rdma_client_stale_generation_reaps_total Connections retired instead of reuse after a peer publication/incarnation change\n";
   s += "# TYPE dfkv_rdma_client_stale_generation_reaps_total counter\n";
   s += "dfkv_rdma_client_stale_generation_reaps_total " +
        std::to_string(
-           stale_generation_reaps_.load(std::memory_order_relaxed)) + "\n";
+           stale_publication_reaps_.load(std::memory_order_relaxed)) + "\n";
+  s += remote_rail_health_->MetricsText(devs_);
   return s;
 }
 
-void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
+void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c,
+                            RemoteRailOutcome remote_outcome) {
+  CompleteRemoteLease(c, remote_outcome);
   bool refresh_ok = false;
   {
     std::lock_guard<std::mutex> lk(mu_);
@@ -1572,12 +1807,12 @@ void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
   }
 
   bool reusable = false;
-  bool generation_current = false;
+  bool publication_current = false;
   {
     std::lock_guard<std::mutex> lk(mu_);
-    generation_current =
-        peer_topologies_->IsCurrent(node, c->peer_generation);
-    if (generation_current) {
+    publication_current = peer_topologies_->IsCurrent(
+        node, c->peer_id, c->peer_publication);
+    if (publication_current) {
       auto& idle = lane == Lane::kData
                        ? pool_
                        : (lane == Lane::kSgData ? sg_pool_ : control_pool_);
@@ -1588,8 +1823,8 @@ void RdmaTransport::Release(const std::string& node, Lane lane, Conn* c) {
       }
     }
   }
-  if (!reusable && !generation_current)
-    stale_generation_reaps_.fetch_add(1, std::memory_order_relaxed);
+  if (!reusable && !publication_current)
+    stale_publication_reaps_.fetch_add(1, std::memory_order_relaxed);
   if (!reusable) Destroy(c);
 }
 
@@ -1663,7 +1898,7 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
     bool request_posted = false;
     if (op == WireOp::kCache) {
       if (payload_len > conn->data_capacity()) {
-        Release(node, lane, conn);
+        Release(node, lane, conn, RemoteRailOutcome::kAbandon);
         return Status::kInvalid;
       }
       ibv_mr* payload_mr =
@@ -1685,7 +1920,7 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
     } else if (op == WireOp::kRange) {
       if (!out || length > conn->data_capacity() ||
           length > std::numeric_limits<uint32_t>::max()) {
-        Release(node, lane, conn);
+        Release(node, lane, conn, RemoteRailOutcome::kAbandon);
         return Status::kInvalid;
       }
       attempt_out.resize(static_cast<size_t>(length));

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -26,6 +26,7 @@
 #include "transport/transport.h"
 #include "transport/rail_select.h"
 #include "transport/rdma_resource_budget.h"
+#include "transport/remote_rail_health.h"
 
 namespace dfkv {
 namespace rdma {
@@ -97,6 +98,8 @@ class RdmaTransport : public Transport {
   // WR_BUDGET / REGISTERED_BYTES_BUDGET): explicit config is a contract.
   void OnTopologyHint(size_t nodes) override;
   void OnPeerTopology(const PeerTopology& topology) override;
+  void OnPeerIdentities(
+      const std::vector<std::string>& live_peer_ids) override;
 
   bool pipelined() const override { return true; }
   size_t MaxSgPayloadSegs() const override { return sg_payload_segs_; }
@@ -128,6 +131,7 @@ class RdmaTransport : public Transport {
       std::vector<size_t>* out_lens) override;
 
  private:
+  friend class RdmaTransportTestPeer;
   struct Conn;
   using RailMask = std::vector<uint8_t>;
   enum class AcquireFailure : uint8_t {
@@ -163,23 +167,29 @@ class RdmaTransport : public Transport {
                         const AcquireOptions& options);
   // Schedules at most one fresh retry. Operations that may commit remotely
   // are retryable only until their first request is posted. cross_rail_retry
-  // is set only while the failed rail stays excluded and another
-  // topology-enabled rail exists.
+  // is set only while the failed rail stays excluded and another currently
+  // topology-compatible, local-eligible, remotely healthy rail exists.
   bool PrepareRetry(
       int attempt, bool from_pool, std::optional<size_t> attempted_rail,
       AcquireFailure failure, ReplaySafety replay_safety, bool request_posted,
       const std::shared_ptr<const rdma::PeerRailSnapshot>& peer,
       RailMask* excluded, bool* cross_rail_retry);
-  void Release(const std::string& node, Lane lane, Conn* c);
+  void Release(const std::string& node, Lane lane, Conn* c,
+               RemoteRailOutcome remote_outcome =
+                   RemoteRailOutcome::kSuccess);
   void Destroy(Conn* c,
                rdma::RailCompletion completion =
                    rdma::RailCompletion::kAdmission);
+  void CompleteRemote(const std::string& peer_id, size_t local_rail,
+                      uint64_t generation, RemoteRailOutcome outcome);
+  void RetireIdlePeerRail(const std::string& peer_id, size_t local_rail);
+  void CompleteRemoteLease(Conn* c, RemoteRailOutcome outcome);
   bool EvictOneIdle();
   // Keep every idle QP alive while its client process is healthy. This lets a
   // short server-side idle reaper reclaim dead clients without forcing the
   // first cache read after an idle gap to discover and rebuild stale QPs.
   void KeepaliveLoop();
-  bool KeepaliveConn(Conn* c);
+  bool KeepaliveConn(Conn* c, rdma::RailCompletion* failure);
   Status RoundTrip(const std::string& node, WireOp op, const BlockKey& key,
                    uint64_t offset, uint64_t length, const void* payload,
                    uint64_t payload_len, std::string* out,
@@ -279,6 +289,7 @@ class RdmaTransport : public Transport {
   std::vector<std::vector<uint8_t>> rail_tiers_;
   bool peer_topology_required_ = false;
   std::unique_ptr<rdma::PeerTopologyStore> peer_topologies_;
+  std::unique_ptr<RemoteRailHealth> remote_rail_health_;
   bool auto_device_ = true;
   bool numa_aware_ = false;
   // Global least-inflight rail admission with per-rail credits, failure
@@ -299,7 +310,7 @@ class RdmaTransport : public Transport {
   std::atomic<uint64_t> cross_rail_retry_exhausted_{0};
   std::atomic<uint64_t> peer_topology_updates_{0};
   std::atomic<uint64_t> no_compatible_rail_{0};
-  std::atomic<uint64_t> stale_generation_reaps_{0};
+  std::atomic<uint64_t> stale_publication_reaps_{0};
   // Deterministic test-only completion-fault targeting. Inert unless
   // DFKV_RDMA_TEST_COMPLETION_FAULT is set.
   std::atomic<uint64_t> test_completion_fault_calls_{0};

--- a/src/transport/remote_rail_health.cc
+++ b/src/transport/remote_rail_health.cc
@@ -1,0 +1,319 @@
+#include "transport/remote_rail_health.h"
+
+#include <algorithm>
+#include <limits>
+#include <unordered_set>
+#include <utility>
+
+namespace dfkv {
+namespace {
+
+constexpr uint64_t kHardMaxCooldownUs = 30000000;
+
+uint64_t SaturatingAdd(uint64_t lhs, uint64_t rhs) {
+  const uint64_t limit = std::numeric_limits<uint64_t>::max();
+  return lhs > limit - rhs ? limit : lhs + rhs;
+}
+
+std::string EscapeLabel(const std::string& value) {
+  std::string escaped;
+  escaped.reserve(value.size());
+  for (char ch : value) {
+    switch (ch) {
+      case '\\':
+        escaped += "\\\\";
+        break;
+      case '"':
+        escaped += "\\\"";
+        break;
+      case '\n':
+        escaped += "\\n";
+        break;
+      default:
+        escaped += ch;
+        break;
+    }
+  }
+  return escaped;
+}
+
+void AppendValue(std::string* text, const char* name, uint64_t value) {
+  text->append(name);
+  text->push_back(' ');
+  text->append(std::to_string(value));
+  text->push_back('\n');
+}
+
+void AppendRailValue(std::string* text, const char* name,
+                     const std::string& escaped_dev, uint64_t value) {
+  text->append(name);
+  text->append("{dev=\"");
+  text->append(escaped_dev);
+  text->append("\"} ");
+  text->append(std::to_string(value));
+  text->push_back('\n');
+}
+
+}  // namespace
+
+RemoteRailHealth::RemoteRailHealth(RemoteRailHealthConfig config)
+    : config_(config) {
+  config_.max_cooldown_us =
+      std::max<uint64_t>(1, std::min(config_.max_cooldown_us,
+                                     kHardMaxCooldownUs));
+  config_.base_cooldown_us =
+      std::max<uint64_t>(1, std::min(config_.base_cooldown_us,
+                                     config_.max_cooldown_us));
+}
+
+std::optional<RemoteRailLease> RemoteRailHealth::TryAcquire(
+    const std::string& peer_id, size_t local_rail, uint64_t now_us) {
+  std::lock_guard<std::mutex> lock(mu_);
+  Counters& rail_counters = rail_counters_[local_rail];
+  if (has_reconciled_ &&
+      live_peer_ids_.find(peer_id) == live_peer_ids_.end()) {
+    ++total_counters_.admissions_denied;
+    ++rail_counters.admissions_denied;
+    return std::nullopt;
+  }
+
+  RailState& state = peers_[peer_id].rails[local_rail];
+  if (Unavailable(state, now_us)) {
+    ++total_counters_.admissions_denied;
+    ++rail_counters.admissions_denied;
+    return std::nullopt;
+  }
+
+  const bool recovery_probe = state.consecutive_failures != 0;
+  const uint64_t generation = NextGenerationLocked();
+  state.active_leases.emplace(
+      generation, ActiveLease{state.health_epoch, recovery_probe});
+  if (recovery_probe) {
+    state.recovery_probe_active = true;
+    ++total_counters_.recovery_probes;
+    ++rail_counters.recovery_probes;
+  } else {
+    ++total_counters_.normal_leases;
+    ++rail_counters.normal_leases;
+  }
+  return RemoteRailLease{generation, state.health_epoch, recovery_probe};
+}
+
+RemoteRailCompletion RemoteRailHealth::Complete(
+    const std::string& peer_id, size_t local_rail, uint64_t generation,
+    RemoteRailOutcome outcome, uint64_t now_us) {
+  std::lock_guard<std::mutex> lock(mu_);
+  auto peer = peers_.find(peer_id);
+  if (peer == peers_.end()) return {};
+  auto rail = peer->second.rails.find(local_rail);
+  if (rail == peer->second.rails.end()) return {};
+
+  RailState& state = rail->second;
+  auto lease = state.active_leases.find(generation);
+  if (lease == state.active_leases.end()) return {};
+  const ActiveLease completed_lease = lease->second;
+  state.active_leases.erase(lease);
+
+  Counters& rail_counters = rail_counters_[local_rail];
+  if (outcome == RemoteRailOutcome::kAbandon) {
+    if (completed_lease.recovery_probe) state.recovery_probe_active = false;
+    ++total_counters_.abandons;
+    ++rail_counters.abandons;
+    return {};
+  }
+
+  if (outcome == RemoteRailOutcome::kSuccess) {
+    ++total_counters_.successes;
+    ++rail_counters.successes;
+    if (completed_lease.recovery_probe &&
+        state.consecutive_failures != 0) {
+      state.consecutive_failures = 0;
+      state.cooldown_until_us = 0;
+      state.recovery_probe_active = false;
+      if (++state.health_epoch == 0) ++state.health_epoch;
+      ++total_counters_.recoveries;
+      ++rail_counters.recoveries;
+      return {RemoteRailTransition::kRecovered, 0};
+    }
+    if (completed_lease.recovery_probe)
+      state.recovery_probe_active = false;
+    return {};
+  }
+
+  if (!completed_lease.recovery_probe &&
+      completed_lease.health_epoch != state.health_epoch) {
+    return {};
+  }
+
+  const bool entering_cooldown = state.cooldown_until_us <= now_us;
+  if (completed_lease.recovery_probe) state.recovery_probe_active = false;
+  if (state.consecutive_failures != std::numeric_limits<uint64_t>::max())
+    ++state.consecutive_failures;
+  const uint64_t deadline =
+      SaturatingAdd(now_us, CooldownFor(state.consecutive_failures));
+  state.cooldown_until_us = std::max(state.cooldown_until_us, deadline);
+
+  ++total_counters_.endpoint_failures;
+  ++rail_counters.endpoint_failures;
+  if (entering_cooldown) {
+    ++total_counters_.cooldowns;
+    ++rail_counters.cooldowns;
+    return {RemoteRailTransition::kCooled, state.cooldown_until_us};
+  }
+  return {RemoteRailTransition::kNone, state.cooldown_until_us};
+}
+
+std::vector<uint8_t> RemoteRailHealth::AllowedMask(
+    const std::string& peer_id, const std::vector<uint8_t>& candidate_mask,
+    uint64_t now_us) const {
+  std::vector<uint8_t> allowed = candidate_mask;
+  std::lock_guard<std::mutex> lock(mu_);
+  auto peer = peers_.find(peer_id);
+  if (peer == peers_.end()) return allowed;
+
+  for (size_t local_rail = 0; local_rail < allowed.size(); ++local_rail) {
+    if (allowed[local_rail] == 0) continue;
+    auto rail = peer->second.rails.find(local_rail);
+    if (rail != peer->second.rails.end() &&
+        Unavailable(rail->second, now_us)) {
+      allowed[local_rail] = 0;
+    }
+  }
+  return allowed;
+}
+
+void RemoteRailHealth::Reconcile(
+    const std::vector<std::string>& live_peer_ids) {
+  std::unordered_set<std::string> live;
+  live.reserve(live_peer_ids.size());
+  for (const std::string& peer_id : live_peer_ids) live.insert(peer_id);
+
+  std::lock_guard<std::mutex> lock(mu_);
+  live_peer_ids_ = std::move(live);
+  has_reconciled_ = true;
+  for (auto peer = peers_.begin(); peer != peers_.end();) {
+    if (live_peer_ids_.find(peer->first) == live_peer_ids_.end()) {
+      peer = peers_.erase(peer);
+    } else {
+      ++peer;
+    }
+  }
+}
+
+std::string RemoteRailHealth::MetricsText(
+    const std::vector<std::string>& dev_names) const {
+  Counters totals;
+  std::vector<Counters> per_rail(dev_names.size());
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    totals = total_counters_;
+    for (size_t rail = 0; rail < per_rail.size(); ++rail) {
+      auto counters = rail_counters_.find(rail);
+      if (counters != rail_counters_.end()) per_rail[rail] = counters->second;
+    }
+  }
+
+  std::string text;
+  text.reserve(2048 + dev_names.size() * 768);
+  text += "# HELP dfkv_rdma_client_remote_rail_normal_leases_total Normal remote endpoint leases granted\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_normal_leases_total counter\n";
+  text += "# HELP dfkv_rdma_client_remote_rail_admissions_denied_total Admissions denied by authoritative topology, endpoint cooldown, or an active recovery probe\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_admissions_denied_total counter\n";
+  text += "# HELP dfkv_rdma_client_remote_rail_successes_total Completed successful endpoint leases\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_successes_total counter\n";
+  text += "# HELP dfkv_rdma_client_remote_rail_failures_total Endpoint failures accounted at lease completion\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_failures_total counter\n";
+  text += "# HELP dfkv_rdma_client_remote_rail_cooldowns_total Endpoint cooldown transitions\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_cooldowns_total counter\n";
+  text += "# HELP dfkv_rdma_client_remote_rail_recovery_probes_total Single recovery probe leases granted after cooldown\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_recovery_probes_total counter\n";
+  text += "# HELP dfkv_rdma_client_remote_rail_recoveries_total Successful endpoint recoveries\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_recoveries_total counter\n";
+  text += "# HELP dfkv_rdma_client_remote_rail_abandons_total Leases released without endpoint evidence\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_abandons_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_normal_leases_by_rail_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_admissions_denied_by_rail_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_successes_by_rail_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_failures_by_rail_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_cooldowns_by_rail_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_recovery_probes_by_rail_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_recoveries_by_rail_total counter\n";
+  text += "# TYPE dfkv_rdma_client_remote_rail_abandons_by_rail_total counter\n";
+
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_normal_leases_total",
+              totals.normal_leases);
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_admissions_denied_total",
+              totals.admissions_denied);
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_successes_total",
+              totals.successes);
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_failures_total",
+              totals.endpoint_failures);
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_cooldowns_total",
+              totals.cooldowns);
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_recovery_probes_total",
+              totals.recovery_probes);
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_recoveries_total",
+              totals.recoveries);
+  AppendValue(&text, "dfkv_rdma_client_remote_rail_abandons_total",
+              totals.abandons);
+
+  for (size_t rail = 0; rail < dev_names.size(); ++rail) {
+    const std::string dev = EscapeLabel(dev_names[rail]);
+    const Counters& counters = per_rail[rail];
+    AppendRailValue(&text,
+                    "dfkv_rdma_client_remote_rail_normal_leases_by_rail_total",
+                    dev, counters.normal_leases);
+    AppendRailValue(
+        &text,
+        "dfkv_rdma_client_remote_rail_admissions_denied_by_rail_total", dev,
+        counters.admissions_denied);
+    AppendRailValue(&text,
+                    "dfkv_rdma_client_remote_rail_successes_by_rail_total", dev,
+                    counters.successes);
+    AppendRailValue(&text,
+                    "dfkv_rdma_client_remote_rail_failures_by_rail_total", dev,
+                    counters.endpoint_failures);
+    AppendRailValue(&text,
+                    "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total", dev,
+                    counters.cooldowns);
+    AppendRailValue(
+        &text,
+        "dfkv_rdma_client_remote_rail_recovery_probes_by_rail_total", dev,
+        counters.recovery_probes);
+    AppendRailValue(&text,
+                    "dfkv_rdma_client_remote_rail_recoveries_by_rail_total", dev,
+                    counters.recoveries);
+    AppendRailValue(&text,
+                    "dfkv_rdma_client_remote_rail_abandons_by_rail_total", dev,
+                    counters.abandons);
+  }
+  return text;
+}
+
+uint64_t RemoteRailHealth::CooldownFor(
+    uint64_t consecutive_failures) const {
+  uint64_t cooldown = config_.base_cooldown_us;
+  for (uint64_t failure = 1;
+       failure < consecutive_failures && cooldown < config_.max_cooldown_us;
+       ++failure) {
+    if (cooldown > config_.max_cooldown_us / 2) {
+      cooldown = config_.max_cooldown_us;
+    } else {
+      cooldown *= 2;
+    }
+  }
+  return std::min(cooldown, config_.max_cooldown_us);
+}
+
+uint64_t RemoteRailHealth::NextGenerationLocked() {
+  const uint64_t generation = next_generation_++;
+  if (next_generation_ == 0) next_generation_ = 1;
+  return generation;
+}
+
+bool RemoteRailHealth::Unavailable(const RailState& state, uint64_t now_us) {
+  return state.consecutive_failures != 0 &&
+         (state.cooldown_until_us > now_us || state.recovery_probe_active);
+}
+
+}  // namespace dfkv

--- a/src/transport/remote_rail_health.h
+++ b/src/transport/remote_rail_health.h
@@ -1,0 +1,126 @@
+#ifndef DFKV_TRANSPORT_REMOTE_RAIL_HEALTH_H_
+#define DFKV_TRANSPORT_REMOTE_RAIL_HEALTH_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace dfkv {
+
+struct RemoteRailHealthConfig {
+  uint64_t base_cooldown_us = 1000000;
+  uint64_t max_cooldown_us = 30000000;
+};
+
+enum class RemoteRailOutcome : uint8_t {
+  kSuccess,
+  kEndpointFailure,
+  kAbandon,
+};
+
+struct RemoteRailLease {
+  uint64_t generation = 0;
+  uint64_t health_epoch = 0;
+  bool recovery_probe = false;
+};
+
+enum class RemoteRailTransition : uint8_t {
+  kNone,
+  kCooled,
+  kRecovered,
+};
+
+struct RemoteRailCompletion {
+  RemoteRailTransition transition = RemoteRailTransition::kNone;
+  uint64_t cooldown_until_us = 0;
+};
+
+// Per-peer, per-local-rail endpoint health. Time-taking operations receive an
+// explicit monotonic timestamp so the policy is deterministic in tests and
+// independent of the caller's clock source.
+class RemoteRailHealth {
+ public:
+  explicit RemoteRailHealth(RemoteRailHealthConfig config = {});
+
+  // Healthy, live endpoints admit ordinary leases. Once an endpoint has
+  // failed, admissions are denied until its cooldown expires; exactly one
+  // caller then receives the recovery-probe lease. Before the first Reconcile,
+  // unknown identities remain usable for constructor-order compatibility.
+  // Afterwards, an identity absent from the latest topology is denied.
+  std::optional<RemoteRailLease> TryAcquire(const std::string& peer_id,
+                                            size_t local_rail,
+                                            uint64_t now_us);
+
+  // Completes a lease at most once. Unknown generations, completions after
+  // Reconcile removed an identity, and endpoint failures from health epochs
+  // superseded by a successful recovery probe are ignored.
+  RemoteRailCompletion Complete(const std::string& peer_id, size_t local_rail,
+                                uint64_t generation,
+                                RemoteRailOutcome outcome, uint64_t now_us);
+
+  // Removes currently unavailable endpoint rails from a stable local-rail
+  // candidate mask. This is an observation only: it never claims a probe.
+  std::vector<uint8_t> AllowedMask(const std::string& peer_id,
+                                   const std::vector<uint8_t>& candidate_mask,
+                                   uint64_t now_us) const;
+
+  // MDS topology becomes authoritative at the first call. All state and
+  // outstanding leases belonging to identities absent from live_peer_ids are
+  // discarded, and subsequent admissions remain fenced to the latest set.
+  void Reconcile(const std::vector<std::string>& live_peer_ids);
+
+  // Prometheus text contains process aggregates and fixed local-device labels
+  // only. Peer identities and addresses are never exported as labels.
+  std::string MetricsText(const std::vector<std::string>& dev_names) const;
+
+ private:
+  struct ActiveLease {
+    uint64_t health_epoch = 0;
+    bool recovery_probe = false;
+  };
+
+  struct RailState {
+    uint64_t health_epoch = 0;
+    uint64_t consecutive_failures = 0;
+    uint64_t cooldown_until_us = 0;
+    bool recovery_probe_active = false;
+    std::unordered_map<uint64_t, ActiveLease> active_leases;
+  };
+
+  struct PeerState {
+    std::unordered_map<size_t, RailState> rails;
+  };
+
+  struct Counters {
+    uint64_t normal_leases = 0;
+    uint64_t successes = 0;
+    uint64_t admissions_denied = 0;
+    uint64_t endpoint_failures = 0;
+    uint64_t cooldowns = 0;
+    uint64_t recovery_probes = 0;
+    uint64_t recoveries = 0;
+    uint64_t abandons = 0;
+  };
+
+  uint64_t CooldownFor(uint64_t consecutive_failures) const;
+  uint64_t NextGenerationLocked();
+  static bool Unavailable(const RailState& state, uint64_t now_us);
+
+  RemoteRailHealthConfig config_;
+  mutable std::mutex mu_;
+  std::unordered_map<std::string, PeerState> peers_;
+  std::unordered_set<std::string> live_peer_ids_;
+  bool has_reconciled_ = false;
+  std::unordered_map<size_t, Counters> rail_counters_;
+  Counters total_counters_;
+  uint64_t next_generation_ = 1;
+};
+
+}  // namespace dfkv
+
+#endif  // DFKV_TRANSPORT_REMOTE_RAIL_HEALTH_H_

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -86,6 +86,11 @@ struct PeerTopology {
   uint64_t generation = 0;
   bool complete = false;
   std::vector<PeerRailTopology> rails;
+  // Stable MDS identity is distinct from the routable address. `present=false`
+  // retires this exact identity/address binding without affecting a replacement
+  // peer that has already claimed the address.
+  std::string peer_id;
+  bool present = true;
 };
 
 
@@ -157,6 +162,14 @@ class Transport {
   // transports without heterogeneous path selection ignore it.
   virtual void OnPeerTopology(const PeerTopology& topology) {
     (void)topology;
+  }
+
+  // Full stable-identity membership after one topology adoption. Stateful
+  // transports use this authoritative set to discard health for departed
+  // identities; address callbacks alone cannot distinguish address reuse.
+  virtual void OnPeerIdentities(
+      const std::vector<std::string>& live_peer_ids) {
+    (void)live_peer_ids;
   }
 
   // True if CacheMany/RangeMany pipeline requests on one connection (RDMA). When

--- a/test/client/dynamic_members_test.cc
+++ b/test/client/dynamic_members_test.cc
@@ -289,10 +289,22 @@ struct HintRecordingTransport : dfkv::Transport {
     peer_topologies.push_back(topology);
     cv.notify_all();
   }
+  void OnPeerIdentities(
+      const std::vector<std::string>& live_peer_ids) override {
+    std::lock_guard<std::mutex> lock(mu);
+    peer_identity_sets.push_back(live_peer_ids);
+    cv.notify_all();
+  }
   bool WaitForPeerTopologies(size_t count) {
     std::unique_lock<std::mutex> lock(mu);
     return cv.wait_for(lock, std::chrono::seconds(5), [&] {
       return peer_topologies.size() >= count;
+    });
+  }
+  bool WaitForPeerIdentitySets(size_t count) {
+    std::unique_lock<std::mutex> lock(mu);
+    return cv.wait_for(lock, std::chrono::seconds(5), [&] {
+      return peer_identity_sets.size() >= count;
     });
   }
   bool WaitForHints(size_t count) {
@@ -308,6 +320,10 @@ struct HintRecordingTransport : dfkv::Transport {
     std::lock_guard<std::mutex> lock(mu);
     return peer_topologies;
   }
+  std::vector<std::vector<std::string>> PeerIdentitySets() const {
+    std::lock_guard<std::mutex> lock(mu);
+    return peer_identity_sets;
+  }
   std::vector<std::string> CachePeers() const {
     std::lock_guard<std::mutex> lock(mu);
     return cache_peers;
@@ -320,6 +336,7 @@ struct HintRecordingTransport : dfkv::Transport {
   std::condition_variable cv;
   std::vector<size_t> hints;
   std::vector<PeerTopology> peer_topologies;
+  std::vector<std::vector<std::string>> peer_identity_sets;
   std::vector<std::string> cache_peers;
   rdma::PeerTopologyStore topology_store{{"ib0"}, {{0}}, true};
   Status Cache(const std::string& peer, const dfkv::BlockKey&, const void*,
@@ -391,10 +408,14 @@ TEST(DynamicMembers, LegacyMdsFallbackAdoptsIncompleteTopology) {
   const std::vector<PeerTopology> topologies = transport.PeerTopologies();
   ASSERT_EQ(topologies.size(), 1u);
   EXPECT_EQ(topologies[0].peer_addr, "127.0.0.1:28101");
+  EXPECT_EQ(topologies[0].peer_id, "legacy-n1");
+  EXPECT_TRUE(topologies[0].present);
   EXPECT_EQ(topologies[0].generation,
             MembersTopologyEpoch(std::vector<MemberInfo>{peer}));
   EXPECT_FALSE(topologies[0].complete);
   EXPECT_TRUE(topologies[0].rails.empty());
+  EXPECT_EQ(transport.PeerIdentitySets(),
+            (std::vector<std::vector<std::string>>{{"legacy-n1"}}));
 }
 
 TEST(DynamicMembers, TransportFailureDoesNotTriggerLegacyFallback) {
@@ -430,6 +451,8 @@ TEST(DynamicMembers, RailHealthChangePropagatesWithoutPlacementChurn) {
   const std::vector<PeerTopology> initial = transport.PeerTopologies();
   ASSERT_EQ(initial.size(), 1u);
   EXPECT_EQ(initial[0].peer_addr, "127.0.0.1:28001");
+  EXPECT_EQ(initial[0].peer_id, "n1");
+  EXPECT_TRUE(initial[0].present);
   EXPECT_TRUE(initial[0].complete);
   EXPECT_EQ(initial[0].generation,
             MembersTopologyEpoch(std::vector<MemberInfo>{peer}));
@@ -449,12 +472,17 @@ TEST(DynamicMembers, RailHealthChangePropagatesWithoutPlacementChurn) {
   const std::vector<PeerTopology> changed = transport.PeerTopologies();
   ASSERT_EQ(changed.size(), 2u);
   EXPECT_EQ(changed[1].peer_addr, initial[0].peer_addr);
+  EXPECT_EQ(changed[1].peer_id, initial[0].peer_id);
+  EXPECT_TRUE(changed[1].present);
   EXPECT_NE(changed[1].generation, initial[0].generation);
   EXPECT_EQ(changed[1].generation,
             MembersTopologyEpoch(std::vector<MemberInfo>{peer}));
   ASSERT_EQ(changed[1].rails.size(), 2u);
   EXPECT_TRUE(changed[1].rails[0].healthy);
   EXPECT_FALSE(changed[1].rails[1].healthy);
+  ASSERT_TRUE(transport.WaitForPeerIdentitySets(2));
+  EXPECT_EQ(transport.PeerIdentitySets(),
+            (std::vector<std::vector<std::string>>{{"n1"}, {"n1"}}));
 
   // Placement was adopted once. The partial rail transition was independently
   // forwarded to the transport without another ring adoption/scale hint.
@@ -463,6 +491,95 @@ TEST(DynamicMembers, RailHealthChangePropagatesWithoutPlacementChurn) {
   EXPECT_EQ(hints[0], 1u);
   EXPECT_TRUE(client.WaitForRing(0));
   EXPECT_TRUE(mds.only_topology_requests());
+}
+
+TEST(DynamicMembers, StableIdentityTracksAddressReplacementAndRemoval) {
+  using P = std::vector<std::pair<std::string, std::string>>;
+  MemberInfo peer{"stable-n1", "127.0.0.1", 28301, 1};
+  peer.has_health = true;
+  peer.health.ring_eligible = true;
+  peer.health.ib_devices = {{"ib0", 4, 5, true}};
+  ScriptedTopologyMds mds({peer});
+  HintRecordingTransport transport;
+  KVClient client(P{}, Hdr(), &transport);
+  // A long interval prevents the guarded empty placement from reaching its
+  // persistence threshold before the first authoritative removal is asserted.
+  client.StartMdsDiscovery({mds.endpoint()}, "identity-test", 1000);
+
+  ASSERT_TRUE(transport.WaitForPeerTopologies(1));
+  ASSERT_TRUE(transport.WaitForPeerIdentitySets(1));
+  const uint64_t initial_generation =
+      MembersTopologyEpoch(std::vector<MemberInfo>{peer});
+  const auto initial_snapshot =
+      transport.PeerSnapshot("127.0.0.1:28301");
+  ASSERT_EQ(initial_snapshot->peer_id, "stable-n1");
+  ASSERT_EQ(initial_snapshot->generation, initial_generation);
+
+  // A routing address change explicitly retires the old address, then
+  // publishes the same stable identity at its new address.
+  peer.port = 28302;
+  mds.SetMembers({peer});
+  ASSERT_TRUE(transport.WaitForPeerTopologies(3));
+  ASSERT_TRUE(transport.WaitForPeerIdentitySets(2));
+  const uint64_t address_generation =
+      MembersTopologyEpoch(std::vector<MemberInfo>{peer});
+  const auto address_snapshot =
+      transport.PeerSnapshot("127.0.0.1:28302");
+  ASSERT_EQ(address_snapshot->peer_id, "stable-n1");
+  ASSERT_EQ(address_snapshot->generation, address_generation);
+  EXPECT_EQ(initial_snapshot->peer_id, "stable-n1");
+  EXPECT_EQ(initial_snapshot->generation, initial_generation);
+
+  // Reusing an address for a different MDS id is an identity replacement, not
+  // an address-derived alias of the old peer.
+  peer.id = "replacement-n2";
+  mds.SetMembers({peer});
+  ASSERT_TRUE(transport.WaitForPeerTopologies(5));
+  ASSERT_TRUE(transport.WaitForPeerIdentitySets(3));
+  const uint64_t replacement_generation =
+      MembersTopologyEpoch(std::vector<MemberInfo>{peer});
+  const auto replacement_snapshot =
+      transport.PeerSnapshot("127.0.0.1:28302");
+  ASSERT_EQ(replacement_snapshot->peer_id, "replacement-n2");
+  ASSERT_EQ(replacement_snapshot->generation, replacement_generation);
+  EXPECT_EQ(address_snapshot->peer_id, "stable-n1");
+  EXPECT_EQ(address_snapshot->generation, address_generation);
+
+  // The replace-all empty view removes the final identity even though the
+  // placement guard may deliberately retain its route.
+  mds.SetMembers({});
+  ASSERT_TRUE(transport.WaitForPeerTopologies(6));
+  ASSERT_TRUE(transport.WaitForPeerIdentitySets(4));
+  client.StopMdsDiscovery();
+
+  const auto updates = transport.PeerTopologies();
+  ASSERT_EQ(updates.size(), 6u);
+  EXPECT_EQ(updates[0].peer_id, "stable-n1");
+  EXPECT_EQ(updates[0].peer_addr, "127.0.0.1:28301");
+  EXPECT_TRUE(updates[0].present);
+  EXPECT_EQ(updates[1].peer_id, "stable-n1");
+  EXPECT_EQ(updates[1].peer_addr, "127.0.0.1:28301");
+  EXPECT_EQ(updates[1].generation, address_generation);
+  EXPECT_FALSE(updates[1].present);
+  EXPECT_EQ(updates[2].peer_id, "stable-n1");
+  EXPECT_EQ(updates[2].peer_addr, "127.0.0.1:28302");
+  EXPECT_TRUE(updates[2].present);
+  EXPECT_EQ(updates[3].peer_id, "stable-n1");
+  EXPECT_EQ(updates[3].peer_addr, "127.0.0.1:28302");
+  EXPECT_EQ(updates[3].generation, replacement_generation);
+  EXPECT_FALSE(updates[3].present);
+  EXPECT_EQ(updates[4].peer_id, "replacement-n2");
+  EXPECT_EQ(updates[4].peer_addr, "127.0.0.1:28302");
+  EXPECT_TRUE(updates[4].present);
+  EXPECT_EQ(updates[5].peer_id, "replacement-n2");
+  EXPECT_EQ(updates[5].peer_addr, "127.0.0.1:28302");
+  EXPECT_EQ(updates[5].generation,
+            MembersTopologyEpoch(std::vector<MemberInfo>{}));
+  EXPECT_FALSE(updates[5].present);
+  EXPECT_EQ(transport.PeerIdentitySets(),
+            (std::vector<std::vector<std::string>>{
+                {"stable-n1"}, {"stable-n1"}, {"replacement-n2"}, {}}));
+  EXPECT_TRUE(transport.PeerSnapshot("127.0.0.1:28302")->peer_id.empty());
 }
 
 TEST(DynamicMembers, GuardRejectedShrinkInvalidatesOmittedRoutablePeers) {
@@ -499,29 +616,34 @@ TEST(DynamicMembers, GuardRejectedShrinkInvalidatesOmittedRoutablePeers) {
   ASSERT_NE(shrink_generation, initial_generation);
   const std::vector<PeerTopology> updates = transport.PeerTopologies();
   ASSERT_EQ(updates.size(), 6u);
-  EXPECT_EQ(updates[3].peer_addr, "127.0.0.1:28201");
-  EXPECT_EQ(updates[3].generation, shrink_generation);
-  EXPECT_TRUE(updates[3].complete);
-  for (size_t i = 4; i < 6; ++i) {
+  for (size_t i = 3; i < 5; ++i) {
     EXPECT_EQ(updates[i].generation, shrink_generation);
+    EXPECT_FALSE(updates[i].present);
     EXPECT_FALSE(updates[i].complete);
     EXPECT_TRUE(updates[i].rails.empty());
   }
-  EXPECT_NE(updates[4].peer_addr, updates[5].peer_addr);
-  EXPECT_TRUE((updates[4].peer_addr == "127.0.0.1:28202" ||
-               updates[4].peer_addr == "127.0.0.1:28203"));
-  EXPECT_TRUE((updates[5].peer_addr == "127.0.0.1:28202" ||
-               updates[5].peer_addr == "127.0.0.1:28203"));
+  EXPECT_NE(updates[3].peer_id, updates[4].peer_id);
+  EXPECT_TRUE((updates[3].peer_id == "n1" || updates[3].peer_id == "n2"));
+  EXPECT_TRUE((updates[4].peer_id == "n1" || updates[4].peer_id == "n2"));
+  EXPECT_EQ(updates[5].peer_id, "n0");
+  EXPECT_EQ(updates[5].peer_addr, "127.0.0.1:28201");
+  EXPECT_EQ(updates[5].generation, shrink_generation);
+  EXPECT_TRUE(updates[5].present);
+  EXPECT_TRUE(updates[5].complete);
+  ASSERT_TRUE(transport.WaitForPeerIdentitySets(2));
+  EXPECT_EQ(transport.PeerIdentitySets(),
+            (std::vector<std::vector<std::string>>{
+                {"n0", "n1", "n2"}, {"n0"}}));
 
-  // No second placement hint: the guard retained all three routes. The
-  // replace-all invalidations have already made explicitly configured tiers
-  // fail closed for the omitted peers.
+  // No second placement hint: the guard retained all three routes. Explicit
+  // identity retirements remove their address snapshots, so the strict store's
+  // fallback keeps the omitted routes fail-closed without retaining state.
   const auto omitted_two = transport.PeerSnapshot("127.0.0.1:28202");
   const auto omitted_three = transport.PeerSnapshot("127.0.0.1:28203");
-  EXPECT_EQ(omitted_two->generation, shrink_generation);
+  EXPECT_TRUE(omitted_two->peer_id.empty());
   EXPECT_FALSE(omitted_two->complete);
   EXPECT_TRUE(omitted_two->compatible.empty());
-  EXPECT_EQ(omitted_three->generation, shrink_generation);
+  EXPECT_TRUE(omitted_three->peer_id.empty());
   EXPECT_FALSE(omitted_three->complete);
   EXPECT_TRUE(omitted_three->compatible.empty());
   ASSERT_EQ(transport.Hints(), std::vector<size_t>({3u}));

--- a/test/transport/rdma_health_test.cc
+++ b/test/transport/rdma_health_test.cc
@@ -1,4 +1,6 @@
 #include "transport/rdma_health.h"
+#include "transport/remote_rail_health.h"
+#include "transport/rail_select.h"
 
 #include <gtest/gtest.h>
 
@@ -93,4 +95,392 @@ TEST(RdmaHealth, QueryFailureFailsClosed) {
             std::string::npos);
   EXPECT_NE(monitor.MetricsText().find("device=\"ib0\"} 0"),
             std::string::npos);
+}
+
+TEST(RemoteRailHealth, EndpointFailureIsIsolatedByPeerAndSiblingRail) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+
+  auto failed = health.TryAcquire("peer-a", 0, 10);
+  ASSERT_TRUE(failed);
+  ASSERT_FALSE(failed->recovery_probe);
+  const auto cooled =
+      health.Complete("peer-a", 0, failed->generation,
+                      RemoteRailOutcome::kEndpointFailure, 20);
+  EXPECT_EQ(cooled.transition, RemoteRailTransition::kCooled);
+  EXPECT_EQ(cooled.cooldown_until_us, 120u);
+
+  EXPECT_EQ(health.AllowedMask("peer-a", {1, 1}, 20),
+            (std::vector<uint8_t>{0, 1}));
+  EXPECT_EQ(health.AllowedMask("peer-b", {1, 1}, 20),
+            (std::vector<uint8_t>{1, 1}));
+  EXPECT_FALSE(health.TryAcquire("peer-a", 0, 20));
+
+  auto sibling = health.TryAcquire("peer-a", 1, 20);
+  ASSERT_TRUE(sibling);
+  EXPECT_FALSE(sibling->recovery_probe);
+  auto other_peer = health.TryAcquire("peer-b", 0, 20);
+  ASSERT_TRUE(other_peer);
+  EXPECT_FALSE(other_peer->recovery_probe);
+  health.Complete("peer-a", 1, sibling->generation,
+                  RemoteRailOutcome::kSuccess, 21);
+  health.Complete("peer-b", 0, other_peer->generation,
+                  RemoteRailOutcome::kSuccess, 21);
+}
+
+TEST(RemoteRailHealth, CooldownAdmitsExactlyOneSuccessfulRecoveryProbe) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  auto failed = health.TryAcquire("peer", 0, 1);
+  ASSERT_TRUE(failed);
+  health.Complete("peer", 0, failed->generation,
+                  RemoteRailOutcome::kEndpointFailure, 10);
+
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 109));
+  auto probe = health.TryAcquire("peer", 0, 110);
+  ASSERT_TRUE(probe);
+  EXPECT_TRUE(probe->recovery_probe);
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 110))
+      << "an active recovery probe must fence every competing admission";
+
+  const auto recovered =
+      health.Complete("peer", 0, probe->generation,
+                      RemoteRailOutcome::kSuccess, 111);
+  EXPECT_EQ(recovered.transition, RemoteRailTransition::kRecovered);
+  EXPECT_EQ(recovered.cooldown_until_us, 0u);
+  EXPECT_EQ(health.AllowedMask("peer", {1}, 111),
+            (std::vector<uint8_t>{1}));
+  auto ordinary = health.TryAcquire("peer", 0, 111);
+  ASSERT_TRUE(ordinary);
+  EXPECT_FALSE(ordinary->recovery_probe);
+  health.Complete("peer", 0, ordinary->generation,
+                  RemoteRailOutcome::kSuccess, 112);
+}
+
+TEST(RemoteRailHealth, LateOrdinarySuccessCannotBypassRecoveryProbe) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  auto failed = health.TryAcquire("peer", 0, 1);
+  auto already_inflight = health.TryAcquire("peer", 0, 2);
+  ASSERT_TRUE(failed);
+  ASSERT_TRUE(already_inflight);
+  ASSERT_FALSE(failed->recovery_probe);
+  ASSERT_FALSE(already_inflight->recovery_probe);
+
+  health.Complete("peer", 0, failed->generation,
+                  RemoteRailOutcome::kEndpointFailure, 10);
+  const auto late_success =
+      health.Complete("peer", 0, already_inflight->generation,
+                      RemoteRailOutcome::kSuccess, 11);
+  EXPECT_EQ(late_success.transition, RemoteRailTransition::kNone);
+  EXPECT_EQ(health.AllowedMask("peer", {1}, 11),
+            (std::vector<uint8_t>{0}));
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 109));
+  auto probe = health.TryAcquire("peer", 0, 110);
+  ASSERT_TRUE(probe);
+  EXPECT_TRUE(probe->recovery_probe);
+  health.Complete("peer", 0, probe->generation,
+                  RemoteRailOutcome::kSuccess, 111);
+}
+
+TEST(RemoteRailHealth, LateOrdinaryFailureCannotRecoolRecoveredRail) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  auto late_ordinary = health.TryAcquire("peer", 0, 1);
+  auto cooling_failure = health.TryAcquire("peer", 0, 2);
+  ASSERT_TRUE(late_ordinary);
+  ASSERT_TRUE(cooling_failure);
+  ASSERT_FALSE(late_ordinary->recovery_probe);
+  ASSERT_EQ(late_ordinary->health_epoch, cooling_failure->health_epoch);
+
+  health.Complete("peer", 0, cooling_failure->generation,
+                  RemoteRailOutcome::kEndpointFailure, 10);
+  auto probe = health.TryAcquire("peer", 0, 110);
+  ASSERT_TRUE(probe);
+  ASSERT_TRUE(probe->recovery_probe);
+  ASSERT_EQ(probe->health_epoch, late_ordinary->health_epoch);
+  const auto recovered =
+      health.Complete("peer", 0, probe->generation,
+                      RemoteRailOutcome::kSuccess, 111);
+  ASSERT_EQ(recovered.transition, RemoteRailTransition::kRecovered);
+
+  const auto late_failure =
+      health.Complete("peer", 0, late_ordinary->generation,
+                      RemoteRailOutcome::kEndpointFailure, 112);
+  EXPECT_EQ(late_failure.transition, RemoteRailTransition::kNone);
+  EXPECT_EQ(late_failure.cooldown_until_us, 0u);
+  EXPECT_EQ(health.AllowedMask("peer", {1}, 112),
+            (std::vector<uint8_t>{1}));
+  EXPECT_NE(
+      health.MetricsText({"ib0"}).find(
+          "dfkv_rdma_client_remote_rail_failures_total 1\n"),
+      std::string::npos)
+      << "the superseded failure must not be accounted as fresh evidence";
+  auto fresh = health.TryAcquire("peer", 0, 112);
+  ASSERT_TRUE(fresh);
+  EXPECT_FALSE(fresh->recovery_probe);
+  EXPECT_EQ(fresh->health_epoch, probe->health_epoch + 1);
+  health.Complete("peer", 0, fresh->generation,
+                  RemoteRailOutcome::kSuccess, 113);
+}
+
+TEST(RemoteRailHealth, FailedProbeRecoolsWithCappedFakeClockBackoff) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/250});
+  auto initial = health.TryAcquire("peer", 0, 1);
+  ASSERT_TRUE(initial);
+  auto completion =
+      health.Complete("peer", 0, initial->generation,
+                      RemoteRailOutcome::kEndpointFailure, 20);
+  EXPECT_EQ(completion.cooldown_until_us, 120u);
+  EXPECT_EQ(health.AllowedMask("peer", {1}, 119),
+            (std::vector<uint8_t>{0}));
+
+  auto first_probe = health.TryAcquire("peer", 0, 120);
+  ASSERT_TRUE(first_probe);
+  ASSERT_TRUE(first_probe->recovery_probe);
+  completion = health.Complete("peer", 0, first_probe->generation,
+                               RemoteRailOutcome::kEndpointFailure, 130);
+  EXPECT_EQ(completion.transition, RemoteRailTransition::kCooled);
+  EXPECT_EQ(completion.cooldown_until_us, 330u);
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 329));
+
+  auto second_probe = health.TryAcquire("peer", 0, 330);
+  ASSERT_TRUE(second_probe);
+  ASSERT_TRUE(second_probe->recovery_probe);
+  completion = health.Complete("peer", 0, second_probe->generation,
+                               RemoteRailOutcome::kEndpointFailure, 340);
+  EXPECT_EQ(completion.cooldown_until_us, 590u)
+      << "the third cooldown must be capped at 250us";
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 589));
+  auto capped_probe = health.TryAcquire("peer", 0, 590);
+  ASSERT_TRUE(capped_probe);
+  EXPECT_TRUE(capped_probe->recovery_probe);
+  health.Complete("peer", 0, capped_probe->generation,
+                  RemoteRailOutcome::kAbandon, 590);
+}
+
+TEST(RemoteRailHealth, ConfiguredCooldownIsHardCappedAtThirtySeconds) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/60'000'000,
+                             /*max_cooldown_us=*/60'000'000});
+  auto lease = health.TryAcquire("peer", 0, 1);
+  ASSERT_TRUE(lease);
+  const auto completion =
+      health.Complete("peer", 0, lease->generation,
+                      RemoteRailOutcome::kEndpointFailure, 10);
+  EXPECT_EQ(completion.cooldown_until_us, 30'000'010u);
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 30'000'009));
+  auto probe = health.TryAcquire("peer", 0, 30'000'010);
+  ASSERT_TRUE(probe);
+  EXPECT_TRUE(probe->recovery_probe);
+  health.Complete("peer", 0, probe->generation,
+                  RemoteRailOutcome::kAbandon, 30'000'010);
+}
+
+TEST(RemoteRailHealth, AbandonedProbeReleasesTheProbeSlot) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  auto failed = health.TryAcquire("peer", 0, 1);
+  ASSERT_TRUE(failed);
+  health.Complete("peer", 0, failed->generation,
+                  RemoteRailOutcome::kEndpointFailure, 10);
+
+  auto abandoned = health.TryAcquire("peer", 0, 110);
+  ASSERT_TRUE(abandoned);
+  ASSERT_TRUE(abandoned->recovery_probe);
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 110));
+  const auto completion =
+      health.Complete("peer", 0, abandoned->generation,
+                      RemoteRailOutcome::kAbandon, 111);
+  EXPECT_EQ(completion.transition, RemoteRailTransition::kNone);
+
+  auto replacement = health.TryAcquire("peer", 0, 111);
+  ASSERT_TRUE(replacement);
+  EXPECT_TRUE(replacement->recovery_probe);
+  EXPECT_NE(replacement->generation, abandoned->generation);
+  health.Complete("peer", 0, replacement->generation,
+                  RemoteRailOutcome::kSuccess, 112);
+}
+
+TEST(RemoteRailHealth, NonEndpointAbandonsAreHealthNeutral) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+
+  // Local-HCA, resource-admission, and control-path failures are deliberately
+  // represented by abandoning their remote leases: none is peer evidence.
+  for (size_t rail = 0; rail < 3; ++rail) {
+    auto lease = health.TryAcquire("peer", rail, 10);
+    ASSERT_TRUE(lease) << rail;
+    health.Complete("peer", rail, lease->generation,
+                    RemoteRailOutcome::kAbandon, 20 + rail);
+  }
+  EXPECT_EQ(health.AllowedMask("peer", {1, 1, 1}, 23),
+            (std::vector<uint8_t>{1, 1, 1}));
+  for (size_t rail = 0; rail < 3; ++rail) {
+    auto lease = health.TryAcquire("peer", rail, 23);
+    ASSERT_TRUE(lease) << rail;
+    EXPECT_FALSE(lease->recovery_probe) << rail;
+    health.Complete("peer", rail, lease->generation,
+                    RemoteRailOutcome::kSuccess, 24);
+  }
+}
+
+TEST(RemoteRailHealth, ReconcileRemovalFencesStaleAcquireAndCompletion) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+
+  // Constructor-order compatibility permits use before the first topology.
+  auto outstanding = health.TryAcquire("removed", 0, 1);
+  ASSERT_TRUE(outstanding);
+  ASSERT_FALSE(outstanding->recovery_probe);
+
+  health.Reconcile({"survivor"});
+  EXPECT_FALSE(health.TryAcquire("removed", 0, 2));
+  const auto late =
+      health.Complete("removed", 0, outstanding->generation,
+                      RemoteRailOutcome::kEndpointFailure, 3);
+  EXPECT_EQ(late.transition, RemoteRailTransition::kNone);
+  EXPECT_EQ(late.cooldown_until_us, 0u);
+  EXPECT_FALSE(health.TryAcquire("removed", 0, 4))
+      << "a stale completion must not recreate or readmit a removed identity";
+
+  health.Reconcile({"survivor", "removed"});
+  auto republished = health.TryAcquire("removed", 0, 5);
+  ASSERT_TRUE(republished);
+  EXPECT_FALSE(republished->recovery_probe);
+  EXPECT_NE(republished->generation, outstanding->generation);
+  health.Complete("removed", 0, republished->generation,
+                  RemoteRailOutcome::kSuccess, 6);
+}
+
+TEST(RemoteRailHealth, StablePeerTopologyFlapsRetainCooldown) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  auto failed = health.TryAcquire("stable-peer-id", 0, 1);
+  ASSERT_TRUE(failed);
+  health.Complete("stable-peer-id", 0, failed->generation,
+                  RemoteRailOutcome::kEndpointFailure, 10);
+
+  // Address/topology generations may flap, but MDS continues publishing the
+  // same stable identity. Reconcile must therefore retain its endpoint memory.
+  health.Reconcile({"stable-peer-id"});
+  health.Reconcile({"stable-peer-id", "another-peer"});
+  health.Reconcile({"stable-peer-id"});
+  EXPECT_EQ(health.AllowedMask("stable-peer-id", {1}, 109),
+            (std::vector<uint8_t>{0}));
+  EXPECT_FALSE(health.TryAcquire("stable-peer-id", 0, 109));
+  auto probe = health.TryAcquire("stable-peer-id", 0, 110);
+  ASSERT_TRUE(probe);
+  EXPECT_TRUE(probe->recovery_probe);
+  health.Complete("stable-peer-id", 0, probe->generation,
+                  RemoteRailOutcome::kSuccess, 111);
+}
+
+TEST(RemoteRailHealth, EndpointFailureExcludesAttemptedRailForAlternate) {
+  RemoteRailHealth remote(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  rdma::RailPolicy local(
+      2, rdma::RailPolicyConfig{/*credits_per_rail=*/2,
+                                /*error_threshold=*/1,
+                                /*quarantine_us=*/1000,
+                                /*latency_weight=*/1,
+                                /*error_penalty_us=*/100});
+
+  auto first_remote = remote.TryAcquire("peer", 0, 1);
+  ASSERT_TRUE(first_remote);
+  auto first_local = rdma::AcquireWithFallback(
+      local, 1, 1, remote.AllowedMask("peer", {1, 1}, 1), {}, {});
+  ASSERT_TRUE(first_local);
+  ASSERT_EQ(first_local->rail, 0u);
+  local.Complete(*first_local, 1, rdma::RailCompletion::kEndpointFailure, 2);
+  remote.Complete("peer", 0, first_remote->generation,
+                  RemoteRailOutcome::kEndpointFailure, 2);
+
+  const auto retry_mask = remote.AllowedMask("peer", {1, 1}, 2);
+  EXPECT_EQ(retry_mask, (std::vector<uint8_t>{0, 1}));
+  auto retry = rdma::AcquireWithFallback(local, 1, 2, retry_mask, {}, {});
+  ASSERT_TRUE(retry);
+  EXPECT_EQ(retry->rail, 1u);
+  local.Complete(*retry, 1, rdma::RailCompletion::kSuccess, 3);
+
+  const auto local_stats = local.Snapshot(3);
+  ASSERT_EQ(local_stats.size(), 2u);
+  EXPECT_EQ(local_stats[0].endpoint_errors, 1u);
+  EXPECT_EQ(local_stats[0].errors, 0u);
+  EXPECT_FALSE(local_stats[0].quarantined)
+      << "remote endpoint cooling must not change RailPolicy semantics";
+}
+
+TEST(RemoteRailHealth, SoleCooledRailFailsAdmissionWithoutFallback) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  auto lease = health.TryAcquire("peer", 0, 1);
+  ASSERT_TRUE(lease);
+  health.Complete("peer", 0, lease->generation,
+                  RemoteRailOutcome::kEndpointFailure, 10);
+
+  const auto allowed = health.AllowedMask("peer", {1}, 10);
+  EXPECT_EQ(allowed, (std::vector<uint8_t>{0}));
+  EXPECT_FALSE(health.TryAcquire("peer", 0, 10));
+  rdma::RailPolicy local(1);
+  EXPECT_FALSE(
+      rdma::AcquireWithFallback(local, 1, 10, allowed, {}, {}))
+      << "an empty remote-health mask is an explicit admission failure, not "
+         "permission to bypass filtering";
+}
+
+TEST(RemoteRailHealth, CompletionIsAccountedOnceWithFixedCardinalityMetrics) {
+  RemoteRailHealth health(
+      RemoteRailHealthConfig{/*base_cooldown_us=*/100,
+                             /*max_cooldown_us=*/800});
+  auto lease = health.TryAcquire("secret-peer-id", 1, 1);
+  ASSERT_TRUE(lease);
+  const auto first =
+      health.Complete("secret-peer-id", 1, lease->generation,
+                      RemoteRailOutcome::kEndpointFailure, 10);
+  ASSERT_EQ(first.transition, RemoteRailTransition::kCooled);
+  const auto duplicate =
+      health.Complete("secret-peer-id", 1, lease->generation,
+                      RemoteRailOutcome::kEndpointFailure, 11);
+  EXPECT_EQ(duplicate.transition, RemoteRailTransition::kNone);
+  EXPECT_EQ(duplicate.cooldown_until_us, 0u);
+  EXPECT_FALSE(health.TryAcquire("secret-peer-id", 1, 11));
+
+  const std::string metrics =
+      health.MetricsText({"mlx5_0", "mlx5_1", "unused\"rail"});
+  EXPECT_NE(metrics.find("dfkv_rdma_client_remote_rail_failures_total 1\n"),
+            std::string::npos);
+  EXPECT_NE(metrics.find("dfkv_rdma_client_remote_rail_cooldowns_total 1\n"),
+            std::string::npos);
+  EXPECT_NE(
+      metrics.find(
+          "dfkv_rdma_client_remote_rail_admissions_denied_total 1\n"),
+      std::string::npos);
+  EXPECT_NE(
+      metrics.find(
+          "dfkv_rdma_client_remote_rail_failures_by_rail_total{dev=\"mlx5_0\"} 0\n"),
+      std::string::npos);
+  EXPECT_NE(
+      metrics.find(
+          "dfkv_rdma_client_remote_rail_failures_by_rail_total{dev=\"mlx5_1\"} 1\n"),
+      std::string::npos);
+  EXPECT_NE(
+      metrics.find(
+          "dfkv_rdma_client_remote_rail_failures_by_rail_total{dev=\"unused\\\"rail\"} 0\n"),
+      std::string::npos)
+      << "every configured rail must emit a bounded zero-valued series";
+  EXPECT_EQ(metrics.find("secret-peer-id"), std::string::npos);
+  EXPECT_EQ(metrics.find("peer_id="), std::string::npos);
 }

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -66,6 +66,81 @@ class RdmaServerTestPeer {
     return server.recv_segment_registered_rails_;
   }
 };
+
+class RdmaTransportTestPeer {
+ public:
+  struct SeededFailure {
+    uint64_t now_us = 0;
+    RemoteRailCompletion completion;
+  };
+
+  struct RetryDecision {
+    bool retry = false;
+    bool cross_rail = false;
+    std::vector<uint8_t> excluded;
+  };
+
+  static std::optional<SeededFailure> CoolRemoteRail(
+      RdmaTransport* transport, const std::string& peer_id, size_t rail) {
+    const uint64_t now = rdma::RailPolicy::NowMicros();
+    auto lease = transport->remote_rail_health_->TryAcquire(peer_id, rail, now);
+    if (!lease) return std::nullopt;
+    return SeededFailure{
+        now,
+        transport->remote_rail_health_->Complete(
+            peer_id, rail, lease->generation,
+            RemoteRailOutcome::kEndpointFailure, now)};
+  }
+
+  static std::vector<uint8_t> RemoteAllowed(
+      const RdmaTransport& transport, const std::string& peer_id,
+      const std::vector<uint8_t>& candidates, uint64_t now_us) {
+    return transport.remote_rail_health_->AllowedMask(peer_id, candidates,
+                                                      now_us);
+  }
+
+  static size_t DataPoolSize(RdmaTransport* transport,
+                             const std::string& node) {
+    std::lock_guard<std::mutex> lock(transport->mu_);
+    const auto found = transport->pool_.find(node);
+    return found == transport->pool_.end() ? 0 : found->second.size();
+  }
+
+  static uint64_t PeerPublication(const RdmaTransport& transport,
+                                  const std::string& node) {
+    return transport.peer_topologies_->Snapshot(node)->publication;
+  }
+
+  static RdmaTransport::Conn* AcquireData(RdmaTransport* transport,
+                                          const std::string& node) {
+    RdmaTransport::AcquireOptions options;
+    return transport->Acquire(node, RdmaTransport::Lane::kData, options).conn;
+  }
+
+  static void ReleaseData(RdmaTransport* transport, const std::string& node,
+                          RdmaTransport::Conn* conn) {
+    transport->Release(node, RdmaTransport::Lane::kData, conn);
+  }
+
+  static RetryDecision PrepareEndpointRetry(
+      RdmaTransport* transport, bool from_pool, bool replay_safe,
+      bool request_posted, size_t attempted_rail) {
+    auto peer = std::make_shared<rdma::PeerRailSnapshot>();
+    peer->complete = true;
+    peer->peer_healthy.assign(transport->devs_.size(), 1);
+    peer->compatible.assign(transport->devs_.size(), 1);
+    RdmaTransport::RailMask excluded(transport->devs_.size(), 0);
+    bool cross_rail = false;
+    const bool retry = transport->PrepareRetry(
+        /*attempt=*/0, from_pool, attempted_rail,
+        RdmaTransport::AcquireFailure::kEndpoint,
+        replay_safe ? RdmaTransport::ReplaySafety::kReplaySafe
+                    : RdmaTransport::ReplaySafety::kUnsafeAfterPost,
+        request_posted, peer, &excluded, &cross_rail);
+    return RetryDecision{retry, cross_rail, std::move(excluded)};
+  }
+};
+
 }  // namespace dfkv
 
 namespace {
@@ -673,7 +748,7 @@ TEST(RdmaPeerRails, NoIntersectionIsPeerNeutralAndLocallyObservable) {
   }
 }
 
-TEST(RdmaPeerRails, OperationGenerationFencesOlderSnapshots) {
+TEST(RdmaPeerRails, OperationPublicationFencesOlderSnapshots) {
   const std::vector<std::string> devices{"gpu0", "cpu0"};
   std::vector<std::vector<uint8_t>> tiers;
   ASSERT_TRUE(
@@ -683,10 +758,11 @@ TEST(RdmaPeerRails, OperationGenerationFencesOlderSnapshots) {
       PeerTopology{"peer", 100, true, {{"gpu0", true}}}));
   const auto operation = store.Snapshot("peer");
   ASSERT_EQ(operation->generation, 100u);
+  ASSERT_TRUE(store.IsCurrent("peer", operation->publication));
 
   ASSERT_TRUE(store.Update(
       PeerTopology{"peer", 101, true, {{"cpu0", true}}}));
-  EXPECT_FALSE(store.IsCurrent("peer", operation->generation));
+  EXPECT_FALSE(store.IsCurrent("peer", operation->publication));
   EXPECT_EQ(operation->generation, 100u);
   EXPECT_EQ(operation->compatible, (std::vector<uint8_t>{1, 0}));
   const auto current = store.Snapshot("peer");
@@ -3447,4 +3523,593 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
             std::vector<Status>({Status::kOk}));
   EXPECT_EQ(output,
             std::string(value.size(), static_cast<char>(0x5a)));
+}
+
+TEST(RdmaLoopback,
+     EndpointCompletionCoolsOnlyFailedPeerRailAndPublicGetReplays) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv cooldown("DFKV_RDMA_REMOTE_RAIL_COOLDOWN_MS", "30000");
+  ScopedEnv max_cooldown("DFKV_RDMA_REMOTE_RAIL_MAX_COOLDOWN_MS", "30000");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv ambient_local_completion_fault(
+      "DFKV_RDMA_TEST_COMPLETION_FAULT", nullptr);
+  ScopedEnv ambient_endpoint_completion_fault(
+      "DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", nullptr);
+
+  RdmaNode failed_peer("remote-completion-failed-peer");
+  RdmaNode independent_peer("remote-completion-independent-peer");
+  const BlockKey failed_peer_key =
+      ToBlockKey(SelfHdr(), "remote-completion-failed-peer");
+  const BlockKey independent_peer_key =
+      ToBlockKey(SelfHdr(), "remote-completion-independent-peer");
+  const std::string failed_peer_value(64 * 1024, 'f');
+  const std::string independent_peer_value(4096, 'i');
+  {
+    // Seed server state through public operations on a separate transport so
+    // the transport under test begins with deterministic rail-zero admission.
+    RdmaTransport writer(kMaxMsg, rails[0]);
+    ASSERT_EQ(writer.Cache(failed_peer.addr, failed_peer_key,
+                           failed_peer_value.data(), failed_peer_value.size()),
+              Status::kOk);
+    ASSERT_EQ(writer.Cache(independent_peer.addr, independent_peer_key,
+                           independent_peer_value.data(),
+                           independent_peer_value.size()),
+              Status::kOk);
+  }
+
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  PeerTopology failed_topology;
+  failed_topology.peer_addr = failed_peer.addr;
+  failed_topology.peer_id = "remote-completion-failed-peer-id";
+  failed_topology.generation = 1;
+  failed_topology.complete = true;
+  for (const auto& rail : rails)
+    failed_topology.rails.push_back(PeerRailTopology{rail, true});
+  transport.OnPeerTopology(failed_topology);
+
+  PeerTopology independent_topology;
+  independent_topology.peer_addr = independent_peer.addr;
+  independent_topology.peer_id = "remote-completion-independent-peer-id";
+  independent_topology.generation = 1;
+  independent_topology.complete = true;
+  independent_topology.rails.push_back(PeerRailTopology{rails[0], true});
+  independent_topology.rails.push_back(PeerRailTopology{rails[1], false});
+  transport.OnPeerTopology(independent_topology);
+  KVClient failed_client({{"n", failed_peer.addr}}, SelfHdr(), &transport);
+  KVClient independent_client({{"n", independent_peer.addr}}, SelfHdr(),
+                              &transport);
+
+  const std::string before_fault = transport.MetricsText();
+  std::string output(failed_peer_value.size(), '\0');
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", "1:1:1");
+    ASSERT_TRUE(failed_client.Get("remote-completion-failed-peer",
+                                  output.data(), output.size()));
+  }
+  EXPECT_EQ(output, failed_peer_value);
+  const std::string after_fault = transport.MetricsText();
+
+  EXPECT_EQ(CounterVal(after_fault,
+                       "dfkv_rdma_client_remote_rail_failures_total") -
+                CounterVal(before_fault,
+                           "dfkv_rdma_client_remote_rail_failures_total"),
+            1)
+      << "the failed production lease must complete exactly once";
+  EXPECT_EQ(CounterVal(after_fault,
+                       "dfkv_rdma_client_remote_rail_cooldowns_total") -
+                CounterVal(before_fault,
+                           "dfkv_rdma_client_remote_rail_cooldowns_total"),
+            1)
+      << "one endpoint failure must cause one cooldown transition";
+  EXPECT_EQ(
+      CounterVal(after_fault,
+                 "dfkv_rdma_client_remote_rail_admissions_denied_total"),
+      CounterVal(before_fault,
+                 "dfkv_rdma_client_remote_rail_admissions_denied_total"))
+      << "the injected completion is endpoint evidence, not admission failure";
+  EXPECT_EQ(
+      DeviceCounterVal(
+          after_fault,
+          "dfkv_rdma_client_remote_rail_failures_by_rail_total", rails[0]) -
+          DeviceCounterVal(
+              before_fault,
+              "dfkv_rdma_client_remote_rail_failures_by_rail_total", rails[0]),
+      1);
+  EXPECT_EQ(
+      DeviceCounterVal(
+          after_fault,
+          "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total", rails[0]) -
+          DeviceCounterVal(
+              before_fault,
+              "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total", rails[0]),
+      1);
+  EXPECT_EQ(
+      DeviceCounterVal(
+          after_fault,
+          "dfkv_rdma_client_remote_rail_failures_by_rail_total", rails[1]),
+      DeviceCounterVal(
+          before_fault,
+          "dfkv_rdma_client_remote_rail_failures_by_rail_total", rails[1]));
+  EXPECT_EQ(
+      DeviceCounterVal(
+          after_fault,
+          "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total", rails[1]),
+      DeviceCounterVal(
+          before_fault,
+          "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total", rails[1]));
+  EXPECT_EQ(
+      DeviceCounterVal(after_fault, "dfkv_rdma_client_rail_errors_total",
+                       rails[0]),
+      DeviceCounterVal(before_fault, "dfkv_rdma_client_rail_errors_total",
+                       rails[0]))
+      << "endpoint evidence must not blame the local rail";
+  EXPECT_EQ(
+      DeviceCounterVal(after_fault, "dfkv_rdma_client_endpoint_errors_total",
+                       rails[0]) -
+          DeviceCounterVal(before_fault,
+                           "dfkv_rdma_client_endpoint_errors_total", rails[0]),
+      1);
+  for (const auto& rail : rails) {
+    EXPECT_EQ(
+        DeviceCounterVal(after_fault,
+                         "dfkv_rdma_client_rail_selections_total", rail) -
+            DeviceCounterVal(before_fault,
+                             "dfkv_rdma_client_rail_selections_total", rail),
+        1)
+        << rail << ": GET must fail once then replay on its sibling rail";
+  }
+  EXPECT_EQ(
+      CounterVal(after_fault, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before_fault,
+                     "dfkv_rdma_client_cross_rail_retries_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(
+          after_fault,
+          "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(
+              before_fault,
+              "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      1);
+
+  const std::string before_same_peer = after_fault;
+  EXPECT_TRUE(failed_client.Exist("remote-completion-failed-peer"));
+  const std::string after_same_peer = transport.MetricsText();
+  EXPECT_EQ(
+      DeviceCounterVal(after_same_peer,
+                       "dfkv_rdma_client_rail_selections_total", rails[0]),
+      DeviceCounterVal(before_same_peer,
+                       "dfkv_rdma_client_rail_selections_total", rails[0]))
+      << "the next public operation must avoid the cooled peer/rail pair";
+  EXPECT_EQ(
+      DeviceCounterVal(after_same_peer,
+                       "dfkv_rdma_client_rail_selections_total", rails[1]) -
+          DeviceCounterVal(before_same_peer,
+                           "dfkv_rdma_client_rail_selections_total", rails[1]),
+      1)
+      << "the sibling rail remains eligible for the failed peer";
+
+  const std::string before_independent_peer = after_same_peer;
+  EXPECT_TRUE(
+      independent_client.Exist("remote-completion-independent-peer"));
+  const std::string after_independent_peer = transport.MetricsText();
+  EXPECT_EQ(
+      DeviceCounterVal(after_independent_peer,
+                       "dfkv_rdma_client_rail_selections_total", rails[0]) -
+          DeviceCounterVal(before_independent_peer,
+                           "dfkv_rdma_client_rail_selections_total", rails[0]),
+      1)
+      << "remote cooldown is scoped by peer and must not disable this local "
+         "rail for another peer";
+  EXPECT_EQ(
+      DeviceCounterVal(after_independent_peer,
+                       "dfkv_rdma_client_rail_errors_total", rails[0]),
+      DeviceCounterVal(before_fault, "dfkv_rdma_client_rail_errors_total",
+                       rails[0]));
+  EXPECT_EQ(CounterVal(after_independent_peer,
+                       "dfkv_rdma_client_remote_rail_failures_total") -
+                CounterVal(before_fault,
+                           "dfkv_rdma_client_remote_rail_failures_total"),
+            1)
+      << "later successful public operations must not double-complete failure";
+  EXPECT_EQ(CounterVal(after_independent_peer,
+                       "dfkv_rdma_client_remote_rail_cooldowns_total") -
+                CounterVal(before_fault,
+                           "dfkv_rdma_client_remote_rail_cooldowns_total"),
+            1);
+}
+
+TEST(RdmaLoopback,
+     PostSubmitPutFailureCoolsActualRemoteRailWithoutReplay) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv cooldown("DFKV_RDMA_REMOTE_RAIL_COOLDOWN_MS", "30000");
+  ScopedEnv max_cooldown("DFKV_RDMA_REMOTE_RAIL_MAX_COOLDOWN_MS", "30000");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv ambient_local_completion_fault(
+      "DFKV_RDMA_TEST_COMPLETION_FAULT", nullptr);
+  ScopedEnv ambient_endpoint_completion_fault(
+      "DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", nullptr);
+  ScopedEnv ambient_local_failure(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+
+  RdmaNode node("remote-post-submit-put");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  PeerTopology topology;
+  topology.peer_addr = node.addr;
+  topology.peer_id = "remote-post-submit-put-peer";
+  topology.generation = 1;
+  topology.complete = true;
+  for (const auto& rail : rails)
+    topology.rails.push_back(PeerRailTopology{rail, true});
+  transport.OnPeerTopology(topology);
+
+  const std::string key_namespace = "test/remote-post-submit-put";
+  KVClient client({{"n", node.addr}}, key_namespace, &transport);
+  const std::string value(64 * 1024, 'f');
+  const BlockKey failed_key =
+      ToBlockKey(key_namespace, "completion-failed-put");
+  const std::string before_fault = transport.MetricsText();
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", "1:1:1");
+    EXPECT_FALSE(
+        client.Put("completion-failed-put", value.data(), value.size()));
+  }
+  const std::string after_fault = transport.MetricsText();
+
+  EXPECT_EQ(CounterVal(after_fault, "dfkv_rdma_client_v2_put_writes_total") -
+                CounterVal(before_fault,
+                           "dfkv_rdma_client_v2_put_writes_total"),
+            1)
+      << "an unsafe PUT must not be posted again after ambiguous completion";
+  EXPECT_EQ(node.CacheDirectCalls(failed_key), 1u)
+      << "the server must observe exactly the single posted PUT";
+  EXPECT_EQ(
+      CounterVal(after_fault, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before_fault,
+                     "dfkv_rdma_client_cross_rail_retries_total"),
+      0)
+      << "post-submit PUT failure is not replay-safe";
+
+  size_t failed_rail = rails.size();
+  long failed_selections = 0;
+  for (size_t rail = 0; rail < rails.size(); ++rail) {
+    const long selected =
+        DeviceCounterVal(after_fault,
+                         "dfkv_rdma_client_rail_selections_total",
+                         rails[rail]) -
+        DeviceCounterVal(before_fault,
+                         "dfkv_rdma_client_rail_selections_total",
+                         rails[rail]);
+    EXPECT_TRUE(selected == 0 || selected == 1) << rails[rail];
+    if (selected == 1) failed_rail = rail;
+    failed_selections += selected;
+  }
+  ASSERT_EQ(failed_selections, 1);
+  ASSERT_LT(failed_rail, rails.size());
+  const size_t sibling_rail = 1 - failed_rail;
+  EXPECT_EQ(
+      DeviceCounterVal(
+          after_fault,
+          "dfkv_rdma_client_remote_rail_failures_by_rail_total",
+          rails[failed_rail]) -
+          DeviceCounterVal(
+              before_fault,
+              "dfkv_rdma_client_remote_rail_failures_by_rail_total",
+              rails[failed_rail]),
+      1);
+  EXPECT_EQ(
+      DeviceCounterVal(
+          after_fault,
+          "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total",
+          rails[failed_rail]) -
+          DeviceCounterVal(
+              before_fault,
+              "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total",
+              rails[failed_rail]),
+      1)
+      << "the endpoint completion must cool the rail that owned its lease";
+  EXPECT_EQ(
+      DeviceCounterVal(
+          after_fault,
+          "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total",
+          rails[sibling_rail]) -
+          DeviceCounterVal(
+              before_fault,
+              "dfkv_rdma_client_remote_rail_cooldowns_by_rail_total",
+              rails[sibling_rail]),
+      0);
+
+  KVClient future_client({{"n", node.addr}}, key_namespace, &transport);
+  const BlockKey future_key = ToBlockKey(key_namespace, "future-put");
+  ASSERT_TRUE(future_client.Put("future-put", value.data(), value.size()));
+  const std::string after_future = transport.MetricsText();
+  EXPECT_EQ(
+      DeviceCounterVal(after_future,
+                       "dfkv_rdma_client_rail_selections_total",
+                       rails[failed_rail]) -
+          DeviceCounterVal(after_fault,
+                           "dfkv_rdma_client_rail_selections_total",
+                           rails[failed_rail]),
+      0)
+      << "future admission must bypass the cooled endpoint rail";
+  EXPECT_EQ(
+      DeviceCounterVal(after_future,
+                       "dfkv_rdma_client_rail_selections_total",
+                       rails[sibling_rail]) -
+          DeviceCounterVal(after_fault,
+                           "dfkv_rdma_client_rail_selections_total",
+                           rails[sibling_rail]),
+      1);
+  EXPECT_EQ(
+      CounterVal(after_future, "dfkv_rdma_client_v2_put_writes_total") -
+          CounterVal(after_fault, "dfkv_rdma_client_v2_put_writes_total"),
+      1);
+  EXPECT_EQ(node.CacheDirectCalls(future_key), 1u);
+}
+
+TEST(RdmaLoopback, RemoteCooldownBypassesIdlePoolAndUsesSiblingRail) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv cooldown("DFKV_RDMA_REMOTE_RAIL_COOLDOWN_MS", "30000");
+  ScopedEnv max_cooldown("DFKV_RDMA_REMOTE_RAIL_MAX_COOLDOWN_MS", "30000");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+
+  RdmaNode node("remote-idle-bypass");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  PeerTopology topology;
+  topology.peer_addr = node.addr;
+  topology.peer_id = "remote-idle-bypass-peer";
+  topology.generation = 1;
+  topology.complete = true;
+  for (const auto& rail : rails)
+    topology.rails.push_back(PeerRailTopology{rail, true});
+  transport.OnPeerTopology(topology);
+
+  const BlockKey key = ToBlockKey(SelfHdr(), "remote-idle-bypass");
+  const std::string value(64 * 1024, 'r');
+  ASSERT_EQ(transport.Cache(node.addr, key, value.data(), value.size()),
+            Status::kOk);
+  ASSERT_EQ(RdmaTransportTestPeer::DataPoolSize(&transport, node.addr), 1u);
+  const std::string warm = transport.MetricsText();
+  ASSERT_EQ(
+      DeviceCounterVal(warm, "dfkv_rdma_client_rail_selections_total",
+                       rails[0]),
+      1)
+      << "the deterministic first admission must warm local rail zero";
+
+  const auto seeded = RdmaTransportTestPeer::CoolRemoteRail(
+      &transport, topology.peer_id, 0);
+  ASSERT_TRUE(seeded);
+  ASSERT_EQ(seeded->completion.transition, RemoteRailTransition::kCooled);
+  EXPECT_EQ(RdmaTransportTestPeer::RemoteAllowed(
+                transport, topology.peer_id, {1, 1}, seeded->now_us),
+            (std::vector<uint8_t>{0, 1}));
+
+  const std::string before = transport.MetricsText();
+  std::string output;
+  ASSERT_EQ(transport.Range(node.addr, key, 0, value.size(), &output, nullptr),
+            Status::kOk);
+  EXPECT_EQ(output, value);
+  const std::string after = transport.MetricsText();
+  EXPECT_EQ(
+      DeviceCounterVal(after, "dfkv_rdma_client_rail_selections_total",
+                       rails[0]) -
+          DeviceCounterVal(before, "dfkv_rdma_client_rail_selections_total",
+                           rails[0]),
+      0)
+      << "the idle QP on the cooled peer/rail must not bypass admission";
+  EXPECT_EQ(
+      DeviceCounterVal(after, "dfkv_rdma_client_rail_selections_total",
+                       rails[1]) -
+          DeviceCounterVal(before, "dfkv_rdma_client_rail_selections_total",
+                           rails[1]),
+      1);
+  EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_hits_total") -
+                CounterVal(before, "dfkv_rdma_endpoint_cache_hits_total"),
+            0);
+  EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_misses_total") -
+                CounterVal(before, "dfkv_rdma_endpoint_cache_misses_total"),
+            1);
+  EXPECT_EQ(RdmaTransportTestPeer::DataPoolSize(&transport, node.addr), 2u)
+      << "the cooled idle QP remains present only to prove it was bypassed";
+}
+
+TEST(RdmaLoopback, SoleRemoteCooledRailReturnsExplicitFailure) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ScopedEnv cooldown("DFKV_RDMA_REMOTE_RAIL_COOLDOWN_MS", "30000");
+  ScopedEnv max_cooldown("DFKV_RDMA_REMOTE_RAIL_MAX_COOLDOWN_MS", "30000");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+
+  const auto discovered = rdma::RdmaTopology::Discover(
+      {}, rdma::RdmaDiscoveryPolicy::kActiveOnly);
+  if (discovered.status != rdma::RdmaDiscoveryStatus::kOk ||
+      discovered.devices.empty())
+    GTEST_SKIP() << "no ACTIVE RDMA device";
+  const std::string rail = discovered.devices.front().name;
+  RdmaNode node("remote-sole-cooled");
+  RdmaTransport transport(kMaxMsg, rail);
+  PeerTopology topology;
+  topology.peer_addr = node.addr;
+  topology.peer_id = "remote-sole-cooled-peer";
+  topology.generation = 1;
+  topology.complete = true;
+  topology.rails.push_back(PeerRailTopology{rail, true});
+  transport.OnPeerTopology(topology);
+
+  const BlockKey key = ToBlockKey(SelfHdr(), "remote-sole-cooled");
+  const std::string value(4096, 'c');
+  ASSERT_EQ(transport.Cache(node.addr, key, value.data(), value.size()),
+            Status::kOk);
+  ASSERT_EQ(RdmaTransportTestPeer::DataPoolSize(&transport, node.addr), 1u);
+  const auto seeded = RdmaTransportTestPeer::CoolRemoteRail(
+      &transport, topology.peer_id, 0);
+  ASSERT_TRUE(seeded);
+  ASSERT_EQ(seeded->completion.transition, RemoteRailTransition::kCooled);
+
+  const std::string before = transport.MetricsText();
+  std::string output;
+  EXPECT_EQ(transport.Range(node.addr, key, 0, value.size(), &output, nullptr),
+            Status::kNoCompatibleRail);
+  const std::string after = transport.MetricsText();
+  EXPECT_TRUE(output.empty());
+  EXPECT_EQ(CounterVal(after, "dfkv_rdma_client_no_compatible_rail_total") -
+                CounterVal(before,
+                           "dfkv_rdma_client_no_compatible_rail_total"),
+            1);
+  EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_hits_total"),
+            CounterVal(before, "dfkv_rdma_endpoint_cache_hits_total"));
+  EXPECT_EQ(CounterVal(after, "dfkv_rdma_endpoint_cache_misses_total"),
+            CounterVal(before, "dfkv_rdma_endpoint_cache_misses_total"));
+  EXPECT_EQ(RdmaTransportTestPeer::DataPoolSize(&transport, node.addr), 1u);
+}
+
+TEST(RdmaLoopback, StableIdentityTopologyFlapRetainsRemoteCooldown) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ScopedEnv cooldown("DFKV_RDMA_REMOTE_RAIL_COOLDOWN_MS", "30000");
+  ScopedEnv max_cooldown("DFKV_RDMA_REMOTE_RAIL_MAX_COOLDOWN_MS", "30000");
+  const auto discovered = rdma::RdmaTopology::Discover(
+      {}, rdma::RdmaDiscoveryPolicy::kActiveOnly);
+  if (discovered.status != rdma::RdmaDiscoveryStatus::kOk ||
+      discovered.devices.empty())
+    GTEST_SKIP() << "no ACTIVE RDMA device";
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  const std::string rail = discovered.devices.front().name;
+  RdmaTransport transport(kMaxMsg, rail);
+  PeerTopology topology;
+  topology.peer_addr = "unused-peer-address";
+  topology.peer_id = "stable-flapping-peer";
+  topology.generation = 100;
+  topology.complete = true;
+  topology.rails.push_back(PeerRailTopology{rail, true});
+  transport.OnPeerTopology(topology);
+  const uint64_t first_publication =
+      RdmaTransportTestPeer::PeerPublication(transport, topology.peer_addr);
+
+  const auto seeded = RdmaTransportTestPeer::CoolRemoteRail(
+      &transport, topology.peer_id, 0);
+  ASSERT_TRUE(seeded);
+  topology.generation = 7;
+  topology.rails[0].healthy = false;
+  transport.OnPeerTopology(topology);
+  topology.generation = 999;
+  topology.rails[0].healthy = true;
+  transport.OnPeerTopology(topology);
+  EXPECT_GT(
+      RdmaTransportTestPeer::PeerPublication(transport, topology.peer_addr),
+      first_publication)
+      << "health-only snapshots may republish without resetting rail health";
+  EXPECT_EQ(RdmaTransportTestPeer::RemoteAllowed(
+                transport, topology.peer_id, {1}, seeded->now_us),
+            (std::vector<uint8_t>{0}))
+      << "health-only topology generations must not reset stable identity";
+}
+
+
+TEST(RdmaLoopback,
+     LateReleaseCannotRepoolAcrossRemoveAndIdenticalReadd) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  const auto discovered = rdma::RdmaTopology::Discover(
+      {}, rdma::RdmaDiscoveryPolicy::kActiveOnly);
+  if (discovered.status != rdma::RdmaDiscoveryStatus::kOk ||
+      discovered.devices.empty())
+    GTEST_SKIP() << "no ACTIVE RDMA device";
+
+  const std::string rail = discovered.devices.front().name;
+  RdmaNode node("peer-reincarnation");
+  RdmaTransport transport(kMaxMsg, rail);
+  PeerTopology topology;
+  topology.peer_addr = node.addr;
+  topology.peer_id = "reincarnated-peer";
+  topology.generation = 55;
+  topology.complete = true;
+  topology.rails.push_back(PeerRailTopology{rail, true});
+  transport.OnPeerTopology(topology);
+  const uint64_t first_publication =
+      RdmaTransportTestPeer::PeerPublication(transport, node.addr);
+
+  auto* old_active =
+      RdmaTransportTestPeer::AcquireData(&transport, node.addr);
+  ASSERT_NE(old_active, nullptr);
+  ASSERT_EQ(RdmaTransportTestPeer::DataPoolSize(&transport, node.addr), 0u);
+
+  topology.present = false;
+  transport.OnPeerTopology(topology);
+  topology.present = true;
+  transport.OnPeerTopology(topology);
+  EXPECT_GT(RdmaTransportTestPeer::PeerPublication(transport, node.addr),
+            first_publication);
+
+  const std::string before_release = transport.MetricsText();
+  RdmaTransportTestPeer::ReleaseData(&transport, node.addr, old_active);
+  const std::string after_release = transport.MetricsText();
+  EXPECT_EQ(RdmaTransportTestPeer::DataPoolSize(&transport, node.addr), 0u);
+  EXPECT_EQ(
+      CounterVal(after_release,
+                 "dfkv_rdma_client_stale_generation_reaps_total") -
+          CounterVal(before_release,
+                     "dfkv_rdma_client_stale_generation_reaps_total"),
+      1);
+
+  const std::string before_reacquire = transport.MetricsText();
+  auto* current =
+      RdmaTransportTestPeer::AcquireData(&transport, node.addr);
+  ASSERT_NE(current, nullptr);
+  const std::string after_reacquire = transport.MetricsText();
+  EXPECT_EQ(CounterVal(after_reacquire,
+                       "dfkv_rdma_endpoint_cache_hits_total"),
+            CounterVal(before_reacquire,
+                       "dfkv_rdma_endpoint_cache_hits_total"));
+  EXPECT_EQ(CounterVal(after_reacquire,
+                       "dfkv_rdma_endpoint_cache_misses_total") -
+                CounterVal(before_reacquire,
+                           "dfkv_rdma_endpoint_cache_misses_total"),
+            1);
+  RdmaTransportTestPeer::ReleaseData(&transport, node.addr, current);
+  EXPECT_EQ(RdmaTransportTestPeer::DataPoolSize(&transport, node.addr), 1u);
+}
+
+TEST(RdmaLoopback,
+     ReplaySafeEndpointRetryExcludesRailButPostedPutNeverReplays) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+
+  const auto replay_safe = RdmaTransportTestPeer::PrepareEndpointRetry(
+      &transport, /*from_pool=*/false, /*replay_safe=*/true,
+      /*request_posted=*/true, /*attempted_rail=*/0);
+  EXPECT_TRUE(replay_safe.retry);
+  EXPECT_TRUE(replay_safe.cross_rail);
+  EXPECT_EQ(replay_safe.excluded, (std::vector<uint8_t>{1, 0}))
+      << "a fresh replay-safe retry must not revisit the failed endpoint rail";
+
+  const auto posted_put = RdmaTransportTestPeer::PrepareEndpointRetry(
+      &transport, /*from_pool=*/true, /*replay_safe=*/false,
+      /*request_posted=*/true, /*attempted_rail=*/0);
+  EXPECT_FALSE(posted_put.retry);
+  EXPECT_FALSE(posted_put.cross_rail);
+  EXPECT_EQ(posted_put.excluded, (std::vector<uint8_t>{0, 0}));
 }

--- a/test/transport/rdma_topology_test.cc
+++ b/test/transport/rdma_topology_test.cc
@@ -1,4 +1,5 @@
 #include "transport/rdma_topology.h"
+#include "transport/rail_select.h"
 
 #include <gtest/gtest.h>
 
@@ -14,6 +15,7 @@ using dfkv::rdma::RdmaDiscoveryPolicy;
 using dfkv::rdma::RdmaDiscoveryProbe;
 using dfkv::rdma::RdmaDiscoveryStatus;
 using dfkv::rdma::RdmaTopology;
+using dfkv::rdma::PeerTopologyStore;
 
 RdmaDevInfo Device(std::string name, bool active, int numa_node = -1) {
   RdmaDevInfo info;
@@ -278,6 +280,79 @@ TEST(RdmaTopology, FallbackMaskIsEmptyWithoutLocalPreference) {
   const auto unknown = topology.CandidatesFor(-1, true);
   EXPECT_EQ(unknown.locality, RailLocality::kCallerUnknown);
   EXPECT_TRUE(unknown.fallback.empty());
+}
+
+
+TEST(RdmaTopology, StableIdentityMovesAddressAndGuardsRetirement) {
+  PeerTopologyStore store({"ib0"}, {{1}}, /*require_complete=*/true);
+  dfkv::PeerTopology first;
+  first.peer_addr = "10.0.0.1:1000";
+  first.peer_id = "stable-peer";
+  first.generation = 11;
+  first.complete = true;
+  first.rails.push_back(dfkv::PeerRailTopology{"ib0", true});
+  ASSERT_TRUE(store.Update(first));
+  auto snapshot = store.Snapshot(first.peer_addr);
+  EXPECT_EQ(snapshot->peer_id, first.peer_id);
+  EXPECT_EQ(snapshot->generation, 11u);
+  EXPECT_EQ(snapshot->compatible, (std::vector<uint8_t>{1}));
+
+  dfkv::PeerTopology moved = first;
+  moved.peer_addr = "10.0.0.2:2000";
+  moved.generation = 3;
+  ASSERT_TRUE(store.Update(moved));
+  snapshot = store.Snapshot(moved.peer_addr);
+  EXPECT_EQ(snapshot->peer_id, first.peer_id);
+  EXPECT_EQ(snapshot->generation, 3u);
+  EXPECT_EQ(snapshot->compatible, (std::vector<uint8_t>{1}));
+  EXPECT_FALSE(store.Snapshot(first.peer_addr)->complete)
+      << "the superseded address must not retain a second live binding";
+
+  dfkv::PeerTopology stale_removal = moved;
+  stale_removal.present = false;
+  stale_removal.peer_id = "replaced-peer";
+  EXPECT_FALSE(store.Update(stale_removal));
+  EXPECT_EQ(store.Snapshot(moved.peer_addr)->peer_id, "stable-peer")
+      << "late retirement for another identity must not remove the replacement";
+
+  stale_removal.peer_id = "stable-peer";
+  EXPECT_TRUE(store.Update(stale_removal));
+  EXPECT_FALSE(store.Snapshot(moved.peer_addr)->complete);
+}
+
+TEST(RdmaTopology,
+     RemoveAndIdenticalReaddPublishesANewTransportIncarnation) {
+  PeerTopologyStore store({"ib0"}, {{1}}, /*require_complete=*/true);
+  dfkv::PeerTopology topology;
+  topology.peer_addr = "10.0.0.1:1000";
+  topology.peer_id = "stable-peer";
+  topology.generation = 77;
+  topology.complete = true;
+  topology.rails.push_back(dfkv::PeerRailTopology{"ib0", true});
+
+  ASSERT_TRUE(store.Update(topology));
+  const auto first = store.Snapshot(topology.peer_addr);
+  ASSERT_EQ(first->generation, 77u);
+  ASSERT_NE(first->publication, 0u);
+  EXPECT_TRUE(store.IsCurrent(topology.peer_addr, topology.peer_id,
+                              first->publication));
+  EXPECT_FALSE(store.Update(topology))
+      << "the opaque content generation remains equality-only";
+
+  topology.present = false;
+  ASSERT_TRUE(store.Update(topology));
+  EXPECT_FALSE(store.IsCurrent(topology.peer_addr, topology.peer_id,
+                               first->publication));
+
+  topology.present = true;
+  ASSERT_TRUE(store.Update(topology));
+  const auto reincarnated = store.Snapshot(topology.peer_addr);
+  EXPECT_EQ(reincarnated->generation, first->generation);
+  EXPECT_GT(reincarnated->publication, first->publication);
+  EXPECT_FALSE(store.IsCurrent(topology.peer_addr, topology.peer_id,
+                               first->publication));
+  EXPECT_TRUE(store.IsCurrent(topology.peer_addr, topology.peer_id,
+                              reincarnated->publication));
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- track endpoint health by stable peer identity and local RDMA rail
- exclude cooled peer×rail paths from pooled and fresh connection admission
- retry replay-safe operations once on an alternate compatible rail while preserving posted PUT no-replay semantics
- propagate peer rail topology through MDS with generation/incarnation fencing
- add bounded cooldown, recovery probes, fixed-cardinality metrics, documentation, and deterministic fault tests

## Validation
- local full suite: 754 tests, 662 passed, 92 hardware-gated skipped, 0 failed
- 0064 two-rail fault acceptance: 4/4 passed on ib7s400p0,ib7s400p1
- 0064 isolated candidate smoke: PUT 1.51 GB/s, GET 4.29 GB/s, 4096/4096 ops, zero I/O/endpoint/CQ/timeout failures

Built and deployed only in an isolated directory/service on authorized xb01-0064; existing dfkv deployment unchanged.