### PR TITLE
fix: publish GET results safely to CUDA destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v2.19.0 — 2026-08-13
+
+### CUDA GET correctness
+
+- Fixed a `RangeInto`/`RangeIntoMulti` failure in which the host publication
+  path could call `memcpy` with a CUDA device destination and terminate the
+  process with `SIGSEGV`.
+- Added an explicit destination kind to range reads. CUDA GETs now receive RDMA
+  data into operation-owned pinned host staging and publish it with asynchronous
+  host-to-device copies only after the final healthy rail attempt succeeds.
+  Completion remains synchronous: the call returns success only after the CUDA
+  stream has completed publication.
+- Applied the same publication and retry fence to contiguous ranges, mixed
+  host/CUDA scatter-gather ranges, and rail retry, so a failed attempt cannot
+  publish partial CUDA data before a later attempt succeeds.
+- PUT and memory-registration behavior are unchanged and remain GPUDirect.
+  CUDA GET adds temporary pinned host memory, a host-to-device copy, stream
+  synchronization, and associated allocation/registration overhead. This is a
+  known performance tradeoff pending safe direct-GPU retry fencing; deployments
+  should validate pinned-memory and memlock capacity for their concurrent GET
+  payload.
+
 ## v2.11.1 — 2026-08-10
 
 ### Release

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -19,7 +19,7 @@
 | 源码 | `integration/hicache/dfkv_hicache.py` | `integration/vllm/`（包 `dfkv_vllm`） | `integration/lmcache/`（包 `dfkv_connector`） |
 | 接口 | `HiCacheStorage`（`batch_set_v1/get_v1`…） | connector API（scheduler + worker 两侧） | `RemoteConnector`（get/put/batched_\*）/ `DfkvL2Adapter` |
 | key 方案 | 页 hash + pool/component/并行坐标 | chunk hash + pool/component/并行坐标，可追加 binary SG 坐标 | chunk hash + pool/component/并行坐标 |
-| 零拷贝 | 两端零拷贝（GET 直落 HiCache 宿主页，**host-host**） | **GPUDirect RDMA**（KV 直读写 GPU 显存，无 host bounce） | host-host 零拷贝（LMCache pinned arena 一次注册 MR） |
+| 零拷贝 | 两端零拷贝（GET 直落 HiCache 宿主页，**host-host**） | PUT 为 **GPUDirect RDMA**；GET 经临时 pinned host retry staging，最终成功后同步发布到 GPU | host-host 零拷贝（LMCache pinned arena 一次注册 MR） |
 | 块大小 | 固定页（page_size token） | 变长 chunk（SG 多层段合并为一 key） | **任意**（含变长不满末块，走 `GetAuto`） |
 | 典型场景 | SGLang PD 生产（GLM-5.1/5.2 MLA） | vLLM 生产直连（DeepSeek-V4-Flash 多池已验证） | vLLM+LMCache 栈；MP-server 路径给多 KV-group 模型 |
 
@@ -571,21 +571,28 @@ journalctl -u dfkv-server | grep 'rdma conn: protocol=v2 declared=' | grep -o 'q
 
 ## 3. vLLM 直连 — DfkvStoreConnector
 
-`DfkvStoreConnector` 是 vLLM `KVConnectorBase_V1` 直连连接器：把 KV cache 经
-**GPUDirect RDMA** 直接读写到 dfkv 集群，**绕开 LMCache**，占据与
-`MooncakeStoreConnector` 相同的 `--kv-transfer-config` 槽位。生产者和消费者读写同一
-共享池，实现跨请求、跨实例、跨重启的前缀复用。
+`DfkvStoreConnector` 是 vLLM `KVConnectorBase_V1` 直连连接器：把 KV cache 接入
+dfkv 集群，**绕开 LMCache**，占据与 `MooncakeStoreConnector` 相同的
+`--kv-transfer-config` 槽位。生产者和消费者读写同一共享池，实现跨请求、跨实例、
+跨重启的前缀复用。
 
-连接器纯 Python（ctypes over `libdfkv.so`），直接对 **GPU 设备指针**做 RDMA：分页 KV cache
+连接器纯 Python（ctypes over `libdfkv.so`），接收 **GPU 设备指针**。分页 KV cache
 经 `dfkv_register_memory` 一次注册（nvidia-peermem 下 `ibv_reg_mr` 产出 GPUDirect MR），
 只有返回 `0` 才继续；注册失败会抛出启动错误，不会带着未注册指针进入流量。
+PUT 保持从 GPU MR 发起的 GPUDirect RDMA。v2.19 的 GET 则由 native range API
+显式标记 CUDA destination：RDMA 先写入该次操作拥有的 pinned host staging，只有
+最终健康 rail attempt 成功后才用 pinned async H2D copy 发布到 GPU，并同步 CUDA
+stream 后返回成功。失败 attempt 不会提前发布；连续 range、mixed host/CUDA SG 和
+rail retry 使用同一 fence。
+
 每 chunk 的多层段经 **scatter-gather 批量 API** 合并成一个 dfkv key
-（一次多-SGE RDMA / chunk，而非每层段一次），key/磁盘读数 ~20×↓。
+（一次多-SGE 操作 / chunk，而非每层段一次），key/磁盘读数 ~20×↓。
 
 `DfkvStoreConnector` **只支持 RDMA**：每个 vLLM engine 进程都必须设置
 `DFKV_RDMA=1`。`dfkv_open_v2` 后连接器会在启动 poller、热配置和任何流量前
 校验 native handle 报告的 transport；非 `rdma` handle 会立即关闭并报错。
-GPU 设备指针路径没有 TCP 或 host-bounce fallback。
+GPU PUT 没有 TCP fallback；CUDA GET 的 host staging 是 RDMA retry/publication
+机制，不是 TCP fallback。
 
 ### 3.0 角色与前置条件
 
@@ -659,10 +666,10 @@ extra-config 键。namespace 始终绑定该 model identity 与 `vllm/raw-v1`；
 |---|---|---|
 | engine 参数 | `--prefix-caching-hash-algo sha256` | object key 必须是内容定义 hash；`builtin` 被连接器拒绝 |
 | engine 环境 | `PYTHONHASHSEED=0`（所有共享实例同值） | 稳定首块 parent hash；缺失会在每次进程重启后全量 cold miss |
-| engine 环境 | `DFKV_RDMA=1`、`DFKV_RDMA_DEV=<本机 ACTIVE HCA 列表>` | 强制 GPUDirect RDMA；网卡名必须按节点实际拓扑配置 |
-| engine 环境 | `DFKV_RDMA_DEPTH=1` | device-direct SG 每条 QP 仅允许一个在途 CUDA range；吞吐靠连接 fanout，不靠同 QP depth |
+| engine 环境 | `DFKV_RDMA=1`、`DFKV_RDMA_DEV=<本机 ACTIVE HCA 列表>` | 强制 RDMA；PUT 使用 GPUDirect，GET 使用 host retry staging；网卡名必须按节点实际拓扑配置 |
+| engine 环境 | `DFKV_RDMA_DEPTH=1` | 每条 QP 限制一个在途 range；吞吐靠连接 fanout，不靠同 QP depth |
 | engine 环境 | `DFKV_RDMA_NUMA=1` | 每条连接选择 NUMA-local rail 和内存，避免跨 socket 路径 |
-| 容器资源 | Docker/nerdctl `--ulimit memlock=-1:-1`；Kubernetes `ulimits` 等价配置；systemd `LimitMEMLOCK=infinity` | 允许完整 GPU/host pool 注册 MR；8 MiB 默认值会触发 `ibv_reg_mr` 失败和临时注册退化 |
+| 容器资源 | Docker/nerdctl `--ulimit memlock=-1:-1`；Kubernetes `ulimits` 等价配置；systemd `LimitMEMLOCK=infinity` | 允许 GPU MR 及 CUDA GET 临时 pinned host staging；按并发 GET payload 验证 pinned-memory 与 memlock 容量，8 MiB 默认值可能触发 `ibv_reg_mr` 失败或临时注册退化 |
 | 宿主机 | `nvidia-peermem` 已加载 | GPUDirect MR 注册前提 |
 
 nerdctl/Docker 参考（参数必须出现在**创建容器**时，容器启动后再执行
@@ -713,7 +720,7 @@ namespace/key 不一致是预期 cold miss。**空环 / MDS 不可达**可直接
 
 | env | 默认 | 推荐 | 说明 |
 |---|---|---|---|
-| `DFKV_RDMA` / `DFKV_RDMA_DEV` | **无；`DFKV_RDMA=1` 必填** | `1` / 全轨列表 | vLLM 设备指针连接器仅支持 GPUDirect RDMA；unset/TCP 在构造期关闭并拒绝，无 fallback。见 §1.2 |
+| `DFKV_RDMA` / `DFKV_RDMA_DEV` | **无；`DFKV_RDMA=1` 必填** | `1` / 全轨列表 | vLLM GPU 指针连接器仅支持 RDMA；PUT 为 GPUDirect，GET 为 pinned host retry staging + 同步 H2D publication；unset/TCP 在构造期关闭并拒绝，无 fallback。见 §1.2 |
 | `DFKV_RDMA_DEPTH` | `4` | 保持 4 | depth-flat（§1.2） |
 | `DFKV_RDMA_NUMA` | `0` | 多 NUMA 大机 `1` | §1.2 |
 | `DFKV_LIB` / `DFKV_BUILD` | — | so 路径 | 被 extra_config `lib` 覆盖 |
@@ -814,6 +821,11 @@ daemon 线程或进程终止；过载和退出期间都不会静默留下永久�
   RDMA `ExistMany` 复用 GET fanout 分片，并并行 shared-memory rendezvous
   probe。完整 warm API 为 2.02 s；剩余主耗时在 GPU load/engine barrier。
 
+
+v2.19 CUDA GET 的正确性 fence 增加了每次操作的临时 pinned host staging、H2D copy、
+CUDA stream 同步及相关分配/注册成本；其内存峰值随并发 GET payload 增长。这是安全
+direct-GPU retry fencing 落地前的已知性能取舍，不应按旧版 direct-GPU GET 数据外推。
+
 ### 3.7 已知问题 / 排查
 
 | 现象 | 原因 / 解 |
@@ -822,6 +834,7 @@ daemon 线程或进程终止；过载和退出期间都不会静默留下永久�
 | 命中后输出/shape 错误 | 同一 namespace+key 被不同 dtype/page/shape/layout 复用；这是 type-safety violation。停写，bump source-controlled raw-layout ID 并同时发布所有 writer/reader |
 | 每个 RDMA `put` 失败 `rc=-1` | `members` 指了 `--port` 而非 `--rdma-port` |
 | `ibv_reg_mr` 失败 / 无 GPUDirect | GPU 节点没加载 `nvidia-peermem` |
+| CUDA GET pinned allocation / MR 注册失败或吞吐下降 | v2.19 GET 需要按并发 payload 分配临时 pinned host staging，并执行 H2D copy + stream 同步；检查容器/systemd memlock 与宿主机 pinned-memory 容量，压测实际并发和块大小 |
 | 首 token 偶发慢 ~2s | 每 DP rank 一次性 Triton JIT（非 bug）；预热可消 |
 | 异构 HCA 的 SG 宽度不同 | binary SG 坐标把宽度纳入 key；不同宽度互相 cold miss。要共享就统一有效宽度 |
 

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -1,8 +1,13 @@
 #include "client/cuda_ipc.h"
+#include "transport/transport.h"
 
 #include <dlfcn.h>
+#include <unistd.h>
 
-#include <mutex>
+#include <cstring>
+#include <limits>
+#include <new>
+#include <vector>
 
 #include "utils/log.h"
 
@@ -19,6 +24,76 @@ namespace {
 void* SymV2(void* h, const char* v2, const char* legacy) {
   if (void* p = ::dlsym(h, v2)) return p;
   return ::dlsym(h, legacy);
+}
+
+struct RegisteredHostRange {
+  uintptr_t begin;
+  uintptr_t end;
+};
+
+struct PublisherCudaState {
+  CUstream stream = nullptr;
+  CUcontext context = nullptr;
+  int retained_device = -1;
+  CUcontext pending_restore = nullptr;
+  bool has_pending_restore = false;
+  std::vector<RegisteredHostRange> registered;
+};
+
+size_t HostPageSize() {
+  static const size_t page_size = [] {
+    const long value = ::sysconf(_SC_PAGESIZE);
+    return value > 0 ? static_cast<size_t>(value) : size_t{0};
+  }();
+  return page_size;
+}
+
+bool RegisterHostRange(const CudaLib* cuda, PublisherCudaState* state,
+                       const void* source, size_t size) {
+  const size_t page_size = HostPageSize();
+  const uintptr_t address = reinterpret_cast<uintptr_t>(source);
+  if (!source || page_size == 0 ||
+      size > std::numeric_limits<uintptr_t>::max() - address)
+    return false;
+
+  const uintptr_t requested_end = address + size;
+  const uintptr_t begin = address - address % page_size;
+  uintptr_t end = requested_end;
+  const uintptr_t remainder = end % page_size;
+  if (remainder != 0) {
+    const uintptr_t padding = page_size - remainder;
+    if (padding > std::numeric_limits<uintptr_t>::max() - end) return false;
+    end += padding;
+  }
+
+  // Register only holes in the page-aligned union. Batched scatter publication
+  // commonly presents adjacent slices of one vector; registering each slice
+  // independently would overlap the same host pages and fail.
+  uintptr_t cursor = begin;
+  while (cursor < end) {
+    uintptr_t covered_until = cursor;
+    uintptr_t next_registered = end;
+    for (const auto& range : state->registered) {
+      if (range.begin <= cursor && range.end > covered_until)
+        covered_until = range.end;
+      else if (range.begin > cursor && range.begin < next_registered)
+        next_registered = range.begin;
+    }
+    if (covered_until > cursor) {
+      cursor = covered_until;
+      continue;
+    }
+
+    const uintptr_t hole_end = next_registered;
+    state->registered.push_back({cursor, hole_end});
+    if (cuda->HostRegister(reinterpret_cast<void*>(cursor), hole_end - cursor,
+                           0) != kCudaSuccess) {
+      state->registered.pop_back();
+      return false;
+    }
+    cursor = hole_end;
+  }
+  return true;
 }
 }  // namespace
 
@@ -42,6 +117,10 @@ bool CudaLib::Resolve() {
       ::dlsym(h, "cuStreamSynchronize"));
   StreamDestroy = reinterpret_cast<CUresult (*)(CUstream)>(
       SymV2(h, "cuStreamDestroy_v2", "cuStreamDestroy"));
+  HostRegister = reinterpret_cast<CUresult (*)(void*, size_t, unsigned)>(
+      ::dlsym(h, "cuMemHostRegister"));
+  HostUnregister = reinterpret_cast<CUresult (*)(void*)>(
+      ::dlsym(h, "cuMemHostUnregister"));
   IpcGetMemHandle = reinterpret_cast<CUresult (*)(CUipcMemHandle*, CUdeviceptr)>(
       ::dlsym(h, "cuIpcGetMemHandle"));
   IpcOpenMemHandle = reinterpret_cast<CUresult (*)(CUdeviceptr*, CUipcMemHandle,
@@ -57,17 +136,28 @@ bool CudaLib::Resolve() {
       ::dlsym(h, "cuCtxGetDevice"));
   primary_ctx_retain_ = reinterpret_cast<CUresult (*)(CUcontext*, int)>(
       ::dlsym(h, "cuDevicePrimaryCtxRetain"));
-  pointer_get_attribute_ = reinterpret_cast<CUresult (*)(void*, int, CUdeviceptr)>(
-      ::dlsym(h, "cuPointerGetAttribute"));
+  primary_ctx_release_ = reinterpret_cast<CUresult (*)(int)>(
+      SymV2(h, "cuDevicePrimaryCtxRelease_v2",
+            "cuDevicePrimaryCtxRelease"));
+  pointer_get_attribute_ =
+      reinterpret_cast<CUresult (*)(void*, int, CUdeviceptr)>(
+          ::dlsym(h, "cuPointerGetAttribute"));
   if (!init || !MemAlloc || !MemFree || !Memcpy || !MemcpyAsync ||
       !StreamCreate || !StreamSynchronize || !StreamDestroy ||
-      !IpcGetMemHandle || !IpcOpenMemHandle || !IpcCloseMemHandle ||
-      !ctx_get_current_ || !ctx_set_current_ || !ctx_get_device_ ||
-      !primary_ctx_retain_ || !pointer_get_attribute_)
+      !HostRegister || !HostUnregister || !IpcGetMemHandle ||
+      !IpcOpenMemHandle || !IpcCloseMemHandle || !ctx_get_current_ ||
+      !ctx_set_current_ || !ctx_get_device_ || !primary_ctx_retain_ ||
+      !primary_ctx_release_ || !pointer_get_attribute_) {
+    ::dlclose(h);
     return false;
+  }
   // cuInit is idempotent; the host framework normally beat us to it. A
   // failure here (no device, driver/library mismatch) disables the surface.
-  return reinterpret_cast<CUresult (*)(unsigned)>(init)(0) == kCudaSuccess;
+  if (reinterpret_cast<CUresult (*)(unsigned)>(init)(0) != kCudaSuccess) {
+    ::dlclose(h);
+    return false;
+  }
+  return true;
 }
 
 const CudaLib* CudaLib::Get() {
@@ -86,6 +176,27 @@ bool CudaLib::IsDevicePtr(const void* p) const {
                              reinterpret_cast<CUdeviceptr>(p)) != kCudaSuccess)
     return false;  // unregistered host memory: attribute query fails
   return type == kCuMemoryTypeDevice;
+}
+
+bool CudaLib::GetCurrentCtx(CUcontext* context) const {
+  return context && ctx_get_current_(context) == kCudaSuccess;
+}
+
+bool CudaLib::SetCurrentCtx(CUcontext context) const {
+  return ctx_set_current_(context) == kCudaSuccess;
+}
+
+bool CudaLib::RetainPrimaryCtx(int dev, CUcontext* context) const {
+  if (dev < 0 || !context) return false;
+  *context = nullptr;
+  if (primary_ctx_retain_(context, dev) != kCudaSuccess) return false;
+  if (*context) return true;
+  primary_ctx_release_(dev);
+  return false;
+}
+
+bool CudaLib::ReleasePrimaryCtx(int dev) const {
+  return dev >= 0 && primary_ctx_release_(dev) == kCudaSuccess;
 }
 
 bool CudaLib::HasCurrentCtx() const {
@@ -108,10 +219,167 @@ int CudaLib::DeviceOf(const void* p) const {
 }
 
 bool CudaLib::BindPrimaryCtx(int dev) const {
-  if (dev < 0) return false;
   CUcontext ctx = nullptr;
-  if (primary_ctx_retain_(&ctx, dev) != kCudaSuccess || !ctx) return false;
-  return ctx_set_current_(ctx) == kCudaSuccess;
+  if (!RetainPrimaryCtx(dev, &ctx)) return false;
+  if (SetCurrentCtx(ctx)) return true;
+  ReleasePrimaryCtx(dev);
+  return false;
+}
+
+DestinationPublisher::~DestinationPublisher() {
+  if (!finished_) Finish();
+}
+
+bool DestinationPublisher::Copy(
+    void* destination, const void* source, size_t size,
+    DestinationMemoryKind memory_kind) {
+  if (size == 0) return true;
+  if (memory_kind == DestinationMemoryKind::kHost) {
+    std::memcpy(destination, source, size);
+    return true;
+  }
+  if (finished_ || failed_) return false;
+
+  const CudaLib* cuda = static_cast<const CudaLib*>(cuda_);
+  if (!cuda) {
+    cuda = CudaLib::Get();
+    if (!cuda) {
+      failed_ = true;
+      return false;
+    }
+    cuda_ = cuda;
+  }
+
+  const int destination_device = cuda->DeviceOf(destination);
+  if (destination_device < 0 ||
+      (device_ >= 0 && destination_device != device_)) {
+    // One publication owns one stream/context. Fail closed on a second device
+    // rather than publishing only a subset or changing completion semantics.
+    failed_ = true;
+    return false;
+  }
+
+  CUcontext prior_context = nullptr;
+  if (!cuda->GetCurrentCtx(&prior_context)) {
+    failed_ = true;
+    return false;
+  }
+
+  auto* state = static_cast<PublisherCudaState*>(stream_);
+  if (!state) {
+    state = new (std::nothrow) PublisherCudaState();
+    if (!state) {
+      failed_ = true;
+      return false;
+    }
+
+    if (prior_context && cuda->CurrentDevice() == destination_device) {
+      state->context = prior_context;
+    } else if (!cuda->RetainPrimaryCtx(destination_device, &state->context)) {
+      delete state;
+      failed_ = true;
+      return false;
+    } else {
+      state->retained_device = destination_device;
+    }
+
+    const bool changed_context = prior_context != state->context;
+    if (changed_context && !cuda->SetCurrentCtx(state->context)) {
+      // cuCtxSetCurrent is not allowed to strand a successful primary retain.
+      cuda->SetCurrentCtx(prior_context);
+      if (state->retained_device >= 0)
+        cuda->ReleasePrimaryCtx(state->retained_device);
+      delete state;
+      failed_ = true;
+      return false;
+    }
+
+    // Keep the stream publication-owned: TLS reuse would couple pinned-range
+    // lifetime, failure state, and Finish ordering across independent calls.
+    const CUresult create_result =
+        cuda->StreamCreate(&state->stream, kCuStreamNonBlocking);
+    if (create_result != kCudaSuccess || !state->stream) {
+      if (state->stream) cuda->StreamDestroy(state->stream);
+      if (changed_context) cuda->SetCurrentCtx(prior_context);
+      if (state->retained_device >= 0)
+        cuda->ReleasePrimaryCtx(state->retained_device);
+      delete state;
+      failed_ = true;
+      return false;
+    }
+
+    device_ = destination_device;
+    stream_ = state;
+  } else if (prior_context != state->context &&
+             !cuda->SetCurrentCtx(state->context)) {
+    if (!cuda->SetCurrentCtx(prior_context)) {
+      state->pending_restore = prior_context;
+      state->has_pending_restore = true;
+    }
+    failed_ = true;
+    return false;
+  }
+
+  bool copy_ok = RegisterHostRange(cuda, state, source, size);
+  if (copy_ok) {
+    copy_ok =
+        cuda->MemcpyAsync(reinterpret_cast<CUdeviceptr>(destination),
+                          reinterpret_cast<CUdeviceptr>(source), size,
+                          state->stream) == kCudaSuccess;
+  }
+
+  // A publisher never lends its destination context to its caller, not even
+  // between batched Copy calls.
+  if (prior_context != state->context &&
+      !cuda->SetCurrentCtx(prior_context)) {
+    state->pending_restore = prior_context;
+    state->has_pending_restore = true;
+    copy_ok = false;
+  }
+  if (!copy_ok) failed_ = true;
+  return copy_ok;
+}
+
+bool DestinationPublisher::Finish() {
+  if (finished_) return !failed_;
+  finished_ = true;
+  const CudaLib* cuda = static_cast<const CudaLib*>(cuda_);
+  auto* state = static_cast<PublisherCudaState*>(stream_);
+  if (!cuda || !state) return !failed_;
+
+  CUcontext prior_context = nullptr;
+  const bool have_prior = cuda->GetCurrentCtx(&prior_context);
+  if (!have_prior) failed_ = true;
+
+  bool changed_context = false;
+  if (have_prior && prior_context != state->context) {
+    changed_context = cuda->SetCurrentCtx(state->context);
+    if (!changed_context) failed_ = true;
+  }
+
+  // Even after an enqueue/setup failure, synchronization must precede every
+  // unregister because earlier copies can still reference operation staging.
+  if (cuda->StreamSynchronize(state->stream) != kCudaSuccess) failed_ = true;
+  for (auto it = state->registered.rbegin();
+       it != state->registered.rend(); ++it) {
+    if (cuda->HostUnregister(reinterpret_cast<void*>(it->begin)) !=
+        kCudaSuccess)
+      failed_ = true;
+  }
+  if (cuda->StreamDestroy(state->stream) != kCudaSuccess) failed_ = true;
+
+  if (state->has_pending_restore) {
+    if (!cuda->SetCurrentCtx(state->pending_restore)) failed_ = true;
+  } else if (changed_context && !cuda->SetCurrentCtx(prior_context)) {
+    failed_ = true;
+  }
+  if (state->retained_device >= 0 &&
+      !cuda->ReleasePrimaryCtx(state->retained_device))
+    failed_ = true;
+
+  delete state;
+  stream_ = nullptr;
+  return !failed_;
 }
 
 }  // namespace dfkv

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -4,9 +4,11 @@
 #include <dlfcn.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstring>
 #include <limits>
 #include <new>
+#include <string>
 #include <vector>
 
 #include "utils/log.h"
@@ -48,6 +50,16 @@ size_t HostPageSize() {
   return page_size;
 }
 
+void NotePublisherDriverFailure(const std::string& detail) {
+  static std::atomic<uint64_t> failures{0};
+  const uint64_t count =
+      failures.fetch_add(1, std::memory_order_relaxed) + 1;
+  if (count == 1 || (count & 0x3ffu) == 0) {
+    DFKV_LOG_WARN("cuda destination publication driver failure: " + detail +
+                  " failures=" + std::to_string(count));
+  }
+}
+
 bool RegisterHostRange(const CudaLib* cuda, PublisherCudaState* state,
                        const void* source, size_t size) {
   const size_t page_size = HostPageSize();
@@ -86,15 +98,19 @@ bool RegisterHostRange(const CudaLib* cuda, PublisherCudaState* state,
 
     const uintptr_t hole_end = next_registered;
     state->registered.push_back({cursor, hole_end});
-    if (cuda->HostRegister(reinterpret_cast<void*>(cursor), hole_end - cursor,
-                           0) != kCudaSuccess) {
+    const CUresult result = cuda->HostRegister(
+        reinterpret_cast<void*>(cursor), hole_end - cursor, 0);
+    if (result != kCudaSuccess) {
       state->registered.pop_back();
+      NotePublisherDriverFailure("cuMemHostRegister result=" +
+                                 std::to_string(result));
       return false;
     }
     cursor = hole_end;
   }
   return true;
 }
+
 }  // namespace
 
 bool CudaLib::Resolve() {
@@ -322,10 +338,14 @@ bool DestinationPublisher::Copy(
 
   bool copy_ok = RegisterHostRange(cuda, state, source, size);
   if (copy_ok) {
-    copy_ok =
+    const CUresult result =
         cuda->MemcpyAsync(reinterpret_cast<CUdeviceptr>(destination),
                           reinterpret_cast<CUdeviceptr>(source), size,
-                          state->stream) == kCudaSuccess;
+                          state->stream);
+    copy_ok = result == kCudaSuccess;
+    if (!copy_ok)
+      NotePublisherDriverFailure("cuMemcpyAsync result=" +
+                                 std::to_string(result));
   }
 
   // A publisher never lends its destination context to its caller, not even
@@ -359,14 +379,26 @@ bool DestinationPublisher::Finish() {
 
   // Even after an enqueue/setup failure, synchronization must precede every
   // unregister because earlier copies can still reference operation staging.
-  if (cuda->StreamSynchronize(state->stream) != kCudaSuccess) failed_ = true;
+  // This synchronization result is the publication barrier: cleanup below
+  // cannot undo successfully synchronized destination bytes.
+  const CUresult sync_result = cuda->StreamSynchronize(state->stream);
+  if (sync_result != kCudaSuccess) {
+    failed_ = true;
+    NotePublisherDriverFailure("cuStreamSynchronize result=" +
+                               std::to_string(sync_result));
+  }
   for (auto it = state->registered.rbegin();
        it != state->registered.rend(); ++it) {
-    if (cuda->HostUnregister(reinterpret_cast<void*>(it->begin)) !=
-        kCudaSuccess)
-      failed_ = true;
+    const CUresult result =
+        cuda->HostUnregister(reinterpret_cast<void*>(it->begin));
+    if (result != kCudaSuccess)
+      NotePublisherDriverFailure("post-sync cuMemHostUnregister result=" +
+                                 std::to_string(result));
   }
-  if (cuda->StreamDestroy(state->stream) != kCudaSuccess) failed_ = true;
+  const CUresult destroy_result = cuda->StreamDestroy(state->stream);
+  if (destroy_result != kCudaSuccess)
+    NotePublisherDriverFailure("post-sync cuStreamDestroy result=" +
+                               std::to_string(destroy_result));
 
   if (state->has_pending_restore) {
     if (!cuda->SetCurrentCtx(state->pending_restore)) failed_ = true;
@@ -375,7 +407,9 @@ bool DestinationPublisher::Finish() {
   }
   if (state->retained_device >= 0 &&
       !cuda->ReleasePrimaryCtx(state->retained_device))
-    failed_ = true;
+    NotePublisherDriverFailure(
+        "post-sync cuDevicePrimaryCtxRelease device=" +
+        std::to_string(state->retained_device));
 
   delete state;
   stream_ = nullptr;

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstring>
 #include <limits>
+#include <mutex>
 #include <new>
 #include <string>
 #include <vector>
@@ -34,6 +35,24 @@ struct RegisteredHostRange {
   uintptr_t end;
 };
 
+struct ProcessHostRegistration {
+  uintptr_t begin;
+  uintptr_t end;
+  size_t references;
+};
+
+struct HostRegistrationRegistry {
+  std::mutex mutex;
+  std::vector<ProcessHostRegistration> ranges;
+};
+
+HostRegistrationRegistry& ProcessHostRegistry() {
+  // Publishers can be destroyed during process teardown. Keep the registry
+  // alive until process exit rather than depending on static destruction order.
+  static HostRegistrationRegistry* registry = new HostRegistrationRegistry();
+  return *registry;
+}
+
 struct PublisherCudaState {
   CUstream stream = nullptr;
   CUcontext context = nullptr;
@@ -41,7 +60,7 @@ struct PublisherCudaState {
   size_t copy_count = 0;
   CUcontext pending_restore = nullptr;
   bool has_pending_restore = false;
-  std::vector<RegisteredHostRange> registered;
+  std::vector<RegisteredHostRange> leases;
 };
 
 void NotePublisherDriverFailure(const std::string& detail);
@@ -54,7 +73,7 @@ bool EnqueueRegisteredCopy(const CudaLib* cuda, PublisherCudaState* state,
   while (copied < size) {
     const uintptr_t cursor = source_begin + copied;
     const RegisteredHostRange* containing = nullptr;
-    for (const auto& range : state->registered) {
+    for (const auto& range : state->leases) {
       if (range.begin <= cursor && cursor < range.end) {
         containing = &range;
         break;
@@ -103,8 +122,46 @@ void NotePublisherDriverFailure(const std::string& detail) {
   }
 }
 
-bool RegisterHostRange(const CudaLib* cuda, PublisherCudaState* state,
-                       const void* source, size_t size) {
+bool ReleaseHostRangesLocked(
+    const CudaLib* cuda, HostRegistrationRegistry* registry,
+    const std::vector<RegisteredHostRange>& leases, const char* failure_prefix) {
+  bool released = true;
+  for (auto lease = leases.rbegin(); lease != leases.rend(); ++lease) {
+    auto registration = std::find_if(
+        registry->ranges.begin(), registry->ranges.end(),
+        [&](const ProcessHostRegistration& range) {
+          return range.begin == lease->begin && range.end == lease->end;
+        });
+    if (registration == registry->ranges.end() ||
+        registration->references == 0) {
+      NotePublisherDriverFailure(
+          "host registration reference bookkeeping underflow");
+      released = false;
+      continue;
+    }
+
+    --registration->references;
+    if (registration->references != 0) continue;
+
+    const CUresult result =
+        cuda->HostUnregister(reinterpret_cast<void*>(registration->begin));
+    if (result == kCudaSuccess) {
+      registry->ranges.erase(registration);
+    } else {
+      // Keep a zero-reference entry so a driver failure never leaves an
+      // untracked physical pin. A later acquisition can reuse it and its final
+      // release will retry the unregister.
+      NotePublisherDriverFailure(std::string(failure_prefix) +
+                                 " cuMemHostUnregister result=" +
+                                 std::to_string(result));
+      released = false;
+    }
+  }
+  return released;
+}
+
+bool AcquireHostRange(const CudaLib* cuda, PublisherCudaState* state,
+                      const void* source, size_t size) {
   const size_t page_size = HostPageSize();
   const uintptr_t address = reinterpret_cast<uintptr_t>(source);
   if (!source || page_size == 0 ||
@@ -121,38 +178,78 @@ bool RegisterHostRange(const CudaLib* cuda, PublisherCudaState* state,
     end += padding;
   }
 
-  // Register only holes in the page-aligned union. Batched scatter publication
-  // commonly presents adjacent slices of one vector; registering each slice
-  // independently would overlap the same host pages and fail. Copy enqueues
-  // are split at these registration boundaries: CUDA rejects one memcpy
-  // spanning two otherwise adjacent registered allocations.
+  HostRegistrationRegistry& registry = ProcessHostRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+
+  // Build a complete acquisition plan before changing either the global
+  // reference counts or this publisher's leases. The registry is sorted and
+  // non-overlapping; existing physical registrations are acquired whole, while
+  // uncovered holes become distinct CUDA registrations.
+  std::vector<RegisteredHostRange> plan;
+  plan.reserve(registry.ranges.size() + 1);
+  size_t holes = 0;
   uintptr_t cursor = begin;
-  while (cursor < end) {
-    uintptr_t covered_until = cursor;
-    uintptr_t next_registered = end;
-    for (const auto& range : state->registered) {
-      if (range.begin <= cursor && range.end > covered_until)
-        covered_until = range.end;
-      else if (range.begin > cursor && range.begin < next_registered)
-        next_registered = range.begin;
+  for (const auto& range : registry.ranges) {
+    if (range.end <= cursor) continue;
+    if (range.begin >= end) break;
+    if (cursor < range.begin) {
+      plan.push_back({cursor, std::min(end, range.begin)});
+      ++holes;
+      cursor = std::min(end, range.begin);
     }
-    if (covered_until > cursor) {
-      cursor = covered_until;
+    if (cursor >= end) break;
+    if (range.end > cursor) {
+      plan.push_back({range.begin, range.end});
+      cursor = range.end;
+    }
+  }
+  if (cursor < end) {
+    plan.push_back({cursor, end});
+    ++holes;
+  }
+
+  // Reserve before the first CUDA call so bookkeeping allocation cannot fail
+  // after a physical registration has succeeded.
+  registry.ranges.reserve(registry.ranges.size() + holes);
+  state->leases.reserve(state->leases.size() + plan.size());
+
+  std::vector<RegisteredHostRange> acquired;
+  acquired.reserve(plan.size());
+  for (const auto& piece : plan) {
+    auto registration = std::find_if(
+        registry.ranges.begin(), registry.ranges.end(),
+        [&](const ProcessHostRegistration& range) {
+          return range.begin == piece.begin && range.end == piece.end;
+        });
+    if (registration != registry.ranges.end()) {
+      ++registration->references;
+      acquired.push_back(piece);
       continue;
     }
 
-    const uintptr_t hole_end = next_registered;
-    state->registered.push_back({cursor, hole_end});
     const CUresult result = cuda->HostRegister(
-        reinterpret_cast<void*>(cursor), hole_end - cursor, 0);
+        reinterpret_cast<void*>(piece.begin), piece.end - piece.begin,
+        kCuMemHostRegisterPortable);
     if (result != kCudaSuccess) {
-      state->registered.pop_back();
       NotePublisherDriverFailure("cuMemHostRegister result=" +
                                  std::to_string(result));
+      ReleaseHostRangesLocked(cuda, &registry, acquired,
+                              "acquisition rollback");
       return false;
     }
-    cursor = hole_end;
+
+    const auto insertion = std::lower_bound(
+        registry.ranges.begin(), registry.ranges.end(), piece.begin,
+        [](const ProcessHostRegistration& range, uintptr_t range_begin) {
+          return range.begin < range_begin;
+        });
+    registry.ranges.insert(
+        insertion, {piece.begin, piece.end, /*references=*/1});
+    acquired.push_back(piece);
   }
+
+  state->leases.insert(state->leases.end(), acquired.begin(),
+                       acquired.end());
   return true;
 }
 
@@ -381,7 +478,7 @@ bool DestinationPublisher::Copy(
     return false;
   }
 
-  bool copy_ok = RegisterHostRange(cuda, state, source, size);
+  bool copy_ok = AcquireHostRange(cuda, state, source, size);
   if (copy_ok) {
     ++state->copy_count;
     copy_ok =
@@ -427,13 +524,10 @@ bool DestinationPublisher::Finish() {
     NotePublisherDriverFailure("cuStreamSynchronize result=" +
                                std::to_string(sync_result));
   }
-  for (auto it = state->registered.rbegin();
-       it != state->registered.rend(); ++it) {
-    const CUresult result =
-        cuda->HostUnregister(reinterpret_cast<void*>(it->begin));
-    if (result != kCudaSuccess)
-      NotePublisherDriverFailure("post-sync cuMemHostUnregister result=" +
-                                 std::to_string(result));
+  {
+    HostRegistrationRegistry& registry = ProcessHostRegistry();
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    ReleaseHostRangesLocked(cuda, &registry, state->leases, "post-sync");
   }
   const CUresult destroy_result = cuda->StreamDestroy(state->stream);
   if (destroy_result != kCudaSuccess)

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -4,6 +4,7 @@
 #include <dlfcn.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstring>
 #include <limits>
@@ -37,10 +38,52 @@ struct PublisherCudaState {
   CUstream stream = nullptr;
   CUcontext context = nullptr;
   int retained_device = -1;
+  size_t copy_count = 0;
   CUcontext pending_restore = nullptr;
   bool has_pending_restore = false;
   std::vector<RegisteredHostRange> registered;
 };
+
+void NotePublisherDriverFailure(const std::string& detail);
+
+bool EnqueueRegisteredCopy(const CudaLib* cuda, PublisherCudaState* state,
+                           void* destination, const void* source, size_t size) {
+  const uintptr_t source_begin = reinterpret_cast<uintptr_t>(source);
+  size_t copied = 0;
+  size_t chunk_index = 0;
+  while (copied < size) {
+    const uintptr_t cursor = source_begin + copied;
+    const RegisteredHostRange* containing = nullptr;
+    for (const auto& range : state->registered) {
+      if (range.begin <= cursor && cursor < range.end) {
+        containing = &range;
+        break;
+      }
+    }
+    if (!containing) {
+      NotePublisherDriverFailure(
+          "host registration bookkeeping left source uncovered");
+      return false;
+    }
+    const size_t chunk =
+        std::min(size - copied,
+                 static_cast<size_t>(containing->end - cursor));
+    const CUresult result = cuda->MemcpyAsync(
+        reinterpret_cast<CUdeviceptr>(destination) + copied,
+        reinterpret_cast<CUdeviceptr>(source) + copied, chunk, state->stream);
+    if (result != kCudaSuccess) {
+      NotePublisherDriverFailure(
+          "cuMemcpyAsync result=" + std::to_string(result) +
+          " copy=" + std::to_string(state->copy_count) +
+          " chunk=" + std::to_string(chunk_index) +
+          " bytes=" + std::to_string(chunk));
+      return false;
+    }
+    copied += chunk;
+    ++chunk_index;
+  }
+  return true;
+}
 
 size_t HostPageSize() {
   static const size_t page_size = [] {
@@ -80,7 +123,9 @@ bool RegisterHostRange(const CudaLib* cuda, PublisherCudaState* state,
 
   // Register only holes in the page-aligned union. Batched scatter publication
   // commonly presents adjacent slices of one vector; registering each slice
-  // independently would overlap the same host pages and fail.
+  // independently would overlap the same host pages and fail. Copy enqueues
+  // are split at these registration boundaries: CUDA rejects one memcpy
+  // spanning two otherwise adjacent registered allocations.
   uintptr_t cursor = begin;
   while (cursor < end) {
     uintptr_t covered_until = cursor;
@@ -338,14 +383,9 @@ bool DestinationPublisher::Copy(
 
   bool copy_ok = RegisterHostRange(cuda, state, source, size);
   if (copy_ok) {
-    const CUresult result =
-        cuda->MemcpyAsync(reinterpret_cast<CUdeviceptr>(destination),
-                          reinterpret_cast<CUdeviceptr>(source), size,
-                          state->stream);
-    copy_ok = result == kCudaSuccess;
-    if (!copy_ok)
-      NotePublisherDriverFailure("cuMemcpyAsync result=" +
-                                 std::to_string(result));
+    ++state->copy_count;
+    copy_ok =
+        EnqueueRegisteredCopy(cuda, state, destination, source, size);
   }
 
   // A publisher never lends its destination context to its caller, not even

--- a/src/client/cuda_ipc.h
+++ b/src/client/cuda_ipc.h
@@ -30,6 +30,7 @@ constexpr int kCuPointerAttributeMemoryType = 2;    // CU_POINTER_ATTRIBUTE_MEMO
 constexpr int kCuPointerAttributeDeviceOrdinal = 9; // CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL
 constexpr unsigned kCuMemoryTypeDevice = 2;         // CU_MEMORYTYPE_DEVICE
 constexpr unsigned kCuStreamNonBlocking = 1;        // CU_STREAM_NON_BLOCKING
+constexpr unsigned kCuMemHostRegisterPortable = 0x1;  // CU_MEMHOSTREGISTER_PORTABLE
 
 class CudaLib {
  public:

--- a/src/client/cuda_ipc.h
+++ b/src/client/cuda_ipc.h
@@ -1,12 +1,12 @@
-/* CudaLib — dlopen'd CUDA *driver* API surface for the GPU rendezvous path.
+/* CudaLib — dlopen'd CUDA driver API for GPU rendezvous and final device
+ * destination publication.
  *
- * libdfkv.so must not link CUDA: SGLang hosts and CPU-only tools load the
- * same library. Everything here resolves from libcuda.so.1 at first use; if
- * the driver (or any required symbol) is absent, Get() returns nullptr and
- * callers run without GPU dedup — the same "nothing here is load-bearing"
- * rule as NodeDedup. The declarations below intentionally mirror cuda.h so
- * no CUDA toolkit is needed at build time; they are ABI, not API (the driver
- * exports them with C linkage and fixed layouts).
+ * libdfkv.so must not link CUDA: SGLang hosts and CPU-only tools load the same
+ * library. Everything here resolves from libcuda.so.1 at first use. Optional
+ * GPU dedup disables itself when unavailable; an explicitly classified device
+ * publication instead returns failure and never reports unpublished bytes.
+ * The declarations intentionally mirror cuda.h so no CUDA toolkit is needed at
+ * build time; they are ABI, not API (driver exports use fixed C layouts).
  */
 #ifndef DFKV_CUDA_IPC_H_
 #define DFKV_CUDA_IPC_H_
@@ -41,14 +41,17 @@ class CudaLib {
   bool IsDevicePtr(const void* p) const;
   // Device ordinal owning device pointer p; -1 on failure.
   int DeviceOf(const void* p) const;
-  // True iff the calling thread has a current CUDA context. Framework compute
-  // threads always do; the connectors' pure-Python transfer threads (ctypes ->
-  // C ABI, never touched CUDA) do NOT — those must BindPrimaryCtx first.
+  // Current-context access used by scoped publication. GetCurrentCtx succeeds
+  // with a null context when the calling thread has no current CUDA context.
+  bool GetCurrentCtx(CUcontext* context) const;
+  bool SetCurrentCtx(CUcontext context) const;
+  // Retain/release are deliberately separate so every scoped retain can be
+  // paired on partial setup failure as well as normal teardown.
+  bool RetainPrimaryCtx(int dev, CUcontext* context) const;
+  bool ReleasePrimaryCtx(int dev) const;
+  // Legacy helper for GPU-dedup callers whose context is process-lived.
   bool HasCurrentCtx() const;
   int CurrentDevice() const;  // -1 without a context
-  // Make device dev's PRIMARY context current on the calling thread (retains
-  // it once per process — the framework already holds it; this only bumps a
-  // refcount, it never creates a fresh context behind the framework's back).
   bool BindPrimaryCtx(int dev) const;
 
   CUresult (*MemAlloc)(CUdeviceptr*, size_t) = nullptr;
@@ -64,6 +67,8 @@ class CudaLib {
   CUresult (*StreamCreate)(CUstream*, unsigned) = nullptr;
   CUresult (*StreamSynchronize)(CUstream) = nullptr;
   CUresult (*StreamDestroy)(CUstream) = nullptr;
+  CUresult (*HostRegister)(void*, size_t, unsigned) = nullptr;
+  CUresult (*HostUnregister)(void*) = nullptr;
   CUresult (*IpcGetMemHandle)(CUipcMemHandle*, CUdeviceptr) = nullptr;
   CUresult (*IpcOpenMemHandle)(CUdeviceptr*, CUipcMemHandle, unsigned) = nullptr;
   CUresult (*IpcCloseMemHandle)(CUdeviceptr) = nullptr;
@@ -76,6 +81,7 @@ class CudaLib {
   CUresult (*ctx_set_current_)(CUcontext) = nullptr;
   CUresult (*ctx_get_device_)(int*) = nullptr;
   CUresult (*primary_ctx_retain_)(CUcontext*, int) = nullptr;
+  CUresult (*primary_ctx_release_)(int) = nullptr;
   CUresult (*pointer_get_attribute_)(void*, int, CUdeviceptr) = nullptr;
 };
 

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -67,12 +67,6 @@ bool CheckedSizeSum(const std::vector<size_t>& values, size_t* total) {
   return true;
 }
 
-DestinationMemoryKind ClassifyDestination(const void* destination) {
-  const CudaLib* cuda = CudaLib::Get();
-  return cuda && cuda->IsDevicePtr(destination)
-             ? DestinationMemoryKind::kDevice
-             : DestinationMemoryKind::kHost;
-}
 
 void AddMetricBytes(size_t value, uint64_t* total) {
   if constexpr (sizeof(size_t) > sizeof(uint64_t)) {
@@ -229,6 +223,66 @@ KVClient::KVClient(std::vector<std::pair<std::string, std::string>> members,
     cd::Record("transport", transport_reason_, cd::Source::kArg);
     cd::Emit("client");
   });
+}
+
+bool KVClient::RegisterMemory(void* base, size_t size) {
+  const uintptr_t address = reinterpret_cast<uintptr_t>(base);
+  if (!base || size == 0 ||
+      size > std::numeric_limits<uintptr_t>::max() - address) {
+    return false;
+  }
+
+  // Serialize declarations with classification reads so a GET concurrent with
+  // a successful registration cannot slip through the publication gap and
+  // initialize/query CUDA on its registered host destination.
+  std::unique_lock<std::shared_mutex> lock(registered_memory_mu_);
+  const CudaLib* cuda = CudaLib::Get();
+  const DestinationMemoryKind kind =
+      cuda && cuda->IsDevicePtr(base) ? DestinationMemoryKind::kDevice
+                                      : DestinationMemoryKind::kHost;
+  if (!t_->RegisterMemory(base, size)) return false;
+
+  const uintptr_t end = address + size;
+  for (auto it = registered_memory_.begin();
+       it != registered_memory_.end(); ++it) {
+    if (it->base != address) continue;
+    // Same-base declarations are one transport pool. A smaller redeclaration
+    // does not shrink it; growth replaces the older entry and becomes newest.
+    RegisteredMemoryRange updated{
+        address, std::max(it->end, end), kind};
+    registered_memory_.erase(it);
+    registered_memory_.push_back(updated);
+    return true;
+  }
+  registered_memory_.push_back({address, end, kind});
+  return true;
+}
+
+DestinationMemoryKind KVClient::ClassifyDestination(
+    const void* destination, size_t size) const {
+  if (!destination || size == 0) return DestinationMemoryKind::kHost;
+  const uintptr_t address = reinterpret_cast<uintptr_t>(destination);
+  const bool valid =
+      size <= std::numeric_limits<uintptr_t>::max() - address;
+  if (valid) {
+    std::shared_lock<std::shared_mutex> lock(registered_memory_mu_);
+    // Reverse declaration order gives overlaps an explicit latest-wins rule.
+    // Subtraction-based containment cannot wrap at the end of address space.
+    for (auto it = registered_memory_.rbegin();
+         it != registered_memory_.rend(); ++it) {
+      if (address >= it->base && address < it->end &&
+          size <= it->end - address) {
+        return it->kind;
+      }
+    }
+  }
+
+  // No lifetime is known for an unregistered pointer, so caching a host answer
+  // could misclassify a later CUDA allocation that reuses the same VA.
+  const CudaLib* cuda = CudaLib::Get();
+  return cuda && cuda->IsDevicePtr(destination)
+             ? DestinationMemoryKind::kDevice
+             : DestinationMemoryKind::kHost;
 }
 
 void KVClient::AdoptRing(ConHash ring, std::map<std::string, std::string> addr) {
@@ -610,7 +664,7 @@ bool KVClient::GetDirect(const std::string& key, void* out, size_t n) {
   uint64_t value_len = 0;
   std::vector<BlockKey> keys{bk};
   std::vector<RangeDst> dsts{
-      RangeDst{n ? out : nullptr, n, ClassifyDestination(out)}};
+      RangeDst{n ? out : nullptr, n, ClassifyDestination(out, n)}};
   std::vector<uint64_t> value_lens;
   const Status st = t_->RangeInto(node, keys, dsts, &value_lens)[0];
   if (!value_lens.empty()) value_len = value_lens[0];
@@ -686,7 +740,7 @@ bool KVClient::GetAutoDirect(const std::string& key, void* out, size_t cap,
   uint64_t value_len = 0;
   std::vector<BlockKey> keys{bk};
   std::vector<RangeDst> dsts{
-      RangeDst{cap ? out : nullptr, cap, ClassifyDestination(out)}};
+      RangeDst{cap ? out : nullptr, cap, ClassifyDestination(out, cap)}};
   std::vector<uint64_t> value_lens;
   const Status st = t_->RangeInto(node, keys, dsts, &value_lens)[0];
   if (!value_lens.empty()) value_len = value_lens[0];
@@ -827,12 +881,12 @@ std::vector<bool> KVClient::BatchGet(const std::vector<KvGetItem>& items) {
   std::vector<size_t> fetch_map, wait_list;
   std::vector<uint64_t> tokens(N, 0);
   fetch_items.reserve(N);
-  // Host rendezvous can't serve device destinations (memcpy to a device VA);
-  // route those straight to the fetch list unclaimed instead of crashing when
-  // the env switch is set in a GPUDirect process. cu is null on CPU-only hosts.
-  const CudaLib* cu = CudaLib::Get();
+  // Host rendezvous cannot serve device destinations (memcpy to a device VA);
+  // registered pools use the declaration cache, while unregistered pointers
+  // take the conservative CUDA probe.
   for (size_t i = 0; i < N; ++i) {
-    if (cu && cu->IsDevicePtr(items[i].out)) {
+    if (ClassifyDestination(items[i].out, items[i].n) ==
+        DestinationMemoryKind::kDevice) {
       fetch_map.push_back(i);
       fetch_items.push_back(items[i]);
       // token remains zero: this direct fetch has no publish obligation.
@@ -909,7 +963,7 @@ std::vector<bool> KVClient::BatchGetDirect(const std::vector<KvGetItem>& items) 
       for (size_t k : idx) {
         keys.push_back(ToBlockKey(key_namespace_, items[k].key));
         dsts.push_back(RangeDst{items[k].out, n,
-                                ClassifyDestination(items[k].out)});
+                                ClassifyDestination(items[k].out, n)});
       }
       // The transport stages retry-owned bytes, then publishes them into each
       // host or CUDA destination before returning the authoritative size.
@@ -969,9 +1023,9 @@ std::vector<bool> KVClient::BatchGetAuto(const std::vector<KvGetItem>& items,
   std::vector<size_t> fetch_map, wait_list;
   std::vector<uint64_t> tokens(N, 0);
   fetch_items.reserve(N);
-  const CudaLib* cu = CudaLib::Get();  // device destinations bypass (see BatchGet)
   for (size_t i = 0; i < N; ++i) {
-    if (cu && cu->IsDevicePtr(items[i].out)) {
+    if (ClassifyDestination(items[i].out, items[i].n) ==
+        DestinationMemoryKind::kDevice) {
       fetch_map.push_back(i);
       fetch_items.push_back(items[i]);
       // Unclaimed device fetch: token remains zero.
@@ -1067,7 +1121,7 @@ std::vector<bool> KVClient::BatchGetAutoDirect(const std::vector<KvGetItem>& ite
     for (size_t k : idx) {
       keys.push_back(ToBlockKey(key_namespace_, items[k].key));
       dsts.push_back(RangeDst{items[k].out, cap,
-                              ClassifyDestination(items[k].out)});
+                              ClassifyDestination(items[k].out, cap)});
     }
     std::vector<uint64_t> value_lens;
     std::vector<Status> sts = t_->RangeInto(node, keys, dsts, &value_lens);
@@ -1352,18 +1406,19 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
   // Init the GPU rendezvous only once an all-device SG destination shows up:
   // its first pointer selects the primary context for the arena. Mixed and
   // host-only SG items use the ordinary transport publication path.
-  const CudaLib* cu = CudaLib::Get();
   std::vector<char> all_device(items.size(), 0);
   const void* hint = nullptr;
-  if (cu) {
-    for (size_t i = 0; i < items.size(); ++i) {
-      bool all = !items[i].dsts.empty();
-      for (const void* destination : items[i].dsts) {
-        if (!cu->IsDevicePtr(destination)) all = false;
+  for (size_t i = 0; i < items.size(); ++i) {
+    bool all = !items[i].dsts.empty() &&
+               items[i].dsts.size() == items[i].caps.size();
+    for (size_t j = 0; all && j < items[i].dsts.size(); ++j) {
+      if (ClassifyDestination(items[i].dsts[j], items[i].caps[j]) !=
+          DestinationMemoryKind::kDevice) {
+        all = false;
       }
-      all_device[i] = all ? 1 : 0;
-      if (all && !hint) hint = items[i].dsts[0];
     }
+    all_device[i] = all ? 1 : 0;
+    if (all && !hint) hint = items[i].dsts[0];
   }
   GpuNodeDedup* gd = hint ? GpuDedup(hint) : nullptr;
   if (!gd || items.empty()) {
@@ -1557,7 +1612,7 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         for (size_t j = 0; j < items[k].dsts.size(); ++j)
           d.payloads.emplace_back(
               items[k].dsts[j], items[k].caps[j],
-              ClassifyDestination(items[k].dsts[j]));
+              ClassifyDestination(items[k].dsts[j], items[k].caps[j]));
         dsts.push_back(std::move(d));
       }
       std::vector<size_t> value_lens;

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -67,6 +67,13 @@ bool CheckedSizeSum(const std::vector<size_t>& values, size_t* total) {
   return true;
 }
 
+DestinationMemoryKind ClassifyDestination(const void* destination) {
+  const CudaLib* cuda = CudaLib::Get();
+  return cuda && cuda->IsDevicePtr(destination)
+             ? DestinationMemoryKind::kDevice
+             : DestinationMemoryKind::kHost;
+}
+
 void AddMetricBytes(size_t value, uint64_t* total) {
   if constexpr (sizeof(size_t) > sizeof(uint64_t)) {
     if (value > std::numeric_limits<uint64_t>::max()) {
@@ -602,7 +609,8 @@ bool KVClient::GetDirect(const std::string& key, void* out, size_t n) {
   const BlockKey bk = ToBlockKey(key_namespace_, key);
   uint64_t value_len = 0;
   std::vector<BlockKey> keys{bk};
-  std::vector<RangeDst> dsts{RangeDst{n ? out : nullptr, n}};
+  std::vector<RangeDst> dsts{
+      RangeDst{n ? out : nullptr, n, ClassifyDestination(out)}};
   std::vector<uint64_t> value_lens;
   const Status st = t_->RangeInto(node, keys, dsts, &value_lens)[0];
   if (!value_lens.empty()) value_len = value_lens[0];
@@ -634,8 +642,9 @@ bool KVClient::GetAutoDirect(const std::string& key, std::string* out,
   uint64_t value_len = 0;
   out->resize(max_bytes);
   std::vector<BlockKey> keys{bk};
-  std::vector<RangeDst> dsts{
-      RangeDst{max_bytes ? &(*out)[0] : nullptr, max_bytes}};
+  std::vector<RangeDst> dsts{RangeDst{
+      max_bytes ? &(*out)[0] : nullptr, max_bytes,
+      DestinationMemoryKind::kHost}};
   std::vector<uint64_t> value_lens;
   const Status st = t_->RangeInto(node, keys, dsts, &value_lens)[0];
   if (!value_lens.empty()) value_len = value_lens[0];
@@ -676,7 +685,8 @@ bool KVClient::GetAutoDirect(const std::string& key, void* out, size_t cap,
   const BlockKey bk = ToBlockKey(key_namespace_, key);
   uint64_t value_len = 0;
   std::vector<BlockKey> keys{bk};
-  std::vector<RangeDst> dsts{RangeDst{cap ? out : nullptr, cap}};
+  std::vector<RangeDst> dsts{
+      RangeDst{cap ? out : nullptr, cap, ClassifyDestination(out)}};
   std::vector<uint64_t> value_lens;
   const Status st = t_->RangeInto(node, keys, dsts, &value_lens)[0];
   if (!value_lens.empty()) value_len = value_lens[0];
@@ -898,10 +908,11 @@ std::vector<bool> KVClient::BatchGetDirect(const std::vector<KvGetItem>& items) 
       dsts.reserve(idx.size());
       for (size_t k : idx) {
         keys.push_back(ToBlockKey(key_namespace_, items[k].key));
-        dsts.push_back(RangeDst{items[k].out, n});
+        dsts.push_back(RangeDst{items[k].out, n,
+                                ClassifyDestination(items[k].out)});
       }
-      // Raw payload lands straight in items[].out; authoritative stored sizes
-      // return in the response prefix.
+      // The transport stages retry-owned bytes, then publishes them into each
+      // host or CUDA destination before returning the authoritative size.
       std::vector<uint64_t> value_lens;
       std::vector<Status> sts = t_->RangeInto(node, keys, dsts, &value_lens);
       bool resp = false, ioerr = false;
@@ -1034,8 +1045,8 @@ std::vector<bool> KVClient::BatchGetAutoDirect(const std::vector<KvGetItem>& ite
     return std::vector<bool>(hit.begin(), hit.end());
   }
   // RDMA: group by (node, cap) so each group shares the Range length, then
-  // pipeline. Same zero-copy datapath as BatchGet; the only difference is we
-  // accept any payload_len <= cap (instead of == n) and report the true length.
+  // pipeline. Same staged-publication datapath as BatchGet; the only
+  // difference is accepting payload_len <= cap and reporting the true length.
   std::map<std::pair<std::string, size_t>, std::vector<size_t>> by;
   for (size_t i = 0; i < N; ++i) {
     std::string node = Route(items[i].key);
@@ -1055,7 +1066,8 @@ std::vector<bool> KVClient::BatchGetAutoDirect(const std::vector<KvGetItem>& ite
     dsts.reserve(idx.size());
     for (size_t k : idx) {
       keys.push_back(ToBlockKey(key_namespace_, items[k].key));
-      dsts.push_back(RangeDst{items[k].out, cap});
+      dsts.push_back(RangeDst{items[k].out, cap,
+                              ClassifyDestination(items[k].out)});
     }
     std::vector<uint64_t> value_lens;
     std::vector<Status> sts = t_->RangeInto(node, keys, dsts, &value_lens);
@@ -1337,16 +1349,23 @@ GpuNodeDedup* KVClient::GpuDedup(const void* device_dst_hint) {
 std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items,
                                            std::vector<size_t>* out_lens) {
   const auto t0 = std::chrono::steady_clock::now();
-  // Init the GPU rendezvous only once a DEVICE destination shows up: its
-  // pointer picks the primary context to bind when this (transfer) thread
-  // has none, and host-only callers never pay for an arena.
-  GpuNodeDedup* gd = nullptr;
-  if (const CudaLib* cu0 = CudaLib::Get()) {
-    const void* hint = nullptr;
-    for (const auto& it : items)
-      if (!it.dsts.empty() && cu0->IsDevicePtr(it.dsts[0])) { hint = it.dsts[0]; break; }
-    if (hint) gd = GpuDedup(hint);
+  // Init the GPU rendezvous only once an all-device SG destination shows up:
+  // its first pointer selects the primary context for the arena. Mixed and
+  // host-only SG items use the ordinary transport publication path.
+  const CudaLib* cu = CudaLib::Get();
+  std::vector<char> all_device(items.size(), 0);
+  const void* hint = nullptr;
+  if (cu) {
+    for (size_t i = 0; i < items.size(); ++i) {
+      bool all = !items[i].dsts.empty();
+      for (const void* destination : items[i].dsts) {
+        if (!cu->IsDevicePtr(destination)) all = false;
+      }
+      all_device[i] = all ? 1 : 0;
+      if (all && !hint) hint = items[i].dsts[0];
+    }
   }
+  GpuNodeDedup* gd = hint ? GpuDedup(hint) : nullptr;
   if (!gd || items.empty()) {
     std::vector<size_t> lengths;
     auto result = BatchGetAutoSgDirect(items, &lengths);
@@ -1356,12 +1375,10 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
     if (out_lens) *out_lens = std::move(lengths);
     return RecordBatch(OpMetrics::kGet, t0, std::move(result), bytes);
   }
-  // Same-host rendezvous for GPU destinations (phase 2b, see node_dedup_gpu.h):
-  // the vLLM connector's SG gets land in device memory, where lockstep TP
-  // ranks re-fetch identical TP-replicated KV. Payloads rendezvous through
-  // per-process GPU staging arenas (CUDA IPC + NVLink D2D); every outcome
-  // degrades to the plain remote path.
-  const CudaLib* cu = CudaLib::Get();  // non-null: gd exists
+  // Same-host rendezvous for all-device GPU destinations (phase 2b, see
+  // node_dedup_gpu.h): the vLLM connector's SG lands in device memory, where
+  // lockstep TP ranks re-fetch identical TP-replicated KV. Mixed SG items use
+  // the ordinary staged publication path instead.
   const size_t N = items.size();
   std::vector<bool> res(N, false);
   std::vector<size_t> lens(N, 0);
@@ -1381,12 +1398,11 @@ std::vector<bool> KVClient::BatchGetAutoSg(const std::vector<KvGetItemSg>& items
   for (size_t i = 0; i < N; ++i)
     totals_valid[i] = CheckedSizeSum(items[i].caps, &total_caps[i]) ? 1 : 0;
   for (size_t i = 0; i < N; ++i) {
-    // Eligible = well-shaped AND device-memory destination. Host-destination
-    // SG items (or malformed ones the Direct guard rejects) skip the
-    // rendezvous entirely — an unclaimed fetch has no publish obligation.
+    // Eligible = well-shaped AND entirely device memory. Mixed SG must bypass
+    // GPU rendezvous because its CUDA IPC copier cannot publish host segments.
     const bool eligible = !items[i].key.empty() && !items[i].dsts.empty() &&
                           items[i].dsts.size() == items[i].caps.size() &&
-                          totals_valid[i] && cu->IsDevicePtr(items[i].dsts[0]);
+                          totals_valid[i] && all_device[i];
     if (!eligible) {
       fetch_map.push_back(i);
       fetch_items.push_back(items[i]);
@@ -1539,7 +1555,9 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         RangeDstMulti d;
         d.payloads.reserve(items[k].dsts.size());
         for (size_t j = 0; j < items[k].dsts.size(); ++j)
-          d.payloads.emplace_back(items[k].dsts[j], items[k].caps[j]);
+          d.payloads.emplace_back(
+              items[k].dsts[j], items[k].caps[j],
+              ClassifyDestination(items[k].dsts[j]));
         dsts.push_back(std::move(d));
       }
       std::vector<size_t> value_lens;

--- a/src/client/kv_client.h
+++ b/src/client/kv_client.h
@@ -8,11 +8,13 @@
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -135,9 +137,7 @@ class KVClient {
   // for zero-copy transfer, so Put/Get resolve every covered buffer to the
   // pre-registered pool MR. Returns false when RDMA cannot register the full
   // range; copying transports such as TCP return true without work.
-  bool RegisterMemory(void* base, size_t size) {
-    return t_->RegisterMemory(base, size);
-  }
+  bool RegisterMemory(void* base, size_t size);
 
   // Runtime payload-segment width of one transport window. Logical SG calls may
   // exceed it: the transport splits them into one ordered operation internally.
@@ -218,6 +218,8 @@ class KVClient {
   bool ExistDirect(const std::string& key, Status* status);
   bool RemoveDirect(const std::string& key);
   void InvalidateRendezvous(const BlockKey& key);
+  DestinationMemoryKind ClassifyDestination(const void* destination,
+                                             size_t size) const;
 
   // Plain batch bodies; public methods own the one metric record across direct
   // and rendezvous paths.
@@ -236,6 +238,16 @@ class KVClient {
                                 std::chrono::steady_clock::time_point t0,
                                 std::vector<bool> flags, uint64_t bytes);
 
+  struct RegisteredMemoryRange {
+    uintptr_t base;
+    uintptr_t end;  // exclusive
+    DestinationMemoryKind kind;
+  };
+  // RegisterMemory is rare; GET classification takes only this shared lock and
+  // scans the small declaration list without allocating. Newer overlapping
+  // declarations win, matching a successful same-base growth deterministically.
+  mutable std::shared_mutex registered_memory_mu_;
+  std::vector<RegisteredMemoryRange> registered_memory_;
   mutable std::mutex ring_mu_;  // guards ring_ + addr_
   ConHash ring_;
   std::map<std::string, std::string> addr_;  // name -> ip:port

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -2629,11 +2629,21 @@ std::vector<Status> RdmaTransport::RangeInto(
       }
     }
     if (conn_ok) {
+      DestinationPublisher publisher;
       for (size_t i = 0; i < count; ++i) {
-        if (result[i] == Status::kOk && attempt_data_lens[i] != 0) {
-          std::memcpy(destinations[i].payload, attempt_outputs[i].data(),
-                      static_cast<size_t>(attempt_data_lens[i]));
-        }
+        if (result[i] == Status::kOk && attempt_data_lens[i] != 0 &&
+            !publisher.Copy(destinations[i].payload,
+                            attempt_outputs[i].data(),
+                            static_cast<size_t>(attempt_data_lens[i]),
+                            destinations[i].memory_kind))
+          result[i] = Status::kIOError;
+      }
+      if (!publisher.Finish()) {
+        for (size_t i = 0; i < count; ++i)
+          if (result[i] == Status::kOk &&
+              destinations[i].memory_kind ==
+                  DestinationMemoryKind::kDevice)
+            result[i] = Status::kIOError;
       }
       if (value_lens) *value_lens = std::move(attempt_value_lens);
       Release(node, Lane::kData, conn);
@@ -3216,6 +3226,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     }
 
     if (conn_ok) {
+      DestinationPublisher publisher;
       for (size_t i = 0; i < count; ++i) {
         if (result[i] != Status::kOk) continue;
         size_t copied = 0;
@@ -3223,10 +3234,26 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
           const size_t remaining = staged_out_lengths[i] - copied;
           const size_t n = std::min(payload.second, remaining);
           if (n != 0) {
-            std::memcpy(payload.first, staged_outputs[i].data() + copied, n);
+            if (!publisher.Copy(payload.first,
+                                staged_outputs[i].data() + copied, n,
+                                payload.memory_kind))
+              result[i] = Status::kIOError;
             copied += n;
           }
           if (copied == staged_out_lengths[i]) break;
+        }
+      }
+      if (!publisher.Finish()) {
+        for (size_t i = 0; i < count; ++i) {
+          const bool has_device = std::any_of(
+              destinations[i].payloads.begin(),
+              destinations[i].payloads.end(),
+              [](const RangeDstSegment& segment) {
+                return segment.memory_kind ==
+                       DestinationMemoryKind::kDevice;
+              });
+          if (has_device && result[i] == Status::kOk)
+            result[i] = Status::kIOError;
         }
       }
       if (out_lengths) *out_lengths = staged_out_lengths;

--- a/src/transport/tcp_transport.cc
+++ b/src/transport/tcp_transport.cc
@@ -357,6 +357,12 @@ std::vector<Status> TcpTransport::RangeInto(
   if (keys.size() != dsts.size())
     return std::vector<Status>(keys.size(), Status::kInvalid);
   if (value_lens) value_lens->assign(keys.size(), 0);
+  const bool has_device =
+      std::any_of(dsts.begin(), dsts.end(), [](const RangeDst& dst) {
+        return dst.memory_kind == DestinationMemoryKind::kDevice;
+      });
+  if (has_device)
+    return Transport::RangeInto(node, keys, dsts, value_lens);
   std::vector<Status> statuses;
   statuses.reserve(keys.size());
   for (size_t i = 0; i < keys.size(); ++i) {

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -32,11 +32,22 @@ inline std::vector<Status> InvalidStatuses(size_t count) {
 }
 
 
+enum class DestinationMemoryKind : uint8_t {
+  kHost,
+  kDevice,
+};
+
+// One read target. The memory kind is explicit because a CUDA device virtual
+// address must never be passed to a CPU memcpy. Host is the compatibility
+// default for existing transports and string-backed callers.
+struct RangeDst {
+  void* payload;
+  size_t n;
+  DestinationMemoryKind memory_kind = DestinationMemoryKind::kHost;
+};
+
 // One write in a batch (data must outlive the CacheMany call).
 struct CacheItem { BlockKey key; const void* data; size_t len; };
-// One zero-copy read target: up to `n` bytes are written into `payload`.
-// The authoritative stored length is returned separately by the read call.
-struct RangeDst { void* payload; size_t n; };
 // One zero-copy write source. The raw value is gathered directly from payload.
 // The buffer must outlive CacheFrom and remain unmodified until it returns.
 struct CacheSrc {
@@ -51,11 +62,44 @@ struct CacheSrcMulti {
   BlockKey key;
   std::vector<std::pair<const void*, size_t>> payloads;
 };
+struct RangeDstSegment {
+  RangeDstSegment(
+      void* payload_in, size_t size_in,
+      DestinationMemoryKind memory_kind_in = DestinationMemoryKind::kHost)
+      : first(payload_in), second(size_in), memory_kind(memory_kind_in) {}
+
+  void* first;
+  size_t second;
+  DestinationMemoryKind memory_kind;
+};
 // Scatter-gather read target: the stored payload (one concatenated blob) is
 // scattered across N caller buffers in order, each receiving its own size worth
-// of bytes (RDMA multi-SGE RECV). The destination capacity = sum of segment sizes.
+// of bytes. The destination capacity is the sum of segment sizes.
 struct RangeDstMulti {
-  std::vector<std::pair<void*, size_t>> payloads;  // (ptr, size) in order
+  std::vector<RangeDstSegment> payloads;
+};
+
+// Publishes operation-owned host staging into caller destinations. Host copies
+// are direct and do not touch CUDA. The first device copy lazily binds its
+// destination primary context and creates one nonblocking stream; Finish waits
+// once for every enqueued device copy before destroying that stream.
+class DestinationPublisher {
+ public:
+  DestinationPublisher() = default;
+  ~DestinationPublisher();
+  DestinationPublisher(const DestinationPublisher&) = delete;
+  DestinationPublisher& operator=(const DestinationPublisher&) = delete;
+
+  bool Copy(void* destination, const void* source, size_t size,
+            DestinationMemoryKind memory_kind);
+  bool Finish();
+
+ private:
+  const void* cuda_ = nullptr;
+  void* stream_ = nullptr;
+  int device_ = -1;
+  bool failed_ = false;
+  bool finished_ = false;
 };
 // Common per-endpoint connection-pool policy. A transport may ignore it when
 // its connection lifecycle is protocol-defined, but pooled transports use the
@@ -237,9 +281,9 @@ class Transport {
     return r;
   }
 
-  // Zero-copy read: up to dsts[i].n raw stored bytes land directly in
-  // dsts[i].payload. value_lens[i] is the authoritative full stored size.
-  // Default: Range + copy; RDMA overrides with direct writes.
+  // Read into caller-provided host or CUDA destinations. value_lens[i] is the
+  // authoritative full stored size. The default uses Range plus final
+  // publication; RDMA overrides while retaining the same publication contract.
   virtual std::vector<Status> RangeInto(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDst>& dsts,
@@ -247,16 +291,47 @@ class Transport {
     if (value_lens) value_lens->assign(keys.size(), 0);
     if (dsts.size() != keys.size()) return InvalidStatuses(keys.size());
     std::vector<Status> r(keys.size(), Status::kInvalid);
+    const bool has_device =
+        std::any_of(dsts.begin(), dsts.end(), [](const RangeDst& dst) {
+          return dst.memory_kind == DestinationMemoryKind::kDevice;
+        });
+    if (!has_device) {
+      for (size_t i = 0; i < keys.size(); ++i) {
+        if (!ValidBuffer(dsts[i].payload, dsts[i].n)) continue;
+        std::string raw;
+        uint64_t stored = 0;
+        Status st = Range(node, keys[i], 0, dsts[i].n, &raw, &stored);
+        r[i] = st;
+        if (value_lens) (*value_lens)[i] = stored;
+        if (st != Status::kOk) continue;
+        const size_t n = std::min(raw.size(), dsts[i].n);
+        if (n) std::memcpy(dsts[i].payload, raw.data(), n);
+      }
+      return r;
+    }
+
+    // Device copies are asynchronous until the one Finish below, so every
+    // Range result must remain alive for the entire publication.
+    std::vector<std::string> raw_values(keys.size());
+    DestinationPublisher publisher;
     for (size_t i = 0; i < keys.size(); ++i) {
       if (!ValidBuffer(dsts[i].payload, dsts[i].n)) continue;
-      std::string raw;
       uint64_t stored = 0;
-      Status st = Range(node, keys[i], 0, dsts[i].n, &raw, &stored);
+      Status st =
+          Range(node, keys[i], 0, dsts[i].n, &raw_values[i], &stored);
       r[i] = st;
       if (value_lens) (*value_lens)[i] = stored;
       if (st != Status::kOk) continue;
-      size_t n = std::min(raw.size(), dsts[i].n);
-      if (n) std::memcpy(dsts[i].payload, raw.data(), n);
+      const size_t n = std::min(raw_values[i].size(), dsts[i].n);
+      if (n && !publisher.Copy(dsts[i].payload, raw_values[i].data(), n,
+                               dsts[i].memory_kind))
+        r[i] = Status::kIOError;
+    }
+    if (!publisher.Finish()) {
+      for (size_t i = 0; i < dsts.size(); ++i)
+        if (r[i] == Status::kOk &&
+            dsts[i].memory_kind == DestinationMemoryKind::kDevice)
+          r[i] = Status::kIOError;
     }
     return r;
   }
@@ -314,11 +389,11 @@ class Transport {
   }
 
   // Scatter-gather read: raw stored bytes are split across each key's caller
-  // buffers in order. The default implementation reads once into a contiguous
-  // scratch value and split-copies it, so every transport is correct without
-  // scatter support. RDMA overrides this with a multi-SGE receive directly into
-  // registered destinations. out_lens[i] is the authoritative stored length
-  // (zero on miss), independent of destination capacity.
+  // buffers in order. The default reads once into contiguous operation-owned
+  // scratch and publishes each segment. RDMA uses registered operation-owned
+  // staging so retries and failed completions can never mutate caller memory.
+  // out_lens[i] is the authoritative stored length (zero on miss), independent
+  // of destination capacity.
   virtual std::vector<Status> RangeIntoMulti(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
@@ -355,6 +430,7 @@ class Transport {
     }
     std::vector<uint64_t> stored;
     const auto valid_result = RangeInto(node, valid_keys, flat, &stored);
+    DestinationPublisher publisher;
     for (size_t valid_i = 0;
          valid_i < indices.size() && valid_i < valid_result.size(); ++valid_i) {
       const size_t i = indices[valid_i];
@@ -369,15 +445,30 @@ class Transport {
         result[i] = Status::kInvalid;
         continue;
       }
+      if (out_lens)
+        (*out_lens)[i] = static_cast<size_t>(stored[valid_i]);
       size_t remaining = static_cast<size_t>(stored[valid_i]);
       size_t off = 0;
       for (const auto& p : dsts[i].payloads) {
         const size_t copy = std::min(p.second, remaining);
-        if (copy) std::memcpy(p.first, scratch[i].data() + off, copy);
+        if (copy &&
+            !publisher.Copy(p.first, scratch[i].data() + off, copy,
+                            p.memory_kind))
+          result[i] = Status::kIOError;
         off += copy;
         remaining -= copy;
       }
-      if (out_lens) (*out_lens)[i] = static_cast<size_t>(stored[valid_i]);
+    }
+    if (!publisher.Finish()) {
+      for (size_t i : indices) {
+        const bool has_device = std::any_of(
+            dsts[i].payloads.begin(), dsts[i].payloads.end(),
+            [](const RangeDstSegment& segment) {
+              return segment.memory_kind == DestinationMemoryKind::kDevice;
+            });
+        if (has_device && result[i] == Status::kOk)
+          result[i] = Status::kIOError;
+      }
     }
     return result;
   }

--- a/test/client/get_auto_pipelined_test.cc
+++ b/test/client/get_auto_pipelined_test.cc
@@ -8,6 +8,7 @@
 #include "client/key_map.h"
 
 #include <gtest/gtest.h>
+#include <limits>
 #include <cstring>
 #include <map>
 #include <string>
@@ -23,6 +24,14 @@ struct FakePipelinedTransport : Transport {
   std::map<std::string, std::string> blobs;  // key.Filename() -> payload
   std::string dead;
   int range_calls = 0, rangeinto_calls = 0;
+  std::vector<DestinationMemoryKind> last_range_kinds;
+  std::vector<std::vector<DestinationMemoryKind>> last_multi_kinds;
+  int register_calls = 0;
+
+  bool RegisterMemory(void*, size_t) override {
+    ++register_calls;
+    return true;
+  }
 
   bool pipelined() const override { return true; }
 
@@ -50,6 +59,10 @@ struct FakePipelinedTransport : Transport {
                                 const std::vector<RangeDst>& dsts,
                                 std::vector<uint64_t>* value_lens) override {
     ++rangeinto_calls;
+    last_range_kinds.clear();
+    last_range_kinds.reserve(dsts.size());
+    for (const auto& dst : dsts)
+      last_range_kinds.push_back(dst.memory_kind);
     value_lens->assign(keys.size(), 0);
     std::vector<Status> r(keys.size(), Status::kNotFound);
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -64,6 +77,38 @@ struct FakePipelinedTransport : Transport {
       r[i] = Status::kOk;
     }
     return r;
+  }
+
+  std::vector<Status> RangeIntoMulti(
+      const std::string&, const std::vector<BlockKey>& keys,
+      const std::vector<RangeDstMulti>& dsts,
+      std::vector<size_t>* value_lens) override {
+    value_lens->assign(keys.size(), 0);
+    last_multi_kinds.clear();
+    last_multi_kinds.reserve(dsts.size());
+    std::vector<Status> result(keys.size(), Status::kNotFound);
+    for (size_t i = 0; i < keys.size(); ++i) {
+      std::vector<DestinationMemoryKind> kinds;
+      kinds.reserve(dsts[i].payloads.size());
+      for (const auto& segment : dsts[i].payloads)
+        kinds.push_back(segment.memory_kind);
+      last_multi_kinds.push_back(std::move(kinds));
+
+      auto it = blobs.find(keys[i].Filename());
+      if (it == blobs.end()) continue;
+      (*value_lens)[i] = it->second.size();
+      size_t offset = 0;
+      for (const auto& segment : dsts[i].payloads) {
+        const size_t copy =
+            std::min(segment.second, it->second.size() - offset);
+        if (copy)
+          std::memcpy(segment.first, it->second.data() + offset, copy);
+        offset += copy;
+        if (offset == it->second.size()) break;
+      }
+      result[i] = Status::kOk;
+    }
+    return result;
   }
 };
 
@@ -140,4 +185,45 @@ TEST(GetAutoPipelined, MissReturnsFalse) {
   EXPECT_FALSE(c.GetAuto("absent", buf.data(), buf.size(), &got));
   std::string s;
   EXPECT_FALSE(c.GetAuto("absent", &s, 64));
+}
+
+TEST(GetAutoPipelined, RegisteredHostSubrangesClassifyWithoutCudaOnGet) {
+  FakePipelinedTransport t;
+  KVClient c = MakeClient(&t);
+  std::vector<char> pool(4096, '\0');
+  ASSERT_TRUE(c.RegisterMemory(pool.data(), 1024));
+  ASSERT_TRUE(c.RegisterMemory(pool.data(), pool.size()));
+  ASSERT_EQ(t.register_calls, 2);
+
+  ASSERT_TRUE(c.RegisterMemory(pool.data() + 512, 1024));
+  ASSERT_EQ(t.register_calls, 3);
+  const uintptr_t address = reinterpret_cast<uintptr_t>(pool.data());
+  const size_t wrapping_size =
+      std::numeric_limits<uintptr_t>::max() - address + 1;
+  EXPECT_FALSE(c.RegisterMemory(pool.data(), wrapping_size));
+  EXPECT_EQ(t.register_calls, 3);
+  const std::string scalar_value(127, 's');
+  t.blobs[ToBlockKey("test/model", "registered-scalar").Filename()] =
+      scalar_value;
+  size_t got = 0;
+  char* const scalar_destination = pool.data() + 777;
+  ASSERT_TRUE(c.GetAuto("registered-scalar", scalar_destination,
+                        scalar_value.size(), &got));
+  EXPECT_EQ(got, scalar_value.size());
+  ASSERT_EQ(t.last_range_kinds.size(), 1);
+  EXPECT_EQ(t.last_range_kinds[0], DestinationMemoryKind::kHost);
+
+  const std::string sg_value = "registered-host-scatter-gather";
+  t.blobs[ToBlockKey("test/model", "registered-sg").Filename()] = sg_value;
+  KvGetItemSg item;
+  item.key = "registered-sg";
+  item.dsts = {pool.data() + 31, pool.data() + 503, pool.data() + 2049};
+  item.caps = {5, 9, sg_value.size() - 14};
+  std::vector<size_t> lengths;
+  ASSERT_EQ(c.BatchGetAutoSg({item}, &lengths), std::vector<bool>({true}));
+  ASSERT_EQ(lengths, std::vector<size_t>({sg_value.size()}));
+  ASSERT_EQ(t.last_multi_kinds.size(), 1);
+  EXPECT_EQ(t.last_multi_kinds[0],
+            std::vector<DestinationMemoryKind>(
+                3, DestinationMemoryKind::kHost));
 }

--- a/test/transport/connection_pool_test.cc
+++ b/test/transport/connection_pool_test.cc
@@ -105,6 +105,56 @@ TEST(ConnectionPool, CorrectnessAcrossManyKeys) {
   n->srv->Stop();
 }
 
+TEST(ConnectionPool, DeviceDestinationsUseStagedPublication) {
+  auto n = Start("device_destination");
+  TcpTransport t;
+  const BlockKey key = ToBlockKey("test/model", "device_destination");
+  const std::string value = "abcdefgh";
+  ASSERT_EQ(t.Cache(n->addr, key, value.data(), value.size()), Status::kOk);
+  const uint64_t accepts = n->srv->AcceptCount();
+
+  std::string device_destination(value.size(), '!');
+  std::vector<uint64_t> value_lengths;
+  const auto device_status = t.RangeInto(
+      n->addr, {key},
+      {RangeDst{device_destination.data(), device_destination.size(),
+                DestinationMemoryKind::kDevice}},
+      &value_lengths);
+  ASSERT_EQ(device_status.size(), 1u);
+  EXPECT_EQ(device_status[0], Status::kIOError);
+  ASSERT_EQ(value_lengths.size(), 1u);
+  EXPECT_EQ(value_lengths[0], value.size());
+  EXPECT_EQ(device_destination, std::string(value.size(), '!'));
+
+  std::string host_segment(3, '!');
+  std::string device_segment(value.size() - host_segment.size(), '!');
+  const RangeDstMulti mixed_destination{{
+      RangeDstSegment{host_segment.data(), host_segment.size()},
+      RangeDstSegment{device_segment.data(), device_segment.size(),
+                      DestinationMemoryKind::kDevice},
+  }};
+  std::vector<size_t> out_lengths;
+  const auto mixed_status =
+      t.RangeIntoMulti(n->addr, {key}, {mixed_destination}, &out_lengths);
+  ASSERT_EQ(mixed_status.size(), 1u);
+  EXPECT_EQ(mixed_status[0], Status::kIOError);
+  ASSERT_EQ(out_lengths.size(), 1u);
+  EXPECT_EQ(out_lengths[0], value.size());
+  EXPECT_EQ(host_segment, value.substr(0, host_segment.size()));
+  EXPECT_EQ(device_segment, std::string(device_segment.size(), '!'));
+
+  std::string host_destination(value.size(), '!');
+  const auto host_status = t.RangeInto(
+      n->addr, {key},
+      {RangeDst{host_destination.data(), host_destination.size()}},
+      &value_lengths);
+  ASSERT_EQ(host_status.size(), 1u);
+  EXPECT_EQ(host_status[0], Status::kOk);
+  EXPECT_EQ(host_destination, value);
+  EXPECT_EQ(n->srv->AcceptCount(), accepts);
+  n->srv->Stop();
+}
+
 TEST(ConnectionPool, SurvivesStalePooledConnection) {
   // Put via transport, restart the server (old pooled fd is now stale), then a
   // new request must transparently reconnect (retry once) — not hard-fail.

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -5,6 +5,7 @@
 // no RDMA device is present. Built only when DFKV_WITH_RDMA is defined. Run under
 // ThreadSanitizer to exercise the worker-pool / QP concurrency.
 #include "client/kv_client.h"
+#include "client/cuda_ipc.h"
 #include "client/node_dedup.h"
 #include "client/key_map.h"
 #include "cache/kv_node_server.h"
@@ -374,6 +375,76 @@ struct FakePoolRail {
     return offset <= declared && length <= declared - offset;
   }
 };
+
+std::string CudaTestBytes(size_t size, uint8_t seed) {
+  std::string bytes(size, '\0');
+  for (size_t i = 0; i < size; ++i) {
+    bytes[i] = static_cast<char>(
+        (static_cast<unsigned>(seed) + 131u * i + 17u * (i >> 3)) & 0xffu);
+  }
+  return bytes;
+}
+
+// CUDA allocation with sentinels on both sides of the caller-visible range.
+// Upload/download use the dlopen'd driver surface, so this test binary needs
+// neither CUDA headers nor a link-time dependency on libcuda.
+class CudaGuardedBuffer {
+ public:
+  static constexpr size_t kGuardBytes = 37;
+  static constexpr uint8_t kGuardByte = 0xa7;
+
+  CudaGuardedBuffer(const CudaLib* cuda, size_t payload_size)
+      : cuda_(cuda), payload_size_(payload_size) {}
+  ~CudaGuardedBuffer() {
+    if (base_) cuda_->MemFree(base_);
+  }
+
+  bool Allocate() {
+    if (cuda_->MemAlloc(&base_, payload_size_ + 2 * kGuardBytes) !=
+        kCudaSuccess) {
+      base_ = 0;
+      return false;
+    }
+    const std::string initial(payload_size_ + 2 * kGuardBytes,
+                              static_cast<char>(kGuardByte));
+    return cuda_->Memcpy(base_,
+                         reinterpret_cast<CUdeviceptr>(initial.data()),
+                         initial.size()) == kCudaSuccess;
+  }
+
+  void* payload() const {
+    return reinterpret_cast<void*>(base_ + kGuardBytes);
+  }
+
+  bool ReadPayload(std::string* out) const {
+    out->assign(payload_size_, '\0');
+    return cuda_->Memcpy(reinterpret_cast<CUdeviceptr>(out->data()),
+                         base_ + kGuardBytes, payload_size_) == kCudaSuccess;
+  }
+
+  bool GuardsIntact() const {
+    std::string allocation(payload_size_ + 2 * kGuardBytes, '\0');
+    if (cuda_->Memcpy(reinterpret_cast<CUdeviceptr>(allocation.data()), base_,
+                      allocation.size()) != kCudaSuccess) {
+      return false;
+    }
+    const std::string guard(kGuardBytes, static_cast<char>(kGuardByte));
+    return allocation.compare(0, kGuardBytes, guard) == 0 &&
+           allocation.compare(kGuardBytes + payload_size_, kGuardBytes,
+                              guard) == 0;
+  }
+
+ private:
+  const CudaLib* cuda_;
+  size_t payload_size_;
+  CUdeviceptr base_ = 0;
+};
+
+const CudaLib* ActiveCudaForTest() {
+  const CudaLib* cuda = CudaLib::Get();
+  if (!cuda || !cuda->BindPrimaryCtx(0)) return nullptr;
+  return cuda;
+}
 
 }  // namespace
 
@@ -2868,6 +2939,117 @@ TEST(RdmaLoopback, DefaultDeclarationKeepsGlobalCap) {
   EXPECT_EQ(got, v);
 }
 
+TEST(RdmaLoopback, ScalarGetPublishesExactBytesToGuardedCudaDestination) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  const CudaLib* cuda = ActiveCudaForTest();
+  if (!cuda) GTEST_SKIP() << "no usable CUDA device";
+  ScopedEnv host_dedup("DFKV_CLIENT_NODE_DEDUP", nullptr);
+  ScopedEnv gpu_dedup("DFKV_CLIENT_NODE_DEDUP_GPU", nullptr);
+  ScopedEnv completion_fault("DFKV_RDMA_TEST_COMPLETION_FAULT", nullptr);
+  ScopedEnv endpoint_fault("DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT",
+                           nullptr);
+  ScopedEnv local_failure("DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS",
+                          nullptr);
+
+  RdmaNode node("cuda-scalar-get");
+  RdmaTransport transport(kMaxMsg);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  const std::string value = CudaTestBytes(8197, 0x31);
+  ASSERT_TRUE(client.Put("cuda-scalar", value.data(), value.size()));
+
+  CudaGuardedBuffer destination(cuda, value.size());
+  ASSERT_TRUE(destination.Allocate());
+  ASSERT_TRUE(cuda->IsDevicePtr(destination.payload()));
+  ASSERT_TRUE(client.Get("cuda-scalar", destination.payload(), value.size()));
+
+  // Read back immediately after Get returns. The API contract is synchronous:
+  // its private nonblocking CUDA stream must already be synchronized here.
+  std::string actual;
+  ASSERT_TRUE(destination.ReadPayload(&actual));
+  EXPECT_EQ(actual, value);
+  EXPECT_TRUE(destination.GuardsIntact());
+}
+
+TEST(RdmaLoopback,
+     MultiSegmentGetPublishesUnequalExactBytesToGuardedCudaDestinations) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  const CudaLib* cuda = ActiveCudaForTest();
+  if (!cuda) GTEST_SKIP() << "no usable CUDA device";
+  ScopedEnv host_dedup("DFKV_CLIENT_NODE_DEDUP", nullptr);
+  ScopedEnv gpu_dedup("DFKV_CLIENT_NODE_DEDUP_GPU", nullptr);
+  ScopedEnv completion_fault("DFKV_RDMA_TEST_COMPLETION_FAULT", nullptr);
+  ScopedEnv endpoint_fault("DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT",
+                           nullptr);
+  ScopedEnv local_failure("DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS",
+                          nullptr);
+
+  // Host first is deliberate: treating the whole SG item as host from its
+  // first segment crashes on the following CUDA pointer. The remaining three
+  // CUDA segments have unequal, odd capacities and independent guards.
+  constexpr std::array<size_t, 4> kSegmentSizes{613, 997, 2051, 4099};
+  const size_t total = kSegmentSizes[0] + kSegmentSizes[1] +
+                       kSegmentSizes[2] + kSegmentSizes[3];
+  const std::string value = CudaTestBytes(total, 0x6d);
+
+  RdmaNode node("cuda-multisegment-get");
+  RdmaTransport transport(kMaxMsg);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  ASSERT_TRUE(client.Put("cuda-multisegment", value.data(), value.size()));
+
+  const std::string host_guard(
+      CudaGuardedBuffer::kGuardBytes,
+      static_cast<char>(CudaGuardedBuffer::kGuardByte));
+  std::string host_allocation(
+      kSegmentSizes[0] + 2 * CudaGuardedBuffer::kGuardBytes,
+      static_cast<char>(CudaGuardedBuffer::kGuardByte));
+  char* const host_payload =
+      host_allocation.data() + CudaGuardedBuffer::kGuardBytes;
+
+  std::array<std::unique_ptr<CudaGuardedBuffer>, 3> device_buffers;
+  KvGetItemSg get;
+  get.key = "cuda-multisegment";
+  get.dsts.push_back(host_payload);
+  get.caps.push_back(kSegmentSizes[0]);
+  for (size_t i = 0; i < device_buffers.size(); ++i) {
+    const size_t segment = i + 1;
+    device_buffers[i] =
+        std::make_unique<CudaGuardedBuffer>(cuda, kSegmentSizes[segment]);
+    ASSERT_TRUE(device_buffers[i]->Allocate()) << "segment " << segment;
+    ASSERT_TRUE(cuda->IsDevicePtr(device_buffers[i]->payload()))
+        << "segment " << segment;
+    get.dsts.push_back(device_buffers[i]->payload());
+    get.caps.push_back(kSegmentSizes[segment]);
+  }
+
+  std::vector<size_t> lengths;
+  ASSERT_EQ(client.BatchGetAutoSg({get}, &lengths),
+            std::vector<bool>({true}));
+  ASSERT_EQ(lengths, std::vector<size_t>({value.size()}));
+
+  // Every immediate read observes API-return state. Odd, unequal boundaries
+  // expose word-sized over-copy, and host-first ordering proves memory kind is
+  // classified per segment rather than once per SG item.
+  EXPECT_EQ(std::string(host_payload, kSegmentSizes[0]),
+            value.substr(0, kSegmentSizes[0]));
+  EXPECT_EQ(host_allocation.substr(0, CudaGuardedBuffer::kGuardBytes),
+            host_guard);
+  EXPECT_EQ(host_allocation.substr(CudaGuardedBuffer::kGuardBytes +
+                                   kSegmentSizes[0]),
+            host_guard);
+  size_t offset = kSegmentSizes[0];
+  for (size_t i = 0; i < device_buffers.size(); ++i) {
+    const size_t segment = i + 1;
+    std::string actual;
+    ASSERT_TRUE(device_buffers[i]->ReadPayload(&actual))
+        << "segment " << segment;
+    EXPECT_EQ(actual, value.substr(offset, kSegmentSizes[segment]))
+        << "segment " << segment;
+    EXPECT_TRUE(device_buffers[i]->GuardsIntact())
+        << "segment " << segment;
+    offset += kSegmentSizes[segment];
+  }
+}
+
 TEST(RdmaLoopback,
      PooledPostSubmitFailureDoesNotReplayPutAndGetRemainsReplaySafe) {
   ScopedEnv configured_device("DFKV_RDMA_DEV", nullptr);
@@ -3112,6 +3294,82 @@ TEST(RdmaLoopback, ClientLocalRailFailureRetriesFreshPutAndGet) {
                        "dfkv_rdma_client_stale_pool_retries_total"),
             get_stale_before)
       << "a local-rail failure is not a stale-endpoint retry";
+}
+
+TEST(RdmaLoopback,
+     ReplaySafeTwoRailRetryPublishesExactBytesToCudaDestination) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two active devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  const CudaLib* cuda = ActiveCudaForTest();
+  if (!cuda) GTEST_SKIP() << "no usable CUDA device";
+
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  ScopedEnv ambient_completion_fault("DFKV_RDMA_TEST_COMPLETION_FAULT",
+                                     nullptr);
+  ScopedEnv ambient_endpoint_fault(
+      "DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", nullptr);
+  ScopedEnv ambient_local_failure(
+      "DFKV_RDMA_TEST_LOCAL_RAIL_FAILURE_ATTEMPTS", nullptr);
+  ScopedEnv host_dedup("DFKV_CLIENT_NODE_DEDUP", nullptr);
+  ScopedEnv gpu_dedup("DFKV_CLIENT_NODE_DEDUP_GPU", nullptr);
+
+  RdmaNode node("cuda-cross-rail-get");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  const std::string value = CudaTestBytes(64 * 1024 + 3, 0x93);
+  ASSERT_TRUE(client.Put("cuda-cross-rail", value.data(), value.size()));
+
+  CudaGuardedBuffer destination(cuda, value.size());
+  ASSERT_TRUE(destination.Allocate());
+  ASSERT_TRUE(cuda->IsDevicePtr(destination.payload()));
+  const std::string before = transport.MetricsText();
+  const long stale_before =
+      CounterVal(before, "dfkv_rdma_client_stale_pool_retries_total");
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1");
+    ASSERT_TRUE(client.Get("cuda-cross-rail", destination.payload(),
+                           value.size()));
+  }
+
+  // Successful return is the publication fence: readback must need no
+  // application-side stream synchronization.
+  std::string actual;
+  ASSERT_TRUE(destination.ReadPayload(&actual));
+  EXPECT_EQ(actual, value);
+  EXPECT_TRUE(destination.GuardsIntact());
+
+  const std::string after = transport.MetricsText();
+  ExpectTwoDistinctRailAttempts(before, after, rails, 1);
+  ExpectReleasedRailResources(before, after, rails);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_v2_get_writes_total") -
+          CounterVal(before, "dfkv_rdma_client_v2_get_writes_total"),
+      2);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
+          CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_successes_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_successes_total"),
+      1);
+  EXPECT_EQ(
+      CounterVal(after,
+                 "dfkv_rdma_client_cross_rail_retry_exhausted_total") -
+          CounterVal(before,
+                     "dfkv_rdma_client_cross_rail_retry_exhausted_total"),
+      0);
+  EXPECT_EQ(
+      CounterVal(after, "dfkv_rdma_client_stale_pool_retries_total"),
+      stale_before);
 }
 
 TEST(RdmaLoopback, SingleEnabledRailFallbackIsNotCrossRailRetry) {


### PR DESCRIPTION
## Problem
v2.19.0 RangeInto/RangeIntoMulti can treat a CUDA device pointer as host memory after RDMA completion, causing SIGSEGV/coredump in vLLM KV-cache GET. Retry publication also needs operation-owned staging and exact completion fencing.

## Fix
- classify scalar, batch, and SG destination memory explicitly
- stage GET results in operation-owned host memory and publish to CUDA only after final successful completion
- use synchronized CUDA H2D publication with process-wide overlapping pinned-page registration leases
- preserve host fast paths and cache successful RegisterMemory destination kinds
- route TCP device destinations through the staged base implementation
- add scalar, mixed-SG, and two-rail replay-safe CUDA regressions

## Evidence
- upstream v2.19.0 scalar CUDA regression exits 139 on xb01-0064 B200
- candidate scalar, unequal mixed SG, and replay-safe two-rail CUDA tests: 3/3 passed across 3 repeats
- host 1 MiB GET benchmark: v2.19.0 4.31 GB/s; candidate 4.29 GB/s
- local ctest: 764 cases, no failures; hardware/integration cases skip when unavailable
- final independent review: no P0-P2 blockers

Only xb01-0064 was used for hardware validation.