### PR TITLE
fix(rdma): write GETs directly into caller buffers; fence retries by QP teardown

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -2522,15 +2522,9 @@ std::vector<Status> RdmaTransport::RangeInto(
     completion_fault.BeginAttempt(attempt);
     final_timeout = false;
     std::fill(result.begin(), result.end(), Status::kIOError);
-    std::vector<std::vector<char>> attempt_outputs(count);
-    std::vector<uint64_t> attempt_data_lens(count, 0);
     std::vector<uint64_t> attempt_value_lens(count, 0);
     for (size_t i = 0; i < count; ++i) {
-      if (bad[i]) {
-        result[i] = Status::kInvalid;
-      } else {
-        attempt_outputs[i].resize(destinations[i].n);
-      }
+      if (bad[i]) result[i] = Status::kInvalid;
     }
     AcquireOptions options;
     options.force_new = attempt != 0;
@@ -2569,10 +2563,13 @@ std::vector<Status> RdmaTransport::RangeInto(
         const size_t item_index = base + slot;
         if (bad[item_index]) continue;
         const RangeDst& destination = destinations[item_index];
-        std::vector<char>& output = attempt_outputs[item_index];
+        // Server DMA lands directly in the caller buffer (GPUDirect when it is
+        // device memory; a host bounce here would fault on CUDA pointers).
+        // Rail-retry fencing comes from Destroy(conn) below: tearing down the
+        // QP drops in-flight remote writes before the next attempt reposts.
         if (destination.n != 0) {
           output_mrs[slot] =
-              ep.RegisterTransient(output.data(), output.size());
+              ep.RegisterTransient(destination.payload, destination.n);
           if (!output_mrs[slot]) {
             conn_ok = false;
             break;
@@ -2581,7 +2578,7 @@ std::vector<Status> RdmaTransport::RangeInto(
         std::vector<RdmaWriteTarget> targets;
         if (destination.n != 0) {
           targets.push_back(
-              {reinterpret_cast<uint64_t>(output.data()),
+              {reinterpret_cast<uint64_t>(destination.payload),
                output_mrs[slot]->rkey,
                static_cast<uint32_t>(destination.n)});
         }
@@ -2624,27 +2621,10 @@ std::vector<Status> RdmaTransport::RangeInto(
           break;
         }
         result[item_index] = status;
-        attempt_data_lens[item_index] = data_len;
         attempt_value_lens[item_index] = value_len;
       }
     }
     if (conn_ok) {
-      DestinationPublisher publisher;
-      for (size_t i = 0; i < count; ++i) {
-        if (result[i] == Status::kOk && attempt_data_lens[i] != 0 &&
-            !publisher.Copy(destinations[i].payload,
-                            attempt_outputs[i].data(),
-                            static_cast<size_t>(attempt_data_lens[i]),
-                            destinations[i].memory_kind))
-          result[i] = Status::kIOError;
-      }
-      if (!publisher.Finish()) {
-        for (size_t i = 0; i < count; ++i)
-          if (result[i] == Status::kOk &&
-              destinations[i].memory_kind ==
-                  DestinationMemoryKind::kDevice)
-            result[i] = Status::kIOError;
-      }
       if (value_lens) *value_lens = std::move(attempt_value_lens);
       Release(node, Lane::kData, conn);
       if (cross_rail_retry)
@@ -2966,16 +2946,13 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     if (out_lengths) out_lengths->assign(count, 0);
     return result;
   }
-  // Keep fully validated items across a rail retry, but fence every server DMA
-  // in operation-owned storage. Caller segments are published only after all
-  // remaining items complete on the final healthy connection.
+  // Server DMA lands directly in the caller segments (GPUDirect when they are
+  // device memory; a host bounce here would fault on CUDA pointers).
+  // Rail-retry fencing comes from Destroy(conn): tearing down the QP drops
+  // in-flight remote writes before the next attempt reposts, and a retried
+  // item is rewritten in full from window 0.
   std::vector<char> completed(count, 0);
-  std::vector<std::vector<char>> staged_outputs(count);
-  std::vector<size_t> staged_out_lengths(count, 0);
-  for (size_t i = 0; i < count; ++i) {
-    if (!bad[i]) staged_outputs[i].resize(capacities[i]);
-  }
-  if (valid_count == 0) return result;
+  std::vector<size_t> out_value_lens(count, 0);
   rdma::OperationContext operation;
   if (!operation.Submit() || !operation.ClaimPoller()) return result;
   bool final_timeout = false;
@@ -2993,7 +2970,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
         result[i] = Status::kInvalid;
       } else if (!completed[i]) {
         result[i] = Status::kIOError;
-        staged_out_lengths[i] = 0;
+        out_value_lens[i] = 0;
         ++remaining_count;
       }
     }
@@ -3095,16 +3072,14 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
             const auto& payload =
                 destination.payloads[progress.segment_index++];
             if (payload.second == 0) continue;
-            char* const target =
-                staged_outputs[progress.item].data() +
-                progress.logical_offset + window_capacity;
-            ibv_mr* mr = ep.RegisterTransient(target, payload.second);
+            ibv_mr* mr =
+                ep.RegisterTransient(payload.first, payload.second);
             if (!mr) {
               conn_ok = false;
               break;
             }
             targets.push_back(
-                {reinterpret_cast<uint64_t>(target), mr->rkey,
+                {reinterpret_cast<uint64_t>(payload.first), mr->rkey,
                  static_cast<uint32_t>(payload.second)});
             mrs.push_back(mr);
             window_capacity += payload.second;
@@ -3216,7 +3191,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
             }
             progress.finished = true;
             completed[progress.item] = 1;
-            staged_out_lengths[progress.item] =
+            out_value_lens[progress.item] =
                 static_cast<size_t>(progress.response_value_len);
             --remaining;
           }
@@ -3226,37 +3201,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     }
 
     if (conn_ok) {
-      DestinationPublisher publisher;
-      for (size_t i = 0; i < count; ++i) {
-        if (result[i] != Status::kOk) continue;
-        size_t copied = 0;
-        for (const auto& payload : destinations[i].payloads) {
-          const size_t remaining = staged_out_lengths[i] - copied;
-          const size_t n = std::min(payload.second, remaining);
-          if (n != 0) {
-            if (!publisher.Copy(payload.first,
-                                staged_outputs[i].data() + copied, n,
-                                payload.memory_kind))
-              result[i] = Status::kIOError;
-            copied += n;
-          }
-          if (copied == staged_out_lengths[i]) break;
-        }
-      }
-      if (!publisher.Finish()) {
-        for (size_t i = 0; i < count; ++i) {
-          const bool has_device = std::any_of(
-              destinations[i].payloads.begin(),
-              destinations[i].payloads.end(),
-              [](const RangeDstSegment& segment) {
-                return segment.memory_kind ==
-                       DestinationMemoryKind::kDevice;
-              });
-          if (has_device && result[i] == Status::kOk)
-            result[i] = Status::kIOError;
-        }
-      }
-      if (out_lengths) *out_lengths = staged_out_lengths;
+      if (out_lengths) *out_lengths = out_value_lens;
       Release(node, Lane::kSgData, conn);
       if (cross_rail_retry)
         cross_rail_retry_successes_.fetch_add(1,

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -390,8 +390,10 @@ class Transport {
 
   // Scatter-gather read: raw stored bytes are split across each key's caller
   // buffers in order. The default reads once into contiguous operation-owned
-  // scratch and publishes each segment. RDMA uses registered operation-owned
-  // staging so retries and failed completions can never mutate caller memory.
+  // scratch and publishes each segment. RDMA registers the caller segments and
+  // lets server DMA land in them directly (GPUDirect when they are device
+  // memory); on failure the destination contents are unspecified, and QP
+  // teardown fences in-flight DMA before any retry or return.
   // out_lens[i] is the authoritative stored length (zero on miss), independent
   // of destination capacity.
   virtual std::vector<Status> RangeIntoMulti(

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -5716,6 +5716,56 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
   EXPECT_EQ(output, output_at_return);
 }
 
+// The SG read path (RangeIntoMulti) shares the direct-write contract: server
+// DMA lands straight in the caller segments, so a failed GET may leave
+// partial payload behind, but QP teardown fences every in-flight write before
+// the call returns, and a later successful GET rewrites the item in full.
+TEST(RdmaLoopback, FailedSgGetLeavesCallerSegmentsStableAfterReturn) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  RdmaNode node("sg-failed-get-fence");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  const std::string value(64 * 1024, 'q');
+  ASSERT_TRUE(client.Put("sg-failed-get", value.data(), value.size()));
+
+  std::string first(4096, '\x5a');
+  std::string second(value.size() - first.size(), '\x5a');
+  KvGetItemSg get{"sg-failed-get", {first.data(), second.data()},
+                  {first.size(), second.size()}};
+  std::vector<size_t> lengths;
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1,1:2:1");
+    EXPECT_FALSE(client.BatchGetAutoSg({get}, &lengths)[0]);
+  }
+  // Partial payload may already sit in the segments (unspecified contents on
+  // failure); what the fence guarantees is that they stop changing here.
+  const std::string first_at_return = first;
+  const std::string second_at_return = second;
+
+  // Drive another synchronous control completion; teardown must have fenced
+  // every in-flight DMA before the failed call returned.
+  std::vector<char> exists;
+  EXPECT_EQ(transport.ExistMany(
+                node.addr, {ToBlockKey(SelfHdr(), "sg-failed-get")}, &exists),
+            std::vector<Status>({Status::kOk}));
+  EXPECT_EQ(first, first_at_return);
+  EXPECT_EQ(second, second_at_return);
+
+  // A clean retry through the same destinations must rewrite the item in
+  // full: no first-attempt residue can leak through a successful GET.
+  ASSERT_TRUE(client.BatchGetAutoSg({get}, &lengths)[0]);
+  ASSERT_EQ(lengths[0], value.size());
+  EXPECT_EQ(first + second, value);
+}
+
 TEST(RdmaLoopback,
      EndpointCompletionCoolsOnlyFailedPeerRailAndPublicGetReplays) {
   if (!HaveRdma())

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -5668,8 +5668,10 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
   EXPECT_EQ(exists, std::vector<char>({0}));
 
   // Seed a readable value with both fault seams disabled, then fail both local
-  // attempts of a fresh public GET. Neither failed attempt may mutate its
-  // caller destination.
+  // attempts of a fresh public GET. Server DMA lands directly in the caller
+  // destination, so a faulted completion may leave partial payload behind; the
+  // fence must guarantee the buffer stops changing once the failed GET
+  // returns.
   KVClient writer({{"n", node.addr}}, key_namespace, &transport);
   ASSERT_TRUE(writer.Put("failed-get", value.data(), value.size()));
   KVClient reader({{"n", node.addr}}, key_namespace, &transport);
@@ -5683,8 +5685,7 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
   after = transport.MetricsText();
   ExpectTwoDistinctRailAttempts(before, after, rails, 2);
   ExpectReleasedRailResources(before, after, rails);
-  EXPECT_EQ(output,
-            std::string(value.size(), static_cast<char>(0x5a)));
+  const std::string output_at_return = output;
   EXPECT_EQ(
       CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
           CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
@@ -5706,13 +5707,13 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
             CounterVal(before,
                        "dfkv_rdma_client_stale_pool_retries_total"));
 
-  // Drive another synchronous control completion before checking the sentinel
-  // again; failed QP teardown must fence every old DMA before retry/return.
+  // Drive another synchronous control completion before checking the buffer
+  // again; failed QP teardown must fence every old DMA before retry/return, so
+  // nothing may land after the failed GET returned.
   EXPECT_EQ(transport.ExistMany(
                 node.addr, {ToBlockKey(key_namespace, "failed-get")}, &exists),
             std::vector<Status>({Status::kOk}));
-  EXPECT_EQ(output,
-            std::string(value.size(), static_cast<char>(0x5a)));
+  EXPECT_EQ(output, output_at_return);
 }
 
 TEST(RdmaLoopback,


### PR DESCRIPTION
fix(rdma): write GETs directly into caller buffers; fence retries by QP teardown