### PR TITLE
feat(log): per-node get/put/exist stats + IB rail(dev) logging

### DIFF
--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -1431,6 +1431,13 @@ class DfkvStoreWorker:
                     and os.environ.get("DFKV_CLIENT_NODE_DEDUP_GPU") is None):
                 os.environ["DFKV_CLIENT_NODE_DEDUP_GPU"] = "1"
 
+        # dfkv: per-rank client log suffix, mirroring the access log's
+        # ``.r{rank}`` form (access_log._build_sink), so the
+        # DFKV_CLIENT_PERNODE_STATS files of concurrent workers never share
+        # one file: dfkv_client_get.log.r3 etc. setdefault keeps an
+        # operator-provided suffix authoritative.
+        os.environ.setdefault("DFKV_CLIENT_LOG_SUFFIX", f"r{self.tp_rank}")
+
         client_kwargs = dict(
             members=extra.get("members", ""),
             mds_endpoints=mds_endpoints,

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1,6 +1,9 @@
 #include "client/kv_client.h"
 
+#include <unistd.h>
+
 #include <array>
+#include <cctype>
 #include <atomic>
 #include <climits>
 #include <chrono>
@@ -1215,11 +1218,202 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
   return RecordBatch(OpMetrics::kExist, t0, std::move(res), 0);
 }
 
+namespace {
+
+// Shared per-node (ip:port) stats for GET/PUT/EXIST. Gated by
+// DFKV_CLIENT_PERNODE_STATS=1 (off by default); emitted to
+// $DFKV_ACCESS_DIR/<file>.<suffix> (append+flush) if set, else stderr.
+bool PernodeOn() {
+  static const bool on = [] {
+    const char* e = std::getenv("DFKV_CLIENT_PERNODE_STATS");
+    return e && *e && *e != '0';
+  }();
+  return on;
+}
+
+struct PernodeStat {
+  uint64_t keys = 0, bytes = 0, busy_us = 0, wall_us = 0, shards = 0;
+  uint64_t min_b = std::numeric_limits<uint64_t>::max(), max_b = 0;  // value size
+  uint64_t hit = 0;        // successes: GET retrieved / PUT written / EXIST present
+  uint64_t fail = 0;       // routed failures (status != ok among issued keys)
+  uint32_t fail_mask = 0;  // bit i set when Status value i appears among failures
+  std::string first_fail;  // fingerprint of the first failed key on this node
+  std::string dev;         // IB rail device of the slowest shard (the one setting wall_us)
+};
+
+const char* PernodeStatusName(Status s) {
+  switch (s) {
+    case Status::kOk: return "kOk";
+    case Status::kNotFound: return "kNotFound";
+    case Status::kCacheFull: return "kCacheFull";
+    case Status::kQuotaExceeded: return "kQuotaExceeded";
+    case Status::kIOError: return "kIOError";
+    case Status::kInvalid: return "kInvalid";
+  }
+  return "kUnknown";
+}
+
+// Cheap key fingerprint (len + first bytes as hex; no hashing on the hot path).
+std::string PernodeKeyFp(const std::string& key) {
+  static const char* H = "0123456789abcdef";
+  std::string hex;
+  const size_t n = key.size() < 8 ? key.size() : 8;
+  for (size_t i = 0; i < n; ++i) {
+    const unsigned char c = static_cast<unsigned char>(key[i]);
+    hex += H[c >> 4];
+    hex += H[c & 0xf];
+  }
+  return "len=" + std::to_string(key.size()) + ":" + hex;
+}
+
+std::string PernodeFmt1(uint64_t x10) {  // one decimal from an x10 integer
+  return std::to_string(x10 / 10) + "." + std::to_string(x10 % 10);
+}
+
+// Per-process file suffix, mirroring the vLLM connector access log's
+// ``access.log.r{tp_rank}`` convention: the integration layer exports
+// DFKV_CLIENT_LOG_SUFFIX (e.g. "r3") for every worker it launches so each
+// rank owns its file. Without it the pid keeps concurrent local processes
+// from interleaving one shared file.
+std::string PernodeSuffix() {
+  static const std::string suffix = [] {
+    const char* e = std::getenv("DFKV_CLIENT_LOG_SUFFIX");
+    std::string s = e && *e ? e : "p" + std::to_string(::getpid());
+    for (char& c : s)
+      if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_')
+        c = '_';  // a separator smuggled via the env must not escape the dir
+    return s;
+  }();
+  return suffix;
+}
+
+// One FILE* per distinct file name (opened once); nullptr => stderr fallback.
+void PernodeWrite(const char* fname, const std::vector<std::string>& lines) {
+  static std::mutex mu;
+  static std::map<std::string, FILE*> sinks;
+  std::lock_guard<std::mutex> lk(mu);
+  auto it = sinks.find(fname);
+  FILE* sink;
+  if (it != sinks.end()) {
+    sink = it->second;
+  } else {
+    sink = nullptr;
+    const char* dir = std::getenv("DFKV_ACCESS_DIR");
+    if (dir && *dir) {
+      const std::string path =
+          std::string(dir) + "/" + fname + "." + PernodeSuffix();
+      sink = std::fopen(path.c_str(), "a");
+      if (!sink)
+        DFKV_LOG_WARN("pernode: cannot open " + path + "; using stderr");
+    }
+    sinks[fname] = sink;
+  }
+  if (sink) {
+    char ts[32];
+    std::time_t tt = std::time(nullptr);
+    std::tm tm{};
+    localtime_r(&tt, &tm);
+    std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tm);
+    for (const auto& ln : lines) std::fprintf(sink, "%s %s\n", ts, ln.c_str());
+    std::fflush(sink);
+  } else {
+    for (const auto& ln : lines) DFKV_LOG_INFO(ln);
+  }
+}
+
+// op: 0=get, 1=put, 2=exist. Sort slowest first, emit one TOTAL + per-node line.
+void EmitPernode(int op, const char* label, const char* fname,
+                 const std::map<std::string, PernodeStat>& per,
+                 const std::map<std::string, std::string>& addr2name,
+                 uint64_t total_wall_us, uint64_t N, uint64_t preroute_fail) {
+  std::vector<const std::pair<const std::string, PernodeStat>*> rows;
+  rows.reserve(per.size());
+  for (const auto& it : per) rows.push_back(&it);
+  for (size_t i = 0; i + 1 < rows.size(); ++i) {  // selection sort (few nodes)
+    size_t mx = i;
+    for (size_t j = i + 1; j < rows.size(); ++j)
+      if (rows[j]->second.wall_us > rows[mx]->second.wall_us) mx = j;
+    if (mx != i) { auto* t = rows[i]; rows[i] = rows[mx]; rows[mx] = t; }
+  }
+  uint64_t tk = 0, tb = 0, th = 0, tf = 0,
+           tmin = std::numeric_limits<uint64_t>::max(), tmax = 0;
+  for (auto* r : rows) {
+    const PernodeStat& a = r->second;
+    tk += a.keys; tb += a.bytes; th += a.hit; tf += a.fail;
+    if (a.max_b > 0) {
+      if (a.min_b < tmin) tmin = a.min_b;
+      if (a.max_b > tmax) tmax = a.max_b;
+    }
+  }
+  if (tmax == 0) tmin = 0;
+
+  std::vector<std::string> lines;
+  lines.reserve(rows.size() + 1);
+  {
+    const uint64_t mbps10 =
+        total_wall_us ? (tb * 10 + total_wall_us / 2) / total_wall_us : 0;
+    const uint64_t avgv = tk ? (tb + tk / 2) / tk : 0;
+    std::string s = std::string("pernode-") + label + " TOTAL: " + label +
+                    "_ms=" + PernodeFmt1((total_wall_us + 50) / 100) +
+                    " keys=" + std::to_string(N) +
+                    " servers=" + std::to_string(rows.size()) +
+                    " bytes=" + std::to_string(tb) +
+                    " avg_bytes/key=" + std::to_string(avgv) +
+                    " min_bytes=" + std::to_string(tmin) +
+                    " max_bytes=" + std::to_string(tmax) +
+                    " MB/s=" + PernodeFmt1(mbps10);
+    if (op == 0) s += " hit=" + std::to_string(th);
+    else if (op == 2) s += " absent=" + std::to_string(tk - th);
+    else s += " fail_keys=" + std::to_string(tf + preroute_fail) +
+              " preroute_fail=" + std::to_string(preroute_fail);
+    lines.push_back(std::move(s));
+  }
+  for (auto* r : rows) {
+    const PernodeStat& a = r->second;
+    const uint64_t mbps10 =
+        a.wall_us ? (a.bytes * 10 + a.wall_us / 2) / a.wall_us : 0;
+    const uint64_t avgv = a.keys ? (a.bytes + a.keys / 2) / a.keys : 0;
+    const uint64_t us_per_key = a.keys ? (a.busy_us + a.keys / 2) / a.keys : 0;
+    const uint64_t nmin = a.max_b ? a.min_b : 0;
+    auto nit = addr2name.find(r->first);
+    std::string s = std::string("pernode-") + label + ": node=" + r->first +
+        (nit != addr2name.end() ? (" name=" + nit->second) : std::string()) +
+        (a.dev.empty() ? std::string() : (" dev=" + a.dev)) +
+        " keys=" + std::to_string(a.keys) +
+        " bytes=" + std::to_string(a.bytes) +
+        " avg_bytes/key=" + std::to_string(avgv) +
+        " min_bytes=" + std::to_string(nmin) +
+        " max_bytes=" + std::to_string(a.max_b) +
+        " shards=" + std::to_string(a.shards) +
+        " wall_us=" + std::to_string(a.wall_us) +
+        " MB/s=" + PernodeFmt1(mbps10) +
+        " avg_us/key=" + std::to_string(us_per_key);
+    if (op == 0) s += " hit=" + std::to_string(a.hit);
+    else if (op == 2) s += " absent=" + std::to_string(a.keys - a.hit);
+    if (a.fail > 0) {  // error info only when this node had failures
+      std::string codes;
+      for (int b = 0; b < 6; ++b)
+        if (a.fail_mask & (1u << b)) {
+          if (!codes.empty()) codes += ",";
+          codes += PernodeStatusName(static_cast<Status>(b));
+        }
+      s += " FAIL keys=" + std::to_string(a.fail) + " codes=" + codes +
+           " first_fail=" + a.first_fail;
+    }
+    lines.push_back(std::move(s));
+  }
+  PernodeWrite(fname, lines);
+}
+
+}  // namespace
+
 std::vector<bool> KVClient::BatchExistDirect(
     const std::vector<std::string>& keys, std::vector<Status>* statuses) {
   const size_t N = keys.size();
   std::vector<char> e(N, 0);
   std::vector<Status> raw(N, Status::kInvalid);
+  const bool pernode_on = PernodeOn();
+  const auto call_t0 = std::chrono::steady_clock::now();  // whole-call wall (stats)
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
     RunParallel(N, BatchWorkers(N), [&](size_t i) {
       e[i] = ExistDirect(keys[i], &raw[i]) ? 1 : 0;
@@ -1240,6 +1434,7 @@ std::vector<bool> KVClient::BatchExistDirect(
   std::vector<std::pair<std::string, std::vector<size_t>>> groups =
       ShardReadGroups(std::vector<std::pair<std::string, std::vector<size_t>>>(
           by_node.begin(), by_node.end()));
+  std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
   RunReadScheduled(groups.size(), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
@@ -1249,7 +1444,34 @@ std::vector<bool> KVClient::BatchExistDirect(
     bkeys.reserve(idx.size());
     for (size_t k : idx) bkeys.push_back(ToBlockKey(key_namespace_, keys[k]));
     std::vector<char> ex;
-    std::vector<Status> sts = t_->ExistMany(node, bkeys, &ex);
+    std::string shard_dev;
+    const auto pn_t0 = std::chrono::steady_clock::now();
+    std::vector<Status> sts =
+        t_->ExistMany(node, bkeys, &ex, pernode_on ? &shard_dev : nullptr);
+    if (pernode_on) {
+      const uint64_t us = static_cast<uint64_t>(
+          std::chrono::duration<double, std::micro>(
+              std::chrono::steady_clock::now() - pn_t0).count());
+      uint64_t present = 0, failn = 0;
+      uint32_t fmask = 0;
+      std::string ff;
+      for (size_t m = 0; m < idx.size(); ++m) {
+        if (m < ex.size() && ex[m]) present++;  // hit = key exists
+        const Status st = (m < sts.size()) ? sts[m] : Status::kInvalid;
+        if (st == Status::kIOError || st == Status::kInvalid) {  // probe error
+          failn++;
+          fmask |= (1u << static_cast<int>(st));
+          if (ff.empty()) ff = PernodeKeyFp(keys[idx[m]]);
+        }
+      }
+      gstat[g].keys = idx.size();  // bytes/min/max stay 0 (exist has no payload)
+      gstat[g].busy_us = us;
+      gstat[g].hit = present;
+      gstat[g].fail = failn;
+      gstat[g].fail_mask = fmask;
+      gstat[g].first_fail = ff;
+      gstat[g].dev = std::move(shard_dev);
+    }
     bool resp = false, ioerr = false;
     // kInvalid (oversize/per-item guard) is neither: it must not clear the
     // peer cooldown (resp) nor trip MarkBad (ioerr).
@@ -1263,6 +1485,35 @@ std::vector<bool> KVClient::BatchExistDirect(
       e[idx[m]] = (m < ex.size() && ex[m]) ? 1 : 0;
     }
   });
+  if (pernode_on) {
+    std::map<std::string, PernodeStat> per;
+    for (size_t g = 0; g < groups.size(); ++g) {
+      if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+      PernodeStat& a = per[groups[g].first];
+      a.keys += gstat[g].keys;
+      a.busy_us += gstat[g].busy_us;
+      if (gstat[g].busy_us > a.wall_us) {
+        a.wall_us = gstat[g].busy_us;
+        a.dev = gstat[g].dev;  // slowest shard's rail
+      }
+      a.shards += 1;
+      a.hit += gstat[g].hit;
+      a.fail += gstat[g].fail;
+      a.fail_mask |= gstat[g].fail_mask;
+      if (a.first_fail.empty() && !gstat[g].first_fail.empty())
+        a.first_fail = gstat[g].first_fail;
+    }
+    std::map<std::string, std::string> addr2name;
+    {
+      std::lock_guard<std::mutex> lk(ring_mu_);
+      for (const auto& kv : addr_) addr2name[kv.second] = kv.first;
+    }
+    const uint64_t total_wall_us = static_cast<uint64_t>(
+        std::chrono::duration<double, std::micro>(
+            std::chrono::steady_clock::now() - call_t0).count());
+    EmitPernode(2, "exist", "dfkv_client_exist.log", per, addr2name,
+                total_wall_us, N, 0);
+  }
   if (statuses) *statuses = std::move(raw);
   return std::vector<bool>(e.begin(), e.end());
 }
@@ -1340,11 +1591,13 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
       over[i] = 1;
   }
 
+  const bool pernode_on = PernodeOn();
+  uint64_t preroute_fail = 0;  // dropped before routing (oversize guard / no route)
   std::map<std::string, std::vector<size_t>> by_node;
   for (size_t i = 0; i < N; ++i) {
-    if (over[i]) continue;
+    if (over[i]) { preroute_fail++; continue; }
     std::string node = Route(items[i].key);
-    if (node.empty()) continue;
+    if (node.empty()) { preroute_fail++; continue; }
     by_node[node].push_back(i);
   }
   // Shard each per-node put group the same way the read path does (shared knobs
@@ -1356,6 +1609,7 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   std::vector<std::pair<std::string, std::vector<size_t>>> groups =
       ShardReadGroups(std::vector<std::pair<std::string, std::vector<size_t>>>(
           by_node.begin(), by_node.end()));
+  std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
   RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
@@ -1371,7 +1625,42 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
         s.payloads.emplace_back(items[k].ptrs[j], items[k].sizes[j]);
       srcs.push_back(std::move(s));
     }
-    std::vector<Status> sts = t_->CacheFromMulti(node, srcs);
+    std::string shard_dev;
+    const auto pn_t0 = std::chrono::steady_clock::now();
+    std::vector<Status> sts =
+        t_->CacheFromMulti(node, srcs, pernode_on ? &shard_dev : nullptr);
+    if (pernode_on) {
+      const uint64_t us = static_cast<uint64_t>(
+          std::chrono::duration<double, std::micro>(
+              std::chrono::steady_clock::now() - pn_t0).count());
+      uint64_t vb = 0, hits = 0, failn = 0,
+               mn = std::numeric_limits<uint64_t>::max(), mx = 0;
+      uint32_t fmask = 0;
+      std::string ff;
+      for (size_t m = 0; m < idx.size() && m < sts.size(); ++m) {
+        if (sts[m] == Status::kOk) {
+          hits++;
+          const uint64_t b = total_bytes[idx[m]];
+          vb += b;
+          if (b < mn) mn = b;
+          if (b > mx) mx = b;
+        } else {
+          failn++;
+          fmask |= (1u << static_cast<int>(sts[m]));
+          if (ff.empty()) ff = PernodeKeyFp(items[idx[m]].key);
+        }
+      }
+      gstat[g].keys = idx.size();
+      gstat[g].bytes = vb;
+      gstat[g].busy_us = us;
+      gstat[g].min_b = mn;
+      gstat[g].max_b = mx;
+      gstat[g].hit = hits;
+      gstat[g].fail = failn;
+      gstat[g].fail_mask = fmask;
+      gstat[g].first_fail = ff;
+      gstat[g].dev = std::move(shard_dev);
+    }
     for (size_t m = 0; m < idx.size(); ++m) {
       ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
       if (ok[idx[m]]) InvalidateRendezvous(srcs[m].key);
@@ -1385,6 +1674,40 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     }
     if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
   });
+  if (pernode_on) {
+    std::map<std::string, PernodeStat> per;
+    for (size_t g = 0; g < groups.size(); ++g) {
+      if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+      PernodeStat& a = per[groups[g].first];
+      a.keys += gstat[g].keys;
+      a.bytes += gstat[g].bytes;
+      a.busy_us += gstat[g].busy_us;
+      if (gstat[g].busy_us > a.wall_us) {
+        a.wall_us = gstat[g].busy_us;
+        a.dev = gstat[g].dev;  // slowest shard's rail
+      }
+      a.shards += 1;
+      a.hit += gstat[g].hit;
+      a.fail += gstat[g].fail;
+      a.fail_mask |= gstat[g].fail_mask;
+      if (gstat[g].max_b > 0) {
+        if (gstat[g].min_b < a.min_b) a.min_b = gstat[g].min_b;
+        if (gstat[g].max_b > a.max_b) a.max_b = gstat[g].max_b;
+      }
+      if (a.first_fail.empty() && !gstat[g].first_fail.empty())
+        a.first_fail = gstat[g].first_fail;
+    }
+    std::map<std::string, std::string> addr2name;
+    {
+      std::lock_guard<std::mutex> lk(ring_mu_);
+      for (const auto& kv : addr_) addr2name[kv.second] = kv.first;
+    }
+    const uint64_t total_wall_us = static_cast<uint64_t>(
+        std::chrono::duration<double, std::micro>(
+            std::chrono::steady_clock::now() - t0).count());
+    EmitPernode(1, "put", "dfkv_client_put.log", per, addr2name,
+                total_wall_us, N, preroute_fail);
+  }
   uint64_t bytes = 0;
   for (size_t i = 0; i < N; ++i)
     if (ok[i]) AddMetricBytes(total_bytes[i], &bytes);
@@ -1570,6 +1893,16 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
   std::vector<char> hit(N, 0);
   std::vector<size_t> lens(N, 0);  // distinct indices => thread-safe writes
 
+  // Per-node (ip:port) GET timing (DFKV_CLIENT_PERNODE_STATS=1, off by default):
+  // accumulate keys/bytes/time by target server across all passes, emit one line
+  // per node at return to spot slow nodes. busy_us sums per-shard service time
+  // (=> avg_us/key); wall_us takes the max shard time — shards run in parallel,
+  // so it approximates the node's wall time, the honest basis for MB/s (summing
+  // parallel shard time would understate throughput).
+  const bool pernode_on = PernodeOn();
+  std::map<std::string, PernodeStat> pernode;
+  const auto call_t0 = std::chrono::steady_clock::now();  // whole-call wall (stats)
+
   // Validate shape and aggregate capacity; the transport windows arbitrary
   // descriptor counts internally.
   std::vector<char> over(N, 0);
@@ -1596,6 +1929,7 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         groups = ShardReadGroups(
             std::vector<std::pair<std::pair<std::string, size_t>,
                                   std::vector<size_t>>>(by.begin(), by.end()));
+    std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
     RunReadScheduled(groups.size(), [&](size_t g) {
       const std::string& node = groups[g].first.first;
       uint64_t now = NowMs();
@@ -1616,8 +1950,31 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         dsts.push_back(std::move(d));
       }
       std::vector<size_t> value_lens;
-      std::vector<Status> sts =
-          t_->RangeIntoMulti(node, keys, dsts, &value_lens);
+      std::string shard_dev;
+      const auto pn_t0 = std::chrono::steady_clock::now();
+      std::vector<Status> sts = t_->RangeIntoMulti(
+          node, keys, dsts, &value_lens, pernode_on ? &shard_dev : nullptr);
+      if (pernode_on) {
+        const uint64_t us = static_cast<uint64_t>(
+            std::chrono::duration<double, std::micro>(
+                std::chrono::steady_clock::now() - pn_t0).count());
+        uint64_t vb = 0, hits = 0, mn = std::numeric_limits<uint64_t>::max(), mx = 0;
+        for (size_t v = 0; v < value_lens.size() && v < sts.size(); ++v)
+          if (sts[v] == Status::kOk) {
+            hits++;
+            const uint64_t b = value_lens[v];
+            vb += b;
+            if (b < mn) mn = b;
+            if (b > mx) mx = b;
+          }
+        gstat[g].keys = idx.size();
+        gstat[g].bytes = vb;
+        gstat[g].busy_us = us;
+        gstat[g].min_b = mn;  // UINT64_MAX if this shard had no kOk key
+        gstat[g].max_b = mx;
+        gstat[g].hit = hits;
+        gstat[g].dev = std::move(shard_dev);
+      }
       bool resp = false, ioerr = false;
       // kInvalid (oversize/per-item guard) is neither: it must not clear the
       // peer cooldown (resp) nor trip MarkBad (ioerr).
@@ -1636,6 +1993,25 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         hit[idx[m]] = 1;
       }
     });
+    if (pernode_on) {
+      for (size_t g = 0; g < groups.size(); ++g) {
+        if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+        PernodeStat& a = pernode[groups[g].first.first];
+        a.keys += gstat[g].keys;
+        a.bytes += gstat[g].bytes;
+        a.busy_us += gstat[g].busy_us;
+        if (gstat[g].busy_us > a.wall_us) {
+          a.wall_us = gstat[g].busy_us;
+          a.dev = gstat[g].dev;  // slowest shard's rail
+        }
+        a.shards += 1;
+        a.hit += gstat[g].hit;
+        if (gstat[g].max_b > 0) {  // shard had >=1 successful key
+          if (gstat[g].min_b < a.min_b) a.min_b = gstat[g].min_b;
+          if (gstat[g].max_b > a.max_b) a.max_b = gstat[g].max_b;
+        }
+      }
+    }
   };
   std::vector<size_t> all(N);
   for (size_t i = 0; i < N; ++i) all[i] = i;
@@ -1650,6 +2026,18 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
       if (!over[i] && !hit[i]) missed.push_back(i);
     if (missed.empty() || missed.size() > N / 2) break;
     run_pass(missed);
+  }
+  if (pernode_on) {
+    const uint64_t total_wall_us = static_cast<uint64_t>(
+        std::chrono::duration<double, std::micro>(
+            std::chrono::steady_clock::now() - call_t0).count());
+    std::map<std::string, std::string> addr2name;
+    {
+      std::lock_guard<std::mutex> lk(ring_mu_);
+      for (const auto& kv : addr_) addr2name[kv.second] = kv.first;
+    }
+    EmitPernode(0, "get", "dfkv_client_get.log", pernode, addr2name,
+                total_wall_us, N, 0);
   }
   if (out_lens) *out_lens = std::move(lens);
   return std::vector<bool>(hit.begin(), hit.end());

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -2380,7 +2380,7 @@ std::vector<Status> RdmaTransport::RangeMany(
 
 std::vector<Status> RdmaTransport::ExistMany(
     const std::string& node, const std::vector<BlockKey>& keys,
-    std::vector<char>* exists) {
+    std::vector<char>* exists, std::string* out_dev) {
   const size_t count = keys.size();
   if (exists == nullptr) return InvalidStatuses(count);
   exists->assign(count, 0);
@@ -2413,6 +2413,7 @@ std::vector<Status> RdmaTransport::ExistMany(
       return result;
     }
     Conn* conn = acquired.conn;
+    if (out_dev) *out_dev = devs_[conn->rail_index];
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
@@ -2688,7 +2689,7 @@ std::vector<Status> RdmaTransport::CacheFrom(
 }
 
 std::vector<Status> RdmaTransport::CacheFromMulti(
-    const std::string& node, const std::vector<CacheSrcMulti>& sources) {
+    const std::string& node, const std::vector<CacheSrcMulti>& sources, std::string* out_dev) {
   const size_t count = sources.size();
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) return result;
@@ -2748,6 +2749,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       return result;
     }
     Conn* conn = acquired.conn;
+    if (out_dev) *out_dev = devs_[conn->rail_index];
     rdma::RcEndpoint& ep = conn->ep;
     const size_t seg_limit = std::max<size_t>(1, ep.max_sge() - 1);
     bool conn_ok = !InjectLocalRailFailure(attempt);
@@ -2926,7 +2928,7 @@ bool RdmaTransport::NoteBlock(size_t n) const {
 std::vector<Status> RdmaTransport::RangeIntoMulti(
     const std::string& node, const std::vector<BlockKey>& keys,
     const std::vector<RangeDstMulti>& destinations,
-    std::vector<size_t>* out_lengths) {
+    std::vector<size_t>* out_lengths, std::string* out_dev) {
   const size_t count = keys.size();
   if (destinations.size() != count) {
     if (out_lengths) out_lengths->assign(count, 0);
@@ -3018,6 +3020,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       return result;
     }
     Conn* conn = acquired.conn;
+    if (out_dev) *out_dev = devs_[conn->rail_index];
     rdma::RcEndpoint& ep = conn->ep;
     const size_t target_limit =
         std::max<size_t>(1, std::min(ep.max_sge() - 1,

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -114,7 +114,8 @@ class RdmaTransport : public Transport {
       std::vector<uint64_t>* value_lens = nullptr) override;
   std::vector<Status> ExistMany(const std::string& node,
                                 const std::vector<BlockKey>& keys,
-                                std::vector<char>* exists) override;
+                                std::vector<char>* exists,
+                                std::string* out_dev = nullptr) override;
   std::vector<Status> RangeInto(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDst>& dsts,
@@ -124,11 +125,12 @@ class RdmaTransport : public Transport {
   // for dfkv_batch_put_sg / dfkv_batch_get_auto_sg).
   std::vector<Status> CacheFromMulti(
       const std::string& node,
-      const std::vector<CacheSrcMulti>& srcs) override;
+      const std::vector<CacheSrcMulti>& srcs,
+      std::string* out_dev = nullptr) override;
   std::vector<Status> RangeIntoMulti(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* out_lens) override;
+      std::vector<size_t>* out_lens, std::string* out_dev = nullptr) override;
 
  private:
   friend class RdmaTransportTestPeer;

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -267,7 +267,9 @@ class Transport {
   // accounting (kIOError => transport failure; anything else => node responded).
   virtual std::vector<Status> ExistMany(const std::string& node,
                                         const std::vector<BlockKey>& keys,
-                                        std::vector<char>* exists) {
+                                        std::vector<char>* exists,
+                                        std::string* out_dev = nullptr) {
+    if (out_dev) out_dev->clear();  // RDMA rail device; base/TCP has none
     if (exists == nullptr) return InvalidStatuses(keys.size());
     exists->assign(keys.size(), 0);
     std::vector<Status> r;
@@ -352,7 +354,9 @@ class Transport {
   // through CacheFrom (no payload zero-copy, but correct on any transport). The
   // RDMA transport overrides this to gather the segments via a multi-SGE SEND.
   virtual std::vector<Status> CacheFromMulti(
-      const std::string& node, const std::vector<CacheSrcMulti>& srcs) {
+      const std::string& node, const std::vector<CacheSrcMulti>& srcs,
+      std::string* out_dev = nullptr) {
+    if (out_dev) out_dev->clear();  // RDMA rail device; base/TCP has none
     std::vector<Status> result(srcs.size(), Status::kInvalid);
     std::vector<std::vector<char>> bufs(srcs.size());
     std::vector<CacheSrc> flat;
@@ -397,7 +401,8 @@ class Transport {
   virtual std::vector<Status> RangeIntoMulti(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* out_lens) {
+      std::vector<size_t>* out_lens, std::string* out_dev = nullptr) {
+    if (out_dev) out_dev->clear();  // RDMA rail device; base/TCP has none
     const size_t n = keys.size();
     if (out_lens) out_lens->assign(n, 0);
     if (n == 0) return {};

--- a/test/client/c_api_test.cc
+++ b/test/client/c_api_test.cc
@@ -60,7 +60,8 @@ class CApiTransport final : public dfkv::Transport {
   std::vector<dfkv::Status> RangeIntoMulti(
       const std::string&, const std::vector<dfkv::BlockKey>& keys,
       const std::vector<dfkv::RangeDstMulti>&,
-      std::vector<size_t>* out_lens) override {
+      std::vector<size_t>* out_lens,
+      std::string* /*out_dev*/ = nullptr) override {
     range_into_multi_called.store(true, std::memory_order_relaxed);
     Throw();
     if (out_lens) out_lens->assign(keys.size(), 0);

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -155,7 +155,8 @@ class MetricsTransport final : public Transport {
   }
 
   std::vector<Status> CacheFromMulti(
-      const std::string&, const std::vector<CacheSrcMulti>& srcs) override {
+      const std::string&, const std::vector<CacheSrcMulti>& srcs,
+      std::string* /*out_dev*/ = nullptr) override {
     std::lock_guard<std::mutex> lock(mu);
     const bool ok = RunAttemptsLocked(srcs.size(), [&] {
       remote_put_commits += srcs.size();
@@ -174,7 +175,8 @@ class MetricsTransport final : public Transport {
   std::vector<Status> RangeIntoMulti(
       const std::string&, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* out_lens) override {
+      std::vector<size_t>* out_lens,
+      std::string* /*out_dev*/ = nullptr) override {
     std::lock_guard<std::mutex> lock(mu);
     ++range_multi_calls;
     if (out_lens) out_lens->assign(keys.size(), 0);

--- a/test/client/endpoint_ownership_test.cc
+++ b/test/client/endpoint_ownership_test.cc
@@ -26,7 +26,8 @@ class RecordingTransport final : public Transport {
   }
   std::vector<Status> CacheFromMulti(
       const std::string& node,
-      const std::vector<CacheSrcMulti>& srcs) override {
+      const std::vector<CacheSrcMulti>& srcs,
+      std::string* /*out_dev*/ = nullptr) override {
     {
       std::lock_guard<std::mutex> lock(mu_);
       selected_nodes_.push_back(node);

--- a/test/client/get_auto_pipelined_test.cc
+++ b/test/client/get_auto_pipelined_test.cc
@@ -83,7 +83,8 @@ struct FakePipelinedTransport : Transport {
   std::vector<Status> RangeIntoMulti(
       const std::string&, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* value_lens) override {
+      std::vector<size_t>* value_lens,
+      std::string* /*out_dev*/ = nullptr) override {
     value_lens->assign(keys.size(), 0);
     last_multi_kinds.clear();
     last_multi_kinds.reserve(dsts.size());


### PR DESCRIPTION
Opt-in client-side data-plane observability (DFKV_CLIENT_PERNODE_STATS=1, off by default). Every BatchGetAutoSg / BatchPutSg / BatchExist emits one TOTAL line plus per-node (ip:port -> member name) lines sorted slowest first -- keys, bytes, wall/busy time, MB/s, min/max value size, hit/fail counts with status fingerprints, and the IB rail device that served the slowest shard. This is the tooling that located both the per-key 350ms CUDA-publish stall and the all-nodes-uniformly-slow signature during the 2.19.1 warm-start investigation.

Transport reports the serving rail via a new optional out_dev out-param on ExistMany/CacheFromMulti/RangeIntoMulti (default nullptr, cleared by the base; test fakes updated for the signature change).

Files land in $DFKV_ACCESS_DIR/<op>.log.<suffix> (else stderr), where <op> is dfkv_client_get / dfkv_client_put / dfkv_client_exist and <suffix> mirrors the vLLM connector access log convention (access.log.r{tp_rank}): the connector exports
DFKV_CLIENT_LOG_SUFFIX=r{tp_rank} per worker; without the env the pid (p<pid>) keeps concurrent local processes from interleaving one file. Log rotation is intentionally left to a follow-up.