### PR TITLE
perf(rdma): direct GET publication with safe retirement and per-node telemetry

### DIFF
--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -93,6 +93,30 @@ _T = TypeVar("_T")
 def _rotate_list(values: list[_T], offset: int) -> list[_T]:
     return values[offset:] + values[:offset]
 
+def _process_log_suffix(
+    *,
+    dp_rank: int,
+    pp_rank: int,
+    tp_rank: int,
+    global_rank: int,
+    pid: int | None = None,
+    prefix: str | None = None,
+) -> str:
+    """Return a process-unique native-client log suffix.
+
+    DP/PP/TP/global coordinates make the file attributable across distributed
+    layouts. PID is the collision fence when ranks are reused by colocated
+    engines or the launcher cannot provide a globally unique rank.
+    """
+    process_id = os.getpid() if pid is None else pid
+    identity = (
+        f"dp{dp_rank}_pp{pp_rank}_tp{tp_rank}_"
+        f"g{global_rank}_p{process_id}"
+    )
+    if prefix == identity or (prefix and prefix.endswith(f"_{identity}")):
+        return prefix
+    return f"{prefix}_{identity}" if prefix else identity
+
 def _batch_rotation_offset(
     req_id: str,
     block_hashes: list[BlockHash],
@@ -1431,12 +1455,16 @@ class DfkvStoreWorker:
                     and os.environ.get("DFKV_CLIENT_NODE_DEDUP_GPU") is None):
                 os.environ["DFKV_CLIENT_NODE_DEDUP_GPU"] = "1"
 
-        # dfkv: per-rank client log suffix, mirroring the access log's
-        # ``.r{rank}`` form (access_log._build_sink), so the
-        # DFKV_CLIENT_PERNODE_STATS files of concurrent workers never share
-        # one file: dfkv_client_get.log.r3 etc. setdefault keeps an
-        # operator-provided suffix authoritative.
-        os.environ.setdefault("DFKV_CLIENT_LOG_SUFFIX", f"r{self.tp_rank}")
+        # Native per-node logs must not collide across colocated DP/PP/TP
+        # workers. Preserve an operator prefix, but always append the complete
+        # rank identity and PID collision fence instead of trusting TP alone.
+        os.environ["DFKV_CLIENT_LOG_SUFFIX"] = _process_log_suffix(
+            dp_rank=self.dp_rank,
+            pp_rank=self.pp_rank,
+            tp_rank=self.tp_rank,
+            global_rank=parallel_config.rank,
+            prefix=os.environ.get("DFKV_CLIENT_LOG_SUFFIX"),
+        )
 
         client_kwargs = dict(
             members=extra.get("members", ""),

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -1431,6 +1431,13 @@ class DfkvStoreWorker:
                     and os.environ.get("DFKV_CLIENT_NODE_DEDUP_GPU") is None):
                 os.environ["DFKV_CLIENT_NODE_DEDUP_GPU"] = "1"
 
+        # dfkv: per-rank client log suffix, mirroring the access log's
+        # ``.r{rank}`` form (access_log._build_sink), so the
+        # DFKV_CLIENT_PERNODE_STATS files of concurrent workers never share
+        # one file: dfkv_client_get.log.r3 etc. setdefault keeps an
+        # operator-provided suffix authoritative.
+        os.environ.setdefault("DFKV_CLIENT_LOG_SUFFIX", f"r{self.tp_rank}")
+
         client_kwargs = dict(
             members=extra.get("members", ""),
             mds_endpoints=mds_endpoints,

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -516,7 +516,14 @@ void RdmaServer::Serve(int boot_fd) {
       const auto found = writers_.find(token);
       if (found != writers_.end()) writer = found->second;
     }
-    if (writer) {
+    if (!writer) {
+      // Only a token registered by a capability-negotiated bootstrap may
+      // operate the retirement control plane. Never manufacture proof for an
+      // arbitrary nonzero value.
+      ::close(boot_fd);
+      return;
+    }
+    {
       std::unique_lock<std::mutex> lock(writer->mu);
       if (!writer->retired && writer->endpoint)
         writer->endpoint->CancelResponderWrites();
@@ -537,7 +544,11 @@ void RdmaServer::Serve(int boot_fd) {
     return;
   }
 
-  const uint64_t declared = rdma::ParseDevFrameCaps(devbuf);
+  // Parse capability and payload geometry from the same raw u64, but never
+  // allow the request bit to leak into max-block checks or slot arithmetic.
+  const bool writer_retirement_requested =
+      rdma::DevFrameRequestsWriterRetirement(devbuf);
+  const uint64_t declared = rdma::ParseDevFrameMaxBlock(devbuf);
   if (rdma::ParseDevFrameProtocol(devbuf) != rdma::kDevProtoV2 ||
       declared == 0) {
     DFKV_LOG_ERROR("rdma: rejecting peer without required v2 negotiation");
@@ -741,10 +752,18 @@ void RdmaServer::Serve(int boot_fd) {
     ::close(boot_fd);
     return;
   }
-  auto writer = std::make_shared<WriterState>();
-  writer->endpoint = &ep;
-  const uint64_t writer_token = RegisterWriter(writer);
+  std::shared_ptr<WriterState> writer;
+  uint64_t writer_token = 0;
+  if (writer_retirement_requested) {
+    writer = std::make_shared<WriterState>();
+    writer->endpoint = &ep;
+    writer_token = RegisterWriter(writer);
+  }
   auto retire_writer = [&] {
+    // An unnegotiated client keeps the legacy teardown path. Only a bootstrap
+    // that requested retirement owns a registered token and the explicit
+    // responder-WRITE drain/proof lifecycle.
+    if (!writer) return;
     const bool retired = ep.RetireResponderWrites();
     if (!retired)
       DFKV_LOG_ERROR("rdma: responder WRITE CQ drain failed");
@@ -753,25 +772,23 @@ void RdmaServer::Serve(int boot_fd) {
       writer->endpoint = nullptr;
       writer->retired = retired;
     }
-    if (!retired) std::abort();
     writer->retired_cv.notify_all();
-    std::lock_guard<std::mutex> lock(writer_mu_);
-    writers_.erase(writer_token);
+    {
+      std::lock_guard<std::mutex> lock(writer_mu_);
+      writers_.erase(writer_token);
+    }
+    if (!retired) std::abort();
   };
   // Receives must be posted before readiness becomes visible. Publish the
   // leased receive-segment address, rkey and slot geometry only after the QP is
   // armed, so the client cannot issue a one-sided write into an unready slot.
-  char ready = 1;
   const rdma::RecvSegmentInfo info{
       reinterpret_cast<uint64_t>(recv_lease.data()),
       recv_segment_mr->rkey, slot_size};
-  char encoded[rdma::kRecvSegmentInfoBytes];
-  char encoded_token[rdma::kV2WriterTokenBytes];
-  rdma::EncodeRecvSegmentInfo(info, encoded);
-  net::PutU64(encoded_token, writer_token);
-  const bool ok = net::WriteAll(boot_fd, &ready, 1) &&
-                  net::WriteAll(boot_fd, encoded, sizeof(encoded)) &&
-                  net::WriteAll(boot_fd, encoded_token, sizeof(encoded_token));
+  char readiness[rdma::kV2RetirementReadinessBytes];
+  const size_t readiness_bytes =
+      rdma::EncodeV2Readiness(info, writer_token, readiness);
+  const bool ok = net::WriteAll(boot_fd, readiness, readiness_bytes);
   ::close(boot_fd);
   if (!ok) {
     retire_writer();

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/random.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -40,6 +41,29 @@ namespace {
 static_assert(wire_limits::kIoAlign == rdma::kDirectIoAlign,
               "wire_limits must mirror the RDMA direct-IO alignment");
 using wire_limits::ResolveMaxPayload;
+// Draw every token from the kernel CRNG. Unlike a userspace PRNG or counter,
+// getrandom has no inherited/reset state that can replay after fork or restart.
+uint64_t RandomNonzeroWriterToken() {
+  for (;;) {
+    uint64_t token = 0;
+    size_t filled = 0;
+    while (filled < sizeof(token)) {
+      const ssize_t n =
+          ::getrandom(reinterpret_cast<char*>(&token) + filled,
+                      sizeof(token) - filled, 0);
+      if (n > 0) {
+        filled += static_cast<size_t>(n);
+        continue;
+      }
+      if (n < 0 && errno == EINTR) continue;
+      const int error = n < 0 ? errno : 0;
+      DFKV_LOG_ERROR("rdma: secure writer-token generation failed errno=" +
+                     std::to_string(error));
+      std::abort();
+    }
+    if (token != 0) return token;
+  }
+}
 
 // Monotonic seconds for the async-read submit->complete latency stamp. Read
 // twice per deferred GET (prep + completion), both off the SSD-bound path, so
@@ -115,6 +139,15 @@ void LogTopologySummary(size_t configured, size_t initialized,
   DFKV_LOG_INFO(summary);
 }
 }  // namespace
+uint64_t RdmaServer::RegisterWriter(
+    const std::shared_ptr<WriterState>& writer) {
+  for (;;) {
+    const uint64_t token = RandomNonzeroWriterToken();
+    std::lock_guard<std::mutex> lock(writer_mu_);
+    if (writers_.emplace(token, writer).second) return token;
+  }
+}
+
 
 RdmaServer::RdmaServer(Handler handler, size_t max_msg,
                        const std::string& dev_name)
@@ -475,6 +508,26 @@ void RdmaServer::Serve(int boot_fd) {
     ::close(boot_fd);
     return;
   }
+  if (rdma::IsV2RetireWriter(devbuf)) {
+    const uint64_t token = rdma::ParseDevFrameCaps(devbuf);
+    std::shared_ptr<WriterState> writer;
+    {
+      std::lock_guard<std::mutex> lock(writer_mu_);
+      const auto found = writers_.find(token);
+      if (found != writers_.end()) writer = found->second;
+    }
+    if (writer) {
+      std::unique_lock<std::mutex> lock(writer->mu);
+      if (!writer->retired && writer->endpoint)
+        writer->endpoint->CancelResponderWrites();
+      writer->retired_cv.wait(lock, [&] { return writer->retired; });
+    }
+    char proof[rdma::kV2RetireProofBytes];
+    rdma::EncodeV2RetireProof(token, proof);
+    net::WriteAll(boot_fd, proof, sizeof(proof));
+    ::close(boot_fd);
+    return;
+  }
   // Capability probes are answered without creating a QP.
   if (rdma::IsV2Probe(devbuf)) {
     char reply[rdma::kV2ProbeReplyBytes];
@@ -688,6 +741,23 @@ void RdmaServer::Serve(int boot_fd) {
     ::close(boot_fd);
     return;
   }
+  auto writer = std::make_shared<WriterState>();
+  writer->endpoint = &ep;
+  const uint64_t writer_token = RegisterWriter(writer);
+  auto retire_writer = [&] {
+    const bool retired = ep.RetireResponderWrites();
+    if (!retired)
+      DFKV_LOG_ERROR("rdma: responder WRITE CQ drain failed");
+    {
+      std::lock_guard<std::mutex> lock(writer->mu);
+      writer->endpoint = nullptr;
+      writer->retired = retired;
+    }
+    if (!retired) std::abort();
+    writer->retired_cv.notify_all();
+    std::lock_guard<std::mutex> lock(writer_mu_);
+    writers_.erase(writer_token);
+  };
   // Receives must be posted before readiness becomes visible. Publish the
   // leased receive-segment address, rkey and slot geometry only after the QP is
   // armed, so the client cannot issue a one-sided write into an unready slot.
@@ -696,11 +766,17 @@ void RdmaServer::Serve(int boot_fd) {
       reinterpret_cast<uint64_t>(recv_lease.data()),
       recv_segment_mr->rkey, slot_size};
   char encoded[rdma::kRecvSegmentInfoBytes];
+  char encoded_token[rdma::kV2WriterTokenBytes];
   rdma::EncodeRecvSegmentInfo(info, encoded);
+  net::PutU64(encoded_token, writer_token);
   const bool ok = net::WriteAll(boot_fd, &ready, 1) &&
-                  net::WriteAll(boot_fd, encoded, sizeof(encoded));
+                  net::WriteAll(boot_fd, encoded, sizeof(encoded)) &&
+                  net::WriteAll(boot_fd, encoded_token, sizeof(encoded_token));
   ::close(boot_fd);
-  if (!ok) return;
+  if (!ok) {
+    retire_writer();
+    return;
+  }
   v2_conns_.fetch_add(1, std::memory_order_relaxed);
 
   // Register this endpoint so Stop() can Wake() us out of WaitComp and join. The
@@ -708,7 +784,10 @@ void RdmaServer::Serve(int boot_fd) {
   // Stop sees us in live_eps_ (and wakes us) or we see running_==false here.
   {
     std::lock_guard<std::mutex> lk(conn_mu_);
-    if (!running_) return;
+    if (!running_) {
+      retire_writer();
+      return;
+    }
     live_eps_.insert(&ep);
   }
   ep.last_active_us_.store(SteadyUs(), std::memory_order_relaxed);
@@ -1359,6 +1438,7 @@ void RdmaServer::Serve(int boot_fd) {
                                                 std::memory_order_relaxed);
         return false;
       }
+      if (wc.opcode == IBV_WC_RDMA_WRITE) return true;
       if (wc.opcode == IBV_WC_SEND) {
         const size_t sid = static_cast<size_t>(wc.wr_id);
         if (sid >= K) return false;
@@ -1652,6 +1732,7 @@ void RdmaServer::Serve(int boot_fd) {
     rail_stats.active_conns.fetch_sub(1, std::memory_order_relaxed);
     active_conns_.fetch_sub(1, std::memory_order_relaxed);
     { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
+    retire_writer();
     return;
   }
 sync_serve_loop:;
@@ -1671,6 +1752,7 @@ sync_serve_loop:;
                                                std::memory_order_relaxed);
         fail = true; break;
       }
+      if (wc.opcode == IBV_WC_RDMA_WRITE) continue;
       if (wc.opcode == IBV_WC_SEND) {
         size_t sid = static_cast<size_t>(wc.wr_id);
         // Finish any deferred read while its source slot is still owned and
@@ -1726,8 +1808,11 @@ sync_serve_loop:;
   rail_stats.active_conns.fetch_sub(1, std::memory_order_relaxed);
   active_conns_.fetch_sub(1, std::memory_order_relaxed);
   { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
-  // ep dtor tears down the QP; the peer observes the drop as an error completion.
+  retire_writer();
+  // Writer retirement proof, not ep destruction, fences client destinations.
+  // The endpoint destructor below only releases verbs resources.
 }
+
 
 std::string RdmaServer::MetricsText() const {
   auto m = [](std::string& s, const char* name, const char* type, const char* help,

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -1,21 +1,24 @@
 /* RDMA cache-node listener — native v2 libibverbs RC. Bounded 32,786-byte
  * per-QP control buffers share a process-wide registered payload segment.
  * Peers that cannot negotiate v2 are rejected.
- * The TCP listener only bootstraps QPs. Startup discovers the first ACTIVE HCA
- * automatically, or resolves every explicitly configured HCA into a fixed
- * topology (including initially inactive ports), then anchors shared PD/MRs.
+ * The TCP listener bootstraps QPs and proves failed writer generations retired.
+ * Startup discovers the first ACTIVE HCA automatically, or resolves every
+ * explicitly configured HCA into a fixed topology (including initially inactive
+ * ports), then anchors shared PD/MRs.
  * shutdown(listen_fd) keeps Stop() interruptible. */
 #ifndef DFKV_RDMA_SERVER_H_
 #define DFKV_RDMA_SERVER_H_
 
 #include <atomic>
 #include <cstddef>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -171,6 +174,16 @@ class RdmaServer {
     std::shared_ptr<std::atomic<bool>> done;
   };
 
+  struct WriterState {
+    std::mutex mu;
+    std::condition_variable retired_cv;
+    rdma::RcEndpoint* endpoint = nullptr;
+    bool retired = false;
+  };
+  // Register a writer under an OS-random, nonzero token. Candidate insertion
+  // and collision detection are atomic with respect to retire lookups.
+  uint64_t RegisterWriter(const std::shared_ptr<WriterState>& writer);
+
   // Per-device counters make a partial rail failure or affinity imbalance
   // visible without polling host counters. The rail set is fixed by Start().
   struct RailStats {
@@ -202,6 +215,8 @@ class RdmaServer {
   std::mutex conn_mu_;
   std::vector<Conn> conns_;
   std::unordered_set<rdma::RcEndpoint*> live_eps_;
+  std::mutex writer_mu_;
+  std::unordered_map<uint64_t, std::shared_ptr<WriterState>> writers_;
   // One process-wide pinned receive segment replaces per-connection payload
   // buffers. Each v2 connection leases depth * aligned_slot_size bytes, and
   // each rail's shared PD registers the segment once. This makes connection

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1426,25 +1426,21 @@ std::string PernodeFmt1(uint64_t x10) {
   return std::to_string(x10 / 10) + "." + std::to_string(x10 % 10);
 }
 
-const std::string& PernodeSuffix() {
-  static const std::string suffix = [] {
-    const char* env_suffix = std::getenv("DFKV_CLIENT_LOG_SUFFIX");
-    const std::string pid_tag = "p" + std::to_string(::getpid());
-    std::string value =
-        env_suffix && *env_suffix ? env_suffix : pid_tag;
-    for (char& c : value)
-      if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_')
-        c = '_';
-    // A launcher-supplied rank identity is attributable but not necessarily
-    // process-unique (for example TP rank repeats across DP/PP groups).
-    if (value != pid_tag &&
-        (value.size() <= pid_tag.size() ||
-         value.compare(value.size() - pid_tag.size(), pid_tag.size(),
-                       pid_tag) != 0))
-      value += "_" + pid_tag;
-    return value;
-  }();
-  return suffix;
+std::string PernodeSuffix() {
+  const char* env_suffix = std::getenv("DFKV_CLIENT_LOG_SUFFIX");
+  const std::string pid_tag = "p" + std::to_string(::getpid());
+  std::string value = env_suffix && *env_suffix ? env_suffix : pid_tag;
+  for (char& c : value)
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_')
+      c = '_';
+  // A launcher-supplied rank identity is attributable but not necessarily
+  // process-unique (for example TP rank repeats across DP/PP groups).
+  if (value != pid_tag &&
+      (value.size() <= pid_tag.size() ||
+       value.compare(value.size() - pid_tag.size(), pid_tag.size(), pid_tag) !=
+           0))
+    value += "_" + pid_tag;
+  return value;
 }
 
 // File I/O is confined to this worker. Producers only move an already-formatted

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1,6 +1,9 @@
 #include "client/kv_client.h"
 
+#include <unistd.h>
+
 #include <array>
+#include <cctype>
 #include <atomic>
 #include <climits>
 #include <chrono>
@@ -1215,11 +1218,202 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
   return RecordBatch(OpMetrics::kExist, t0, std::move(res), 0);
 }
 
+namespace {
+
+// Shared per-node (ip:port) stats for GET/PUT/EXIST. Gated by
+// DFKV_CLIENT_PERNODE_STATS=1 (off by default); emitted to
+// $DFKV_ACCESS_DIR/<file>.<suffix> (append+flush) if set, else stderr.
+bool PernodeOn() {
+  static const bool on = [] {
+    const char* e = std::getenv("DFKV_CLIENT_PERNODE_STATS");
+    return e && *e && *e != '0';
+  }();
+  return on;
+}
+
+struct PernodeStat {
+  uint64_t keys = 0, bytes = 0, busy_us = 0, wall_us = 0, shards = 0;
+  uint64_t min_b = std::numeric_limits<uint64_t>::max(), max_b = 0;  // value size
+  uint64_t hit = 0;        // successes: GET retrieved / PUT written / EXIST present
+  uint64_t fail = 0;       // routed failures (status != ok among issued keys)
+  uint32_t fail_mask = 0;  // bit i set when Status value i appears among failures
+  std::string first_fail;  // fingerprint of the first failed key on this node
+  std::string dev;         // IB rail device of the slowest shard (the one setting wall_us)
+};
+
+const char* PernodeStatusName(Status s) {
+  switch (s) {
+    case Status::kOk: return "kOk";
+    case Status::kNotFound: return "kNotFound";
+    case Status::kCacheFull: return "kCacheFull";
+    case Status::kQuotaExceeded: return "kQuotaExceeded";
+    case Status::kIOError: return "kIOError";
+    case Status::kInvalid: return "kInvalid";
+  }
+  return "kUnknown";
+}
+
+// Cheap key fingerprint (len + first bytes as hex; no hashing on the hot path).
+std::string PernodeKeyFp(const std::string& key) {
+  static const char* H = "0123456789abcdef";
+  std::string hex;
+  const size_t n = key.size() < 8 ? key.size() : 8;
+  for (size_t i = 0; i < n; ++i) {
+    const unsigned char c = static_cast<unsigned char>(key[i]);
+    hex += H[c >> 4];
+    hex += H[c & 0xf];
+  }
+  return "len=" + std::to_string(key.size()) + ":" + hex;
+}
+
+std::string PernodeFmt1(uint64_t x10) {  // one decimal from an x10 integer
+  return std::to_string(x10 / 10) + "." + std::to_string(x10 % 10);
+}
+
+// Per-process file suffix, mirroring the vLLM connector access log's
+// ``access.log.r{tp_rank}`` convention: the integration layer exports
+// DFKV_CLIENT_LOG_SUFFIX (e.g. "r3") for every worker it launches so each
+// rank owns its file. Without it the pid keeps concurrent local processes
+// from interleaving one shared file.
+std::string PernodeSuffix() {
+  static const std::string suffix = [] {
+    const char* e = std::getenv("DFKV_CLIENT_LOG_SUFFIX");
+    std::string s = e && *e ? e : "p" + std::to_string(::getpid());
+    for (char& c : s)
+      if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_')
+        c = '_';  // a separator smuggled via the env must not escape the dir
+    return s;
+  }();
+  return suffix;
+}
+
+// One FILE* per distinct file name (opened once); nullptr => stderr fallback.
+void PernodeWrite(const char* fname, const std::vector<std::string>& lines) {
+  static std::mutex mu;
+  static std::map<std::string, FILE*> sinks;
+  std::lock_guard<std::mutex> lk(mu);
+  auto it = sinks.find(fname);
+  FILE* sink;
+  if (it != sinks.end()) {
+    sink = it->second;
+  } else {
+    sink = nullptr;
+    const char* dir = std::getenv("DFKV_ACCESS_DIR");
+    if (dir && *dir) {
+      const std::string path =
+          std::string(dir) + "/" + fname + "." + PernodeSuffix();
+      sink = std::fopen(path.c_str(), "a");
+      if (!sink)
+        DFKV_LOG_WARN("pernode: cannot open " + path + "; using stderr");
+    }
+    sinks[fname] = sink;
+  }
+  if (sink) {
+    char ts[32];
+    std::time_t tt = std::time(nullptr);
+    std::tm tm{};
+    localtime_r(&tt, &tm);
+    std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tm);
+    for (const auto& ln : lines) std::fprintf(sink, "%s %s\n", ts, ln.c_str());
+    std::fflush(sink);
+  } else {
+    for (const auto& ln : lines) DFKV_LOG_INFO(ln);
+  }
+}
+
+// op: 0=get, 1=put, 2=exist. Sort slowest first, emit one TOTAL + per-node line.
+void EmitPernode(int op, const char* label, const char* fname,
+                 const std::map<std::string, PernodeStat>& per,
+                 const std::map<std::string, std::string>& addr2name,
+                 uint64_t total_wall_us, uint64_t N, uint64_t preroute_fail) {
+  std::vector<const std::pair<const std::string, PernodeStat>*> rows;
+  rows.reserve(per.size());
+  for (const auto& it : per) rows.push_back(&it);
+  for (size_t i = 0; i + 1 < rows.size(); ++i) {  // selection sort (few nodes)
+    size_t mx = i;
+    for (size_t j = i + 1; j < rows.size(); ++j)
+      if (rows[j]->second.wall_us > rows[mx]->second.wall_us) mx = j;
+    if (mx != i) { auto* t = rows[i]; rows[i] = rows[mx]; rows[mx] = t; }
+  }
+  uint64_t tk = 0, tb = 0, th = 0, tf = 0,
+           tmin = std::numeric_limits<uint64_t>::max(), tmax = 0;
+  for (auto* r : rows) {
+    const PernodeStat& a = r->second;
+    tk += a.keys; tb += a.bytes; th += a.hit; tf += a.fail;
+    if (a.max_b > 0) {
+      if (a.min_b < tmin) tmin = a.min_b;
+      if (a.max_b > tmax) tmax = a.max_b;
+    }
+  }
+  if (tmax == 0) tmin = 0;
+
+  std::vector<std::string> lines;
+  lines.reserve(rows.size() + 1);
+  {
+    const uint64_t mbps10 =
+        total_wall_us ? (tb * 10 + total_wall_us / 2) / total_wall_us : 0;
+    const uint64_t avgv = tk ? (tb + tk / 2) / tk : 0;
+    std::string s = std::string("pernode-") + label + " TOTAL: " + label +
+                    "_ms=" + PernodeFmt1((total_wall_us + 50) / 100) +
+                    " keys=" + std::to_string(N) +
+                    " servers=" + std::to_string(rows.size()) +
+                    " bytes=" + std::to_string(tb) +
+                    " avg_bytes/key=" + std::to_string(avgv) +
+                    " min_bytes=" + std::to_string(tmin) +
+                    " max_bytes=" + std::to_string(tmax) +
+                    " MB/s=" + PernodeFmt1(mbps10);
+    if (op == 0) s += " hit=" + std::to_string(th);
+    else if (op == 2) s += " absent=" + std::to_string(tk - th);
+    else s += " fail_keys=" + std::to_string(tf + preroute_fail) +
+              " preroute_fail=" + std::to_string(preroute_fail);
+    lines.push_back(std::move(s));
+  }
+  for (auto* r : rows) {
+    const PernodeStat& a = r->second;
+    const uint64_t mbps10 =
+        a.wall_us ? (a.bytes * 10 + a.wall_us / 2) / a.wall_us : 0;
+    const uint64_t avgv = a.keys ? (a.bytes + a.keys / 2) / a.keys : 0;
+    const uint64_t us_per_key = a.keys ? (a.busy_us + a.keys / 2) / a.keys : 0;
+    const uint64_t nmin = a.max_b ? a.min_b : 0;
+    auto nit = addr2name.find(r->first);
+    std::string s = std::string("pernode-") + label + ": node=" + r->first +
+        (nit != addr2name.end() ? (" name=" + nit->second) : std::string()) +
+        (a.dev.empty() ? std::string() : (" dev=" + a.dev)) +
+        " keys=" + std::to_string(a.keys) +
+        " bytes=" + std::to_string(a.bytes) +
+        " avg_bytes/key=" + std::to_string(avgv) +
+        " min_bytes=" + std::to_string(nmin) +
+        " max_bytes=" + std::to_string(a.max_b) +
+        " shards=" + std::to_string(a.shards) +
+        " wall_us=" + std::to_string(a.wall_us) +
+        " MB/s=" + PernodeFmt1(mbps10) +
+        " avg_us/key=" + std::to_string(us_per_key);
+    if (op == 0) s += " hit=" + std::to_string(a.hit);
+    else if (op == 2) s += " absent=" + std::to_string(a.keys - a.hit);
+    if (a.fail > 0) {  // error info only when this node had failures
+      std::string codes;
+      for (int b = 0; b < 6; ++b)
+        if (a.fail_mask & (1u << b)) {
+          if (!codes.empty()) codes += ",";
+          codes += PernodeStatusName(static_cast<Status>(b));
+        }
+      s += " FAIL keys=" + std::to_string(a.fail) + " codes=" + codes +
+           " first_fail=" + a.first_fail;
+    }
+    lines.push_back(std::move(s));
+  }
+  PernodeWrite(fname, lines);
+}
+
+}  // namespace
+
 std::vector<bool> KVClient::BatchExistDirect(
     const std::vector<std::string>& keys, std::vector<Status>* statuses) {
   const size_t N = keys.size();
   std::vector<char> e(N, 0);
   std::vector<Status> raw(N, Status::kInvalid);
+  const bool pernode_on = PernodeOn();
+  const auto call_t0 = std::chrono::steady_clock::now();  // whole-call wall (stats)
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
     RunParallel(N, BatchWorkers(N), [&](size_t i) {
       e[i] = ExistDirect(keys[i], &raw[i]) ? 1 : 0;
@@ -1240,6 +1434,7 @@ std::vector<bool> KVClient::BatchExistDirect(
   std::vector<std::pair<std::string, std::vector<size_t>>> groups =
       ShardReadGroups(std::vector<std::pair<std::string, std::vector<size_t>>>(
           by_node.begin(), by_node.end()));
+  std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
   RunReadScheduled(groups.size(), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
@@ -1249,7 +1444,34 @@ std::vector<bool> KVClient::BatchExistDirect(
     bkeys.reserve(idx.size());
     for (size_t k : idx) bkeys.push_back(ToBlockKey(key_namespace_, keys[k]));
     std::vector<char> ex;
-    std::vector<Status> sts = t_->ExistMany(node, bkeys, &ex);
+    std::string shard_dev;
+    const auto pn_t0 = std::chrono::steady_clock::now();
+    std::vector<Status> sts =
+        t_->ExistMany(node, bkeys, &ex, pernode_on ? &shard_dev : nullptr);
+    if (pernode_on) {
+      const uint64_t us = static_cast<uint64_t>(
+          std::chrono::duration<double, std::micro>(
+              std::chrono::steady_clock::now() - pn_t0).count());
+      uint64_t present = 0, failn = 0;
+      uint32_t fmask = 0;
+      std::string ff;
+      for (size_t m = 0; m < idx.size(); ++m) {
+        if (m < ex.size() && ex[m]) present++;  // hit = key exists
+        const Status st = (m < sts.size()) ? sts[m] : Status::kInvalid;
+        if (st == Status::kIOError || st == Status::kInvalid) {  // probe error
+          failn++;
+          fmask |= (1u << static_cast<int>(st));
+          if (ff.empty()) ff = PernodeKeyFp(keys[idx[m]]);
+        }
+      }
+      gstat[g].keys = idx.size();  // bytes/min/max stay 0 (exist has no payload)
+      gstat[g].busy_us = us;
+      gstat[g].hit = present;
+      gstat[g].fail = failn;
+      gstat[g].fail_mask = fmask;
+      gstat[g].first_fail = ff;
+      gstat[g].dev = std::move(shard_dev);
+    }
     bool resp = false, ioerr = false;
     // kInvalid (oversize/per-item guard) is neither: it must not clear the
     // peer cooldown (resp) nor trip MarkBad (ioerr).
@@ -1263,6 +1485,35 @@ std::vector<bool> KVClient::BatchExistDirect(
       e[idx[m]] = (m < ex.size() && ex[m]) ? 1 : 0;
     }
   });
+  if (pernode_on) {
+    std::map<std::string, PernodeStat> per;
+    for (size_t g = 0; g < groups.size(); ++g) {
+      if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+      PernodeStat& a = per[groups[g].first];
+      a.keys += gstat[g].keys;
+      a.busy_us += gstat[g].busy_us;
+      if (gstat[g].busy_us > a.wall_us) {
+        a.wall_us = gstat[g].busy_us;
+        a.dev = gstat[g].dev;  // slowest shard's rail
+      }
+      a.shards += 1;
+      a.hit += gstat[g].hit;
+      a.fail += gstat[g].fail;
+      a.fail_mask |= gstat[g].fail_mask;
+      if (a.first_fail.empty() && !gstat[g].first_fail.empty())
+        a.first_fail = gstat[g].first_fail;
+    }
+    std::map<std::string, std::string> addr2name;
+    {
+      std::lock_guard<std::mutex> lk(ring_mu_);
+      for (const auto& kv : addr_) addr2name[kv.second] = kv.first;
+    }
+    const uint64_t total_wall_us = static_cast<uint64_t>(
+        std::chrono::duration<double, std::micro>(
+            std::chrono::steady_clock::now() - call_t0).count());
+    EmitPernode(2, "exist", "dfkv_client_exist.log", per, addr2name,
+                total_wall_us, N, 0);
+  }
   if (statuses) *statuses = std::move(raw);
   return std::vector<bool>(e.begin(), e.end());
 }
@@ -1340,11 +1591,13 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
       over[i] = 1;
   }
 
+  const bool pernode_on = PernodeOn();
+  uint64_t preroute_fail = 0;  // dropped before routing (oversize guard / no route)
   std::map<std::string, std::vector<size_t>> by_node;
   for (size_t i = 0; i < N; ++i) {
-    if (over[i]) continue;
+    if (over[i]) { preroute_fail++; continue; }
     std::string node = Route(items[i].key);
-    if (node.empty()) continue;
+    if (node.empty()) { preroute_fail++; continue; }
     by_node[node].push_back(i);
   }
   // Shard each per-node put group the same way the read path does (shared knobs
@@ -1356,6 +1609,7 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   std::vector<std::pair<std::string, std::vector<size_t>>> groups =
       ShardReadGroups(std::vector<std::pair<std::string, std::vector<size_t>>>(
           by_node.begin(), by_node.end()));
+  std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
   RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
     uint64_t now = NowMs();
@@ -1371,7 +1625,42 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
         s.payloads.emplace_back(items[k].ptrs[j], items[k].sizes[j]);
       srcs.push_back(std::move(s));
     }
-    std::vector<Status> sts = t_->CacheFromMulti(node, srcs);
+    std::string shard_dev;
+    const auto pn_t0 = std::chrono::steady_clock::now();
+    std::vector<Status> sts =
+        t_->CacheFromMulti(node, srcs, pernode_on ? &shard_dev : nullptr);
+    if (pernode_on) {
+      const uint64_t us = static_cast<uint64_t>(
+          std::chrono::duration<double, std::micro>(
+              std::chrono::steady_clock::now() - pn_t0).count());
+      uint64_t vb = 0, hits = 0, failn = 0,
+               mn = std::numeric_limits<uint64_t>::max(), mx = 0;
+      uint32_t fmask = 0;
+      std::string ff;
+      for (size_t m = 0; m < idx.size() && m < sts.size(); ++m) {
+        if (sts[m] == Status::kOk) {
+          hits++;
+          const uint64_t b = total_bytes[idx[m]];
+          vb += b;
+          if (b < mn) mn = b;
+          if (b > mx) mx = b;
+        } else {
+          failn++;
+          fmask |= (1u << static_cast<int>(sts[m]));
+          if (ff.empty()) ff = PernodeKeyFp(items[idx[m]].key);
+        }
+      }
+      gstat[g].keys = idx.size();
+      gstat[g].bytes = vb;
+      gstat[g].busy_us = us;
+      gstat[g].min_b = mn;
+      gstat[g].max_b = mx;
+      gstat[g].hit = hits;
+      gstat[g].fail = failn;
+      gstat[g].fail_mask = fmask;
+      gstat[g].first_fail = ff;
+      gstat[g].dev = std::move(shard_dev);
+    }
     for (size_t m = 0; m < idx.size(); ++m) {
       ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
       if (ok[idx[m]]) InvalidateRendezvous(srcs[m].key);
@@ -1385,6 +1674,40 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     }
     if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
   });
+  if (pernode_on) {
+    std::map<std::string, PernodeStat> per;
+    for (size_t g = 0; g < groups.size(); ++g) {
+      if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+      PernodeStat& a = per[groups[g].first];
+      a.keys += gstat[g].keys;
+      a.bytes += gstat[g].bytes;
+      a.busy_us += gstat[g].busy_us;
+      if (gstat[g].busy_us > a.wall_us) {
+        a.wall_us = gstat[g].busy_us;
+        a.dev = gstat[g].dev;  // slowest shard's rail
+      }
+      a.shards += 1;
+      a.hit += gstat[g].hit;
+      a.fail += gstat[g].fail;
+      a.fail_mask |= gstat[g].fail_mask;
+      if (gstat[g].max_b > 0) {
+        if (gstat[g].min_b < a.min_b) a.min_b = gstat[g].min_b;
+        if (gstat[g].max_b > a.max_b) a.max_b = gstat[g].max_b;
+      }
+      if (a.first_fail.empty() && !gstat[g].first_fail.empty())
+        a.first_fail = gstat[g].first_fail;
+    }
+    std::map<std::string, std::string> addr2name;
+    {
+      std::lock_guard<std::mutex> lk(ring_mu_);
+      for (const auto& kv : addr_) addr2name[kv.second] = kv.first;
+    }
+    const uint64_t total_wall_us = static_cast<uint64_t>(
+        std::chrono::duration<double, std::micro>(
+            std::chrono::steady_clock::now() - t0).count());
+    EmitPernode(1, "put", "dfkv_client_put.log", per, addr2name,
+                total_wall_us, N, preroute_fail);
+  }
   uint64_t bytes = 0;
   for (size_t i = 0; i < N; ++i)
     if (ok[i]) AddMetricBytes(total_bytes[i], &bytes);
@@ -1570,6 +1893,16 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
   std::vector<char> hit(N, 0);
   std::vector<size_t> lens(N, 0);  // distinct indices => thread-safe writes
 
+  // Per-node (ip:port) GET timing (DFKV_CLIENT_PERNODE_STATS=1, off by default):
+  // accumulate keys/bytes/time by target server across all passes, emit one line
+  // per node at return to spot slow nodes. busy_us sums per-shard service time
+  // (=> avg_us/key); wall_us takes the max shard time — shards run in parallel,
+  // so it approximates the node's wall time, the honest basis for MB/s (summing
+  // parallel shard time would understate throughput).
+  const bool pernode_on = PernodeOn();
+  std::map<std::string, PernodeStat> pernode;
+  const auto call_t0 = std::chrono::steady_clock::now();  // whole-call wall (stats)
+
   // Validate shape and aggregate capacity; the transport windows arbitrary
   // descriptor counts internally.
   std::vector<char> over(N, 0);
@@ -1596,6 +1929,7 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         groups = ShardReadGroups(
             std::vector<std::pair<std::pair<std::string, size_t>,
                                   std::vector<size_t>>>(by.begin(), by.end()));
+    std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
     RunReadScheduled(groups.size(), [&](size_t g) {
       const std::string& node = groups[g].first.first;
       uint64_t now = NowMs();
@@ -1616,8 +1950,31 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         dsts.push_back(std::move(d));
       }
       std::vector<size_t> value_lens;
-      std::vector<Status> sts =
-          t_->RangeIntoMulti(node, keys, dsts, &value_lens);
+      std::string shard_dev;
+      const auto pn_t0 = std::chrono::steady_clock::now();
+      std::vector<Status> sts = t_->RangeIntoMulti(
+          node, keys, dsts, &value_lens, pernode_on ? &shard_dev : nullptr);
+      if (pernode_on) {
+        const uint64_t us = static_cast<uint64_t>(
+            std::chrono::duration<double, std::micro>(
+                std::chrono::steady_clock::now() - pn_t0).count());
+        uint64_t vb = 0, hits = 0, mn = std::numeric_limits<uint64_t>::max(), mx = 0;
+        for (size_t v = 0; v < value_lens.size() && v < sts.size(); ++v)
+          if (sts[v] == Status::kOk) {
+            hits++;
+            const uint64_t b = value_lens[v];
+            vb += b;
+            if (b < mn) mn = b;
+            if (b > mx) mx = b;
+          }
+        gstat[g].keys = idx.size();
+        gstat[g].bytes = vb;
+        gstat[g].busy_us = us;
+        gstat[g].min_b = mn;  // UINT64_MAX if this shard had no kOk key
+        gstat[g].max_b = mx;
+        gstat[g].hit = hits;
+        gstat[g].dev = std::move(shard_dev);
+      }
       bool resp = false, ioerr = false;
       // kInvalid (oversize/per-item guard) is neither: it must not clear the
       // peer cooldown (resp) nor trip MarkBad (ioerr).
@@ -1636,6 +1993,25 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         hit[idx[m]] = 1;
       }
     });
+    if (pernode_on) {
+      for (size_t g = 0; g < groups.size(); ++g) {
+        if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+        PernodeStat& a = pernode[groups[g].first.first];
+        a.keys += gstat[g].keys;
+        a.bytes += gstat[g].bytes;
+        a.busy_us += gstat[g].busy_us;
+        if (gstat[g].busy_us > a.wall_us) {
+          a.wall_us = gstat[g].busy_us;
+          a.dev = gstat[g].dev;  // slowest shard's rail
+        }
+        a.shards += 1;
+        a.hit += gstat[g].hit;
+        if (gstat[g].max_b > 0) {  // shard had >=1 successful key
+          if (gstat[g].min_b < a.min_b) a.min_b = gstat[g].min_b;
+          if (gstat[g].max_b > a.max_b) a.max_b = gstat[g].max_b;
+        }
+      }
+    }
   };
   std::vector<size_t> all(N);
   for (size_t i = 0; i < N; ++i) all[i] = i;
@@ -1650,6 +2026,18 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
       if (!over[i] && !hit[i]) missed.push_back(i);
     if (missed.empty() || missed.size() > N / 2) break;
     run_pass(missed);
+  }
+  if (pernode_on) {
+    const uint64_t total_wall_us = static_cast<uint64_t>(
+        std::chrono::duration<double, std::micro>(
+            std::chrono::steady_clock::now() - call_t0).count());
+    std::map<std::string, std::string> addr2name;
+    {
+      std::lock_guard<std::mutex> lk(ring_mu_);
+      for (const auto& kv : addr_) addr2name[kv.second] = kv.first;
+    }
+    EmitPernode(0, "get", "dfkv_client_get.log", pernode, addr2name,
+                total_wall_us, N, 0);
   }
   if (out_lens) *out_lens = std::move(lens);
   return std::vector<bool>(hit.begin(), hit.end());

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1,18 +1,24 @@
 #include "client/kv_client.h"
 
 #include <unistd.h>
+#include <sys/random.h>
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <atomic>
 #include <climits>
+#include <cstdio>
+#include <ctime>
 #include <chrono>
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <cerrno>
 #include <deque>
 #include <functional>
 #include <memory>
+#include <map>
 #include <mutex>
 #include <limits>
 #include <stdexcept>
@@ -23,6 +29,7 @@
 #include "client/key_map.h"
 #include "client/read_scheduler.h"
 #include "utils/log.h"
+#include "utils/sha256.h"
 #include "utils/thread_name.h"
 #include "utils/parallel_for.h"
 #include "transport/transport_factory.h"
@@ -1221,8 +1228,8 @@ std::vector<bool> KVClient::BatchExist(const std::vector<std::string>& keys) {
 namespace {
 
 // Shared per-node (ip:port) stats for GET/PUT/EXIST. Gated by
-// DFKV_CLIENT_PERNODE_STATS=1 (off by default); emitted to
-// $DFKV_ACCESS_DIR/<file>.<suffix> (append+flush) if set, else stderr.
+// DFKV_CLIENT_PERNODE_STATS=1 (off by default). The disabled path is this one
+// cached branch; no clocks, maps, strings, or sink state are touched.
 bool PernodeOn() {
   static const bool on = [] {
     const char* e = std::getenv("DFKV_CLIENT_PERNODE_STATS");
@@ -1232,13 +1239,19 @@ bool PernodeOn() {
 }
 
 struct PernodeStat {
-  uint64_t keys = 0, bytes = 0, busy_us = 0, wall_us = 0, shards = 0;
-  uint64_t min_b = std::numeric_limits<uint64_t>::max(), max_b = 0;  // value size
-  uint64_t hit = 0;        // successes: GET retrieved / PUT written / EXIST present
-  uint64_t fail = 0;       // routed failures (status != ok among issued keys)
-  uint32_t fail_mask = 0;  // bit i set when Status value i appears among failures
-  std::string first_fail;  // fingerprint of the first failed key on this node
-  std::string dev;         // IB rail device of the slowest shard (the one setting wall_us)
+  // issued_keys counts transport items, so a retried GET is counted once per
+  // attempt. logical_keys exists only on TOTAL and always means caller inputs.
+  uint64_t issued_keys = 0, bytes = 0, busy_us = 0, wall_us = 0, shards = 0;
+  uint64_t min_b = std::numeric_limits<uint64_t>::max(), max_b = 0;
+  uint64_t hit = 0;   // GET found / PUT stored / EXIST present
+  uint64_t fail = 0;  // issued responses other than kOk/kNotFound (PUT: non-kOk)
+  uint64_t nonissued_fail = 0;
+  uint64_t invalid_input = 0, no_route = 0, health_cooldown = 0;
+  uint32_t status_mask = 0;       // statuses returned by the transport
+  uint32_t fail_status_mask = 0;  // failed statuses returned by the transport
+  uint32_t nonissued_status_mask = 0;
+  std::string first_fail;         // keyed id of first failed key
+  std::string dev;                // slowest shard's IB rail
 };
 
 const char* PernodeStatusName(Status s) {
@@ -1249,163 +1262,563 @@ const char* PernodeStatusName(Status s) {
     case Status::kQuotaExceeded: return "kQuotaExceeded";
     case Status::kIOError: return "kIOError";
     case Status::kInvalid: return "kInvalid";
+    case Status::kResourceExhausted: return "kResourceExhausted";
+    case Status::kNoCompatibleRail: return "kNoCompatibleRail";
   }
   return "kUnknown";
 }
 
-// Cheap key fingerprint (len + first bytes as hex; no hashing on the hot path).
-std::string PernodeKeyFp(const std::string& key) {
-  static const char* H = "0123456789abcdef";
-  std::string hex;
-  const size_t n = key.size() < 8 ? key.size() : 8;
-  for (size_t i = 0; i < n; ++i) {
-    const unsigned char c = static_cast<unsigned char>(key[i]);
-    hex += H[c >> 4];
-    hex += H[c & 0xf];
-  }
-  return "len=" + std::to_string(key.size()) + ":" + hex;
+uint32_t PernodeStatusBit(Status s) {
+  const int value = static_cast<int>(s);
+  return value >= 0 && value < 32 ? (1u << value) : 0;
 }
 
-std::string PernodeFmt1(uint64_t x10) {  // one decimal from an x10 integer
+std::string PernodeStatusList(uint32_t mask) {
+  std::string out;
+  for (int value = 0; value < 8; ++value) {
+    if ((mask & (1u << value)) == 0) continue;
+    if (!out.empty()) out += ",";
+    out += PernodeStatusName(static_cast<Status>(value));
+  }
+  return out.empty() ? "none" : out;
+}
+
+// Process-local HMAC-SHA256 makes repeated failures correlatable without
+// leaving a dictionary-reversible digest of the raw key in logs. If kernel
+// randomness is unavailable, omit the digest rather than weakening privacy.
+std::string PernodeKeyFp(const std::string& key) {
+  struct Key {
+    std::array<uint8_t, 32> bytes{};
+    bool ready = false;
+  };
+  static const Key process_key = [] {
+    Key result;
+    size_t offset = 0;
+    while (offset < result.bytes.size()) {
+      const ssize_t n =
+          ::getrandom(result.bytes.data() + offset,
+                      result.bytes.size() - offset, 0);
+      if (n > 0) {
+        offset += static_cast<size_t>(n);
+        continue;
+      }
+      if (n < 0 && errno == EINTR) continue;
+      return result;
+    }
+    result.ready = true;
+    return result;
+  }();
+  if (!process_key.ready)
+    return "len=" + std::to_string(key.size()) + ":digest=redacted";
+
+  std::array<uint8_t, 64> inner_pad{}, outer_pad{};
+  inner_pad.fill(0x36);
+  outer_pad.fill(0x5c);
+  for (size_t i = 0; i < process_key.bytes.size(); ++i) {
+    inner_pad[i] ^= process_key.bytes[i];
+    outer_pad[i] ^= process_key.bytes[i];
+  }
+  std::vector<uint8_t> inner(inner_pad.size() + key.size());
+  std::memcpy(inner.data(), inner_pad.data(), inner_pad.size());
+  if (!key.empty())
+    std::memcpy(inner.data() + inner_pad.size(), key.data(), key.size());
+  std::array<uint8_t, 32> inner_digest{};
+  Sha256(inner.data(), inner.size(), inner_digest.data());
+  std::array<uint8_t, 64 + 32> outer{};
+  std::memcpy(outer.data(), outer_pad.data(), outer_pad.size());
+  std::memcpy(outer.data() + outer_pad.size(), inner_digest.data(),
+              inner_digest.size());
+  std::array<uint8_t, 32> digest{};
+  Sha256(outer.data(), outer.size(), digest.data());
+
+  static const char* hex = "0123456789abcdef";
+  std::string id(32, '0');
+  for (size_t i = 0; i < 16; ++i) {
+    id[2 * i] = hex[digest[i] >> 4];
+    id[2 * i + 1] = hex[digest[i] & 0xf];
+  }
+  return "len=" + std::to_string(key.size()) + ":hmac-sha256=" + id;
+}
+
+enum class PernodeNonIssuedReason {
+  kInvalidInput,
+  kNoRoute,
+  kHealthCooldown,
+};
+
+uint32_t PernodeNonIssuedStatusBit(PernodeNonIssuedReason reason) {
+  // Routing absence and a health gate do not produce a transport Status.
+  // Invalid input is a real client-local kInvalid outcome.
+  return reason == PernodeNonIssuedReason::kInvalidInput
+             ? PernodeStatusBit(Status::kInvalid)
+             : 0;
+}
+
+void RecordPernodeNonIssued(PernodeStat* stat,
+                            PernodeNonIssuedReason reason, uint64_t count,
+                            const std::string& first_key) {
+  stat->nonissued_fail += count;
+  switch (reason) {
+    case PernodeNonIssuedReason::kInvalidInput:
+      stat->invalid_input += count;
+      break;
+    case PernodeNonIssuedReason::kNoRoute:
+      stat->no_route += count;
+      break;
+    case PernodeNonIssuedReason::kHealthCooldown:
+      stat->health_cooldown += count;
+      break;
+  }
+  stat->nonissued_status_mask |= PernodeNonIssuedStatusBit(reason);
+  if (stat->first_fail.empty()) stat->first_fail = PernodeKeyFp(first_key);
+}
+
+void MergePernodeNonIssued(PernodeStat* into, const PernodeStat& from) {
+  into->nonissued_fail += from.nonissued_fail;
+  into->invalid_input += from.invalid_input;
+  into->no_route += from.no_route;
+  into->health_cooldown += from.health_cooldown;
+  into->nonissued_status_mask |= from.nonissued_status_mask;
+  if (into->first_fail.empty() && !from.first_fail.empty())
+    into->first_fail = from.first_fail;
+}
+
+std::string PernodeNonIssuedReasons(const PernodeStat& stat) {
+  std::string out;
+  auto append = [&](const char* reason, const char* status, uint64_t count) {
+    if (count == 0) return;
+    if (!out.empty()) out += ",";
+    out += reason;
+    out += ":";
+    out += status;
+    out += "=";
+    out += std::to_string(count);
+  };
+  append("invalid_input", "kInvalid", stat.invalid_input);
+  append("no_route", "not_issued", stat.no_route);
+  append("health_cooldown", "not_issued", stat.health_cooldown);
+  return out.empty() ? "none" : out;
+}
+
+std::string PernodeFmt1(uint64_t x10) {
   return std::to_string(x10 / 10) + "." + std::to_string(x10 % 10);
 }
 
-// Per-process file suffix, mirroring the vLLM connector access log's
-// ``access.log.r{tp_rank}`` convention: the integration layer exports
-// DFKV_CLIENT_LOG_SUFFIX (e.g. "r3") for every worker it launches so each
-// rank owns its file. Without it the pid keeps concurrent local processes
-// from interleaving one shared file.
-std::string PernodeSuffix() {
+const std::string& PernodeSuffix() {
   static const std::string suffix = [] {
-    const char* e = std::getenv("DFKV_CLIENT_LOG_SUFFIX");
-    std::string s = e && *e ? e : "p" + std::to_string(::getpid());
-    for (char& c : s)
+    const char* env_suffix = std::getenv("DFKV_CLIENT_LOG_SUFFIX");
+    const std::string pid_tag = "p" + std::to_string(::getpid());
+    std::string value =
+        env_suffix && *env_suffix ? env_suffix : pid_tag;
+    for (char& c : value)
       if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_')
-        c = '_';  // a separator smuggled via the env must not escape the dir
-    return s;
+        c = '_';
+    // A launcher-supplied rank identity is attributable but not necessarily
+    // process-unique (for example TP rank repeats across DP/PP groups).
+    if (value != pid_tag &&
+        (value.size() <= pid_tag.size() ||
+         value.compare(value.size() - pid_tag.size(), pid_tag.size(),
+                       pid_tag) != 0))
+      value += "_" + pid_tag;
+    return value;
   }();
   return suffix;
 }
 
-// One FILE* per distinct file name (opened once); nullptr => stderr fallback.
-void PernodeWrite(const char* fname, const std::vector<std::string>& lines) {
-  static std::mutex mu;
-  static std::map<std::string, FILE*> sinks;
-  std::lock_guard<std::mutex> lk(mu);
-  auto it = sinks.find(fname);
-  FILE* sink;
-  if (it != sinks.end()) {
-    sink = it->second;
-  } else {
-    sink = nullptr;
-    const char* dir = std::getenv("DFKV_ACCESS_DIR");
-    if (dir && *dir) {
-      const std::string path =
-          std::string(dir) + "/" + fname + "." + PernodeSuffix();
-      sink = std::fopen(path.c_str(), "a");
-      if (!sink)
-        DFKV_LOG_WARN("pernode: cannot open " + path + "; using stderr");
-    }
-    sinks[fname] = sink;
+// File I/O is confined to this worker. Producers only move an already-formatted
+// batch into a bounded queue and notify it. Rotation keeps exactly current +
+// ".1" per operation file, so both memory and disk file count are bounded.
+class PernodeSink {
+ public:
+  static PernodeSink& Instance() {
+    static PernodeSink sink;
+    return sink;
   }
-  if (sink) {
+
+  void Enqueue(const char* fname, std::vector<std::string> lines) {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      if (queue_.size() >= capacity_) {
+        ++dropped_total_;
+        ++dropped_pending_;
+        return;
+      }
+      queue_.push_back({fname, std::move(lines)});
+      high_water_ = std::max(high_water_, queue_.size());
+    }
+    cv_.notify_one();
+  }
+
+  void DrainForTest() {
+    std::unique_lock<std::mutex> lock(mu_);
+    flush_requested_ = true;
+    cv_.notify_one();
+    drained_.wait(lock, [&] {
+      return queue_.empty() && !writing_ && !flush_requested_;
+    });
+  }
+
+  size_t capacity() const { return capacity_; }
+  size_t high_water() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return high_water_;
+  }
+  uint64_t dropped() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return dropped_total_;
+  }
+
+  uint64_t pending_dropped() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return dropped_pending_;
+  }
+  void PauseForTest(bool paused) {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      paused_for_test_ = paused;
+    }
+    if (!paused) cv_.notify_one();
+  }
+
+ private:
+  struct Batch {
+    std::string fname;
+    std::vector<std::string> lines;
+    uint64_t dropped_before = 0;
+  };
+  struct FileState {
+    FILE* file = nullptr;
+    std::string path;
+    uint64_t bytes = 0;
+  };
+
+  PernodeSink()
+      : capacity_(std::min<size_t>(
+            EnvSize("DFKV_CLIENT_PERNODE_QUEUE_CAPACITY", 256), 65536)),
+        rotate_bytes_(EnvSize("DFKV_CLIENT_PERNODE_ROTATE_BYTES", 64u << 20)),
+        worker_([this] { Run(); }) {}
+
+  ~PernodeSink() {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      stopping_ = true;
+    }
+    cv_.notify_one();
+    worker_.join();
+  }
+
+  FileState& Open(const std::string& fname) {
+    FileState& state = files_[fname];
+    if (state.file || !state.path.empty()) return state;
+    const char* dir = std::getenv("DFKV_ACCESS_DIR");
+    if (!dir || !*dir) return state;
+    state.path = std::string(dir) + "/" + fname + "." + PernodeSuffix();
+    state.file = std::fopen(state.path.c_str(), "a");
+    if (!state.file) {
+      DFKV_LOG_WARN("pernode: cannot open " + state.path + "; using stderr");
+      return state;
+    }
+    if (std::fseek(state.file, 0, SEEK_END) == 0) {
+      const long offset = std::ftell(state.file);
+      if (offset > 0) state.bytes = static_cast<uint64_t>(offset);
+    }
+    return state;
+  }
+
+  void Rotate(FileState& state) {
+    if (state.file) std::fclose(state.file);
+    state.file = nullptr;
+    const std::string previous = state.path + ".1";
+    std::remove(previous.c_str());
+    if (std::rename(state.path.c_str(), previous.c_str()) != 0)
+      DFKV_LOG_WARN("pernode: cannot rotate " + state.path);
+    state.file = std::fopen(state.path.c_str(), "w");
+    state.bytes = 0;
+    if (!state.file)
+      DFKV_LOG_WARN("pernode: cannot reopen " + state.path + "; using stderr");
+  }
+
+  void Write(Batch batch) {
     char ts[32];
-    std::time_t tt = std::time(nullptr);
+    const std::time_t tt = std::time(nullptr);
     std::tm tm{};
     localtime_r(&tt, &tm);
     std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tm);
-    for (const auto& ln : lines) std::fprintf(sink, "%s %s\n", ts, ln.c_str());
-    std::fflush(sink);
-  } else {
-    for (const auto& ln : lines) DFKV_LOG_INFO(ln);
+    const std::string drop_line =
+        batch.dropped_before == 0
+            ? std::string()
+            : "pernode-sink DROPPED: dropped_batches=" +
+                  std::to_string(batch.dropped_before);
+    uint64_t batch_bytes = 0;
+    if (!drop_line.empty())
+      batch_bytes += std::strlen(ts) + 1 + drop_line.size() + 1;
+    for (const std::string& line : batch.lines)
+      batch_bytes += std::strlen(ts) + 1 + line.size() + 1;
+
+    FileState& state = Open(batch.fname);
+    if (state.file && state.bytes > 0 &&
+        batch_bytes > rotate_bytes_ - std::min(rotate_bytes_, state.bytes))
+      Rotate(state);
+    if (state.file) {
+      if (!drop_line.empty())
+        std::fprintf(state.file, "%s %s\n", ts, drop_line.c_str());
+      for (const std::string& line : batch.lines)
+        std::fprintf(state.file, "%s %s\n", ts, line.c_str());
+      state.bytes += batch_bytes;
+    } else {
+      if (!drop_line.empty()) DFKV_LOG_INFO(drop_line);
+      for (const std::string& line : batch.lines) DFKV_LOG_INFO(line);
+    }
   }
+
+  void Run() {
+    NameThisThread("dfkv-pernode");
+    for (;;) {
+      Batch batch;
+      bool flush = false;
+      uint64_t reported_drops = 0;
+      {
+        std::unique_lock<std::mutex> lock(mu_);
+        cv_.wait(lock, [&] {
+          return stopping_ || flush_requested_ ||
+                 (!paused_for_test_ && !queue_.empty());
+        });
+        if (queue_.empty()) {
+          if (flush_requested_) {
+            flush = true;
+            writing_ = true;
+          } else if (stopping_) {
+            break;
+          } else {
+            continue;
+          }
+        } else {
+          batch = std::move(queue_.front());
+          queue_.pop_front();
+          batch.dropped_before = dropped_pending_;
+          reported_drops = batch.dropped_before;
+          writing_ = true;
+        }
+      }
+      if (flush) {
+        for (auto& entry : files_)
+          if (entry.second.file) std::fflush(entry.second.file);
+      } else {
+        Write(std::move(batch));
+      }
+      {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (!flush && reported_drops != 0)
+          dropped_pending_ -= std::min(dropped_pending_, reported_drops);
+        writing_ = false;
+        if (flush) flush_requested_ = false;
+        if (queue_.empty() && !flush_requested_) drained_.notify_all();
+      }
+    }
+    // The writer owns every FILE* through final flush/close; producer and
+    // teardown threads only signal and join, never perform sink file I/O.
+    for (auto& entry : files_) {
+      if (entry.second.file) {
+        std::fclose(entry.second.file);
+        entry.second.file = nullptr;
+      }
+    }
+  }
+
+  const size_t capacity_;
+  const uint64_t rotate_bytes_;
+  mutable std::mutex mu_;
+  std::condition_variable cv_;
+  std::condition_variable drained_;
+  std::deque<Batch> queue_;
+  std::map<std::string, FileState> files_;
+  bool writing_ = false;
+  bool stopping_ = false;
+  bool flush_requested_ = false;
+  bool paused_for_test_ = false;
+  size_t high_water_ = 0;
+  uint64_t dropped_total_ = 0;
+  uint64_t dropped_pending_ = 0;
+  std::thread worker_;
+};
+
+void PernodeWrite(const char* fname, std::vector<std::string> lines) {
+  PernodeSink::Instance().Enqueue(fname, std::move(lines));
 }
 
-// op: 0=get, 1=put, 2=exist. Sort slowest first, emit one TOTAL + per-node line.
+// op: 0=get, 1=put, 2=exist. issued_keys counts transport items only.
+// Non-issued routing/health failures remain logical failures and carry their
+// reason/status separately instead of being misreported as transport attempts.
 void EmitPernode(int op, const char* label, const char* fname,
                  const std::map<std::string, PernodeStat>& per,
                  const std::map<std::string, std::string>& addr2name,
-                 uint64_t total_wall_us, uint64_t N, uint64_t preroute_fail) {
+                 uint64_t total_wall_us, uint64_t logical_keys,
+                 uint64_t logical_hits, const PernodeStat& unrouted) {
   std::vector<const std::pair<const std::string, PernodeStat>*> rows;
   rows.reserve(per.size());
   for (const auto& it : per) rows.push_back(&it);
-  for (size_t i = 0; i + 1 < rows.size(); ++i) {  // selection sort (few nodes)
-    size_t mx = i;
-    for (size_t j = i + 1; j < rows.size(); ++j)
-      if (rows[j]->second.wall_us > rows[mx]->second.wall_us) mx = j;
-    if (mx != i) { auto* t = rows[i]; rows[i] = rows[mx]; rows[mx] = t; }
-  }
-  uint64_t tk = 0, tb = 0, th = 0, tf = 0,
-           tmin = std::numeric_limits<uint64_t>::max(), tmax = 0;
-  for (auto* r : rows) {
-    const PernodeStat& a = r->second;
-    tk += a.keys; tb += a.bytes; th += a.hit; tf += a.fail;
-    if (a.max_b > 0) {
-      if (a.min_b < tmin) tmin = a.min_b;
-      if (a.max_b > tmax) tmax = a.max_b;
+  std::sort(rows.begin(), rows.end(), [](const auto* left, const auto* right) {
+    return left->second.wall_us > right->second.wall_us;
+  });
+  uint64_t issued = 0, bytes = 0, hits = 0, failed = 0;
+  uint64_t min_b = std::numeric_limits<uint64_t>::max(), max_b = 0;
+  uint32_t issued_status_mask = 0, issued_fail_status_mask = 0;
+  PernodeStat nonissued = unrouted;
+  for (const auto* row : rows) {
+    const PernodeStat& stat = row->second;
+    issued += stat.issued_keys;
+    bytes += stat.bytes;
+    hits += stat.hit;
+    failed += stat.fail;
+    issued_status_mask |= stat.status_mask;
+    issued_fail_status_mask |= stat.fail_status_mask;
+    MergePernodeNonIssued(&nonissued, stat);
+    if (stat.max_b > 0) {
+      min_b = std::min(min_b, stat.min_b);
+      max_b = std::max(max_b, stat.max_b);
     }
   }
-  if (tmax == 0) tmin = 0;
+  if (max_b == 0) min_b = 0;
 
   std::vector<std::string> lines;
   lines.reserve(rows.size() + 1);
-  {
-    const uint64_t mbps10 =
-        total_wall_us ? (tb * 10 + total_wall_us / 2) / total_wall_us : 0;
-    const uint64_t avgv = tk ? (tb + tk / 2) / tk : 0;
-    std::string s = std::string("pernode-") + label + " TOTAL: " + label +
-                    "_ms=" + PernodeFmt1((total_wall_us + 50) / 100) +
-                    " keys=" + std::to_string(N) +
-                    " servers=" + std::to_string(rows.size()) +
-                    " bytes=" + std::to_string(tb) +
-                    " avg_bytes/key=" + std::to_string(avgv) +
-                    " min_bytes=" + std::to_string(tmin) +
-                    " max_bytes=" + std::to_string(tmax) +
-                    " MB/s=" + PernodeFmt1(mbps10);
-    if (op == 0) s += " hit=" + std::to_string(th);
-    else if (op == 2) s += " absent=" + std::to_string(tk - th);
-    else s += " fail_keys=" + std::to_string(tf + preroute_fail) +
-              " preroute_fail=" + std::to_string(preroute_fail);
-    lines.push_back(std::move(s));
+  const uint64_t mbps10 =
+      total_wall_us ? (bytes * 10 + total_wall_us / 2) / total_wall_us : 0;
+  const uint64_t avg_value = hits ? (bytes + hits / 2) / hits : 0;
+  const uint32_t logical_failure_status_mask =
+      issued_fail_status_mask | nonissued.nonissued_status_mask;
+  std::string total =
+      std::string("pernode-") + label + " TOTAL: " + label +
+      "_ms=" + PernodeFmt1((total_wall_us + 50) / 100) +
+      " logical_keys=" + std::to_string(logical_keys) +
+      " issued_keys=" + std::to_string(issued) +
+      " nonissued_failures=" + std::to_string(nonissued.nonissued_fail) +
+      " servers=" + std::to_string(rows.size()) +
+      " bytes=" + std::to_string(bytes) +
+      " avg_success_bytes=" + std::to_string(avg_value) +
+      " min_bytes=" + std::to_string(min_b) +
+      " max_bytes=" + std::to_string(max_b) +
+      " MB/s=" + PernodeFmt1(mbps10) +
+      " failed_issued_keys=" + std::to_string(failed) +
+      " status_mask=" + std::to_string(issued_status_mask) +
+      " statuses=" + PernodeStatusList(issued_status_mask) +
+      " failure_status_mask=" + std::to_string(issued_fail_status_mask) +
+      " logical_failure_status_mask=" +
+      std::to_string(logical_failure_status_mask) +
+      " nonissued_status_mask=" +
+      std::to_string(nonissued.nonissued_status_mask) +
+      " nonissued_statuses=" +
+      PernodeStatusList(nonissued.nonissued_status_mask) +
+      " invalid_input=" + std::to_string(nonissued.invalid_input) +
+      " no_route=" + std::to_string(nonissued.no_route) +
+      " health_cooldown=" + std::to_string(nonissued.health_cooldown) +
+      " nonissued_reasons=" + PernodeNonIssuedReasons(nonissued);
+  if (op == 0)
+    total += " logical_hits=" + std::to_string(logical_hits) +
+             " logical_not_hit=" +
+             std::to_string(logical_keys - logical_hits) +
+             " missed_issued_keys=" +
+             std::to_string(issued - hits - failed);
+  else if (op == 2)
+    total += " logical_present=" + std::to_string(logical_hits) +
+             " logical_not_present=" +
+             std::to_string(logical_keys - logical_hits) +
+             " absent_issued_keys=" +
+             std::to_string(issued - hits - failed);
+  else
+    total += " logical_success=" + std::to_string(logical_hits) +
+             " logical_fail=" +
+             std::to_string(logical_keys - logical_hits) +
+             " successful_issued_keys=" + std::to_string(hits) +
+             " preroute_fail=" +
+             std::to_string(nonissued.invalid_input + nonissued.no_route);
+  if (nonissued.nonissued_fail > 0)
+    total += " first_nonissued_fail=" + nonissued.first_fail;
+  lines.push_back(std::move(total));
+
+  for (const auto* row : rows) {
+    const PernodeStat& stat = row->second;
+    const uint64_t node_mbps10 =
+        stat.wall_us
+            ? (stat.bytes * 10 + stat.wall_us / 2) / stat.wall_us
+            : 0;
+    const uint64_t avg_value =
+        stat.hit ? (stat.bytes + stat.hit / 2) / stat.hit : 0;
+    const uint64_t us_per_key =
+        stat.issued_keys
+            ? (stat.busy_us + stat.issued_keys / 2) / stat.issued_keys
+            : 0;
+    const uint64_t node_min = stat.max_b ? stat.min_b : 0;
+    auto name = addr2name.find(row->first);
+    const uint32_t node_logical_failure_status_mask =
+        stat.fail_status_mask | stat.nonissued_status_mask;
+    std::string line =
+        std::string("pernode-") + label + ": node=" + row->first +
+        (name != addr2name.end() ? (" name=" + name->second) : std::string()) +
+        (stat.dev.empty() ? std::string() : (" dev=" + stat.dev)) +
+        " issued_keys=" + std::to_string(stat.issued_keys) +
+        " nonissued_failures=" + std::to_string(stat.nonissued_fail) +
+        " bytes=" + std::to_string(stat.bytes) +
+        " avg_success_bytes=" + std::to_string(avg_value) +
+        " min_bytes=" + std::to_string(node_min) +
+        " max_bytes=" + std::to_string(stat.max_b) +
+        " shards=" + std::to_string(stat.shards) +
+        " wall_us=" + std::to_string(stat.wall_us) +
+        " MB/s=" + PernodeFmt1(node_mbps10) +
+        " avg_us/issued_key=" + std::to_string(us_per_key) +
+        " failed_issued_keys=" + std::to_string(stat.fail) +
+        " status_mask=" + std::to_string(stat.status_mask) +
+        " statuses=" + PernodeStatusList(stat.status_mask) +
+        " failure_status_mask=" +
+        std::to_string(stat.fail_status_mask) +
+        " logical_failure_status_mask=" +
+        std::to_string(node_logical_failure_status_mask) +
+        " nonissued_status_mask=" +
+        std::to_string(stat.nonissued_status_mask) +
+        " nonissued_statuses=" +
+        PernodeStatusList(stat.nonissued_status_mask) +
+        " invalid_input=" + std::to_string(stat.invalid_input) +
+        " no_route=" + std::to_string(stat.no_route) +
+        " health_cooldown=" + std::to_string(stat.health_cooldown) +
+        " nonissued_reasons=" + PernodeNonIssuedReasons(stat);
+    if (op == 0)
+      line += " hit_issued_keys=" + std::to_string(stat.hit) +
+              " missed_issued_keys=" +
+              std::to_string(stat.issued_keys - stat.hit - stat.fail);
+    else if (op == 2)
+      line += " present_issued_keys=" + std::to_string(stat.hit) +
+              " absent_issued_keys=" +
+              std::to_string(stat.issued_keys - stat.hit - stat.fail);
+    else
+      line += " successful_issued_keys=" + std::to_string(stat.hit);
+    if (stat.fail > 0 || stat.nonissued_fail > 0)
+      line += " first_fail=" + stat.first_fail;
+    lines.push_back(std::move(line));
   }
-  for (auto* r : rows) {
-    const PernodeStat& a = r->second;
-    const uint64_t mbps10 =
-        a.wall_us ? (a.bytes * 10 + a.wall_us / 2) / a.wall_us : 0;
-    const uint64_t avgv = a.keys ? (a.bytes + a.keys / 2) / a.keys : 0;
-    const uint64_t us_per_key = a.keys ? (a.busy_us + a.keys / 2) / a.keys : 0;
-    const uint64_t nmin = a.max_b ? a.min_b : 0;
-    auto nit = addr2name.find(r->first);
-    std::string s = std::string("pernode-") + label + ": node=" + r->first +
-        (nit != addr2name.end() ? (" name=" + nit->second) : std::string()) +
-        (a.dev.empty() ? std::string() : (" dev=" + a.dev)) +
-        " keys=" + std::to_string(a.keys) +
-        " bytes=" + std::to_string(a.bytes) +
-        " avg_bytes/key=" + std::to_string(avgv) +
-        " min_bytes=" + std::to_string(nmin) +
-        " max_bytes=" + std::to_string(a.max_b) +
-        " shards=" + std::to_string(a.shards) +
-        " wall_us=" + std::to_string(a.wall_us) +
-        " MB/s=" + PernodeFmt1(mbps10) +
-        " avg_us/key=" + std::to_string(us_per_key);
-    if (op == 0) s += " hit=" + std::to_string(a.hit);
-    else if (op == 2) s += " absent=" + std::to_string(a.keys - a.hit);
-    if (a.fail > 0) {  // error info only when this node had failures
-      std::string codes;
-      for (int b = 0; b < 6; ++b)
-        if (a.fail_mask & (1u << b)) {
-          if (!codes.empty()) codes += ",";
-          codes += PernodeStatusName(static_cast<Status>(b));
-        }
-      s += " FAIL keys=" + std::to_string(a.fail) + " codes=" + codes +
-           " first_fail=" + a.first_fail;
-    }
-    lines.push_back(std::move(s));
-  }
-  PernodeWrite(fname, lines);
+  PernodeWrite(fname, std::move(lines));
 }
 
 }  // namespace
+namespace testing {
+void DrainPernodeSink() { PernodeSink::Instance().DrainForTest(); }
+size_t PernodeQueueCapacity() { return PernodeSink::Instance().capacity(); }
+size_t PernodeQueueHighWater() { return PernodeSink::Instance().high_water(); }
+uint64_t PernodeQueueDropped() { return PernodeSink::Instance().dropped(); }
+uint64_t PernodeQueuePendingDropped() {
+  return PernodeSink::Instance().pending_dropped();
+}
+void PausePernodeSink(bool paused) {
+  PernodeSink::Instance().PauseForTest(paused);
+}
+void EnqueuePernodeForTest(const char* fname,
+                           std::vector<std::string> lines) {
+  PernodeSink::Instance().Enqueue(fname, std::move(lines));
+}
+std::string PernodeKeyFingerprintForTest(const std::string& key) {
+  return PernodeKeyFp(key);
+}
+}  // namespace testing
+
 
 std::vector<bool> KVClient::BatchExistDirect(
     const std::vector<std::string>& keys, std::vector<Status>* statuses) {
@@ -1413,7 +1826,8 @@ std::vector<bool> KVClient::BatchExistDirect(
   std::vector<char> e(N, 0);
   std::vector<Status> raw(N, Status::kInvalid);
   const bool pernode_on = PernodeOn();
-  const auto call_t0 = std::chrono::steady_clock::now();  // whole-call wall (stats)
+  std::chrono::steady_clock::time_point call_t0;
+  if (pernode_on) call_t0 = std::chrono::steady_clock::now();
   if (!t_->pipelined()) {  // TCP: parallelize across items with our own threads
     RunParallel(N, BatchWorkers(N), [&](size_t i) {
       e[i] = ExistDirect(keys[i], &raw[i]) ? 1 : 0;
@@ -1425,10 +1839,17 @@ std::vector<bool> KVClient::BatchExistDirect(
   // served key-by-key on one QP; a single-node ring would otherwise serialize
   // thousands of scheduler probes before any KV load can start. Keep original
   // indices in every shard so result ordering is unchanged.
+  std::unique_ptr<PernodeStat> unrouted;
+  if (pernode_on) unrouted = std::make_unique<PernodeStat>();
   std::map<std::string, std::vector<size_t>> by_node;
   for (size_t i = 0; i < N; ++i) {
     std::string node = Route(keys[i]);
-    if (node.empty()) continue;
+    if (node.empty()) {
+      if (pernode_on)
+        RecordPernodeNonIssued(unrouted.get(),
+                               PernodeNonIssuedReason::kNoRoute, 1, keys[i]);
+      continue;
+    }
     by_node[node].push_back(i);
   }
   std::vector<std::pair<std::string, std::vector<size_t>>> groups =
@@ -1437,15 +1858,22 @@ std::vector<bool> KVClient::BatchExistDirect(
   std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
   RunReadScheduled(groups.size(), [&](size_t g) {
     const std::string& node = groups[g].first;
-    uint64_t now = NowMs();
-    if (!health_.Healthy(node, now)) return;
     const std::vector<size_t>& idx = groups[g].second;
+    uint64_t now = NowMs();
+    if (!health_.Healthy(node, now)) {
+      if (pernode_on)
+        RecordPernodeNonIssued(
+            &gstat[g], PernodeNonIssuedReason::kHealthCooldown, idx.size(),
+            keys[idx.front()]);
+      return;
+    }
     std::vector<BlockKey> bkeys;
     bkeys.reserve(idx.size());
     for (size_t k : idx) bkeys.push_back(ToBlockKey(key_namespace_, keys[k]));
     std::vector<char> ex;
     std::string shard_dev;
-    const auto pn_t0 = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point pn_t0;
+    if (pernode_on) pn_t0 = std::chrono::steady_clock::now();
     std::vector<Status> sts =
         t_->ExistMany(node, bkeys, &ex, pernode_on ? &shard_dev : nullptr);
     if (pernode_on) {
@@ -1453,53 +1881,69 @@ std::vector<bool> KVClient::BatchExistDirect(
           std::chrono::duration<double, std::micro>(
               std::chrono::steady_clock::now() - pn_t0).count());
       uint64_t present = 0, failn = 0;
-      uint32_t fmask = 0;
-      std::string ff;
+      uint32_t status_mask = 0, fail_mask = 0;
+      std::string first_fail;
       for (size_t m = 0; m < idx.size(); ++m) {
-        if (m < ex.size() && ex[m]) present++;  // hit = key exists
-        const Status st = (m < sts.size()) ? sts[m] : Status::kInvalid;
-        if (st == Status::kIOError || st == Status::kInvalid) {  // probe error
-          failn++;
-          fmask |= (1u << static_cast<int>(st));
-          if (ff.empty()) ff = PernodeKeyFp(keys[idx[m]]);
+        const Status status =
+            m < sts.size() ? sts[m] : Status::kInvalid;
+        status_mask |= PernodeStatusBit(status);
+        if (status == Status::kOk) {
+          if (m < ex.size() && ex[m]) ++present;
+        } else if (status != Status::kNotFound) {
+          ++failn;
+          fail_mask |= PernodeStatusBit(status);
+          if (first_fail.empty())
+            first_fail = PernodeKeyFp(keys[idx[m]]);
         }
       }
-      gstat[g].keys = idx.size();  // bytes/min/max stay 0 (exist has no payload)
+      gstat[g].issued_keys = idx.size();
       gstat[g].busy_us = us;
       gstat[g].hit = present;
       gstat[g].fail = failn;
-      gstat[g].fail_mask = fmask;
-      gstat[g].first_fail = ff;
+      gstat[g].status_mask = status_mask;
+      gstat[g].fail_status_mask = fail_mask;
+      gstat[g].first_fail = std::move(first_fail);
       gstat[g].dev = std::move(shard_dev);
     }
     bool resp = false, ioerr = false;
     // kInvalid (oversize/per-item guard) is neither: it must not clear the
     // peer cooldown (resp) nor trip MarkBad (ioerr).
-    for (Status s : sts) {
-      if (s == Status::kIOError) ioerr = true;
-      else if (s == Status::kOk || s == Status::kNotFound) resp = true;
+    for (Status status : sts) {
+      if (status == Status::kIOError)
+        ioerr = true;
+      else if (status == Status::kOk || status == Status::kNotFound)
+        resp = true;
     }
-    if (resp) health_.MarkGood(node, NowMs()); else if (ioerr) health_.MarkBad(node, NowMs());
+    if (resp)
+      health_.MarkGood(node, NowMs());
+    else if (ioerr)
+      health_.MarkBad(node, NowMs());
     for (size_t m = 0; m < idx.size(); ++m) {
       if (m < sts.size()) raw[idx[m]] = sts[m];
-      e[idx[m]] = (m < ex.size() && ex[m]) ? 1 : 0;
+      e[idx[m]] =
+          (m < sts.size() && sts[m] == Status::kOk &&
+           m < ex.size() && ex[m])
+              ? 1
+              : 0;
     }
   });
   if (pernode_on) {
     std::map<std::string, PernodeStat> per;
     for (size_t g = 0; g < groups.size(); ++g) {
-      if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+      if (gstat[g].issued_keys == 0 && gstat[g].nonissued_fail == 0) continue;
       PernodeStat& a = per[groups[g].first];
-      a.keys += gstat[g].keys;
+      a.issued_keys += gstat[g].issued_keys;
       a.busy_us += gstat[g].busy_us;
       if (gstat[g].busy_us > a.wall_us) {
         a.wall_us = gstat[g].busy_us;
-        a.dev = gstat[g].dev;  // slowest shard's rail
+        a.dev = gstat[g].dev;
       }
-      a.shards += 1;
+      if (gstat[g].issued_keys > 0) a.shards += 1;
       a.hit += gstat[g].hit;
       a.fail += gstat[g].fail;
-      a.fail_mask |= gstat[g].fail_mask;
+      a.status_mask |= gstat[g].status_mask;
+      a.fail_status_mask |= gstat[g].fail_status_mask;
+      MergePernodeNonIssued(&a, gstat[g]);
       if (a.first_fail.empty() && !gstat[g].first_fail.empty())
         a.first_fail = gstat[g].first_fail;
     }
@@ -1511,8 +1955,10 @@ std::vector<bool> KVClient::BatchExistDirect(
     const uint64_t total_wall_us = static_cast<uint64_t>(
         std::chrono::duration<double, std::micro>(
             std::chrono::steady_clock::now() - call_t0).count());
+    uint64_t logical_present = 0;
+    for (char present : e) logical_present += present != 0;
     EmitPernode(2, "exist", "dfkv_client_exist.log", per, addr2name,
-                total_wall_us, N, 0);
+                total_wall_us, N, logical_present, *unrouted);
   }
   if (statuses) *statuses = std::move(raw);
   return std::vector<bool>(e.begin(), e.end());
@@ -1592,12 +2038,25 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   }
 
   const bool pernode_on = PernodeOn();
-  uint64_t preroute_fail = 0;  // dropped before routing (oversize guard / no route)
+  std::unique_ptr<PernodeStat> unrouted;
+  if (pernode_on) unrouted = std::make_unique<PernodeStat>();
   std::map<std::string, std::vector<size_t>> by_node;
   for (size_t i = 0; i < N; ++i) {
-    if (over[i]) { preroute_fail++; continue; }
+    if (over[i]) {
+      if (pernode_on)
+        RecordPernodeNonIssued(
+            unrouted.get(), PernodeNonIssuedReason::kInvalidInput, 1,
+            items[i].key);
+      continue;
+    }
     std::string node = Route(items[i].key);
-    if (node.empty()) { preroute_fail++; continue; }
+    if (node.empty()) {
+      if (pernode_on)
+        RecordPernodeNonIssued(unrouted.get(),
+                               PernodeNonIssuedReason::kNoRoute, 1,
+                               items[i].key);
+      continue;
+    }
     by_node[node].push_back(i);
   }
   // Shard each per-node put group the same way the read path does (shared knobs
@@ -1612,9 +2071,15 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
   RunParallel(groups.size(), BatchWorkers(groups.size()), [&](size_t g) {
     const std::string& node = groups[g].first;
-    uint64_t now = NowMs();
-    if (!health_.Healthy(node, now)) return;
     const std::vector<size_t>& idx = groups[g].second;
+    uint64_t now = NowMs();
+    if (!health_.Healthy(node, now)) {
+      if (pernode_on)
+        RecordPernodeNonIssued(
+            &gstat[g], PernodeNonIssuedReason::kHealthCooldown, idx.size(),
+            items[idx.front()].key);
+      return;
+    }
     std::vector<CacheSrcMulti> srcs;
     srcs.reserve(idx.size());
     for (size_t k : idx) {
@@ -1626,7 +2091,8 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
       srcs.push_back(std::move(s));
     }
     std::string shard_dev;
-    const auto pn_t0 = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point pn_t0;
+    if (pernode_on) pn_t0 = std::chrono::steady_clock::now();
     std::vector<Status> sts =
         t_->CacheFromMulti(node, srcs, pernode_on ? &shard_dev : nullptr);
     if (pernode_on) {
@@ -1635,34 +2101,40 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
               std::chrono::steady_clock::now() - pn_t0).count());
       uint64_t vb = 0, hits = 0, failn = 0,
                mn = std::numeric_limits<uint64_t>::max(), mx = 0;
-      uint32_t fmask = 0;
-      std::string ff;
-      for (size_t m = 0; m < idx.size() && m < sts.size(); ++m) {
-        if (sts[m] == Status::kOk) {
-          hits++;
-          const uint64_t b = total_bytes[idx[m]];
-          vb += b;
-          if (b < mn) mn = b;
-          if (b > mx) mx = b;
+      uint32_t status_mask = 0, fail_mask = 0;
+      std::string first_fail;
+      for (size_t m = 0; m < idx.size(); ++m) {
+        const Status status =
+            m < sts.size() ? sts[m] : Status::kInvalid;
+        status_mask |= PernodeStatusBit(status);
+        if (status == Status::kOk) {
+          ++hits;
+          const uint64_t value_bytes = total_bytes[idx[m]];
+          vb += value_bytes;
+          mn = std::min(mn, value_bytes);
+          mx = std::max(mx, value_bytes);
         } else {
-          failn++;
-          fmask |= (1u << static_cast<int>(sts[m]));
-          if (ff.empty()) ff = PernodeKeyFp(items[idx[m]].key);
+          ++failn;
+          fail_mask |= PernodeStatusBit(status);
+          if (first_fail.empty())
+            first_fail = PernodeKeyFp(items[idx[m]].key);
         }
       }
-      gstat[g].keys = idx.size();
+      gstat[g].issued_keys = idx.size();
       gstat[g].bytes = vb;
       gstat[g].busy_us = us;
       gstat[g].min_b = mn;
       gstat[g].max_b = mx;
       gstat[g].hit = hits;
       gstat[g].fail = failn;
-      gstat[g].fail_mask = fmask;
-      gstat[g].first_fail = ff;
+      gstat[g].status_mask = status_mask;
+      gstat[g].fail_status_mask = fail_mask;
+      gstat[g].first_fail = std::move(first_fail);
       gstat[g].dev = std::move(shard_dev);
     }
     for (size_t m = 0; m < idx.size(); ++m) {
-      ok[idx[m]] = (sts[m] == Status::kOk) ? 1 : 0;
+      ok[idx[m]] =
+          (m < sts.size() && sts[m] == Status::kOk) ? 1 : 0;
       if (ok[idx[m]]) InvalidateRendezvous(srcs[m].key);
     }
     bool resp = false, ioerr = false;
@@ -1677,22 +2149,24 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
   if (pernode_on) {
     std::map<std::string, PernodeStat> per;
     for (size_t g = 0; g < groups.size(); ++g) {
-      if (gstat[g].keys == 0) continue;  // health-skipped or empty group
+      if (gstat[g].issued_keys == 0 && gstat[g].nonissued_fail == 0) continue;
       PernodeStat& a = per[groups[g].first];
-      a.keys += gstat[g].keys;
+      a.issued_keys += gstat[g].issued_keys;
       a.bytes += gstat[g].bytes;
       a.busy_us += gstat[g].busy_us;
       if (gstat[g].busy_us > a.wall_us) {
         a.wall_us = gstat[g].busy_us;
-        a.dev = gstat[g].dev;  // slowest shard's rail
+        a.dev = gstat[g].dev;
       }
-      a.shards += 1;
+      if (gstat[g].issued_keys > 0) a.shards += 1;
       a.hit += gstat[g].hit;
       a.fail += gstat[g].fail;
-      a.fail_mask |= gstat[g].fail_mask;
+      a.status_mask |= gstat[g].status_mask;
+      a.fail_status_mask |= gstat[g].fail_status_mask;
+      MergePernodeNonIssued(&a, gstat[g]);
       if (gstat[g].max_b > 0) {
-        if (gstat[g].min_b < a.min_b) a.min_b = gstat[g].min_b;
-        if (gstat[g].max_b > a.max_b) a.max_b = gstat[g].max_b;
+        a.min_b = std::min(a.min_b, gstat[g].min_b);
+        a.max_b = std::max(a.max_b, gstat[g].max_b);
       }
       if (a.first_fail.empty() && !gstat[g].first_fail.empty())
         a.first_fail = gstat[g].first_fail;
@@ -1705,8 +2179,10 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
     const uint64_t total_wall_us = static_cast<uint64_t>(
         std::chrono::duration<double, std::micro>(
             std::chrono::steady_clock::now() - t0).count());
+    uint64_t logical_success = 0;
+    for (char success : ok) logical_success += success != 0;
     EmitPernode(1, "put", "dfkv_client_put.log", per, addr2name,
-                total_wall_us, N, preroute_fail);
+                total_wall_us, N, logical_success, *unrouted);
   }
   uint64_t bytes = 0;
   for (size_t i = 0; i < N; ++i)
@@ -1900,8 +2376,14 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
   // so it approximates the node's wall time, the honest basis for MB/s (summing
   // parallel shard time would understate throughput).
   const bool pernode_on = PernodeOn();
-  std::map<std::string, PernodeStat> pernode;
-  const auto call_t0 = std::chrono::steady_clock::now();  // whole-call wall (stats)
+  std::unique_ptr<std::map<std::string, PernodeStat>> pernode;
+  std::unique_ptr<std::vector<char>> nonissued_recorded;
+  std::chrono::steady_clock::time_point call_t0;
+  if (pernode_on) {
+    pernode = std::make_unique<std::map<std::string, PernodeStat>>();
+    nonissued_recorded = std::make_unique<std::vector<char>>(N, 0);
+    call_t0 = std::chrono::steady_clock::now();
+  }
 
   // Validate shape and aggregate capacity; the transport windows arbitrary
   // descriptor counts internally.
@@ -1913,15 +2395,31 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         !CheckedSizeSum(items[i].caps, &total_caps[i]))
       over[i] = 1;
   }
+  std::unique_ptr<PernodeStat> unrouted;
+  if (pernode_on) unrouted = std::make_unique<PernodeStat>();
 
   // Group by (node, total_cap): a group shares the Range length (= sum of caps)
   // so the existing RangeInto windowing/pipelining applies unchanged.
   auto run_pass = [&](const std::vector<size_t>& todo) {
     std::map<std::pair<std::string, size_t>, std::vector<size_t>> by;
     for (size_t i : todo) {
-      if (over[i]) continue;
+      if (over[i]) {
+        if (pernode_on)
+          RecordPernodeNonIssued(
+              unrouted.get(), PernodeNonIssuedReason::kInvalidInput, 1,
+              items[i].key);
+        continue;
+      }
       std::string node = Route(items[i].key);
-      if (node.empty()) continue;
+      if (node.empty()) {
+        if (pernode_on && !(*nonissued_recorded)[i]) {
+          RecordPernodeNonIssued(
+              unrouted.get(), PernodeNonIssuedReason::kNoRoute, 1,
+              items[i].key);
+          (*nonissued_recorded)[i] = 1;
+        }
+        continue;
+      }
       by[{node, total_caps[i]}].push_back(i);
     }
     std::vector<std::pair<std::pair<std::string, size_t>,
@@ -1932,9 +2430,25 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
     std::vector<PernodeStat> gstat(pernode_on ? groups.size() : 0);
     RunReadScheduled(groups.size(), [&](size_t g) {
       const std::string& node = groups[g].first.first;
-      uint64_t now = NowMs();
-      if (!health_.Healthy(node, now)) return;
       const std::vector<size_t>& idx = groups[g].second;
+      uint64_t now = NowMs();
+      if (!health_.Healthy(node, now)) {
+        if (pernode_on) {
+          size_t fresh = 0;
+          size_t first_fresh = 0;
+          for (size_t item_index : idx) {
+            if ((*nonissued_recorded)[item_index]) continue;
+            if (fresh == 0) first_fresh = item_index;
+            (*nonissued_recorded)[item_index] = 1;
+            ++fresh;
+          }
+          if (fresh != 0)
+            RecordPernodeNonIssued(
+                &gstat[g], PernodeNonIssuedReason::kHealthCooldown, fresh,
+                items[first_fresh].key);
+        }
+        return;
+      }
       std::vector<BlockKey> keys;
       std::vector<RangeDstMulti> dsts;
       keys.reserve(idx.size());
@@ -1951,28 +2465,48 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
       }
       std::vector<size_t> value_lens;
       std::string shard_dev;
-      const auto pn_t0 = std::chrono::steady_clock::now();
+      std::chrono::steady_clock::time_point pn_t0;
+      if (pernode_on) pn_t0 = std::chrono::steady_clock::now();
       std::vector<Status> sts = t_->RangeIntoMulti(
           node, keys, dsts, &value_lens, pernode_on ? &shard_dev : nullptr);
       if (pernode_on) {
         const uint64_t us = static_cast<uint64_t>(
             std::chrono::duration<double, std::micro>(
                 std::chrono::steady_clock::now() - pn_t0).count());
-        uint64_t vb = 0, hits = 0, mn = std::numeric_limits<uint64_t>::max(), mx = 0;
-        for (size_t v = 0; v < value_lens.size() && v < sts.size(); ++v)
-          if (sts[v] == Status::kOk) {
-            hits++;
-            const uint64_t b = value_lens[v];
-            vb += b;
-            if (b < mn) mn = b;
-            if (b > mx) mx = b;
+        uint64_t vb = 0, hits = 0, failn = 0,
+                 mn = std::numeric_limits<uint64_t>::max(), mx = 0;
+        uint32_t status_mask = 0, fail_mask = 0;
+        std::string first_fail;
+        const size_t cap = groups[g].first.second;
+        for (size_t m = 0; m < idx.size(); ++m) {
+          Status status = m < sts.size() ? sts[m] : Status::kInvalid;
+          if (status == Status::kOk &&
+              (m >= value_lens.size() || value_lens[m] > cap))
+            status = Status::kInvalid;
+          status_mask |= PernodeStatusBit(status);
+          if (status == Status::kOk) {
+            ++hits;
+            const uint64_t value_bytes = value_lens[m];
+            vb += value_bytes;
+            mn = std::min(mn, value_bytes);
+            mx = std::max(mx, value_bytes);
+          } else if (status != Status::kNotFound) {
+            ++failn;
+            fail_mask |= PernodeStatusBit(status);
+            if (first_fail.empty())
+              first_fail = PernodeKeyFp(items[idx[m]].key);
           }
-        gstat[g].keys = idx.size();
+        }
+        gstat[g].issued_keys = idx.size();
         gstat[g].bytes = vb;
         gstat[g].busy_us = us;
-        gstat[g].min_b = mn;  // UINT64_MAX if this shard had no kOk key
+        gstat[g].min_b = mn;
         gstat[g].max_b = mx;
         gstat[g].hit = hits;
+        gstat[g].fail = failn;
+        gstat[g].status_mask = status_mask;
+        gstat[g].fail_status_mask = fail_mask;
+        gstat[g].first_fail = std::move(first_fail);
         gstat[g].dev = std::move(shard_dev);
       }
       bool resp = false, ioerr = false;
@@ -1985,31 +2519,37 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
       if (resp) health_.MarkGood(node, NowMs());
       else if (ioerr) health_.MarkBad(node, NowMs());
       for (size_t m = 0; m < idx.size(); ++m) {
-        size_t cap = groups[g].first.second;
-        if (sts[m] != Status::kOk || m >= value_lens.size() ||
-            value_lens[m] > cap)
+        const size_t cap = groups[g].first.second;
+        if (m >= sts.size() || sts[m] != Status::kOk ||
+            m >= value_lens.size() || value_lens[m] > cap)
           continue;
-        lens[idx[m]] = static_cast<size_t>(value_lens[m]);
+        lens[idx[m]] = value_lens[m];
         hit[idx[m]] = 1;
       }
     });
     if (pernode_on) {
       for (size_t g = 0; g < groups.size(); ++g) {
-        if (gstat[g].keys == 0) continue;  // health-skipped or empty group
-        PernodeStat& a = pernode[groups[g].first.first];
-        a.keys += gstat[g].keys;
+        if (gstat[g].issued_keys == 0 && gstat[g].nonissued_fail == 0) continue;
+        PernodeStat& a = (*pernode)[groups[g].first.first];
+        a.issued_keys += gstat[g].issued_keys;
         a.bytes += gstat[g].bytes;
         a.busy_us += gstat[g].busy_us;
         if (gstat[g].busy_us > a.wall_us) {
           a.wall_us = gstat[g].busy_us;
-          a.dev = gstat[g].dev;  // slowest shard's rail
+          a.dev = gstat[g].dev;
         }
-        a.shards += 1;
+        if (gstat[g].issued_keys > 0) a.shards += 1;
         a.hit += gstat[g].hit;
-        if (gstat[g].max_b > 0) {  // shard had >=1 successful key
-          if (gstat[g].min_b < a.min_b) a.min_b = gstat[g].min_b;
-          if (gstat[g].max_b > a.max_b) a.max_b = gstat[g].max_b;
+        a.fail += gstat[g].fail;
+        a.status_mask |= gstat[g].status_mask;
+        a.fail_status_mask |= gstat[g].fail_status_mask;
+        MergePernodeNonIssued(&a, gstat[g]);
+        if (gstat[g].max_b > 0) {
+          a.min_b = std::min(a.min_b, gstat[g].min_b);
+          a.max_b = std::max(a.max_b, gstat[g].max_b);
         }
+        if (a.first_fail.empty() && !gstat[g].first_fail.empty())
+          a.first_fail = gstat[g].first_fail;
       }
     }
   };
@@ -2036,8 +2576,10 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
       std::lock_guard<std::mutex> lk(ring_mu_);
       for (const auto& kv : addr_) addr2name[kv.second] = kv.first;
     }
-    EmitPernode(0, "get", "dfkv_client_get.log", pernode, addr2name,
-                total_wall_us, N, 0);
+    uint64_t logical_hits = 0;
+    for (char found : hit) logical_hits += found != 0;
+    EmitPernode(0, "get", "dfkv_client_get.log", *pernode, addr2name,
+                total_wall_us, N, logical_hits, *unrouted);
   }
   if (out_lens) *out_lens = std::move(lens);
   return std::vector<bool>(hit.begin(), hit.end());

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -1247,6 +1247,7 @@ struct PernodeStat {
   uint64_t fail = 0;  // issued responses other than kOk/kNotFound (PUT: non-kOk)
   uint64_t nonissued_fail = 0;
   uint64_t invalid_input = 0, no_route = 0, health_cooldown = 0;
+  uint64_t resource_exhausted = 0, no_compatible_rail = 0;
   uint32_t status_mask = 0;       // statuses returned by the transport
   uint32_t fail_status_mask = 0;  // failed statuses returned by the transport
   uint32_t nonissued_status_mask = 0;
@@ -1344,14 +1345,23 @@ enum class PernodeNonIssuedReason {
   kInvalidInput,
   kNoRoute,
   kHealthCooldown,
+  kResourceExhausted,
+  kNoCompatibleRail,
 };
 
 uint32_t PernodeNonIssuedStatusBit(PernodeNonIssuedReason reason) {
-  // Routing absence and a health gate do not produce a transport Status.
-  // Invalid input is a real client-local kInvalid outcome.
-  return reason == PernodeNonIssuedReason::kInvalidInput
-             ? PernodeStatusBit(Status::kInvalid)
-             : 0;
+  switch (reason) {
+    case PernodeNonIssuedReason::kInvalidInput:
+      return PernodeStatusBit(Status::kInvalid);
+    case PernodeNonIssuedReason::kResourceExhausted:
+      return PernodeStatusBit(Status::kResourceExhausted);
+    case PernodeNonIssuedReason::kNoCompatibleRail:
+      return PernodeStatusBit(Status::kNoCompatibleRail);
+    case PernodeNonIssuedReason::kNoRoute:
+    case PernodeNonIssuedReason::kHealthCooldown:
+      return 0;
+  }
+  return 0;
 }
 
 void RecordPernodeNonIssued(PernodeStat* stat,
@@ -1368,6 +1378,12 @@ void RecordPernodeNonIssued(PernodeStat* stat,
     case PernodeNonIssuedReason::kHealthCooldown:
       stat->health_cooldown += count;
       break;
+    case PernodeNonIssuedReason::kResourceExhausted:
+      stat->resource_exhausted += count;
+      break;
+    case PernodeNonIssuedReason::kNoCompatibleRail:
+      stat->no_compatible_rail += count;
+      break;
   }
   stat->nonissued_status_mask |= PernodeNonIssuedStatusBit(reason);
   if (stat->first_fail.empty()) stat->first_fail = PernodeKeyFp(first_key);
@@ -1378,6 +1394,8 @@ void MergePernodeNonIssued(PernodeStat* into, const PernodeStat& from) {
   into->invalid_input += from.invalid_input;
   into->no_route += from.no_route;
   into->health_cooldown += from.health_cooldown;
+  into->resource_exhausted += from.resource_exhausted;
+  into->no_compatible_rail += from.no_compatible_rail;
   into->nonissued_status_mask |= from.nonissued_status_mask;
   if (into->first_fail.empty() && !from.first_fail.empty())
     into->first_fail = from.first_fail;
@@ -1397,6 +1415,10 @@ std::string PernodeNonIssuedReasons(const PernodeStat& stat) {
   append("invalid_input", "kInvalid", stat.invalid_input);
   append("no_route", "not_issued", stat.no_route);
   append("health_cooldown", "not_issued", stat.health_cooldown);
+  append("resource_exhausted", "kResourceExhausted",
+         stat.resource_exhausted);
+  append("no_compatible_rail", "kNoCompatibleRail",
+         stat.no_compatible_rail);
   return out.empty() ? "none" : out;
 }
 
@@ -1459,6 +1481,7 @@ class PernodeSink {
   }
 
   size_t capacity() const { return capacity_; }
+  uint64_t rotate_bytes() const { return rotate_bytes_; }
   size_t high_water() const {
     std::lock_guard<std::mutex> lock(mu_);
     return high_water_;
@@ -1495,7 +1518,8 @@ class PernodeSink {
   PernodeSink()
       : capacity_(std::min<size_t>(
             EnvSize("DFKV_CLIENT_PERNODE_QUEUE_CAPACITY", 256), 65536)),
-        rotate_bytes_(EnvSize("DFKV_CLIENT_PERNODE_ROTATE_BYTES", 64u << 20)),
+        rotate_bytes_(std::max<size_t>(
+            1, EnvSize("DFKV_CLIENT_PERNODE_ROTATE_BYTES", 64u << 20))),
         worker_([this] { Run(); }) {}
 
   ~PernodeSink() {
@@ -1549,26 +1573,45 @@ class PernodeSink {
             ? std::string()
             : "pernode-sink DROPPED: dropped_batches=" +
                   std::to_string(batch.dropped_before);
-    uint64_t batch_bytes = 0;
-    if (!drop_line.empty())
-      batch_bytes += std::strlen(ts) + 1 + drop_line.size() + 1;
-    for (const std::string& line : batch.lines)
-      batch_bytes += std::strlen(ts) + 1 + line.size() + 1;
 
     FileState& state = Open(batch.fname);
-    if (state.file && state.bytes > 0 &&
-        batch_bytes > rotate_bytes_ - std::min(rotate_bytes_, state.bytes))
-      Rotate(state);
-    if (state.file) {
-      if (!drop_line.empty())
-        std::fprintf(state.file, "%s %s\n", ts, drop_line.c_str());
-      for (const std::string& line : batch.lines)
-        std::fprintf(state.file, "%s %s\n", ts, line.c_str());
-      state.bytes += batch_bytes;
-    } else {
-      if (!drop_line.empty()) DFKV_LOG_INFO(drop_line);
-      for (const std::string& line : batch.lines) DFKV_LOG_INFO(line);
-    }
+    auto write_line = [&](const std::string& line) {
+      if (!state.file) {
+        DFKV_LOG_INFO(line);
+        return;
+      }
+
+      std::string serialized =
+          std::string(ts) + " " + line + "\n";
+      if (serialized.size() > rotate_bytes_) {
+        const size_t original_bytes = serialized.size();
+        serialized = std::string(ts) +
+                     " pernode-sink OVERSIZE: original_bytes=" +
+                     std::to_string(original_bytes) + "\n";
+        if (serialized.size() > rotate_bytes_) {
+          serialized = "OVERSIZE\n";
+          if (serialized.size() > rotate_bytes_) {
+            serialized.assign(static_cast<size_t>(rotate_bytes_), '!');
+            serialized.back() = '\n';
+          }
+        }
+      }
+
+      if (state.bytes > 0 &&
+          (state.bytes >= rotate_bytes_ ||
+           serialized.size() > rotate_bytes_ - state.bytes))
+        Rotate(state);
+      if (!state.file) {
+        DFKV_LOG_INFO(line);
+        return;
+      }
+      if (!serialized.empty())
+        std::fwrite(serialized.data(), 1, serialized.size(), state.file);
+      state.bytes += serialized.size();
+    };
+
+    if (!drop_line.empty()) write_line(drop_line);
+    for (const std::string& line : batch.lines) write_line(line);
   }
 
   void Run() {
@@ -1647,8 +1690,8 @@ void PernodeWrite(const char* fname, std::vector<std::string> lines) {
 }
 
 // op: 0=get, 1=put, 2=exist. issued_keys counts transport items only.
-// Non-issued routing/health failures remain logical failures and carry their
-// reason/status separately instead of being misreported as transport attempts.
+// Client-local routing, health, resource, and topology failures remain logical
+// failures and carry their reason/status separately from transport attempts.
 void EmitPernode(int op, const char* label, const char* fname,
                  const std::map<std::string, PernodeStat>& per,
                  const std::map<std::string, std::string>& addr2name,
@@ -1712,6 +1755,10 @@ void EmitPernode(int op, const char* label, const char* fname,
       " invalid_input=" + std::to_string(nonissued.invalid_input) +
       " no_route=" + std::to_string(nonissued.no_route) +
       " health_cooldown=" + std::to_string(nonissued.health_cooldown) +
+      " resource_exhausted=" +
+      std::to_string(nonissued.resource_exhausted) +
+      " no_compatible_rail=" +
+      std::to_string(nonissued.no_compatible_rail) +
       " nonissued_reasons=" + PernodeNonIssuedReasons(nonissued);
   if (op == 0)
     total += " logical_hits=" + std::to_string(logical_hits) +
@@ -1780,6 +1827,10 @@ void EmitPernode(int op, const char* label, const char* fname,
         " invalid_input=" + std::to_string(stat.invalid_input) +
         " no_route=" + std::to_string(stat.no_route) +
         " health_cooldown=" + std::to_string(stat.health_cooldown) +
+        " resource_exhausted=" +
+        std::to_string(stat.resource_exhausted) +
+        " no_compatible_rail=" +
+        std::to_string(stat.no_compatible_rail) +
         " nonissued_reasons=" + PernodeNonIssuedReasons(stat);
     if (op == 0)
       line += " hit_issued_keys=" + std::to_string(stat.hit) +
@@ -1802,6 +1853,9 @@ void EmitPernode(int op, const char* label, const char* fname,
 namespace testing {
 void DrainPernodeSink() { PernodeSink::Instance().DrainForTest(); }
 size_t PernodeQueueCapacity() { return PernodeSink::Instance().capacity(); }
+uint64_t PernodeRotateBytes() {
+  return PernodeSink::Instance().rotate_bytes();
+}
 size_t PernodeQueueHighWater() { return PernodeSink::Instance().high_water(); }
 uint64_t PernodeQueueDropped() { return PernodeSink::Instance().dropped(); }
 uint64_t PernodeQueuePendingDropped() {
@@ -1880,12 +1934,23 @@ std::vector<bool> KVClient::BatchExistDirect(
       const uint64_t us = static_cast<uint64_t>(
           std::chrono::duration<double, std::micro>(
               std::chrono::steady_clock::now() - pn_t0).count());
-      uint64_t present = 0, failn = 0;
+      uint64_t issuedn = 0, present = 0, failn = 0;
       uint32_t status_mask = 0, fail_mask = 0;
       std::string first_fail;
       for (size_t m = 0; m < idx.size(); ++m) {
         const Status status =
             m < sts.size() ? sts[m] : Status::kInvalid;
+        if (status == Status::kResourceExhausted ||
+            status == Status::kNoCompatibleRail) {
+          RecordPernodeNonIssued(
+              &gstat[g],
+              status == Status::kResourceExhausted
+                  ? PernodeNonIssuedReason::kResourceExhausted
+                  : PernodeNonIssuedReason::kNoCompatibleRail,
+              1, keys[idx[m]]);
+          continue;
+        }
+        ++issuedn;
         status_mask |= PernodeStatusBit(status);
         if (status == Status::kOk) {
           if (m < ex.size() && ex[m]) ++present;
@@ -1896,13 +1961,14 @@ std::vector<bool> KVClient::BatchExistDirect(
             first_fail = PernodeKeyFp(keys[idx[m]]);
         }
       }
-      gstat[g].issued_keys = idx.size();
-      gstat[g].busy_us = us;
+      gstat[g].issued_keys = issuedn;
+      gstat[g].busy_us = issuedn == 0 ? 0 : us;
       gstat[g].hit = present;
       gstat[g].fail = failn;
       gstat[g].status_mask = status_mask;
       gstat[g].fail_status_mask = fail_mask;
-      gstat[g].first_fail = std::move(first_fail);
+      if (gstat[g].first_fail.empty())
+        gstat[g].first_fail = std::move(first_fail);
       gstat[g].dev = std::move(shard_dev);
     }
     bool resp = false, ioerr = false;
@@ -2099,13 +2165,24 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
       const uint64_t us = static_cast<uint64_t>(
           std::chrono::duration<double, std::micro>(
               std::chrono::steady_clock::now() - pn_t0).count());
-      uint64_t vb = 0, hits = 0, failn = 0,
+      uint64_t issuedn = 0, vb = 0, hits = 0, failn = 0,
                mn = std::numeric_limits<uint64_t>::max(), mx = 0;
       uint32_t status_mask = 0, fail_mask = 0;
       std::string first_fail;
       for (size_t m = 0; m < idx.size(); ++m) {
         const Status status =
             m < sts.size() ? sts[m] : Status::kInvalid;
+        if (status == Status::kResourceExhausted ||
+            status == Status::kNoCompatibleRail) {
+          RecordPernodeNonIssued(
+              &gstat[g],
+              status == Status::kResourceExhausted
+                  ? PernodeNonIssuedReason::kResourceExhausted
+                  : PernodeNonIssuedReason::kNoCompatibleRail,
+              1, items[idx[m]].key);
+          continue;
+        }
+        ++issuedn;
         status_mask |= PernodeStatusBit(status);
         if (status == Status::kOk) {
           ++hits;
@@ -2120,16 +2197,17 @@ std::vector<bool> KVClient::BatchPutSg(const std::vector<KvPutItemSg>& items) {
             first_fail = PernodeKeyFp(items[idx[m]].key);
         }
       }
-      gstat[g].issued_keys = idx.size();
+      gstat[g].issued_keys = issuedn;
       gstat[g].bytes = vb;
-      gstat[g].busy_us = us;
+      gstat[g].busy_us = issuedn == 0 ? 0 : us;
       gstat[g].min_b = mn;
       gstat[g].max_b = mx;
       gstat[g].hit = hits;
       gstat[g].fail = failn;
       gstat[g].status_mask = status_mask;
       gstat[g].fail_status_mask = fail_mask;
-      gstat[g].first_fail = std::move(first_fail);
+      if (gstat[g].first_fail.empty())
+        gstat[g].first_fail = std::move(first_fail);
       gstat[g].dev = std::move(shard_dev);
     }
     for (size_t m = 0; m < idx.size(); ++m) {
@@ -2473,7 +2551,7 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
         const uint64_t us = static_cast<uint64_t>(
             std::chrono::duration<double, std::micro>(
                 std::chrono::steady_clock::now() - pn_t0).count());
-        uint64_t vb = 0, hits = 0, failn = 0,
+        uint64_t issuedn = 0, vb = 0, hits = 0, failn = 0,
                  mn = std::numeric_limits<uint64_t>::max(), mx = 0;
         uint32_t status_mask = 0, fail_mask = 0;
         std::string first_fail;
@@ -2483,6 +2561,17 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
           if (status == Status::kOk &&
               (m >= value_lens.size() || value_lens[m] > cap))
             status = Status::kInvalid;
+          if (status == Status::kResourceExhausted ||
+              status == Status::kNoCompatibleRail) {
+            RecordPernodeNonIssued(
+                &gstat[g],
+                status == Status::kResourceExhausted
+                    ? PernodeNonIssuedReason::kResourceExhausted
+                    : PernodeNonIssuedReason::kNoCompatibleRail,
+                1, items[idx[m]].key);
+            continue;
+          }
+          ++issuedn;
           status_mask |= PernodeStatusBit(status);
           if (status == Status::kOk) {
             ++hits;
@@ -2497,16 +2586,17 @@ std::vector<bool> KVClient::BatchGetAutoSgDirect(const std::vector<KvGetItemSg>&
               first_fail = PernodeKeyFp(items[idx[m]].key);
           }
         }
-        gstat[g].issued_keys = idx.size();
+        gstat[g].issued_keys = issuedn;
         gstat[g].bytes = vb;
-        gstat[g].busy_us = us;
+        gstat[g].busy_us = issuedn == 0 ? 0 : us;
         gstat[g].min_b = mn;
         gstat[g].max_b = mx;
         gstat[g].hit = hits;
         gstat[g].fail = failn;
         gstat[g].status_mask = status_mask;
         gstat[g].fail_status_mask = fail_mask;
-        gstat[g].first_fail = std::move(first_fail);
+        if (gstat[g].first_fail.empty())
+          gstat[g].first_fail = std::move(first_fail);
         gstat[g].dev = std::move(shard_dev);
       }
       bool resp = false, ioerr = false;

--- a/src/transport/dev_frame.h
+++ b/src/transport/dev_frame.h
@@ -1,6 +1,6 @@
 /* RDMA v2 bootstrap device frame.
  *
- * [name | NUL | "DCP2" u32 | max_block_bytes u64 | protocol u8]
+ * [name | NUL | "DCP2" u32 | (request bit | max_block_bytes) u64 | protocol u8]
  *
  * The declaration and protocol marker are mandatory. Header-only and
  * verbs-free so protocol rejection is unit-testable without RDMA hardware.
@@ -17,6 +17,13 @@ namespace dfkv::rdma {
 constexpr size_t kDevNameBytes = 32;
 constexpr uint32_t kDevCapsV2Magic = 0x32504344u;  // ASCII "DCP2" (LE)
 constexpr uint8_t kDevProtoV2 = 2;
+// Bit 63 of the raw declaration is a bootstrap capability request. It is not
+// part of max_block_bytes and must be removed before any geometry, capacity,
+// or limit calculation. Keeping the raw-field parser separate also preserves
+// the full 64-bit opaque value used by writer-retirement control frames.
+constexpr uint64_t kDevFrameRequestWriterRetirement = uint64_t{1} << 63;
+constexpr uint64_t kDevFrameMaxBlockMask =
+    ~kDevFrameRequestWriterRetirement;
 
 // Room a device name must leave in the fixed 32-byte frame: NUL terminator +
 // "DCP2" u32 + max_block_bytes u64 + protocol u8. A name at most this long
@@ -77,6 +84,16 @@ inline uint64_t ParseDevFrameCaps(const char in[kDevNameBytes]) {
   uint64_t value = 0;
   std::memcpy(&value, in + nul + 5, 8);
   return value;
+}
+// Parse the declared block size of a normal bootstrap frame. Callers doing
+// geometry/capacity work must use this masked view, never ParseDevFrameCaps.
+inline uint64_t ParseDevFrameMaxBlock(const char in[kDevNameBytes]) {
+  return ParseDevFrameCaps(in) & kDevFrameMaxBlockMask;
+}
+
+inline bool DevFrameRequestsWriterRetirement(
+    const char in[kDevNameBytes]) {
+  return (ParseDevFrameCaps(in) & kDevFrameRequestWriterRetirement) != 0;
 }
 
 inline uint8_t ParseDevFrameProtocol(const char in[kDevNameBytes]) {

--- a/src/transport/rdma_protocol.h
+++ b/src/transport/rdma_protocol.h
@@ -60,6 +60,36 @@ inline bool ParseV2ProbeReply(const char in[kV2ProbeReplyBytes]) {
          static_cast<uint8_t>(in[4]) == kDevProtoV2;
 }
 
+// Failure-path writer retirement. The client reconnects with the opaque
+// per-QP writer token. The responder cancels later PostWrite calls, transitions
+// that QP to ERR, drains every signaled WRITE CQE, and only then echoes proof.
+// The proof is the protocol fence that permits retry/return with the same
+// caller/CUDA destination; QP destruction and MR teardown are not fences.
+constexpr const char* kV2RetireWriterDevice = "__dfkv_retire__";
+constexpr uint64_t kV2RetireProofMagic = 0x32524657564b4644ull;  // "DFKVWFR2"
+constexpr size_t kV2WriterTokenBytes = 8;
+constexpr size_t kV2RetireProofBytes = 16;
+
+inline bool IsV2RetireWriter(const char frame[kDevNameBytes]) {
+  size_t n = 0;
+  while (n < kDevNameBytes && frame[n] != '\0') ++n;
+  return std::string(frame, n) == kV2RetireWriterDevice &&
+         ParseDevFrameProtocol(frame) == kDevProtoV2 &&
+         ParseDevFrameCaps(frame) != 0;
+}
+
+inline void EncodeV2RetireProof(
+    uint64_t token, char out[kV2RetireProofBytes]) {
+  net::PutU64(out, kV2RetireProofMagic);
+  net::PutU64(out + 8, token);
+}
+
+inline bool ParseV2RetireProof(
+    const char in[kV2RetireProofBytes], uint64_t token) {
+  return net::GetU64(in) == kV2RetireProofMagic &&
+         net::GetU64(in + 8) == token;
+}
+
 // Multi-window GET IDs name one of the negotiated per-connection logical
 // request slots. Keeping the namespace bounded by queue depth both caps server
 // state and makes duplicate ownership explicit.

--- a/src/transport/rdma_protocol.h
+++ b/src/transport/rdma_protocol.h
@@ -39,6 +39,10 @@ constexpr uint64_t kV2MultiWrPutMagic = 0x325257495455504dull;  // "MPUTIWR2"
 constexpr const char* kV2ProbeDevice = "__dfkv_v2__";
 constexpr uint32_t kV2ProbeMagic = 0x33564644u;  // ASCII "DFV3" (LE)
 constexpr size_t kV2ProbeReplyBytes = 8;
+// Probe reply byte 5 was reserved in the original 8-byte reply. Advertising
+// here is backward-compatible: old clients validate only magic/version, while
+// new clients fail before real QP bootstrap unless this bit is present.
+constexpr uint8_t kV2ProbeCapWriterRetirement = 1u << 0;
 
 inline bool IsV2Probe(const char frame[kDevNameBytes]) {
   size_t n = 0;
@@ -47,10 +51,13 @@ inline bool IsV2Probe(const char frame[kDevNameBytes]) {
          ParseDevFrameProtocol(frame) == kDevProtoV2;
 }
 
-inline void EncodeV2ProbeReply(char out[kV2ProbeReplyBytes]) {
+inline void EncodeV2ProbeReply(
+    char out[kV2ProbeReplyBytes],
+    uint8_t capabilities = kV2ProbeCapWriterRetirement) {
   std::memset(out, 0, kV2ProbeReplyBytes);
   std::memcpy(out, &kV2ProbeMagic, sizeof(kV2ProbeMagic));
   out[4] = static_cast<char>(kDevProtoV2);
+  out[5] = static_cast<char>(capabilities);
 }
 
 inline bool ParseV2ProbeReply(const char in[kV2ProbeReplyBytes]) {
@@ -58,6 +65,17 @@ inline bool ParseV2ProbeReply(const char in[kV2ProbeReplyBytes]) {
   std::memcpy(&magic, in, sizeof(magic));
   return magic == kV2ProbeMagic &&
          static_cast<uint8_t>(in[4]) == kDevProtoV2;
+}
+
+inline uint8_t ParseV2ProbeCapabilities(
+    const char in[kV2ProbeReplyBytes]) {
+  return ParseV2ProbeReply(in) ? static_cast<uint8_t>(in[5]) : 0;
+}
+
+inline bool V2ProbeSupportsWriterRetirement(
+    const char in[kV2ProbeReplyBytes]) {
+  return (ParseV2ProbeCapabilities(in) &
+          kV2ProbeCapWriterRetirement) != 0;
 }
 
 // Failure-path writer retirement. The client reconnects with the opaque
@@ -180,6 +198,44 @@ inline bool DecodeRecvSegmentInfo(const char in[kRecvSegmentInfoBytes],
          info->slot_size % kV2DataOffset == 0 &&
          info->base_addr <=
              std::numeric_limits<uint64_t>::max() - (info->slot_size - 1);
+}
+
+// The original readiness response is exactly one ready byte plus the 24-byte
+// receive-segment descriptor. A negotiated writer-retirement connection
+// appends its nonzero token; an unnegotiated client must see no extra bytes.
+constexpr size_t kV2LegacyReadinessBytes = 1 + kRecvSegmentInfoBytes;
+constexpr size_t kV2RetirementReadinessBytes =
+    kV2LegacyReadinessBytes + kV2WriterTokenBytes;
+static_assert(kV2LegacyReadinessBytes == 25);
+
+inline size_t V2ReadinessBytes(bool writer_retirement_negotiated) {
+  return writer_retirement_negotiated ? kV2RetirementReadinessBytes
+                                      : kV2LegacyReadinessBytes;
+}
+
+inline size_t EncodeV2Readiness(
+    const RecvSegmentInfo& info, uint64_t writer_token,
+    char out[kV2RetirementReadinessBytes]) {
+  std::memset(out, 0, kV2RetirementReadinessBytes);
+  out[0] = 1;
+  EncodeRecvSegmentInfo(info, out + 1);
+  if (writer_token == 0) return kV2LegacyReadinessBytes;
+  net::PutU64(out + kV2LegacyReadinessBytes, writer_token);
+  return kV2RetirementReadinessBytes;
+}
+
+inline bool DecodeV2Readiness(
+    const char* in, size_t bytes, bool writer_retirement_negotiated,
+    RecvSegmentInfo* info, uint64_t* writer_token) {
+  if (bytes != V2ReadinessBytes(writer_retirement_negotiated) || in[0] != 1 ||
+      !DecodeRecvSegmentInfo(in + 1, info)) {
+    return false;
+  }
+  *writer_token =
+      writer_retirement_negotiated
+          ? net::GetU64(in + kV2LegacyReadinessBytes)
+          : 0;
+  return !writer_retirement_negotiated || *writer_token != 0;
 }
 
 }  // namespace dfkv::rdma

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -2522,15 +2522,9 @@ std::vector<Status> RdmaTransport::RangeInto(
     completion_fault.BeginAttempt(attempt);
     final_timeout = false;
     std::fill(result.begin(), result.end(), Status::kIOError);
-    std::vector<std::vector<char>> attempt_outputs(count);
-    std::vector<uint64_t> attempt_data_lens(count, 0);
     std::vector<uint64_t> attempt_value_lens(count, 0);
     for (size_t i = 0; i < count; ++i) {
-      if (bad[i]) {
-        result[i] = Status::kInvalid;
-      } else {
-        attempt_outputs[i].resize(destinations[i].n);
-      }
+      if (bad[i]) result[i] = Status::kInvalid;
     }
     AcquireOptions options;
     options.force_new = attempt != 0;
@@ -2569,10 +2563,13 @@ std::vector<Status> RdmaTransport::RangeInto(
         const size_t item_index = base + slot;
         if (bad[item_index]) continue;
         const RangeDst& destination = destinations[item_index];
-        std::vector<char>& output = attempt_outputs[item_index];
+        // Server DMA lands directly in the caller buffer (GPUDirect when it is
+        // device memory; a host bounce here would fault on CUDA pointers).
+        // Rail-retry fencing comes from Destroy(conn) below: tearing down the
+        // QP drops in-flight remote writes before the next attempt reposts.
         if (destination.n != 0) {
           output_mrs[slot] =
-              ep.RegisterTransient(output.data(), output.size());
+              ep.RegisterTransient(destination.payload, destination.n);
           if (!output_mrs[slot]) {
             conn_ok = false;
             break;
@@ -2581,7 +2578,7 @@ std::vector<Status> RdmaTransport::RangeInto(
         std::vector<RdmaWriteTarget> targets;
         if (destination.n != 0) {
           targets.push_back(
-              {reinterpret_cast<uint64_t>(output.data()),
+              {reinterpret_cast<uint64_t>(destination.payload),
                output_mrs[slot]->rkey,
                static_cast<uint32_t>(destination.n)});
         }
@@ -2624,27 +2621,10 @@ std::vector<Status> RdmaTransport::RangeInto(
           break;
         }
         result[item_index] = status;
-        attempt_data_lens[item_index] = data_len;
         attempt_value_lens[item_index] = value_len;
       }
     }
     if (conn_ok) {
-      DestinationPublisher publisher;
-      for (size_t i = 0; i < count; ++i) {
-        if (result[i] == Status::kOk && attempt_data_lens[i] != 0 &&
-            !publisher.Copy(destinations[i].payload,
-                            attempt_outputs[i].data(),
-                            static_cast<size_t>(attempt_data_lens[i]),
-                            destinations[i].memory_kind))
-          result[i] = Status::kIOError;
-      }
-      if (!publisher.Finish()) {
-        for (size_t i = 0; i < count; ++i)
-          if (result[i] == Status::kOk &&
-              destinations[i].memory_kind ==
-                  DestinationMemoryKind::kDevice)
-            result[i] = Status::kIOError;
-      }
       if (value_lens) *value_lens = std::move(attempt_value_lens);
       Release(node, Lane::kData, conn);
       if (cross_rail_retry)
@@ -2966,16 +2946,13 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     if (out_lengths) out_lengths->assign(count, 0);
     return result;
   }
-  // Keep fully validated items across a rail retry, but fence every server DMA
-  // in operation-owned storage. Caller segments are published only after all
-  // remaining items complete on the final healthy connection.
+  // Server DMA lands directly in the caller segments (GPUDirect when they are
+  // device memory; a host bounce here would fault on CUDA pointers).
+  // Rail-retry fencing comes from Destroy(conn): tearing down the QP drops
+  // in-flight remote writes before the next attempt reposts, and a retried
+  // item is rewritten in full from window 0.
   std::vector<char> completed(count, 0);
-  std::vector<std::vector<char>> staged_outputs(count);
-  std::vector<size_t> staged_out_lengths(count, 0);
-  for (size_t i = 0; i < count; ++i) {
-    if (!bad[i]) staged_outputs[i].resize(capacities[i]);
-  }
-  if (valid_count == 0) return result;
+  std::vector<size_t> out_value_lens(count, 0);
   rdma::OperationContext operation;
   if (!operation.Submit() || !operation.ClaimPoller()) return result;
   bool final_timeout = false;
@@ -2993,7 +2970,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
         result[i] = Status::kInvalid;
       } else if (!completed[i]) {
         result[i] = Status::kIOError;
-        staged_out_lengths[i] = 0;
+        out_value_lens[i] = 0;
         ++remaining_count;
       }
     }
@@ -3095,16 +3072,14 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
             const auto& payload =
                 destination.payloads[progress.segment_index++];
             if (payload.second == 0) continue;
-            char* const target =
-                staged_outputs[progress.item].data() +
-                progress.logical_offset + window_capacity;
-            ibv_mr* mr = ep.RegisterTransient(target, payload.second);
+            ibv_mr* mr =
+                ep.RegisterTransient(payload.first, payload.second);
             if (!mr) {
               conn_ok = false;
               break;
             }
             targets.push_back(
-                {reinterpret_cast<uint64_t>(target), mr->rkey,
+                {reinterpret_cast<uint64_t>(payload.first), mr->rkey,
                  static_cast<uint32_t>(payload.second)});
             mrs.push_back(mr);
             window_capacity += payload.second;
@@ -3216,7 +3191,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
             }
             progress.finished = true;
             completed[progress.item] = 1;
-            staged_out_lengths[progress.item] =
+            out_value_lens[progress.item] =
                 static_cast<size_t>(progress.response_value_len);
             --remaining;
           }
@@ -3226,37 +3201,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     }
 
     if (conn_ok) {
-      DestinationPublisher publisher;
-      for (size_t i = 0; i < count; ++i) {
-        if (result[i] != Status::kOk) continue;
-        size_t copied = 0;
-        for (const auto& payload : destinations[i].payloads) {
-          const size_t remaining = staged_out_lengths[i] - copied;
-          const size_t n = std::min(payload.second, remaining);
-          if (n != 0) {
-            if (!publisher.Copy(payload.first,
-                                staged_outputs[i].data() + copied, n,
-                                payload.memory_kind))
-              result[i] = Status::kIOError;
-            copied += n;
-          }
-          if (copied == staged_out_lengths[i]) break;
-        }
-      }
-      if (!publisher.Finish()) {
-        for (size_t i = 0; i < count; ++i) {
-          const bool has_device = std::any_of(
-              destinations[i].payloads.begin(),
-              destinations[i].payloads.end(),
-              [](const RangeDstSegment& segment) {
-                return segment.memory_kind ==
-                       DestinationMemoryKind::kDevice;
-              });
-          if (has_device && result[i] == Status::kOk)
-            result[i] = Status::kIOError;
-        }
-      }
-      if (out_lengths) *out_lengths = staged_out_lengths;
+      if (out_lengths) *out_lengths = out_value_lens;
       Release(node, Lane::kSgData, conn);
       if (cross_rail_retry)
         cross_rail_retry_successes_.fetch_add(1,

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -992,7 +992,7 @@ bool RdmaTransport::ProbeV2(const std::string& node) const {
   const bool ok =
       net::WriteAll(fd, frame, sizeof(frame)) &&
       net::ReadAll(fd, reply, sizeof(reply)) &&
-      rdma::ParseV2ProbeReply(reply);
+      rdma::V2ProbeSupportsWriterRetirement(reply);
   ::close(fd);
   if (!ok) v2_probe_failures_.fetch_add(1, std::memory_order_relaxed);
   return ok;
@@ -1205,8 +1205,9 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
 
   const std::string& dev = devs_[ridx];
   if (!ProbeV2(node)) {
-    DFKV_LOG_ERROR("rdma: peer " + node +
-                   " does not support the required v2 protocol");
+    DFKV_LOG_ERROR(
+        "rdma: peer " + node +
+        " does not advertise the required v2 writer-retirement capability");
     complete_unowned_lease(rdma::RailCompletion::kEndpointFailure);
     resource_budget_->Release(budget_request);
     result.failure = AcquireFailure::kEndpoint;
@@ -1248,8 +1249,13 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
 
   char devbuf[rdma::kDevNameBytes];
-  rdma::EncodeDevFrame(auto_device_ ? std::string() : dev, conn_declared,
-                       devbuf, rdma::kDevProtoV2);
+  // The probe above proves the peer understands bit 63 before a real QP is
+  // created. Echo the request on this bootstrap so a rolling-upgraded server
+  // sends the token only to a client that will consume it.
+  const uint64_t bootstrap_declared =
+      conn_declared | rdma::kDevFrameRequestWriterRetirement;
+  rdma::EncodeDevFrame(auto_device_ ? std::string() : dev,
+                       bootstrap_declared, devbuf, rdma::kDevProtoV2);
   char mine[rdma::kQpInfoBytes], remote_qp_bytes[rdma::kQpInfoBytes];
   rdma::QpInfo my = conn->ep.Local();
   my.depth = static_cast<uint16_t>(std::min<size_t>(conn_depth, 256));
@@ -1303,16 +1309,15 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     depth_refunds_.fetch_add(1, std::memory_order_relaxed);
   }
 
-  char ready = 0;
-  char encoded[rdma::kRecvSegmentInfoBytes];
-  char encoded_token[rdma::kV2WriterTokenBytes];
-  if (!net::ReadAll(fd, &ready, 1) || ready != 1 ||
-      !net::ReadAll(fd, encoded, sizeof(encoded)) ||
-      !net::ReadAll(fd, encoded_token, sizeof(encoded_token)) ||
-      !rdma::DecodeRecvSegmentInfo(encoded, &conn->recv_segment) ||
-      (conn->writer_token = net::GetU64(encoded_token)) == 0) {
-    DFKV_LOG_ERROR("rdma: peer " + node +
-                   " did not provide a valid v2 receive segment");
+  char readiness[rdma::kV2RetirementReadinessBytes];
+  if (!net::ReadAll(fd, readiness, sizeof(readiness)) ||
+      !rdma::DecodeV2Readiness(
+          readiness, sizeof(readiness),
+          /*writer_retirement_negotiated=*/true, &conn->recv_segment,
+          &conn->writer_token)) {
+    DFKV_LOG_ERROR(
+        "rdma: peer " + node +
+        " did not provide a valid retirement-capable v2 receive segment");
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
     result.failure = AcquireFailure::kEndpoint;
@@ -2433,6 +2438,7 @@ std::vector<Status> RdmaTransport::ExistMany(
   const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
+  bool out_dev_set = false;
   for (int attempt = 0; attempt < 2; ++attempt) {
     std::fill(result.begin(), result.end(), Status::kIOError);
     std::fill(exists->begin(), exists->end(), 0);
@@ -2456,7 +2462,16 @@ std::vector<Status> RdmaTransport::ExistMany(
       return result;
     }
     Conn* conn = acquired.conn;
-    if (out_dev) *out_dev = devs_[conn->rail_index];
+    if (out_dev) {
+      const std::string& attempted_dev = devs_[conn->rail_index];
+      if (!out_dev_set) {
+        *out_dev = attempted_dev;
+        out_dev_set = true;
+      } else if (*out_dev != attempted_dev) {
+        *out_dev += "->";
+        *out_dev += attempted_dev;
+      }
+    }
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
@@ -2752,6 +2767,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
+  bool out_dev_set = false;
   CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
   for (int attempt = 0; attempt < 2; ++attempt) {
     // A fresh attempt is possible only before any request is posted;
@@ -2777,7 +2793,16 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       return result;
     }
     Conn* conn = acquired.conn;
-    if (out_dev) *out_dev = devs_[conn->rail_index];
+    if (out_dev) {
+      const std::string& attempted_dev = devs_[conn->rail_index];
+      if (!out_dev_set) {
+        *out_dev = attempted_dev;
+        out_dev_set = true;
+      } else if (*out_dev != attempted_dev) {
+        *out_dev += "->";
+        *out_dev += attempted_dev;
+      }
+    }
     rdma::RcEndpoint& ep = conn->ep;
     const size_t seg_limit = std::max<size_t>(1, ep.max_sge() - 1);
     bool conn_ok = !InjectLocalRailFailure(attempt);
@@ -3008,6 +3033,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
   const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
+  bool out_dev_set = false;
   CompletionFaultOperation completion_fault(&test_completion_fault_calls_);
   for (int attempt = 0; attempt < 2; ++attempt) {
     completion_fault.BeginAttempt(attempt);
@@ -3044,7 +3070,16 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       return result;
     }
     Conn* conn = acquired.conn;
-    if (out_dev) *out_dev = devs_[conn->rail_index];
+    if (out_dev) {
+      const std::string& attempted_dev = devs_[conn->rail_index];
+      if (!out_dev_set) {
+        *out_dev = attempted_dev;
+        out_dev_set = true;
+      } else if (*out_dev != attempted_dev) {
+        *out_dev += "->";
+        *out_dev += attempted_dev;
+      }
+    }
     rdma::RcEndpoint& ep = conn->ep;
     const size_t target_limit =
         std::max<size_t>(1, std::min(ep.max_sge() - 1,

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -2380,7 +2380,7 @@ std::vector<Status> RdmaTransport::RangeMany(
 
 std::vector<Status> RdmaTransport::ExistMany(
     const std::string& node, const std::vector<BlockKey>& keys,
-    std::vector<char>* exists) {
+    std::vector<char>* exists, std::string* out_dev) {
   const size_t count = keys.size();
   if (exists == nullptr) return InvalidStatuses(count);
   exists->assign(count, 0);
@@ -2413,6 +2413,7 @@ std::vector<Status> RdmaTransport::ExistMany(
       return result;
     }
     Conn* conn = acquired.conn;
+    if (out_dev) *out_dev = devs_[conn->rail_index];
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
         ep.window(), static_cast<size_t>(conn->lease.credits));
@@ -2668,7 +2669,7 @@ std::vector<Status> RdmaTransport::CacheFrom(
 }
 
 std::vector<Status> RdmaTransport::CacheFromMulti(
-    const std::string& node, const std::vector<CacheSrcMulti>& sources) {
+    const std::string& node, const std::vector<CacheSrcMulti>& sources, std::string* out_dev) {
   const size_t count = sources.size();
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) return result;
@@ -2728,6 +2729,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       return result;
     }
     Conn* conn = acquired.conn;
+    if (out_dev) *out_dev = devs_[conn->rail_index];
     rdma::RcEndpoint& ep = conn->ep;
     const size_t seg_limit = std::max<size_t>(1, ep.max_sge() - 1);
     bool conn_ok = !InjectLocalRailFailure(attempt);
@@ -2906,7 +2908,7 @@ bool RdmaTransport::NoteBlock(size_t n) const {
 std::vector<Status> RdmaTransport::RangeIntoMulti(
     const std::string& node, const std::vector<BlockKey>& keys,
     const std::vector<RangeDstMulti>& destinations,
-    std::vector<size_t>* out_lengths) {
+    std::vector<size_t>* out_lengths, std::string* out_dev) {
   const size_t count = keys.size();
   if (destinations.size() != count) {
     if (out_lengths) out_lengths->assign(count, 0);
@@ -2995,6 +2997,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       return result;
     }
     Conn* conn = acquired.conn;
+    if (out_dev) *out_dev = devs_[conn->rail_index];
     rdma::RcEndpoint& ep = conn->ep;
     const size_t target_limit =
         std::max<size_t>(1, std::min(ep.max_sge() - 1,

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -236,6 +236,27 @@ class CompletionFaultOperation {
 // rdma::ClassifyCompletion and attribute them kRailFailure.
 constexpr ibv_wc_status kLocalFaultWcStatus = IBV_WC_GENERAL_ERR;
 
+// A response DONE is the success fence: the responder posts it after signaled
+// WRITEs on the same RC QP. An ambiguous attempt must obtain server proof that
+// its writer token is retired and every WRITE CQE is terminal before the same
+// caller/CUDA destination can be retried, returned, or deregistered.
+bool RetireRemoteWriter(const std::string& node, uint64_t token,
+                        int connect_ms, int io_ms) {
+  if (token == 0) return false;
+  const int fd = net::Dial(node, connect_ms, io_ms);
+  if (fd < 0) return false;
+  char request[rdma::kDevNameBytes];
+  rdma::EncodeDevFrame(rdma::kV2RetireWriterDevice, token, request,
+                       rdma::kDevProtoV2);
+  char proof[rdma::kV2RetireProofBytes];
+  const bool retired =
+      net::WriteAll(fd, request, sizeof(request)) &&
+      net::ReadAll(fd, proof, sizeof(proof)) &&
+      rdma::ParseV2RetireProof(proof, token);
+  ::close(fd);
+  return retired;
+}
+
 // Reap one signaled request completion and one status RECV per posted request.
 // Every poll consumes the same absolute deadline; a partial CQ drain cannot
 // restart the timeout budget. slot_count may exceed posted when invalid items
@@ -262,6 +283,10 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
   int need = static_cast<int>(2 * posted);
   CompletionDeadline deadline(timeout_ms);
   while (need > 0) {
+    if (rdma::TestConsumeBlockedResponderWriteFault()) {
+      if (worst_status) *worst_status = kLocalFaultWcStatus;
+      return false;
+    }
     const int remaining_ms = deadline.Remaining();
     if (remaining_ms == 0) {
       if (timed_out) *timed_out = true;
@@ -270,6 +295,10 @@ bool ReapPosted(rdma::RcEndpoint& ep, size_t posted, size_t slot_count,
     const int got = ep.WaitComp(wcs.data(), static_cast<int>(wcs.size()),
                                 remaining_ms);
     if (got <= 0) {
+      if (rdma::TestConsumeBlockedResponderWriteFault()) {
+        if (worst_status) *worst_status = kLocalFaultWcStatus;
+        return false;
+      }
       if (got == 0 && timed_out) *timed_out = true;
       if (got < 0 && worst_status) {
         // CQ notification/polling itself failed: local rail evidence (the
@@ -348,6 +377,7 @@ void MarkClientLocalFailure(std::vector<Status>* result, Status status) {
 struct RdmaTransport::Conn {
   rdma::RcEndpoint ep;
   rdma::RecvSegmentInfo recv_segment;
+  uint64_t writer_token = 0;
   size_t rail_index = 0;
   uint64_t peer_publication = 0;
   std::string peer_id;
@@ -818,9 +848,8 @@ void RdmaTransport::Destroy(Conn* c, rdma::RailCompletion completion) {
              ? RemoteRailOutcome::kEndpointFailure
              : RemoteRailOutcome::kAbandon);
 
-  // The endpoint owns the QP, CQs, and all transient/pool MRs. Destroy it
-  // synchronously before returning either rail credits or process resources,
-  // so a retry cannot overlap stale WRs that still reference caller memory.
+  // Direct GET failure paths have already obtained responder-retirement proof.
+  // Deletion releases terminal verbs resources; it is not a DMA fence.
   delete c;
   if (credit_held) {
     const uint64_t now = rdma::RailPolicy::NowMicros();
@@ -1276,9 +1305,12 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
 
   char ready = 0;
   char encoded[rdma::kRecvSegmentInfoBytes];
+  char encoded_token[rdma::kV2WriterTokenBytes];
   if (!net::ReadAll(fd, &ready, 1) || ready != 1 ||
       !net::ReadAll(fd, encoded, sizeof(encoded)) ||
-      !rdma::DecodeRecvSegmentInfo(encoded, &conn->recv_segment)) {
+      !net::ReadAll(fd, encoded_token, sizeof(encoded_token)) ||
+      !rdma::DecodeRecvSegmentInfo(encoded, &conn->recv_segment) ||
+      (conn->writer_token = net::GetU64(encoded_token)) == 0) {
     DFKV_LOG_ERROR("rdma: peer " + node +
                    " did not provide a valid v2 receive segment");
     ::close(fd);
@@ -2012,6 +2044,12 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
     }
 
     const size_t failed_rail = conn->rail_index;
+    if (op == WireOp::kRange &&
+        !RetireRemoteWriter(node, conn->writer_token, connect_ms_, io_ms_)) {
+      DFKV_LOG_ERROR(
+          "rdma: no responder-retirement proof for failed direct GET");
+      std::abort();
+    }
     Destroy(conn, completion);
     const AcquireFailure failure =
         completion == rdma::RailCompletion::kRailFailure &&
@@ -2360,6 +2398,11 @@ std::vector<Status> RdmaTransport::RangeMany(
       return result;
     }
     const size_t failed_rail = conn->rail_index;
+    if (!RetireRemoteWriter(node, conn->writer_token, connect_ms_, io_ms_)) {
+      DFKV_LOG_ERROR(
+          "rdma: no responder-retirement proof for failed batch GET");
+      std::abort();
+    }
     Destroy(conn, completion);
     const AcquireFailure failure =
         completion == rdma::RailCompletion::kRailFailure
@@ -2560,14 +2603,14 @@ std::vector<Status> RdmaTransport::RangeInto(
       const size_t width = std::min(window, count - base);
       std::vector<ibv_mr*> output_mrs(width, nullptr);
       size_t posted = 0;
+      // Server DMA lands directly in caller/CUDA memory. DONE fences success;
+      // ambiguity retires the responder token before this memory is reused.
       for (size_t slot = 0; slot < width; ++slot) {
         const size_t item_index = base + slot;
         if (bad[item_index]) continue;
         const RangeDst& destination = destinations[item_index];
         // Server DMA lands directly in the caller buffer (GPUDirect when it is
         // device memory; a host bounce here would fault on CUDA pointers).
-        // Rail-retry fencing comes from Destroy(conn) below: tearing down the
-        // QP drops in-flight remote writes before the next attempt reposts.
         if (destination.n != 0) {
           output_mrs[slot] =
               ep.RegisterTransient(destination.payload, destination.n);
@@ -2635,6 +2678,11 @@ std::vector<Status> RdmaTransport::RangeInto(
       return result;
     }
     const size_t failed_rail = conn->rail_index;
+    if (!RetireRemoteWriter(node, conn->writer_token, connect_ms_, io_ms_)) {
+      DFKV_LOG_ERROR(
+          "rdma: no responder-retirement proof for failed direct GET");
+      std::abort();
+    }
     Destroy(conn, completion);
     const AcquireFailure failure =
         completion == rdma::RailCompletion::kRailFailure
@@ -2948,11 +2996,9 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
     if (out_lengths) out_lengths->assign(count, 0);
     return result;
   }
-  // Server DMA lands directly in the caller segments (GPUDirect when they are
-  // device memory; a host bounce here would fault on CUDA pointers).
-  // Rail-retry fencing comes from Destroy(conn): tearing down the QP drops
-  // in-flight remote writes before the next attempt reposts, and a retried
-  // item is rewritten in full from window 0.
+  // Server DMA lands directly in caller/CUDA segments. Every DONE fences its
+  // successful WRITEs. An ambiguous window retires its responder token before
+  // another rail restarts an incomplete item from window zero.
   std::vector<char> completed(count, 0);
   std::vector<size_t> out_value_lens(count, 0);
   rdma::OperationContext operation;
@@ -2994,6 +3040,7 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
           acquired.failure == AcquireFailure::kNoCompatibleRail)
         MarkClientLocalFailure(&result, acquired.status);
       operation.Complete(false);
+      if (out_lengths) *out_lengths = out_value_lens;
       return result;
     }
     Conn* conn = acquired.conn;
@@ -3213,6 +3260,11 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       return result;
     }
     const size_t failed_rail = conn->rail_index;
+    if (!RetireRemoteWriter(node, conn->writer_token, connect_ms_, io_ms_)) {
+      DFKV_LOG_ERROR(
+          "rdma: no responder-retirement proof for failed SG GET");
+      std::abort();
+    }
     Destroy(conn, completion);
     for (size_t i = 0; i < count; ++i) {
       if (!bad[i] && !completed[i]) result[i] = Status::kIOError;
@@ -3229,12 +3281,14 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
     if (final_timeout) operation.RequestCancel();
     operation.Complete(false);
+    if (out_lengths) *out_lengths = out_value_lens;
     return result;
   }
   if (cross_rail_retry)
     cross_rail_retry_exhausted_.fetch_add(1, std::memory_order_relaxed);
   if (final_timeout) operation.RequestCancel();
   operation.Complete(false);
+  if (out_lengths) *out_lengths = out_value_lens;
   return result;
 }
 

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -114,7 +114,8 @@ class RdmaTransport : public Transport {
       std::vector<uint64_t>* value_lens = nullptr) override;
   std::vector<Status> ExistMany(const std::string& node,
                                 const std::vector<BlockKey>& keys,
-                                std::vector<char>* exists) override;
+                                std::vector<char>* exists,
+                                std::string* out_dev = nullptr) override;
   std::vector<Status> RangeInto(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDst>& dsts,
@@ -124,11 +125,12 @@ class RdmaTransport : public Transport {
   // for dfkv_batch_put_sg / dfkv_batch_get_auto_sg).
   std::vector<Status> CacheFromMulti(
       const std::string& node,
-      const std::vector<CacheSrcMulti>& srcs) override;
+      const std::vector<CacheSrcMulti>& srcs,
+      std::string* out_dev = nullptr) override;
   std::vector<Status> RangeIntoMulti(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* out_lens) override;
+      std::vector<size_t>* out_lens, std::string* out_dev = nullptr) override;
 
  private:
   friend class RdmaTransportTestPeer;

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
@@ -70,6 +71,18 @@ std::atomic<uint64_t> g_pool_mr_active{0};
 std::atomic<uint64_t> g_transient_user_mr_active{0};
 std::atomic<uint64_t> g_cq_completions{0};
 std::atomic<uint64_t> g_cq_errors{0};
+
+// The default path is one relaxed load in PostWrite. Tests can arm a bounded
+// number of responder WRITEs and hold them before ibv_post_send.
+std::atomic<size_t> g_test_block_writes{0};
+std::mutex g_test_write_mu;
+std::condition_variable g_test_write_cv;
+size_t g_test_write_entered = 0;
+size_t g_test_write_exited = 0;
+size_t g_test_write_faults_consumed = 0;
+size_t g_test_write_cancellations = 0;
+size_t g_test_write_releases = 0;
+
 
 int ObserveCqPoll(ibv_wc* out, int got) {
   if (got < 0) {
@@ -195,6 +208,61 @@ void SharedReleasePoolMr(ibv_context* ctx, ibv_mr* mr) {
   }
 }
 }  // namespace
+
+void TestBlockNextResponderWrites(size_t count) {
+  std::lock_guard<std::mutex> lock(g_test_write_mu);
+  g_test_write_entered = 0;
+  g_test_write_exited = 0;
+  g_test_write_faults_consumed = 0;
+  g_test_write_cancellations = 0;
+  g_test_write_releases = count == 0 ? count : 0;
+  g_test_block_writes.store(count, std::memory_order_release);
+}
+
+bool TestWaitForBlockedResponderWrites(size_t count, int timeout_ms) {
+  std::unique_lock<std::mutex> lock(g_test_write_mu);
+  return g_test_write_cv.wait_for(
+      lock, std::chrono::milliseconds(timeout_ms),
+      [&] { return g_test_write_entered >= count; });
+}
+
+bool TestWaitForReleasedResponderWrites(size_t count, int timeout_ms) {
+  std::unique_lock<std::mutex> lock(g_test_write_mu);
+  return g_test_write_cv.wait_for(
+      lock, std::chrono::milliseconds(timeout_ms),
+      [&] { return g_test_write_exited >= count; });
+}
+
+void TestReleaseBlockedResponderWrites() {
+  {
+    std::lock_guard<std::mutex> lock(g_test_write_mu);
+    g_test_write_releases = std::numeric_limits<size_t>::max();
+    g_test_block_writes.store(0, std::memory_order_release);
+  }
+  g_test_write_cv.notify_all();
+}
+
+void TestReleaseOneBlockedResponderWrite() {
+  {
+    std::lock_guard<std::mutex> lock(g_test_write_mu);
+    ++g_test_write_releases;
+  }
+  g_test_write_cv.notify_all();
+}
+
+bool TestWaitForResponderWriteCancellations(size_t count, int timeout_ms) {
+  std::unique_lock<std::mutex> lock(g_test_write_mu);
+  return g_test_write_cv.wait_for(
+      lock, std::chrono::milliseconds(timeout_ms),
+      [&] { return g_test_write_cancellations >= count; });
+}
+
+bool TestConsumeBlockedResponderWriteFault() {
+  std::lock_guard<std::mutex> lock(g_test_write_mu);
+  if (g_test_write_faults_consumed == g_test_write_entered) return false;
+  ++g_test_write_faults_consumed;
+  return true;
+}
 
 uint64_t RcEndpoint::AdhocUserMrTotal() {
   return g_adhoc_user_mr.load(std::memory_order_relaxed);
@@ -324,7 +392,9 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth,
 
   chan_ = ibv_create_comp_channel(ctx_);
   if (!chan_) { Close(); return false; }
-  int cqe = static_cast<int>(depth_ * 2 + 4);
+  const size_t cqe_per_slot =
+      v2_responder ? kV2MaxGetTargets + 2 : 2;
+  int cqe = static_cast<int>(depth_ * cqe_per_slot + 4);
   cq_ = ibv_create_cq(ctx_, cqe, nullptr, chan_, 0);
   if (!cq_) { Close(); return false; }
   if (ibv_req_notify_cq(cq_, 0) != 0) { Close(); return false; }
@@ -346,9 +416,9 @@ bool RcEndpoint::Open(const char* dev_name, size_t cap, size_t depth,
     }
   }
 
-  // A v2 server GET may chain one unsignaled RDMA WRITE per protocol target
-  // plus one signaled status SEND. Target count is fleet-wide and independent
-  // of either HCA's max_sge because every WRITE itself has one SGE.
+  // A v2 server GET may chain one signaled RDMA WRITE per protocol target plus
+  // one signaled status SEND. Target count is fleet-wide and independent of
+  // either HCA's max_sge because every WRITE itself has one SGE.
   static_assert(kV2MaxGetTargets == kMaxSge - 1);
   const size_t wr_per_slot =
       v2_responder ? (kV2MaxGetTargets + 1) : 2;
@@ -707,6 +777,40 @@ void RcEndpoint::ReleaseTransient(ibv_mr* mr) {
   g_transient_user_mr_active.fetch_sub(1, std::memory_order_relaxed);
 }
 
+void RcEndpoint::CancelResponderWrites() {
+  if (!responder_cancelled_.exchange(true, std::memory_order_acq_rel)) {
+    std::lock_guard<std::mutex> lock(g_test_write_mu);
+    if (g_test_write_entered > g_test_write_exited)
+      ++g_test_write_cancellations;
+    g_test_write_cv.notify_all();
+  }
+  Wake();
+}
+
+bool RcEndpoint::RetireResponderWrites() {
+  CancelResponderWrites();
+  if (!qp_) return pending_responder_writes_ == 0;
+  ibv_qp_attr attr{};
+  ibv_qp_init_attr init{};
+  if (ibv_query_qp(qp_, &attr, IBV_QP_STATE, &init) != 0) return false;
+  if (attr.qp_state != IBV_QPS_ERR) {
+    attr = {};
+    attr.qp_state = IBV_QPS_ERR;
+    if (ibv_modify_qp(qp_, &attr, IBV_QP_STATE) != 0) return false;
+  }
+  std::vector<ibv_wc> wcs(std::max<size_t>(1, depth_));
+  while (pending_responder_writes_ != 0) {
+    const int got = ibv_poll_cq(cq_, static_cast<int>(wcs.size()), wcs.data());
+    if (got < 0) return false;
+    if (got == 0) {
+      std::this_thread::yield();
+      continue;
+    }
+    ObserveCompletions(wcs.data(), got);
+  }
+  return true;
+}
+
 bool RcEndpoint::PostSendScatter(size_t slot, size_t hdr_len, const void* payload,
                                  size_t payload_len, ibv_mr* payload_mr) {
   if (slot >= depth_ || hdr_len > cap_ ||
@@ -809,6 +913,30 @@ bool RcEndpoint::PostWrite(size_t slot, const void* source, size_t length,
       remote_addr == 0 || remote_rkey == 0) {
     return false;
   }
+  if (responder_cancelled_.load(std::memory_order_acquire)) return false;
+  bool test_blocked = false;
+  size_t remaining = g_test_block_writes.load(std::memory_order_acquire);
+  while (remaining != 0 &&
+         !g_test_block_writes.compare_exchange_weak(
+             remaining, remaining - 1, std::memory_order_acq_rel,
+             std::memory_order_acquire)) {
+  }
+  if (remaining != 0) {
+    test_blocked = true;
+    std::unique_lock<std::mutex> lock(g_test_write_mu);
+    const size_t ordinal = ++g_test_write_entered;
+    g_test_write_cv.notify_all();
+    g_test_write_cv.wait(
+        lock, [ordinal] { return g_test_write_releases >= ordinal; });
+  }
+  if (responder_cancelled_.load(std::memory_order_acquire)) {
+    if (test_blocked) {
+      std::lock_guard<std::mutex> lock(g_test_write_mu);
+      ++g_test_write_exited;
+      g_test_write_cv.notify_all();
+    }
+    return false;
+  }
   ibv_sge sge{};
   sge.addr = reinterpret_cast<uintptr_t>(source);
   sge.length = static_cast<uint32_t>(length);
@@ -818,10 +946,17 @@ bool RcEndpoint::PostWrite(size_t slot, const void* source, size_t length,
   wr.sg_list = &sge;
   wr.num_sge = length ? 1 : 0;
   wr.opcode = IBV_WR_RDMA_WRITE;
-  wr.send_flags = 0;
+  wr.send_flags = IBV_SEND_SIGNALED;
   wr.wr.rdma.remote_addr = remote_addr;
   wr.wr.rdma.rkey = remote_rkey;
-  return ibv_post_send(qp_, &wr, &bad) == 0;
+  const bool posted = ibv_post_send(qp_, &wr, &bad) == 0;
+  if (posted) ++pending_responder_writes_;
+  if (test_blocked) {
+    std::lock_guard<std::mutex> lock(g_test_write_mu);
+    ++g_test_write_exited;
+    g_test_write_cv.notify_all();
+  }
+  return posted;
 }
 
 bool RcEndpoint::PostWriteImm(size_t slot, size_t length,
@@ -939,8 +1074,19 @@ bool RcEndpoint::PostWriteImmScatterMulti(
   return ibv_post_send(qp_, &wr, &bad) == 0;
 }
 
+int RcEndpoint::ObserveCompletions(ibv_wc* out, int got) {
+  got = ObserveCqPoll(out, got);
+  for (int i = 0; i < got; ++i) {
+    if (out[i].opcode == IBV_WC_RDMA_WRITE &&
+        pending_responder_writes_ != 0) {
+      --pending_responder_writes_;
+    }
+  }
+  return got;
+}
+
 int RcEndpoint::PollComp(ibv_wc* out, int max) {
-  return ObserveCqPoll(out, ibv_poll_cq(cq_, max, out));
+  return ObserveCompletions(out, ibv_poll_cq(cq_, max, out));
 }
 
 int RcEndpoint::WaitComp(ibv_wc* out, int max, int timeout_ms) {
@@ -949,37 +1095,37 @@ int RcEndpoint::WaitComp(ibv_wc* out, int max, int timeout_ms) {
     auto deadline = Clock::now() + std::chrono::milliseconds(timeout_ms < 0 ? 0 : timeout_ms);
     for (;;) {
       int got = ibv_poll_cq(cq_, max, out);
-      if (got != 0) return ObserveCqPoll(out, got);
+      if (got != 0) return ObserveCompletions(out, got);
       pollfd pfd = {wake_rfd_, POLLIN, 0};
       if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN)) return -1;
-      if (timeout_ms == 0) return ObserveCqPoll(out, 0);
+      if (timeout_ms == 0) return ObserveCompletions(out, 0);
       if (timeout_ms > 0 && Clock::now() >= deadline)
-        return ObserveCqPoll(out, 0);
+        return ObserveCompletions(out, 0);
     }
   }
   for (;;) {
     int got = ibv_poll_cq(cq_, max, out);
-    if (got != 0) return ObserveCqPoll(out, got);
+    if (got != 0) return ObserveCompletions(out, got);
     // No completion ready: arm notify, poll once more (close the race where a
     // completion arrived between the empty poll and the notify), then block on
     // the comp-channel fd OR the wake pipe (so Stop() can interrupt us).
-    if (ibv_req_notify_cq(cq_, 0) != 0) return ObserveCqPoll(out, -1);
+    if (ibv_req_notify_cq(cq_, 0) != 0) return ObserveCompletions(out, -1);
     got = ibv_poll_cq(cq_, max, out);
-    if (got != 0) return ObserveCqPoll(out, got);
+    if (got != 0) return ObserveCompletions(out, got);
     pollfd pfds[2] = {{chan_->fd, POLLIN, 0}, {wake_rfd_, POLLIN, 0}};
     int pr = ::poll(pfds, 2, timeout_ms);
     if (pr < 0) {
       if (errno == EINTR) continue;
-      return ObserveCqPoll(out, -1);
+      return ObserveCompletions(out, -1);
     }
     if (pr == 0)
-      return ObserveCqPoll(out, ibv_poll_cq(cq_, max, out));
+      return ObserveCompletions(out, ibv_poll_cq(cq_, max, out));
     if (pfds[1].revents & POLLIN) return -1;  // expected shutdown wake
     if (pfds[0].revents & POLLIN) {
       ibv_cq* ev_cq = nullptr;
       void* ev_ctx = nullptr;
       if (ibv_get_cq_event(chan_, &ev_cq, &ev_ctx) != 0)
-        return ObserveCqPoll(out, -1);
+        return ObserveCompletions(out, -1);
       ibv_ack_cq_events(ev_cq, 1);
     }
   }

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -194,7 +194,8 @@ class RcEndpoint {
   // current operation. `remote_write=true` is for receive targets; false keeps
   // const/read-only send sources valid. Registered pool MRs with sufficient
   // access are reused. The endpoint owns ad-hoc MRs until ReleaseTransient() or
-  // Close(), so a failed/timed-out QP tears down before deregistration.
+  // Close(); ambiguous direct GETs obtain responder-retirement proof before
+  // either happens.
   ibv_mr* RegisterTransient(void* addr, size_t len,
                             bool remote_write = true);
   void ReleaseTransient(ibv_mr* mr);
@@ -227,10 +228,9 @@ class RcEndpoint {
       size_t slot, const std::vector<std::pair<void*, uint32_t>>& segs,
       const std::vector<ibv_mr*>& mrs, size_t hdr_bytes);
 
-  // RDMA v2 one-sided primitives. PostWrite is intentionally UNSIGNALED: a
-  // following signaled status SEND on the same RC QP fences its source buffer
-  // lifetime and produces the sole server-side completion. WRITE_WITH_IMM is
-  // signaled because it is the client's request operation.
+  // RDMA v2 one-sided primitives. Responder PostWrite is signaled: its CQE is
+  // tracked until DONE on success or explicit writer retirement on ambiguity.
+  // WRITE_WITH_IMM is the client's signaled request operation.
   bool PostWrite(size_t slot, const void* source, size_t length,
                  ibv_mr* source_mr, uint64_t remote_addr,
                  uint32_t remote_rkey);
@@ -271,6 +271,12 @@ class RcEndpoint {
   // Unblock a thread sitting in WaitComp (so the server can join its Serve
   // threads at shutdown). Thread-safe vs the waiter.
   void Wake();
+  // Responder retirement protocol. Every PostWrite is signaled. Cancellation
+  // prevents later posts and wakes the owner; RetireResponderWrites moves the QP
+  // to ERR and consumes all tracked WRITE CQEs before the server sends proof to
+  // the client. This is the failure fence; ibv_destroy_qp is cleanup only.
+  void CancelResponderWrites();
+  bool RetireResponderWrites();
   void set_busy_poll(bool v) { busy_poll_ = v; }
   void set_num_qp(size_t n) { num_qp_ = n > 0 ? n : 1; }
   size_t num_qp() const { return num_qp_; }
@@ -279,6 +285,7 @@ class RcEndpoint {
   // syscall and CQ contention at high thread counts.
 
  private:
+  int ObserveCompletions(ibv_wc* out, int got);
   void Close();
 
   ibv_context* ctx_ = nullptr;
@@ -311,11 +318,24 @@ class RcEndpoint {
     ibv_mr* mr;
   };
   std::vector<PoolMr> pool_mr_;
-  // Operation-scoped out-of-pool MRs. These are released after completion, or
-  // after QP teardown on every failure/timeout path.
+  // Operation-scoped out-of-pool MRs. These are released after a successful
+  // DONE, or after explicit responder-retirement proof on failure.
   std::vector<ibv_mr*> transient_mr_;
   QpInfo local_;
+  std::atomic<bool> responder_cancelled_{false};
+  size_t pending_responder_writes_ = 0;  // responder owner thread only
 };
+
+// Deterministic loopback-only responder seam. It blocks the next `count`
+// PostWrite calls before ibv_post_send, allowing tests to hold real remote
+// WRITEs in flight while the client times out, fences, retries, or returns.
+void TestBlockNextResponderWrites(size_t count);
+bool TestWaitForBlockedResponderWrites(size_t count, int timeout_ms);
+bool TestWaitForReleasedResponderWrites(size_t count, int timeout_ms);
+void TestReleaseBlockedResponderWrites();
+bool TestConsumeBlockedResponderWriteFault();
+bool TestWaitForResponderWriteCancellations(size_t count, int timeout_ms);
+void TestReleaseOneBlockedResponderWrite();
 
 }  // namespace rdma
 }  // namespace dfkv

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -390,8 +390,10 @@ class Transport {
 
   // Scatter-gather read: raw stored bytes are split across each key's caller
   // buffers in order. The default reads once into contiguous operation-owned
-  // scratch and publishes each segment. RDMA uses registered operation-owned
-  // staging so retries and failed completions can never mutate caller memory.
+  // scratch and publishes each segment. RDMA registers the caller segments and
+  // lets server DMA land in them directly (GPUDirect when they are device
+  // memory); on failure the destination contents are unspecified, and QP
+  // teardown fences in-flight DMA before any retry or return.
   // out_lens[i] is the authoritative stored length (zero on miss), independent
   // of destination capacity.
   virtual std::vector<Status> RangeIntoMulti(

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -267,7 +267,9 @@ class Transport {
   // accounting (kIOError => transport failure; anything else => node responded).
   virtual std::vector<Status> ExistMany(const std::string& node,
                                         const std::vector<BlockKey>& keys,
-                                        std::vector<char>* exists) {
+                                        std::vector<char>* exists,
+                                        std::string* out_dev = nullptr) {
+    if (out_dev) out_dev->clear();  // RDMA rail device; base/TCP has none
     if (exists == nullptr) return InvalidStatuses(keys.size());
     exists->assign(keys.size(), 0);
     std::vector<Status> r;
@@ -352,7 +354,9 @@ class Transport {
   // through CacheFrom (no payload zero-copy, but correct on any transport). The
   // RDMA transport overrides this to gather the segments via a multi-SGE SEND.
   virtual std::vector<Status> CacheFromMulti(
-      const std::string& node, const std::vector<CacheSrcMulti>& srcs) {
+      const std::string& node, const std::vector<CacheSrcMulti>& srcs,
+      std::string* out_dev = nullptr) {
+    if (out_dev) out_dev->clear();  // RDMA rail device; base/TCP has none
     std::vector<Status> result(srcs.size(), Status::kInvalid);
     std::vector<std::vector<char>> bufs(srcs.size());
     std::vector<CacheSrc> flat;
@@ -399,7 +403,8 @@ class Transport {
   virtual std::vector<Status> RangeIntoMulti(
       const std::string& node, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* out_lens) {
+      std::vector<size_t>* out_lens, std::string* out_dev = nullptr) {
+    if (out_dev) out_dev->clear();  // RDMA rail device; base/TCP has none
     const size_t n = keys.size();
     if (out_lens) out_lens->assign(n, 0);
     if (n == 0) return {};

--- a/test/client/c_api_test.cc
+++ b/test/client/c_api_test.cc
@@ -60,7 +60,8 @@ class CApiTransport final : public dfkv::Transport {
   std::vector<dfkv::Status> RangeIntoMulti(
       const std::string&, const std::vector<dfkv::BlockKey>& keys,
       const std::vector<dfkv::RangeDstMulti>&,
-      std::vector<size_t>* out_lens) override {
+      std::vector<size_t>* out_lens,
+      std::string* /*out_dev*/ = nullptr) override {
     range_into_multi_called.store(true, std::memory_order_relaxed);
     Throw();
     if (out_lens) out_lens->assign(keys.size(), 0);

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -155,7 +155,8 @@ class MetricsTransport final : public Transport {
   }
 
   std::vector<Status> CacheFromMulti(
-      const std::string&, const std::vector<CacheSrcMulti>& srcs) override {
+      const std::string&, const std::vector<CacheSrcMulti>& srcs,
+      std::string* /*out_dev*/ = nullptr) override {
     std::lock_guard<std::mutex> lock(mu);
     const bool ok = RunAttemptsLocked(srcs.size(), [&] {
       remote_put_commits += srcs.size();
@@ -174,7 +175,8 @@ class MetricsTransport final : public Transport {
   std::vector<Status> RangeIntoMulti(
       const std::string&, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* out_lens) override {
+      std::vector<size_t>* out_lens,
+      std::string* /*out_dev*/ = nullptr) override {
     std::lock_guard<std::mutex> lock(mu);
     ++range_multi_calls;
     if (out_lens) out_lens->assign(keys.size(), 0);

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -10,18 +10,85 @@
 #include <cstring>
 #include <initializer_list>
 
+#include <fstream>
+#include <limits>
 #include <string>
 #include <chrono>
 #include <cstdlib>
 #include <map>
 #include <mutex>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <thread>
 #include <type_traits>
 #include <vector>
+#include <iterator>
+
+
+namespace dfkv::testing {
+void DrainPernodeSink();
+size_t PernodeQueueCapacity();
+size_t PernodeQueueHighWater();
+uint64_t PernodeQueueDropped();
+uint64_t PernodeQueuePendingDropped();
+void PausePernodeSink(bool paused);
+void EnqueuePernodeForTest(const char* fname,
+                           std::vector<std::string> lines);
+std::string PernodeKeyFingerprintForTest(const std::string& key);
+}  // namespace dfkv::testing
 
 using namespace dfkv;  // NOLINT
 
+struct PernodeMetricsEnv {
+  std::string dir =
+      "/tmp/dfkv-pernode-metrics-" + std::to_string(::getpid());
+  std::string suffix =
+      "dp0_pp0_tp0_g0_p" + std::to_string(::getpid());
+
+  PernodeMetricsEnv() {
+    ::mkdir(dir.c_str(), 0700);
+    ::setenv("DFKV_CLIENT_PERNODE_STATS", "1", 1);
+    ::setenv("DFKV_ACCESS_DIR", dir.c_str(), 1);
+    ::setenv("DFKV_CLIENT_LOG_SUFFIX", suffix.c_str(), 1);
+    ::setenv("DFKV_CLIENT_PERNODE_QUEUE_CAPACITY", "4", 1);
+    ::setenv("DFKV_CLIENT_PERNODE_ROTATE_BYTES", "512", 1);
+  }
+  std::string Path(const std::string& file) const {
+    return dir + "/" + file + "." + suffix;
+  }
+};
+
+PernodeMetricsEnv pernode_env;
+
+std::string ReadText(const std::string& path) {
+  std::ifstream input(path);
+  return std::string(std::istreambuf_iterator<char>(input),
+                     std::istreambuf_iterator<char>());
+}
+
+std::string CurrentAndPrevious(const std::string& file) {
+  const std::string current = pernode_env.Path(file);
+  return ReadText(current + ".1") + ReadText(current);
+}
+
+bool HasLineWith(const std::string& text,
+                 std::initializer_list<std::string> fields) {
+  size_t begin = 0;
+  while (begin <= text.size()) {
+    const size_t end = text.find('\n', begin);
+    const std::string line =
+        text.substr(begin, end == std::string::npos ? std::string::npos
+                                                    : end - begin);
+    bool all = true;
+    for (const std::string& field : fields)
+      all = all && line.find(field) != std::string::npos;
+    if (all) return true;
+    if (end == std::string::npos) break;
+    begin = end + 1;
+  }
+  return false;
+}
 namespace {
 class MetricsTransport final : public Transport {
  public:
@@ -51,6 +118,9 @@ class MetricsTransport final : public Transport {
   size_t range_calls = 0;
   size_t range_multi_calls = 0;
   size_t range_multi_misses = 0;
+  size_t cache_status_limit = std::numeric_limits<size_t>::max();
+  size_t range_status_limit = std::numeric_limits<size_t>::max();
+  size_t exist_status_limit = std::numeric_limits<size_t>::max();
   uint64_t cross_rail_retries = 0;
   uint64_t cross_rail_retry_successes = 0;
   uint64_t cross_rail_retry_exhausted = 0;
@@ -168,8 +238,10 @@ class MetricsTransport final : public Transport {
         values[src.key.Filename()] = std::move(value);
       }
     });
-    return std::vector<Status>(
+    std::vector<Status> result(
         srcs.size(), ok ? Status::kOk : Status::kIOError);
+    result.resize(std::min(result.size(), cache_status_limit));
+    return result;
   }
 
   std::vector<Status> RangeIntoMulti(
@@ -212,6 +284,16 @@ class MetricsTransport final : public Transport {
         --range_multi_misses;
       }
     }
+    result.resize(std::min(result.size(), range_status_limit));
+    return result;
+  }
+
+  std::vector<Status> ExistMany(
+      const std::string& node, const std::vector<BlockKey>& keys,
+      std::vector<char>* exists, std::string* out_dev = nullptr) override {
+    std::vector<Status> result =
+        Transport::ExistMany(node, keys, exists, out_dev);
+    result.resize(std::min(result.size(), exist_status_limit));
     return result;
   }
 
@@ -932,4 +1014,280 @@ TEST(ClientRetries, SgGetRetriesTransientMinorityMisses) {
                 std::string(retry_second.data(), retry_second.size()),
             value);
   EXPECT_EQ(transport.range_multi_calls, 2u);
+}
+
+TEST(ClientPernodeStats, OutputsFailuresRetriesAndBoundedRotation) {
+  MetricsTransport transport;
+  dfkv::testing::DrainPernodeSink();
+  transport.pipeline = true;
+  KVClient client({{"node-a", "10.0.0.1:12000"}},
+                  "pernode/contract", &transport);
+  const std::array<std::string, 3> keys{
+      "secret-put-alpha", "secret-put-beta", "secret-put-gamma"};
+  const std::string value = "payload";
+
+  transport.cache_status_limit = 1;
+  std::vector<KvPutItemSg> puts;
+  for (const std::string& key : keys)
+    puts.push_back({key, {value.data()}, {value.size()}});
+  EXPECT_EQ(client.BatchPutSg(puts),
+            std::vector<bool>({true, false, false}));
+  dfkv::testing::DrainPernodeSink();
+  const std::string put_log =
+      CurrentAndPrevious("dfkv_client_put.log");
+  EXPECT_NE(put_log.find(
+                "logical_keys=3 issued_keys=3"),
+            std::string::npos)
+      << put_log;
+  EXPECT_NE(put_log.find("logical_success=1 logical_fail=2"),
+            std::string::npos)
+      << put_log;
+  EXPECT_NE(put_log.find("failed_issued_keys=2"), std::string::npos)
+      << put_log;
+  EXPECT_NE(put_log.find("statuses=kOk,kInvalid"), std::string::npos)
+      << put_log;
+  EXPECT_EQ(put_log.find(keys[1]), std::string::npos)
+      << "raw keys must never be logged";
+  EXPECT_NE(put_log.find("first_fail=len="), std::string::npos) << put_log;
+
+  std::array<std::array<char, 16>, 3> output{};
+  std::vector<KvGetItemSg> gets;
+  for (size_t i = 0; i < keys.size(); ++i)
+    gets.push_back({keys[i], {output[i].data()}, {output[i].size()}});
+  transport.range_status_limit = 1;
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg(gets, &lengths),
+            std::vector<bool>({true, false, false}));
+  dfkv::testing::DrainPernodeSink();
+  std::string get_log = CurrentAndPrevious("dfkv_client_get.log");
+  EXPECT_NE(get_log.find("logical_keys=3 issued_keys=3"),
+            std::string::npos)
+      << get_log;
+  EXPECT_NE(get_log.find("failed_issued_keys=2"), std::string::npos)
+      << get_log;
+  EXPECT_NE(get_log.find("failure_status_mask=32"), std::string::npos)
+      << get_log;
+  EXPECT_EQ(get_log.find(keys[1]), std::string::npos);
+
+  transport.range_status_limit = std::numeric_limits<size_t>::max();
+  transport.range_multi_misses = 1;
+  EXPECT_EQ(client.BatchGetAutoSg(gets, &lengths),
+            std::vector<bool>({true, true, true}));
+  dfkv::testing::DrainPernodeSink();
+  get_log = CurrentAndPrevious("dfkv_client_get.log");
+  EXPECT_NE(get_log.find(
+                "logical_keys=3 issued_keys=4"),
+            std::string::npos)
+      << get_log;
+  EXPECT_NE(get_log.find("logical_hits=3 logical_not_hit=0"),
+            std::string::npos)
+      << get_log;
+
+  transport.exist_status_limit = 1;
+  EXPECT_EQ(
+      client.BatchExist(std::vector<std::string>(keys.begin(), keys.end())),
+      std::vector<bool>({true, false, false}));
+  dfkv::testing::DrainPernodeSink();
+  const std::string exist_log =
+      CurrentAndPrevious("dfkv_client_exist.log");
+  EXPECT_NE(exist_log.find("logical_keys=3 issued_keys=3"),
+            std::string::npos)
+      << exist_log;
+  EXPECT_NE(exist_log.find("failed_issued_keys=2"), std::string::npos)
+      << exist_log;
+  EXPECT_NE(exist_log.find("failure_status_mask=32"), std::string::npos)
+      << exist_log;
+
+  EXPECT_EQ(dfkv::testing::PernodeQueueCapacity(), 4u);
+  EXPECT_GT(dfkv::testing::PernodeQueueHighWater(), 0u);
+  EXPECT_LE(dfkv::testing::PernodeQueueHighWater(),
+            dfkv::testing::PernodeQueueCapacity());
+  std::ifstream rotated(
+      pernode_env.Path("dfkv_client_get.log") + ".1");
+  EXPECT_TRUE(rotated.good()) << "fixed .1 rotation file was not created";
+}
+
+TEST(ClientPernodeStats, FingerprintsAreKeyedStableAndNeverExposeRawKeys) {
+  const std::string key = "dictionary-guessable-secret-key";
+  const std::string first =
+      dfkv::testing::PernodeKeyFingerprintForTest(key);
+  const std::string second =
+      dfkv::testing::PernodeKeyFingerprintForTest(key);
+
+  EXPECT_EQ(first, second);
+  EXPECT_NE(first.find("len=" + std::to_string(key.size())),
+            std::string::npos);
+  EXPECT_NE(first.find("hmac-sha256="), std::string::npos);
+  EXPECT_EQ(first.find("fnv"), std::string::npos);
+  EXPECT_EQ(first.find(key), std::string::npos);
+}
+
+TEST(ClientPernodeStats, RecordsEveryPretransportRoutingFailure) {
+  dfkv::testing::DrainPernodeSink();
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({}, "pernode/no-route", &transport);
+  const std::string value = "payload";
+  std::array<char, 16> output{};
+
+  const KvGetItemSg invalid_get{
+      "invalid-get-secret", {output.data()}, {}};
+  const KvGetItemSg unrouted_get{
+      "unrouted-get-secret", {output.data()}, {output.size()}};
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg({invalid_get, unrouted_get}, &lengths),
+            std::vector<bool>({false, false}));
+  EXPECT_EQ(client.BatchExist({"unrouted-exist-secret"}),
+            std::vector<bool>({false}));
+  const KvPutItemSg invalid_put{
+      "invalid-put-secret", {value.data()}, {}};
+  const KvPutItemSg unrouted_put{
+      "unrouted-put-secret", {value.data()}, {value.size()}};
+  EXPECT_EQ(client.BatchPutSg({invalid_put, unrouted_put}),
+            std::vector<bool>({false, false}));
+  dfkv::testing::DrainPernodeSink();
+
+  const std::string get_log =
+      CurrentAndPrevious("dfkv_client_get.log");
+  EXPECT_TRUE(HasLineWith(
+      get_log,
+      {"pernode-get TOTAL:", "logical_keys=2", "issued_keys=0",
+       "nonissued_failures=2", "invalid_input=1", "no_route=1",
+       "health_cooldown=0",
+       "nonissued_reasons=invalid_input:kInvalid=1,"
+       "no_route:not_issued=1"}))
+      << get_log;
+  EXPECT_TRUE(HasLineWith(
+      get_log,
+      {"failure_status_mask=0", "logical_failure_status_mask=32",
+       "nonissued_status_mask=32", "nonissued_statuses=kInvalid"}))
+      << get_log;
+  EXPECT_EQ(get_log.find("invalid-get-secret"), std::string::npos);
+  EXPECT_EQ(get_log.find("unrouted-get-secret"), std::string::npos);
+
+  const std::string exist_log =
+      CurrentAndPrevious("dfkv_client_exist.log");
+  EXPECT_TRUE(HasLineWith(
+      exist_log,
+      {"pernode-exist TOTAL:", "logical_keys=1", "issued_keys=0",
+       "nonissued_failures=1", "no_route=1",
+       "nonissued_reasons=no_route:not_issued=1"}))
+      << exist_log;
+  EXPECT_EQ(exist_log.find("unrouted-exist-secret"), std::string::npos);
+
+  const std::string put_log =
+      CurrentAndPrevious("dfkv_client_put.log");
+  EXPECT_TRUE(HasLineWith(
+      put_log,
+      {"pernode-put TOTAL:", "logical_keys=2", "issued_keys=0",
+       "nonissued_failures=2", "invalid_input=1", "no_route=1",
+       "preroute_fail=2"}))
+      << put_log;
+  EXPECT_EQ(put_log.find("invalid-put-secret"), std::string::npos);
+  EXPECT_EQ(put_log.find("unrouted-put-secret"), std::string::npos);
+}
+
+TEST(ClientPernodeStats, RecordsGetExistAndPutHealthCooldownSkips) {
+  dfkv::testing::DrainPernodeSink();
+  const std::string value = "payload";
+
+  MetricsTransport get_transport;
+  get_transport.pipeline = true;
+  get_transport.Script(
+      {{0, MetricsTransport::AttemptResult::kRailFailure}});
+  KVClient get_client({{"get-node", "10.0.0.1:12100"}},
+                      "pernode/get-cooldown", &get_transport);
+  std::array<char, 16> output{};
+  KvGetItemSg get{"cooling-get-secret",
+                  {output.data()}, {output.size()}};
+  std::vector<size_t> lengths;
+  EXPECT_EQ(get_client.BatchGetAutoSg({get}, &lengths),
+            std::vector<bool>({false}));
+  const size_t get_calls = get_transport.range_multi_calls;
+  EXPECT_EQ(get_client.BatchGetAutoSg({get}, &lengths),
+            std::vector<bool>({false}));
+  EXPECT_EQ(get_transport.range_multi_calls, get_calls);
+  dfkv::testing::DrainPernodeSink();
+
+  MetricsTransport exist_transport;
+  exist_transport.pipeline = true;
+  exist_transport.exist_script = {Status::kIOError};
+  KVClient exist_client({{"exist-node", "10.0.0.1:12200"}},
+                        "pernode/exist-cooldown", &exist_transport);
+  EXPECT_EQ(exist_client.BatchExist({"cooling-exist-secret"}),
+            std::vector<bool>({false}));
+  const size_t exist_calls = exist_transport.exist_calls;
+  EXPECT_EQ(exist_client.BatchExist({"cooling-exist-secret"}),
+            std::vector<bool>({false}));
+  EXPECT_EQ(exist_transport.exist_calls, exist_calls);
+  dfkv::testing::DrainPernodeSink();
+
+  MetricsTransport put_transport;
+  put_transport.pipeline = true;
+  put_transport.Script(
+      {{0, MetricsTransport::AttemptResult::kRailFailure}});
+  KVClient put_client({{"put-node", "10.0.0.1:12300"}},
+                      "pernode/put-cooldown", &put_transport);
+  KvPutItemSg put{"cooling-put-secret",
+                  {value.data()}, {value.size()}};
+  EXPECT_EQ(put_client.BatchPutSg({put}), std::vector<bool>({false}));
+  const size_t put_attempts = put_transport.attempts.size();
+  EXPECT_EQ(put_client.BatchPutSg({put}), std::vector<bool>({false}));
+  EXPECT_EQ(put_transport.attempts.size(), put_attempts);
+  dfkv::testing::DrainPernodeSink();
+
+  const std::string get_log =
+      CurrentAndPrevious("dfkv_client_get.log");
+  EXPECT_TRUE(HasLineWith(
+      get_log,
+      {"pernode-get TOTAL:", "logical_keys=1", "issued_keys=0",
+       "nonissued_failures=1", "health_cooldown=1",
+       "failure_status_mask=0", "logical_failure_status_mask=0",
+       "nonissued_reasons=health_cooldown:not_issued=1"}))
+      << get_log;
+  EXPECT_EQ(get_log.find("cooling-get-secret"), std::string::npos);
+
+  const std::string exist_log =
+      CurrentAndPrevious("dfkv_client_exist.log");
+  EXPECT_TRUE(HasLineWith(
+      exist_log,
+      {"pernode-exist TOTAL:", "logical_keys=1", "issued_keys=0",
+       "nonissued_failures=1", "health_cooldown=1",
+       "nonissued_reasons=health_cooldown:not_issued=1"}))
+      << exist_log;
+  EXPECT_EQ(exist_log.find("cooling-exist-secret"), std::string::npos);
+
+  const std::string put_log =
+      CurrentAndPrevious("dfkv_client_put.log");
+  EXPECT_TRUE(HasLineWith(
+      put_log,
+      {"pernode-put TOTAL:", "logical_keys=1", "issued_keys=0",
+       "nonissued_failures=1", "health_cooldown=1",
+       "nonissued_reasons=health_cooldown:not_issued=1"}))
+      << put_log;
+  EXPECT_EQ(put_log.find("cooling-put-secret"), std::string::npos);
+}
+
+TEST(ClientPernodeStats, QueueDropsAreReportedByNextWrittenBatch) {
+  dfkv::testing::DrainPernodeSink();
+  EXPECT_EQ(dfkv::testing::PernodeQueuePendingDropped(), 0u);
+  const size_t capacity = dfkv::testing::PernodeQueueCapacity();
+  const uint64_t dropped_before = dfkv::testing::PernodeQueueDropped();
+
+  dfkv::testing::PausePernodeSink(true);
+  for (size_t i = 0; i < capacity + 2; ++i)
+    dfkv::testing::EnqueuePernodeForTest(
+        "dfkv_client_drop_test.log",
+        {"sink-test batch=" + std::to_string(i)});
+  EXPECT_EQ(dfkv::testing::PernodeQueueDropped() - dropped_before, 2u);
+  EXPECT_EQ(dfkv::testing::PernodeQueuePendingDropped(), 2u);
+  dfkv::testing::PausePernodeSink(false);
+  dfkv::testing::DrainPernodeSink();
+
+  EXPECT_EQ(dfkv::testing::PernodeQueuePendingDropped(), 0u);
+  const std::string log =
+      CurrentAndPrevious("dfkv_client_drop_test.log");
+  EXPECT_NE(log.find("pernode-sink DROPPED: dropped_batches=2"),
+            std::string::npos)
+      << log;
 }

--- a/test/client/client_metrics_test.cc
+++ b/test/client/client_metrics_test.cc
@@ -29,6 +29,7 @@
 namespace dfkv::testing {
 void DrainPernodeSink();
 size_t PernodeQueueCapacity();
+uint64_t PernodeRotateBytes();
 size_t PernodeQueueHighWater();
 uint64_t PernodeQueueDropped();
 uint64_t PernodeQueuePendingDropped();
@@ -52,7 +53,7 @@ struct PernodeMetricsEnv {
     ::setenv("DFKV_ACCESS_DIR", dir.c_str(), 1);
     ::setenv("DFKV_CLIENT_LOG_SUFFIX", suffix.c_str(), 1);
     ::setenv("DFKV_CLIENT_PERNODE_QUEUE_CAPACITY", "4", 1);
-    ::setenv("DFKV_CLIENT_PERNODE_ROTATE_BYTES", "512", 1);
+    ::setenv("DFKV_CLIENT_PERNODE_ROTATE_BYTES", "1024", 1);
   }
   std::string Path(const std::string& file) const {
     return dir + "/" + file + "." + suffix;
@@ -108,6 +109,8 @@ class MetricsTransport final : public Transport {
   mutable std::mutex mu;
   std::map<std::string, std::string> values;
   std::vector<Status> exist_script;
+  std::vector<Status> cache_statuses;
+  std::vector<Status> range_multi_statuses;
   std::vector<ScriptedAttempt> attempt_script;
   std::vector<ScriptedAttempt> attempts;
   std::vector<size_t> replay_item_counts;
@@ -226,8 +229,15 @@ class MetricsTransport final : public Transport {
 
   std::vector<Status> CacheFromMulti(
       const std::string&, const std::vector<CacheSrcMulti>& srcs,
-      std::string* /*out_dev*/ = nullptr) override {
+      std::string* out_dev = nullptr) override {
     std::lock_guard<std::mutex> lock(mu);
+    if (!cache_statuses.empty()) {
+      std::vector<Status> result(srcs.size(), Status::kInvalid);
+      for (size_t i = 0; i < result.size(); ++i)
+        result[i] = cache_statuses[std::min(i, cache_statuses.size() - 1)];
+      return result;
+    }
+    const size_t attempt_begin = attempts.size();
     const bool ok = RunAttemptsLocked(srcs.size(), [&] {
       remote_put_commits += srcs.size();
       for (const auto& src : srcs) {
@@ -238,6 +248,7 @@ class MetricsTransport final : public Transport {
         values[src.key.Filename()] = std::move(value);
       }
     });
+    SetOutDevLocked(attempt_begin, out_dev);
     std::vector<Status> result(
         srcs.size(), ok ? Status::kOk : Status::kIOError);
     result.resize(std::min(result.size(), cache_status_limit));
@@ -248,13 +259,21 @@ class MetricsTransport final : public Transport {
       const std::string&, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
       std::vector<size_t>* out_lens,
-      std::string* /*out_dev*/ = nullptr) override {
+      std::string* out_dev = nullptr) override {
     std::lock_guard<std::mutex> lock(mu);
     ++range_multi_calls;
     if (out_lens) out_lens->assign(keys.size(), 0);
     if (dsts.size() != keys.size()) return InvalidStatuses(keys.size());
+    if (!range_multi_statuses.empty()) {
+      std::vector<Status> scripted(keys.size(), Status::kInvalid);
+      for (size_t i = 0; i < scripted.size(); ++i)
+        scripted[i] =
+            range_multi_statuses[std::min(i, range_multi_statuses.size() - 1)];
+      return scripted;
+    }
     std::vector<Status> result(keys.size(), Status::kNotFound);
     range_multi_item_calls.assign(keys.size(), 0);
+    const size_t attempt_begin = attempts.size();
     const bool ok = RunAttemptsLocked(
         keys.size(), [&](size_t begin, size_t end) {
       for (size_t i = begin; i < end; ++i) {
@@ -274,6 +293,7 @@ class MetricsTransport final : public Transport {
         result[i] = Status::kOk;
       }
     });
+    SetOutDevLocked(attempt_begin, out_dev);
     if (!ok) {
       result.assign(keys.size(), Status::kIOError);
     } else {
@@ -312,6 +332,20 @@ class MetricsTransport final : public Transport {
   }
 
  private:
+  void SetOutDevLocked(size_t attempt_begin, std::string* out_dev) const {
+    if (!out_dev || attempt_begin >= attempts.size()) return;
+    out_dev->clear();
+    for (size_t i = attempt_begin; i < attempts.size(); ++i) {
+      const std::string dev = "ib" + std::to_string(attempts[i].rail);
+      if (out_dev->empty()) {
+        *out_dev = dev;
+      } else if (*out_dev != dev) {
+        *out_dev += "->";
+        *out_dev += dev;
+      }
+    }
+  }
+
   template <typename Success>
   bool RunAttemptsLocked(size_t item_count, Success&& success) {
     const std::vector<ScriptedAttempt> script =
@@ -1268,6 +1302,96 @@ TEST(ClientPernodeStats, RecordsGetExistAndPutHealthCooldownSkips) {
   EXPECT_EQ(put_log.find("cooling-put-secret"), std::string::npos);
 }
 
+TEST(ClientPernodeStats, ClientLocalTransportOutcomesAreNotIssued) {
+  dfkv::testing::DrainPernodeSink();
+  MetricsTransport transport;
+  transport.pipeline = true;
+  transport.cache_statuses = {
+      Status::kResourceExhausted, Status::kNoCompatibleRail};
+  transport.range_multi_statuses = {
+      Status::kResourceExhausted, Status::kNoCompatibleRail};
+  transport.exist_script = {
+      Status::kResourceExhausted, Status::kNoCompatibleRail};
+  KVClient client({{"local-node", "10.0.0.1:12400"}},
+                  "pernode/client-local", &transport);
+  const std::string value = "payload";
+  const std::array<std::string, 2> keys{"local-secret-a", "local-secret-b"};
+
+  std::vector<KvPutItemSg> puts;
+  for (const std::string& key : keys)
+    puts.push_back({key, {value.data()}, {value.size()}});
+  EXPECT_EQ(client.BatchPutSg(puts), std::vector<bool>({false, false}));
+
+  std::array<std::array<char, 16>, 2> output{};
+  std::vector<KvGetItemSg> gets;
+  for (size_t i = 0; i < keys.size(); ++i)
+    gets.push_back({keys[i], {output[i].data()}, {output[i].size()}});
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg(gets, &lengths),
+            std::vector<bool>({false, false}));
+  EXPECT_EQ(client.BatchExist({keys[0], keys[1]}),
+            std::vector<bool>({false, false}));
+  dfkv::testing::DrainPernodeSink();
+
+  for (const char* file : {"dfkv_client_get.log", "dfkv_client_put.log",
+                           "dfkv_client_exist.log"}) {
+    const std::string log = CurrentAndPrevious(file);
+    EXPECT_TRUE(HasLineWith(
+        log,
+        {"TOTAL:", "logical_keys=2", "issued_keys=0",
+         "failed_issued_keys=0", "status_mask=0", "failure_status_mask=0",
+         "nonissued_failures=2", "logical_failure_status_mask=192",
+         "nonissued_status_mask=192",
+         "nonissued_statuses=kResourceExhausted,kNoCompatibleRail",
+         "resource_exhausted=1", "no_compatible_rail=1",
+         "nonissued_reasons=resource_exhausted:kResourceExhausted=1,"
+         "no_compatible_rail:kNoCompatibleRail=1"}))
+        << file << "\n" << log;
+    EXPECT_EQ(log.find(keys[0]), std::string::npos) << log;
+    EXPECT_EQ(log.find(keys[1]), std::string::npos) << log;
+  }
+}
+
+TEST(ClientPernodeStats, RetryRailPathPreservesAttemptOrderAndSingleRail) {
+  dfkv::testing::DrainPernodeSink();
+  MetricsTransport transport;
+  transport.pipeline = true;
+  KVClient client({{"rail-node", "10.0.0.1:12500"}},
+                  "pernode/rail-path", &transport);
+  const std::string value = "rail-payload";
+  ASSERT_TRUE(client.Put("rail-key", value.data(), value.size()));
+
+  transport.Script({
+      {0, MetricsTransport::AttemptResult::kRailFailure},
+      {1, MetricsTransport::AttemptResult::kSuccess},
+  });
+  std::array<char, 32> output{};
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg(
+                {{"rail-key", {output.data()}, {output.size()}}}, &lengths),
+            std::vector<bool>({true}));
+  dfkv::testing::DrainPernodeSink();
+  std::string log = CurrentAndPrevious("dfkv_client_get.log");
+  EXPECT_TRUE(HasLineWith(
+      log, {"pernode-get:", "node=10.0.0.1:12500",
+            "dev=ib0->ib1", "issued_keys=1"}))
+      << log;
+
+  transport.Script({
+      {3, MetricsTransport::AttemptResult::kSuccess},
+  });
+  EXPECT_EQ(client.BatchGetAutoSg(
+                {{"rail-key", {output.data()}, {output.size()}}}, &lengths),
+            std::vector<bool>({true}));
+  dfkv::testing::DrainPernodeSink();
+  log = CurrentAndPrevious("dfkv_client_get.log");
+  EXPECT_TRUE(HasLineWith(
+      log, {"pernode-get:", "node=10.0.0.1:12500",
+            "dev=ib3", "issued_keys=1"}))
+      << log;
+  EXPECT_EQ(log.find("dev=ib3->"), std::string::npos) << log;
+}
+
 TEST(ClientPernodeStats, QueueDropsAreReportedByNextWrittenBatch) {
   dfkv::testing::DrainPernodeSink();
   EXPECT_EQ(dfkv::testing::PernodeQueuePendingDropped(), 0u);
@@ -1290,4 +1414,41 @@ TEST(ClientPernodeStats, QueueDropsAreReportedByNextWrittenBatch) {
   EXPECT_NE(log.find("pernode-sink DROPPED: dropped_batches=2"),
             std::string::npos)
       << log;
+}
+
+TEST(ClientPernodeStats, RotationSplitsBatchesAndBoundsOversizeLines) {
+  dfkv::testing::DrainPernodeSink();
+  const uint64_t bound = dfkv::testing::PernodeRotateBytes();
+  ASSERT_EQ(bound, 1024u);
+  const std::string file = "dfkv_client_rotation_test.log";
+  const std::string current = pernode_env.Path(file);
+  const std::string previous = current + ".1";
+  const std::string first = "rotation-first " + std::string(700, 'a');
+  const std::string oversize = "rotation-oversize " + std::string(2000, 'x');
+  const std::string last = "rotation-last " + std::string(700, 'b');
+
+  dfkv::testing::EnqueuePernodeForTest(
+      file.c_str(), {first, oversize, last});
+  dfkv::testing::DrainPernodeSink();
+
+  struct stat current_stat {};
+  struct stat previous_stat {};
+  ASSERT_EQ(::stat(current.c_str(), &current_stat), 0);
+  ASSERT_EQ(::stat(previous.c_str(), &previous_stat), 0);
+  EXPECT_LE(static_cast<uint64_t>(current_stat.st_size), bound);
+  EXPECT_LE(static_cast<uint64_t>(previous_stat.st_size), bound);
+
+  const std::string current_text = ReadText(current);
+  const std::string previous_text = ReadText(previous);
+  ASSERT_FALSE(current_text.empty());
+  ASSERT_FALSE(previous_text.empty());
+  EXPECT_EQ(current_text.back(), '\n');
+  EXPECT_EQ(previous_text.back(), '\n');
+  const std::string combined = previous_text + current_text;
+  EXPECT_NE(combined.find("rotation-first"), std::string::npos) << combined;
+  EXPECT_NE(combined.find("pernode-sink OVERSIZE: original_bytes="),
+            std::string::npos)
+      << combined;
+  EXPECT_NE(combined.find("rotation-last"), std::string::npos) << combined;
+  EXPECT_EQ(combined.find(std::string(2000, 'x')), std::string::npos);
 }

--- a/test/client/endpoint_ownership_test.cc
+++ b/test/client/endpoint_ownership_test.cc
@@ -26,7 +26,8 @@ class RecordingTransport final : public Transport {
   }
   std::vector<Status> CacheFromMulti(
       const std::string& node,
-      const std::vector<CacheSrcMulti>& srcs) override {
+      const std::vector<CacheSrcMulti>& srcs,
+      std::string* /*out_dev*/ = nullptr) override {
     {
       std::lock_guard<std::mutex> lock(mu_);
       selected_nodes_.push_back(node);

--- a/test/client/get_auto_pipelined_test.cc
+++ b/test/client/get_auto_pipelined_test.cc
@@ -38,7 +38,7 @@ struct PernodeFallbackEnv {
     ::setenv("DFKV_ACCESS_DIR", dir.c_str(), 1);
     ::unsetenv("DFKV_CLIENT_LOG_SUFFIX");
     ::setenv("DFKV_CLIENT_PERNODE_QUEUE_CAPACITY", "8", 1);
-    ::setenv("DFKV_CLIENT_PERNODE_ROTATE_BYTES", "512", 1);
+    ::setenv("DFKV_CLIENT_PERNODE_ROTATE_BYTES", "1024", 1);
   }
   std::string GetLogPath() const {
     return dir + "/dfkv_client_get.log.p" + std::to_string(::getpid());

--- a/test/client/get_auto_pipelined_test.cc
+++ b/test/client/get_auto_pipelined_test.cc
@@ -7,17 +7,56 @@
 #include "transport/transport.h"
 #include "client/key_map.h"
 
+#include <array>
+#include <cstdlib>
+#include <fstream>
 #include <algorithm>
 #include <gtest/gtest.h>
 #include <limits>
+#include <iterator>
 #include <cstring>
 #include <map>
 #include <string>
 #include <vector>
+#include <sys/stat.h>
+#include <unistd.h>
 
 using namespace dfkv;  // NOLINT
 
+namespace dfkv::testing {
+void DrainPernodeSink();
+}  // namespace dfkv::testing
+
+
 namespace {
+struct PernodeFallbackEnv {
+  std::string dir =
+      "/tmp/dfkv-pernode-get-auto-" + std::to_string(::getpid());
+  PernodeFallbackEnv() {
+    ::mkdir(dir.c_str(), 0700);
+    ::setenv("DFKV_CLIENT_PERNODE_STATS", "1", 1);
+    ::setenv("DFKV_ACCESS_DIR", dir.c_str(), 1);
+    ::unsetenv("DFKV_CLIENT_LOG_SUFFIX");
+    ::setenv("DFKV_CLIENT_PERNODE_QUEUE_CAPACITY", "8", 1);
+    ::setenv("DFKV_CLIENT_PERNODE_ROTATE_BYTES", "512", 1);
+  }
+  std::string GetLogPath() const {
+    return dir + "/dfkv_client_get.log.p" + std::to_string(::getpid());
+  }
+};
+
+PernodeFallbackEnv pernode_fallback_env;
+
+std::string ReadGetLogs() {
+  const std::string path = pernode_fallback_env.GetLogPath();
+  std::ifstream previous(path + ".1");
+  std::ifstream current(path);
+  return std::string(std::istreambuf_iterator<char>(previous),
+                     std::istreambuf_iterator<char>()) +
+         std::string(std::istreambuf_iterator<char>(current),
+                     std::istreambuf_iterator<char>());
+}
+
 
 // Pipelined transport that serves stored blobs only through RangeInto and counts
 // each entry point, so a test can prove GetAuto never falls back to Range here.
@@ -28,6 +67,7 @@ struct FakePipelinedTransport : Transport {
   std::vector<DestinationMemoryKind> last_range_kinds;
   std::vector<std::vector<DestinationMemoryKind>> last_multi_kinds;
   int register_calls = 0;
+  size_t multi_status_limit = std::numeric_limits<size_t>::max();
 
   bool RegisterMemory(void*, size_t) override {
     ++register_calls;
@@ -110,6 +150,7 @@ struct FakePipelinedTransport : Transport {
       }
       result[i] = Status::kOk;
     }
+    result.resize(std::min(result.size(), multi_status_limit));
     return result;
   }
 };
@@ -287,4 +328,43 @@ TEST(GetAutoPipelined,
     EXPECT_EQ(allocations[i],
               std::string(allocations[i].size(), kSentinel))
         << "failed destination " << i;
+}
+
+TEST(GetAutoPipelined, ShortStatusVectorIsInvalidAndUsesPidFallbackSuffix) {
+  FakePipelinedTransport transport;
+  dfkv::testing::DrainPernodeSink();
+  KVClient client = MakeClient(&transport);
+  const std::array<std::string, 3> keys{
+      "secret-get-alpha", "secret-get-beta", "secret-get-gamma"};
+  const std::string value = "abc";
+  for (const std::string& key : keys)
+    transport.blobs[ToBlockKey("test/model", key).Filename()] = value;
+  transport.multi_status_limit = 1;
+
+  std::array<std::array<char, 8>, 3> outputs{};
+  std::vector<KvGetItemSg> items;
+  for (size_t i = 0; i < keys.size(); ++i)
+    items.push_back(
+        {keys[i], {outputs[i].data()}, {outputs[i].size()}});
+  std::vector<size_t> lengths;
+  EXPECT_EQ(client.BatchGetAutoSg(items, &lengths),
+            std::vector<bool>({true, false, false}));
+  EXPECT_EQ(lengths, std::vector<size_t>({value.size(), 0, 0}));
+
+  dfkv::testing::DrainPernodeSink();
+  const std::string output = ReadGetLogs();
+  EXPECT_NE(output.find("logical_keys=3 issued_keys=3"),
+            std::string::npos)
+      << output;
+  EXPECT_NE(output.find("failed_issued_keys=2"), std::string::npos)
+      << output;
+  EXPECT_NE(output.find("statuses=kOk,kInvalid"), std::string::npos)
+      << output;
+  EXPECT_NE(output.find("first_fail=len="), std::string::npos) << output;
+  for (const std::string& key : keys)
+    EXPECT_EQ(output.find(key), std::string::npos)
+        << "raw keys must not be logged";
+  std::ifstream fallback(pernode_fallback_env.GetLogPath());
+  EXPECT_TRUE(fallback.good())
+      << "unset suffix must fall back to a process-unique PID";
 }

--- a/test/client/get_auto_pipelined_test.cc
+++ b/test/client/get_auto_pipelined_test.cc
@@ -83,7 +83,8 @@ struct FakePipelinedTransport : Transport {
   std::vector<Status> RangeIntoMulti(
       const std::string&, const std::vector<BlockKey>& keys,
       const std::vector<RangeDstMulti>& dsts,
-      std::vector<size_t>* value_lens) override {
+      std::vector<size_t>* value_lens,
+      std::string* /*out_dev*/ = nullptr) override {
     value_lens->assign(keys.size(), 0);
     last_multi_kinds.clear();
     last_multi_kinds.reserve(dsts.size());

--- a/test/transport/dev_frame_caps_test.cc
+++ b/test/transport/dev_frame_caps_test.cc
@@ -24,6 +24,29 @@ TEST(DevFrameCaps, V2RoundTrip) {
   EXPECT_EQ(ParseDevFrameProtocol(frame), kDevProtoV2);
 }
 
+TEST(DevFrameCaps, WriterRetirementRequestDoesNotChangeBlockGeometry) {
+  constexpr uint64_t max_block = 4u << 20;
+  char frame[kDevNameBytes];
+  EncodeDevFrame("ib0", max_block | kDevFrameRequestWriterRetirement, frame);
+
+  EXPECT_EQ(ParseDevFrameCaps(frame),
+            max_block | kDevFrameRequestWriterRetirement);
+  EXPECT_EQ(ParseDevFrameMaxBlock(frame), max_block);
+  EXPECT_TRUE(DevFrameRequestsWriterRetirement(frame));
+  EXPECT_EQ(ParseDevFrameProtocol(frame), kDevProtoV2);
+
+  EncodeDevFrame("ib0", max_block, frame);
+  EXPECT_EQ(ParseDevFrameMaxBlock(frame), max_block);
+  EXPECT_FALSE(DevFrameRequestsWriterRetirement(frame));
+}
+
+TEST(DevFrameCaps, RawOpaqueControlValueKeepsBit63) {
+  constexpr uint64_t token = kDevFrameRequestWriterRetirement | 0x1234;
+  char frame[kDevNameBytes];
+  EncodeDevFrame("__control__", token, frame);
+  EXPECT_EQ(ParseDevFrameCaps(frame), token);
+}
+
 TEST(DevFrameCaps, V2RequiresDeclarationAndTailRoom) {
   char f[kDevNameBytes];
   EncodeDevFrame("ib7s400p0", 0, f, kDevProtoV2);

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -5715,6 +5715,56 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
             std::string(value.size(), static_cast<char>(0x5a)));
 }
 
+// The SG read path (RangeIntoMulti) shares the direct-write contract: server
+// DMA lands straight in the caller segments, so a failed GET may leave
+// partial payload behind, but QP teardown fences every in-flight write before
+// the call returns, and a later successful GET rewrites the item in full.
+TEST(RdmaLoopback, FailedSgGetLeavesCallerSegmentsStableAfterReturn) {
+  if (!HaveRdma())
+    GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
+  const auto rails = ConfiguredTwoTestRails();
+  if (!HaveConfiguredActiveRails(rails))
+    GTEST_SKIP() << "set DFKV_RDMA_DEV to exactly two ACTIVE test devices";
+  ScopedEnv depth("DFKV_RDMA_DEPTH", "4");
+  ScopedEnv credits("DFKV_RDMA_RAIL_CREDITS", kRealHcaRailCredits);
+  ScopedEnv threshold("DFKV_RDMA_RAIL_ERROR_THRESHOLD", "100");
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  RdmaNode node("sg-failed-get-fence");
+  RdmaTransport transport(kMaxMsg, rails[0] + "," + rails[1]);
+  KVClient client({{"n", node.addr}}, SelfHdr(), &transport);
+  const std::string value(64 * 1024, 'q');
+  ASSERT_TRUE(client.Put("sg-failed-get", value.data(), value.size()));
+
+  std::string first(4096, '\x5a');
+  std::string second(value.size() - first.size(), '\x5a');
+  KvGetItemSg get{"sg-failed-get", {first.data(), second.data()},
+                  {first.size(), second.size()}};
+  std::vector<size_t> lengths;
+  {
+    ScopedEnv fault("DFKV_RDMA_TEST_COMPLETION_FAULT", "1:1:1,1:2:1");
+    EXPECT_FALSE(client.BatchGetAutoSg({get}, &lengths)[0]);
+  }
+  // Partial payload may already sit in the segments (unspecified contents on
+  // failure); what the fence guarantees is that they stop changing here.
+  const std::string first_at_return = first;
+  const std::string second_at_return = second;
+
+  // Drive another synchronous control completion; teardown must have fenced
+  // every in-flight DMA before the failed call returned.
+  std::vector<char> exists;
+  EXPECT_EQ(transport.ExistMany(
+                node.addr, {ToBlockKey(SelfHdr(), "sg-failed-get")}, &exists),
+            std::vector<Status>({Status::kOk}));
+  EXPECT_EQ(first, first_at_return);
+  EXPECT_EQ(second, second_at_return);
+
+  // A clean retry through the same destinations must rewrite the item in
+  // full: no first-attempt residue can leak through a successful GET.
+  ASSERT_TRUE(client.BatchGetAutoSg({get}, &lengths)[0]);
+  ASSERT_EQ(lengths[0], value.size());
+  EXPECT_EQ(first + second, value);
+}
+
 TEST(RdmaLoopback,
      EndpointCompletionCoolsOnlyFailedPeerRailAndPublicGetReplays) {
   if (!HaveRdma())

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 #include <sys/mman.h>  // shm_unlink (node-dedup test)
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -80,6 +81,9 @@ class RdmaServerTestPeer {
   static bool HasWriter(RdmaServer* server, uint64_t token) {
     std::lock_guard<std::mutex> lock(server->writer_mu_);
     return server->writers_.find(token) != server->writers_.end();
+  }
+  static void ServeBootstrap(RdmaServer* server, int fd) {
+    server->Serve(fd);
   }
 #ifdef DFKV_WITH_URING
   static void SetUringBackendFactory(
@@ -658,6 +662,45 @@ TEST(RdmaWriterToken, FreshProcessesDoNotReuseStaleTokens) {
   ASSERT_NE(new_process.token, 0u);
   EXPECT_FALSE(new_process.stale_token_found);
   EXPECT_NE(new_process.token, old_process.token);
+}
+
+TEST(RdmaBootstrapCapability, ServerAdvertisesWriterRetirementInProbe) {
+  RdmaServer server(RdmaServer::Handler{}, kMaxMsg);
+  int sockets[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+  std::thread serving(
+      [&] { RdmaServerTestPeer::ServeBootstrap(&server, sockets[1]); });
+
+  char request[rdma::kDevNameBytes];
+  rdma::EncodeDevFrame(rdma::kV2ProbeDevice, 4u << 20, request);
+  const bool wrote = net::WriteAll(sockets[0], request, sizeof(request));
+  char reply[rdma::kV2ProbeReplyBytes];
+  const bool read = wrote && net::ReadAll(sockets[0], reply, sizeof(reply));
+
+  ::close(sockets[0]);
+  serving.join();
+  ASSERT_TRUE(read);
+  EXPECT_TRUE(rdma::V2ProbeSupportsWriterRetirement(reply));
+}
+
+TEST(RdmaBootstrapCapability, UnnegotiatedTokenGetsNoRetirementProof) {
+  RdmaServer server(RdmaServer::Handler{}, kMaxMsg);
+  int sockets[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+  std::thread serving(
+      [&] { RdmaServerTestPeer::ServeBootstrap(&server, sockets[1]); });
+
+  char request[rdma::kDevNameBytes];
+  rdma::EncodeDevFrame(rdma::kV2RetireWriterDevice, 0x12345678, request);
+  const bool wrote = net::WriteAll(sockets[0], request, sizeof(request));
+  char proof[rdma::kV2RetireProofBytes];
+  const bool read =
+      wrote && net::ReadAll(sockets[0], proof, sizeof(proof));
+
+  ::close(sockets[0]);
+  serving.join();
+  ASSERT_TRUE(wrote);
+  EXPECT_FALSE(read);
 }
 
 TEST(RdmaServerStartup, AutoModeKeepsFirstActiveDeviceSemantics) {

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -16,14 +16,17 @@
 #include "transport/rdma_topology.h"
 #include "transport/rdma_protocol.h"
 #include "transport/rdma_verbs.h"
+#include "utils/net_util.h"
 
 #include <gtest/gtest.h>
 #include <sys/mman.h>  // shm_unlink (node-dedup test)
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cerrno>
 #include <algorithm>
 #include <cctype>
 #include <array>
@@ -39,6 +42,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -68,6 +72,14 @@ class RdmaServerTestPeer {
   }
   static size_t RegisteredRailCount(const RdmaServer& server) {
     return server.recv_segment_registered_rails_;
+  }
+  static uint64_t RegisterWriter(RdmaServer* server) {
+    auto writer = std::make_shared<RdmaServer::WriterState>();
+    return server->RegisterWriter(writer);
+  }
+  static bool HasWriter(RdmaServer* server, uint64_t token) {
+    std::lock_guard<std::mutex> lock(server->writer_mu_);
+    return server->writers_.find(token) != server->writers_.end();
   }
 #ifdef DFKV_WITH_URING
   static void SetUringBackendFactory(
@@ -193,6 +205,71 @@ void ConfigureTestRecvSegment() {
   // Keep Soft-RoCE CI below modest RLIMIT_MEMLOCK. Production defaults to
   // 2 GiB, but these fixtures use 256-KiB blocks and need only a small segment.
   ::setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", "33554432", 0);
+}
+
+struct ChildWriterTokenResult {
+  uint64_t token = 0;
+  int status = -1;
+  bool transferred = false;
+  bool stale_token_found = false;
+};
+
+ChildWriterTokenResult WriterTokenFromFreshProcess(uint64_t stale_token = 0) {
+  int pipe_fds[2];
+  if (::pipe(pipe_fds) != 0) return {};
+  const pid_t child = ::fork();
+  if (child < 0) {
+    ::close(pipe_fds[0]);
+    ::close(pipe_fds[1]);
+    return {};
+  }
+  if (child == 0) {
+    ::close(pipe_fds[0]);
+    RdmaServer server(RdmaServer::Handler{}, kMaxMsg);
+    const uint64_t token = RdmaServerTestPeer::RegisterWriter(&server);
+    std::array<char, sizeof(token) + 1> wire{};
+    net::PutU64(wire.data(), token);
+    wire[sizeof(token)] = static_cast<char>(
+        RdmaServerTestPeer::HasWriter(&server, stale_token));
+    size_t written = 0;
+    while (written < wire.size()) {
+      const ssize_t n =
+          ::write(pipe_fds[1], wire.data() + written, wire.size() - written);
+      if (n > 0) {
+        written += static_cast<size_t>(n);
+        continue;
+      }
+      if (n < 0 && errno == EINTR) continue;
+      ::_exit(2);
+    }
+    ::_exit(0);
+  }
+
+  ::close(pipe_fds[1]);
+  ChildWriterTokenResult result;
+  std::array<char, sizeof(result.token) + 1> wire{};
+  size_t received = 0;
+  while (received < wire.size()) {
+    const ssize_t n =
+        ::read(pipe_fds[0], wire.data() + received, wire.size() - received);
+    if (n > 0) {
+      received += static_cast<size_t>(n);
+      continue;
+    }
+    if (n < 0 && errno == EINTR) continue;
+    break;
+  }
+  ::close(pipe_fds[0]);
+  pid_t waited;
+  do {
+    waited = ::waitpid(child, &result.status, 0);
+  } while (waited < 0 && errno == EINTR);
+  result.token = net::GetU64(wire.data());
+  result.stale_token_found = wire[sizeof(result.token)] != 0;
+  result.transferred =
+      received == wire.size() && waited == child &&
+      WIFEXITED(result.status) && WEXITSTATUS(result.status) == 0;
+  return result;
 }
 
 // A cache node serving RDMA: KvNodeServer owns the DiskCacheGroup; RdmaServer
@@ -558,6 +635,30 @@ class ScopedCudaContextRestore {
 };
 
 }  // namespace
+
+TEST(RdmaWriterToken, LiveWritersHaveUniqueNonzeroTokens) {
+  RdmaServer server(RdmaServer::Handler{}, kMaxMsg);
+  std::unordered_set<uint64_t> tokens;
+  constexpr size_t kWriterCount = 1024;
+  for (size_t i = 0; i < kWriterCount; ++i) {
+    const uint64_t token = RdmaServerTestPeer::RegisterWriter(&server);
+    EXPECT_NE(token, 0u);
+    EXPECT_TRUE(tokens.insert(token).second);
+  }
+}
+
+TEST(RdmaWriterToken, FreshProcessesDoNotReuseStaleTokens) {
+  const ChildWriterTokenResult old_process = WriterTokenFromFreshProcess();
+  ASSERT_TRUE(old_process.transferred) << "child status=" << old_process.status;
+  ASSERT_NE(old_process.token, 0u);
+
+  const ChildWriterTokenResult new_process =
+      WriterTokenFromFreshProcess(old_process.token);
+  ASSERT_TRUE(new_process.transferred) << "child status=" << new_process.status;
+  ASSERT_NE(new_process.token, 0u);
+  EXPECT_FALSE(new_process.stale_token_found);
+  EXPECT_NE(new_process.token, old_process.token);
+}
 
 TEST(RdmaServerStartup, AutoModeKeepsFirstActiveDeviceSemantics) {
   ScopedEnv configured_device("DFKV_RDMA_DEV", nullptr);
@@ -5243,17 +5344,13 @@ TEST(RdmaLoopback,
         [&] { return winning_attempt_entered; });
   }
   if (observed_winner) {
-    // Attempt one has completed its RDMA write and been rejected, while the
-    // second rail has not written a byte. Failed-attempt staging must not leak
-    // into the caller's CUDA allocation.
+    // Attempt one completed its direct RDMA write and DONE before the injected
+    // local completion fault. Retirement proof makes that committed payload
+    // stable while the second rail is still blocked.
     std::string before_winner;
     const bool read_ok = destination.ReadPayload(&before_winner);
     EXPECT_TRUE(read_ok);
-    if (read_ok) {
-      EXPECT_EQ(before_winner,
-                std::string(value.size(),
-                            static_cast<char>(CudaGuardedBuffer::kGuardByte)));
-    }
+    if (read_ok) EXPECT_EQ(before_winner, value);
     EXPECT_TRUE(destination.GuardsIntact());
   }
   {
@@ -5707,19 +5804,18 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
             CounterVal(before,
                        "dfkv_rdma_client_stale_pool_retries_total"));
 
-  // Drive another synchronous control completion before checking the buffer
-  // again; failed QP teardown must fence every old DMA before retry/return, so
-  // nothing may land after the failed GET returned.
+  // Drive another synchronous control completion before checking the buffer.
+  // Responder-retirement proof must precede retry/return, so no old writer can
+  // land bytes after the failed GET returned.
   EXPECT_EQ(transport.ExistMany(
                 node.addr, {ToBlockKey(key_namespace, "failed-get")}, &exists),
             std::vector<Status>({Status::kOk}));
   EXPECT_EQ(output, output_at_return);
 }
 
-// The SG read path (RangeIntoMulti) shares the direct-write contract: server
-// DMA lands straight in the caller segments, so a failed GET may leave
-// partial payload behind, but QP teardown fences every in-flight write before
-// the call returns, and a later successful GET rewrites the item in full.
+// The SG read path shares the direct-write contract: failed attempts retire the
+// responder writer and drain its signaled WRITE CQEs before retry/return. A
+// later successful GET rewrites the item in full.
 TEST(RdmaLoopback, FailedSgGetLeavesCallerSegmentsStableAfterReturn) {
   if (!HaveRdma())
     GTEST_SKIP() << "no RDMA device (load two rdma_rxe devices for this test)";
@@ -5750,8 +5846,8 @@ TEST(RdmaLoopback, FailedSgGetLeavesCallerSegmentsStableAfterReturn) {
   const std::string first_at_return = first;
   const std::string second_at_return = second;
 
-  // Drive another synchronous control completion; teardown must have fenced
-  // every in-flight DMA before the failed call returned.
+  // Drive another synchronous control completion; retirement proof must have
+  // made every old writer terminal before the failed call returned.
   std::vector<char> exists;
   EXPECT_EQ(transport.ExistMany(
                 node.addr, {ToBlockKey(SelfHdr(), "sg-failed-get")}, &exists),
@@ -5764,6 +5860,147 @@ TEST(RdmaLoopback, FailedSgGetLeavesCallerSegmentsStableAfterReturn) {
   ASSERT_TRUE(client.BatchGetAutoSg({get}, &lengths)[0]);
   ASSERT_EQ(lengths[0], value.size());
   EXPECT_EQ(first + second, value);
+}
+
+TEST(RdmaLoopback,
+     BlockedResponderWriteRetiresBeforeHostRetryAndReclaimsMr) {
+  ScopedEnv configured_device("DFKV_RDMA_DEV", nullptr);
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+
+  RdmaNode node("writer-retire-retry");
+  RdmaTransport transport(kMaxMsg);
+  const BlockKey key = ToBlockKey(SelfHdr(), "writer-retire-retry");
+  const std::string value = PatternValue(64 * 1024 + 7, 91);
+  ASSERT_EQ(transport.Cache(node.addr, key, value.data(), value.size()),
+            Status::kOk);
+  const uint64_t mr_baseline = rdma::RcEndpoint::TransientUserMrActive();
+  std::string output(value.size(), '\x5a');
+  std::vector<Status> statuses;
+  std::vector<uint64_t> value_lens;
+  std::atomic<bool> returned{false};
+
+  rdma::TestBlockNextResponderWrites(1);
+  std::thread getter([&] {
+    statuses = transport.RangeInto(
+        node.addr, {key}, {{output.data(), output.size()}}, &value_lens);
+    returned.store(true, std::memory_order_release);
+  });
+  const bool blocked =
+      rdma::TestWaitForBlockedResponderWrites(1, 10000);
+  const bool cancelled =
+      blocked && rdma::TestWaitForResponderWriteCancellations(1, 10000);
+  EXPECT_TRUE(blocked);
+  EXPECT_TRUE(cancelled);
+  EXPECT_FALSE(returned.load(std::memory_order_acquire))
+      << "client returned before responder-retirement proof";
+  EXPECT_GT(rdma::RcEndpoint::TransientUserMrActive(), mr_baseline)
+      << "blocked direct attempt did not retain its host MR";
+  EXPECT_EQ(output, std::string(output.size(), '\x5a'))
+      << "blocked old attempt wrote before retirement";
+
+  rdma::TestReleaseOneBlockedResponderWrite();
+  const bool old_writer_exited =
+      rdma::TestWaitForReleasedResponderWrites(1, 10000);
+  if (!old_writer_exited) rdma::TestReleaseBlockedResponderWrites();
+  getter.join();
+  rdma::TestReleaseBlockedResponderWrites();
+
+  EXPECT_TRUE(old_writer_exited);
+  EXPECT_EQ(statuses, std::vector<Status>({Status::kOk}));
+  EXPECT_EQ(value_lens, std::vector<uint64_t>({value.size()}));
+  EXPECT_EQ(output, value);
+  EXPECT_EQ(node.RangeDirectCalls(key), 2u);
+  EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), mr_baseline);
+
+  const std::string at_return = output;
+  std::vector<char> exists;
+  EXPECT_EQ(transport.ExistMany(node.addr, {key}, &exists),
+            std::vector<Status>({Status::kOk}));
+  EXPECT_EQ(output, at_return)
+      << "retired first-attempt writer modified host memory after return";
+  EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), mr_baseline);
+}
+
+TEST(RdmaLoopback,
+     TwoBlockedResponderAttemptsFailSgGetBeforeReturnAndReclaimMrs) {
+  ScopedEnv configured_device("DFKV_RDMA_DEV", nullptr);
+  ScopedEnv rail_tiers("DFKV_RDMA_RAIL_TIERS", nullptr);
+  ScopedEnv keepalive("DFKV_RDMA_KEEPALIVE_MS", "0");
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+
+  RdmaNode node("writer-retire-terminal-sg");
+  RdmaTransport transport(kMaxMsg);
+  const BlockKey key = ToBlockKey(SelfHdr(), "writer-retire-terminal-sg");
+  const std::string value = PatternValue(96 * 1024 + 11, 37);
+  ASSERT_EQ(transport.Cache(node.addr, key, value.data(), value.size()),
+            Status::kOk);
+  const uint64_t mr_baseline = rdma::RcEndpoint::TransientUserMrActive();
+
+  std::array<std::string, 3> segments{
+      std::string(4093, '\x5a'),
+      std::string(32771, '\x5a'),
+      std::string(value.size() - 4093 - 32771, '\x5a')};
+  RangeDstMulti destination{{
+      {segments[0].data(), segments[0].size()},
+      {segments[1].data(), segments[1].size()},
+      {segments[2].data(), segments[2].size()},
+  }};
+  std::vector<Status> statuses;
+  std::vector<size_t> lengths;
+  std::atomic<bool> returned{false};
+
+  rdma::TestBlockNextResponderWrites(2);
+  std::thread getter([&] {
+    statuses =
+        transport.RangeIntoMulti(node.addr, {key}, {destination}, &lengths);
+    returned.store(true, std::memory_order_release);
+  });
+  bool fixture_ok = true;
+  for (size_t attempt = 1; attempt <= 2; ++attempt) {
+    const bool blocked =
+        rdma::TestWaitForBlockedResponderWrites(attempt, 10000);
+    const bool cancelled =
+        blocked &&
+        rdma::TestWaitForResponderWriteCancellations(attempt, 10000);
+    EXPECT_TRUE(blocked) << attempt;
+    EXPECT_TRUE(cancelled) << attempt;
+    fixture_ok = fixture_ok && blocked && cancelled;
+    EXPECT_FALSE(returned.load(std::memory_order_acquire))
+        << "attempt " << attempt << " returned before writer retirement";
+    EXPECT_GT(rdma::RcEndpoint::TransientUserMrActive(), mr_baseline)
+        << "blocked SG attempt did not retain operation MRs";
+    for (const auto& segment : segments)
+      EXPECT_EQ(segment, std::string(segment.size(), '\x5a')) << attempt;
+    rdma::TestReleaseOneBlockedResponderWrite();
+    const bool exited =
+        rdma::TestWaitForReleasedResponderWrites(attempt, 10000);
+    EXPECT_TRUE(exited) << attempt;
+    fixture_ok = fixture_ok && exited;
+    if (!fixture_ok) break;
+  }
+  if (!fixture_ok) rdma::TestReleaseBlockedResponderWrites();
+  getter.join();
+  rdma::TestReleaseBlockedResponderWrites();
+
+  EXPECT_EQ(statuses, std::vector<Status>({Status::kIOError}));
+  EXPECT_EQ(lengths, std::vector<size_t>({0}));
+  EXPECT_EQ(node.RangeDirectCalls(key), 2u);
+  EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), mr_baseline);
+  const auto at_return = segments;
+  std::vector<char> exists;
+  EXPECT_EQ(transport.ExistMany(node.addr, {key}, &exists),
+            std::vector<Status>({Status::kOk}));
+  EXPECT_EQ(segments, at_return)
+      << "retired terminal writers modified SG memory after return";
+
+  const auto recovered =
+      transport.RangeIntoMulti(node.addr, {key}, {destination}, &lengths);
+  ASSERT_EQ(recovered, std::vector<Status>({Status::kOk}));
+  ASSERT_EQ(lengths, std::vector<size_t>({value.size()}));
+  EXPECT_EQ(segments[0] + segments[1] + segments[2], value);
+  EXPECT_EQ(rdma::RcEndpoint::TransientUserMrActive(), mr_baseline);
 }
 
 TEST(RdmaLoopback,

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -5668,8 +5668,10 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
   EXPECT_EQ(exists, std::vector<char>({0}));
 
   // Seed a readable value with both fault seams disabled, then fail both local
-  // attempts of a fresh public GET. Neither failed attempt may mutate its
-  // caller destination.
+  // attempts of a fresh public GET. Server DMA lands directly in the caller
+  // destination, so a faulted completion may leave partial payload behind; the
+  // fence must guarantee the buffer stops changing once the failed GET
+  // returns.
   KVClient writer({{"n", node.addr}}, key_namespace, &transport);
   ASSERT_TRUE(writer.Put("failed-get", value.data(), value.size()));
   KVClient reader({{"n", node.addr}}, key_namespace, &transport);
@@ -5683,8 +5685,7 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
   after = transport.MetricsText();
   ExpectTwoDistinctRailAttempts(before, after, rails, 2);
   ExpectReleasedRailResources(before, after, rails);
-  EXPECT_EQ(output,
-            std::string(value.size(), static_cast<char>(0x5a)));
+  const std::string output_at_return = output;
   EXPECT_EQ(
       CounterVal(after, "dfkv_rdma_client_cross_rail_retries_total") -
           CounterVal(before, "dfkv_rdma_client_cross_rail_retries_total"),
@@ -5706,13 +5707,13 @@ TEST(RdmaLoopback, AllLocalRailsFailOnceAndReclaimOperationResources) {
             CounterVal(before,
                        "dfkv_rdma_client_stale_pool_retries_total"));
 
-  // Drive another synchronous control completion before checking the sentinel
-  // again; failed QP teardown must fence every old DMA before retry/return.
+  // Drive another synchronous control completion before checking the buffer
+  // again; failed QP teardown must fence every old DMA before retry/return, so
+  // nothing may land after the failed GET returned.
   EXPECT_EQ(transport.ExistMany(
                 node.addr, {ToBlockKey(key_namespace, "failed-get")}, &exists),
             std::vector<Status>({Status::kOk}));
-  EXPECT_EQ(output,
-            std::string(value.size(), static_cast<char>(0x5a)));
+  EXPECT_EQ(output, output_at_return);
 }
 
 // The SG read path (RangeIntoMulti) shares the direct-write contract: server

--- a/test/transport/rdma_protocol_test.cc
+++ b/test/transport/rdma_protocol_test.cc
@@ -14,8 +14,53 @@ TEST(RdmaProtocol, ProbeRoundTrip) {
   char reply[kV2ProbeReplyBytes];
   EncodeV2ProbeReply(reply);
   EXPECT_TRUE(ParseV2ProbeReply(reply));
+  EXPECT_TRUE(V2ProbeSupportsWriterRetirement(reply));
+
+  // An old server's reserved bytes are zero. The base v2 reply remains valid
+  // to old clients, but a new direct-buffer client must reject it.
+  EncodeV2ProbeReply(reply, /*capabilities=*/0);
+  EXPECT_TRUE(ParseV2ProbeReply(reply));
+  EXPECT_FALSE(V2ProbeSupportsWriterRetirement(reply));
+
   reply[4] = 1;
   EXPECT_FALSE(ParseV2ProbeReply(reply));
+  EXPECT_FALSE(V2ProbeSupportsWriterRetirement(reply));
+}
+
+TEST(RdmaProtocol, LegacyAndRetirementReadinessHaveExactWireSizes) {
+  const RecvSegmentInfo expected{0x12345000, 0xAABBCCDD, 4u << 20};
+  char wire[kV2RetirementReadinessBytes];
+
+  const size_t legacy_bytes =
+      EncodeV2Readiness(expected, /*writer_token=*/0, wire);
+  EXPECT_EQ(kV2LegacyReadinessBytes, 25u);
+  EXPECT_EQ(legacy_bytes, 25u);
+  EXPECT_EQ(V2ReadinessBytes(/*writer_retirement_negotiated=*/false), 25u);
+  RecvSegmentInfo actual;
+  uint64_t token = 99;
+  EXPECT_TRUE(DecodeV2Readiness(
+      wire, legacy_bytes, /*writer_retirement_negotiated=*/false, &actual,
+      &token));
+  EXPECT_EQ(token, 0u);
+  EXPECT_EQ(actual.base_addr, expected.base_addr);
+  EXPECT_EQ(actual.rkey, expected.rkey);
+  EXPECT_EQ(actual.slot_size, expected.slot_size);
+  EXPECT_FALSE(DecodeV2Readiness(
+      wire, legacy_bytes, /*writer_retirement_negotiated=*/true, &actual,
+      &token));
+
+  constexpr uint64_t writer_token = 0x123456789ABCDEF0ull;
+  const size_t retirement_bytes =
+      EncodeV2Readiness(expected, writer_token, wire);
+  EXPECT_EQ(retirement_bytes, 33u);
+  EXPECT_EQ(V2ReadinessBytes(/*writer_retirement_negotiated=*/true), 33u);
+  EXPECT_TRUE(DecodeV2Readiness(
+      wire, retirement_bytes, /*writer_retirement_negotiated=*/true, &actual,
+      &token));
+  EXPECT_EQ(token, writer_token);
+  EXPECT_FALSE(DecodeV2Readiness(
+      wire, retirement_bytes, /*writer_retirement_negotiated=*/false, &actual,
+      &token));
 }
 
 TEST(RdmaProtocol, SlotGeometryKeepsPayloadAligned) {


### PR DESCRIPTION
## Problem

RDMA GET currently lands payloads in transport-owned staging buffers and copies them into caller/CUDA destinations after completion. At 1 MiB KV-cache objects this extra publication copy limits SSD-to-GPU retrieval throughput. Existing logs also cannot attribute slow GET/PUT/EXIST batches to a server and IB rail.

## Change

- RDMA GET writes directly into registered caller host/CUDA buffers.
- Every responder WRITE is signaled and tracked; failure retry/return requires an explicit server-side writer-retirement proof before the same destination can be reused or deregistered.
- Writer-retirement support is explicitly negotiated: probe capability + bit-63 bootstrap request. New clients reject old servers before QP setup; new servers preserve the exact legacy 25-byte readiness response for old clients. Server-first rolling deployment is supported.
- Retry publication stays bounded to two attempts and preserves atomic multi-segment semantics.
- Optional `DFKV_CLIENT_PERNODE_STATS=1` logs GET/PUT/EXIST totals and per-node rows, including ordered rail paths, issued versus client-local non-issued outcomes, keyed failure fingerprints, bounded async queueing, per-process filenames, and hard-bounded rotation. Disabled by default.
- vLLM workers derive collision-free DP/PP/TP/global-rank/PID log suffixes.

Supersedes #338 and #339 with all review fixes integrated.

## 0064 evidence

Isolated xb01-0064 only; 2 local SSDs, two active IB rails, 1 MiB objects, 16,384 keys, 32 threads, ram tier off, io_uring server.

- v2.20.1 baseline GET: 4.88 / 4.89 / 4.83 GB/s (median 4.88)
- integrated candidate GET: 9.62 / 9.47 / 9.38 GB/s (median 9.47)
- median gain: +94.1%
- candidate PUT: 4.42 GB/s
- all benchmark rounds: 16,384/16,384 successful, zero IO/rail/CQ/completion-timeout/MR failures

## Verification

- Local build: `dfkv`, server/MDS/CLI, RDMA loopback, protocol/dev-frame, client telemetry and SG GET targets.
- Local focused tests: protocol 7/7; dev-frame 16/16; client telemetry 25/25; SG GET 8/8.
- 0064 real RDMA/CUDA gates: direct CUDA publication, two-rail retry exact bytes, blocked responder retirement before retry, two failed responder attempts before MR reclaim, multi-window atomic failure; all passed.
- 0064 GPU dedup: 10/10 passed, including cross-process IPC.
- Full RDMA suite still has two pre-existing hardware-assumption failures reproduced on unmodified v2.20.1 (`MetricsCountersTrackOps`, `MembersReplyHonorsExactBoundAndRejectsOversize`); changed-path gates above pass.

## Rollout

Deploy servers before clients. A new client requires the advertised retirement capability; old clients remain compatible with new servers.