### PR TITLE
fix(metrics): drain request headers before close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Metrics HTTP clean close
+
+- Consume the complete HTTP request-head section, bounded to 32 KiB and by the
+  existing accept-time absolute deadline, before rendering server or MDS
+  metrics. Closing no longer leaves unread Prometheus headers that force Linux
+  to send a TCP RST and truncate large remote scrapes.
+- Preserve the existing one-request connection model, connection cap,
+  slow-drip protection, health/readiness semantics, and send timeout. Successful
+  responses now finish with an explicit write-side shutdown and clean EOF.
+- Add realistic Prometheus headers, a 256 KiB byte-exact response, clean-EOF,
+  split-header, header-drip, and oversized unterminated-header regressions.
+
 ### CUDA GET pinned publication pool
 
 - Replaced per-operation CUDA host registration for GET publication with a

--- a/src/utils/metrics_http.cc
+++ b/src/utils/metrics_http.cc
@@ -45,6 +45,41 @@ uint64_t BoundedEnv(const char* name, uint64_t fallback, uint64_t hard_max,
   }
   return parsed;
 }
+constexpr size_t kMaxHttpRequestHeadBytes = 32 * 1024;
+
+bool ReadRequestHead(
+    int fd, bool deadline_on,
+    std::chrono::steady_clock::time_point deadline,
+    std::string* request_line) {
+  if (request_line == nullptr) return false;
+  const timeval base_timeout{10, 0};
+  std::string line;
+  bool first_line = true;
+  size_t total = 0;
+  while (total < kMaxHttpRequestHeadBytes) {
+    char c = 0;
+    const bool read =
+        deadline_on
+            ? net::ReadAllWithin(fd, &c, 1, base_timeout, deadline)
+            : ::recv(fd, &c, 1, 0) > 0;
+    if (!read) return false;
+    ++total;
+    if (c != '\n') {
+      line.push_back(c);
+      continue;
+    }
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (first_line) {
+      if (line.empty()) return false;
+      *request_line = line;
+      first_line = false;
+    } else if (line.empty()) {
+      return true;
+    }
+    line.clear();
+  }
+  return false;
+}
 }  // namespace
 
 MetricsHttpServer::~MetricsHttpServer() { Stop(); }
@@ -170,29 +205,20 @@ std::string Resp(const char* status_line, const char* ctype, const std::string& 
 
 void MetricsHttpServer::Handle(
     int fd, std::chrono::steady_clock::time_point accepted_at) {
-  // Read just the request line (up to CRLF). Headers/body are ignored — we only
-  // need method + path. Bound the read so a silent peer can't pin the thread.
-  // The request line also has an ABSOLUTE deadline (DFKV_METRICS_FIRST_REQ_MS,
-  // anchored at accept): SO_RCVTIMEO alone is per-syscall, so a drip feeder
-  // (1 byte < 10s apart) would otherwise pin a handler thread. Before every
-  // recv the per-syscall budget is recomputed as min(10s, deadline remaining);
-  // a spent budget closes the connection. 0 disables (legacy behavior).
+  // Consume the complete bounded request-head section before replying. Closing
+  // a socket with unread Prometheus headers is an abortive close on Linux: the
+  // peer sees RST and may lose the tail of a large metrics body even after
+  // WriteAll placed it in the local send buffer.
+  //
+  // The absolute deadline remains anchored at accept and now covers every
+  // header byte, not just the request line. This preserves the slow-drip guard:
+  // each recv uses min(10 s, deadline remaining), and 0 keeps the legacy
+  // no-absolute-deadline behavior.
   const bool deadline_on = first_req_ms_ > 0;
   const auto deadline =
       accepted_at + std::chrono::milliseconds(first_req_ms_);
-  const timeval base_tv{10, 0};
   std::string line;
-  char c;
-  size_t guard = 0;
-  while (guard++ < 8192) {
-    if (deadline_on) {
-      if (!net::ReadAllWithin(fd, &c, 1, base_tv, deadline)) return;
-    } else {
-      if (::recv(fd, &c, 1, 0) <= 0) return;  // peer closed / error
-    }
-    if (c == '\n') break;
-    if (c != '\r') line.push_back(c);
-  }
+  if (!ReadRequestHead(fd, deadline_on, deadline, &line)) return;
   // line == "GET /path HTTP/1.x"
   std::string path;
   {
@@ -220,7 +246,8 @@ void MetricsHttpServer::Handle(
   } else {
     out = Resp("404 Not Found", "text/plain", "not found\n");
   }
-  net::WriteAll(fd, out.data(), out.size());
+  if (!net::WriteAll(fd, out.data(), out.size())) return;
+  ::shutdown(fd, SHUT_WR);
 }
 
 }  // namespace dfkv

--- a/src/utils/metrics_http.h
+++ b/src/utils/metrics_http.h
@@ -65,13 +65,13 @@ class MetricsHttpServer {
 
  private:
   void AcceptLoop();
-  // accepted_at stamps the accept() return so the first complete request line
-  // is due within DFKV_METRICS_FIRST_REQ_MS of ACCEPT, not of scheduling.
+  // accepted_at stamps accept() so the complete first request head is due
+  // within DFKV_METRICS_FIRST_REQ_MS of ACCEPT, not of scheduling.
   void Handle(int fd, std::chrono::steady_clock::time_point accepted_at);
   void ReapDoneLocked();  // join+erase finished handler threads; conn_mu_ held
 
-  // Absolute deadline for the first complete request line after accept — a
-  // drip feeder otherwise never hit the per-syscall SO_RCVTIMEO (0 = off).
+  // Absolute deadline for the first complete request head after accept — a
+  // drip feeder otherwise never hits the per-syscall SO_RCVTIMEO (0 = off).
   static constexpr uint64_t kDefaultFirstReqMs = 30000;
   static constexpr uint64_t kHardFirstReqMs = 3600000;
   // Connection cap for this oneshot/low-frequency port (none existed before).

--- a/test/utils/metrics_http_test.cc
+++ b/test/utils/metrics_http_test.cc
@@ -6,6 +6,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstring>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -54,6 +56,53 @@ int Dial(int port) {
   return net::Dial("127.0.0.1:" + std::to_string(port), 1000, 2000);
 }
 
+struct HttpReadResult {
+  std::string response;
+  bool clean_eof = false;
+  int terminal_errno = 0;
+};
+
+HttpReadResult ReadResponse(int fd) {
+  HttpReadResult result;
+  char buffer[4096];
+  for (;;) {
+    const ssize_t received = ::recv(fd, buffer, sizeof(buffer), 0);
+    if (received > 0) {
+      result.response.append(buffer, static_cast<size_t>(received));
+      continue;
+    }
+    if (received == 0) {
+      result.clean_eof = true;
+    } else {
+      result.terminal_errno = errno;
+    }
+    return result;
+  }
+}
+
+HttpReadResult HttpRequest(int port, const std::string& request,
+                           int read_delay_ms = 0) {
+  HttpReadResult result;
+  const int fd = Dial(port);
+  if (fd < 0) {
+    result.terminal_errno = errno;
+    return result;
+  }
+  const int receive_bytes = 4096;
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &receive_bytes,
+               sizeof(receive_bytes));
+  if (!net::WriteAll(fd, request.data(), request.size())) {
+    result.terminal_errno = errno;
+    ::close(fd);
+    return result;
+  }
+  if (read_delay_ms > 0)
+    std::this_thread::sleep_for(std::chrono::milliseconds(read_delay_ms));
+  result = ReadResponse(fd);
+  ::close(fd);
+  return result;
+}
+
 // Minimal HTTP/1.0 client: send one request, read the whole response (server
 // closes the connection after the body, so recv to EOF).
 std::string HttpGet(int port, const std::string& path) {
@@ -72,6 +121,100 @@ std::string HttpGet(int port, const std::string& path) {
   return resp;
 }
 }  // namespace
+
+TEST(MetricsHttp, PrometheusHeadersLargeBodyEndsWithCleanEof) {
+  const std::string body(256 * 1024, 'm');
+  MetricsHttpServer srv([&body] { return body; });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  const std::string request =
+      "GET /metrics HTTP/1.1\r\n"
+      "Host: 127.0.0.1\r\n"
+      "User-Agent: Prometheus/3.5.0\r\n"
+      "Accept: application/openmetrics-text;version=1.0.0;q=0.8,*/*;q=0.1\r\n"
+      "Accept-Encoding: gzip\r\n"
+      "X-Prometheus-Scrape-Timeout-Seconds: 10\r\n"
+      "\r\n";
+  const HttpReadResult result = HttpRequest(srv.port(), request, 100);
+
+  EXPECT_TRUE(result.clean_eof)
+      << "terminal errno=" << result.terminal_errno
+      << " bytes=" << result.response.size();
+  EXPECT_NE(result.terminal_errno, ECONNRESET);
+  EXPECT_NE(result.response.find("HTTP/1.0 200 OK"), std::string::npos);
+  EXPECT_NE(result.response.find("Content-Length: " +
+                                 std::to_string(body.size())),
+            std::string::npos);
+  const size_t separator = result.response.find("\r\n\r\n");
+  ASSERT_NE(separator, std::string::npos);
+  const std::string actual_body = result.response.substr(separator + 4);
+  ASSERT_EQ(actual_body.size(), body.size());
+  EXPECT_EQ(std::memcmp(actual_body.data(), body.data(), body.size()), 0);
+  srv.Stop();
+}
+
+TEST(MetricsHttp, WaitsForHeaderTerminatorBeforeResponding) {
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  const int fd = Dial(srv.port());
+  ASSERT_GE(fd, 0);
+  const std::string partial =
+      "GET /metrics HTTP/1.1\r\n"
+      "Host: 127.0.0.1\r\n";
+  ASSERT_TRUE(net::WriteAll(fd, partial.data(), partial.size()));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  char byte = 0;
+  errno = 0;
+  EXPECT_EQ(::recv(fd, &byte, 1, MSG_DONTWAIT), -1);
+  EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << errno;
+
+  ASSERT_TRUE(net::WriteAll(fd, "\r\n", 2));
+  const HttpReadResult result = ReadResponse(fd);
+  EXPECT_TRUE(result.clean_eof);
+  EXPECT_NE(result.response.find("HTTP/1.0 200 OK"), std::string::npos);
+  EXPECT_NE(result.response.find("dfkv_x 1"), std::string::npos);
+  ::close(fd);
+  srv.Stop();
+}
+
+TEST(MetricsHttp, SlowDripHeadersUseAcceptTimeAbsoluteDeadline) {
+  ScopedEnv first_req("DFKV_METRICS_FIRST_REQ_MS", "250");
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  const int fd = Dial(srv.port());
+  ASSERT_GE(fd, 0);
+  const std::string prefix =
+      "GET /metrics HTTP/1.1\r\n"
+      "X-Drip: ";
+  ASSERT_TRUE(net::WriteAll(fd, prefix.data(), prefix.size()));
+  for (char c : std::string("slow")) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    if (::send(fd, &c, 1, MSG_NOSIGNAL) <= 0) break;
+  }
+  EXPECT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 0; }, 3000));
+  EXPECT_EQ(srv.DroppedConnections(), 0u);
+  ::close(fd);
+  EXPECT_NE(HttpGet(srv.port(), "/metrics").find("dfkv_x 1"),
+            std::string::npos);
+  srv.Stop();
+}
+
+TEST(MetricsHttp, OversizeUnterminatedHeadersCloseWithinBound) {
+  ScopedEnv first_req("DFKV_METRICS_FIRST_REQ_MS", "5000");
+  MetricsHttpServer srv([] { return std::string("dfkv_x 1\n"); });
+  ASSERT_EQ(srv.Start(0), Status::kOk);
+  const int fd = Dial(srv.port());
+  ASSERT_GE(fd, 0);
+  const std::string request =
+      "GET /metrics HTTP/1.1\r\nX-Oversize: " +
+      std::string(33 * 1024, 'h');
+  net::WriteAll(fd, request.data(), request.size());
+  EXPECT_TRUE(WaitFor([&] { return srv.ActiveConnections() == 0; }, 3000));
+  ::close(fd);
+  EXPECT_NE(HttpGet(srv.port(), "/metrics").find("dfkv_x 1"),
+            std::string::npos);
+  srv.Stop();
+}
 
 TEST(MetricsHttp, ServesMetricsHealthzAnd404) {
   std::atomic<int> renders{0};


### PR DESCRIPTION
## Problem

`MetricsHttpServer` stopped reading after the HTTP request line. Real Prometheus HTTP/1.1 scrapes leave `Host`, `User-Agent`, `Accept`, timeout and other headers unread. Linux closes a socket with unread receive data abortively, so remote clients receive server-originated TCP RST and only a prefix of a large metrics response.

Production v2.22.1 evidence on xb01:

- local scrape: complete 69,028-byte body;
- remote scrape: HTTP 200 followed by `ECONNRESET`, typically 14–20 KiB received;
- tcpdump: response payload followed by RST from the dfkv server;
- 17/17 remote server targets and 2/3 remote MDS targets were DOWN in Prometheus.

## Fix

- Read the complete HTTP request-head section before rendering a response.
- Bound the request head to 32 KiB.
- Keep the existing accept-time absolute `DFKV_METRICS_FIRST_REQ_MS` deadline across every header byte.
- Accept CRLF and LF-only header terminators.
- Reject EOF, timeout and oversized unterminated request heads without rendering.
- Check `WriteAll` and finish successful responses with `shutdown(SHUT_WR)` so the peer observes a clean EOF/FIN.
- Preserve max-connections, handler reaping, health/readiness and one-request-per-connection semantics.

No proxy, linger, sleep, socket-buffer expansion or Prometheus-side tolerance is involved.

## Regression evidence

The realistic regression was written before the source fix. Against the old implementation it failed deterministically:

```text
clean_eof=false
terminal_errno=104 (ECONNRESET)
bytes=32768
expected body=1048576
```

The split-header test also observed a response before the terminating empty line.

Added coverage:

- realistic Prometheus headers + 256 KiB byte-exact body + clean EOF;
- no response before the complete header terminator;
- header drip uses the original accept-time absolute deadline;
- oversized unterminated headers close within the 32 KiB bound;
- all existing metrics/health/readiness/connection-lifecycle tests.

## Verification

Local:

- focused `metrics_http_test`: **14/14 passed**;
- full non-RDMA CTest: **671 total, 638 passed, 33 environment-dependent skipped**;
- RDMA configure/compile: `dfkv_server`, `dfkv_mds`, and `metrics_http_test` built;
- RDMA-build focused suite: **14/14 passed**.

xb01 node 0064, GCC 13.3, real RDMA build:

- `DFKV_WITH_RDMA=ON` focused build passed;
- `metrics_http_test`: **14/14 passed**;
- realistic 256 KiB clean-EOF test passed.

Production rollout and release are intentionally out of scope for this PR.
