### PR TITLE
feat(vllm): add rank-local RDMA rail affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### vLLM rank-local rail affinity
+
+- Added `rail_affinity` and `rail_affinity_fallbacks` to
+  `DfkvStoreConnector`. Before opening the native client, each vLLM worker now
+  maps its world-group local rank to one primary plus a bounded ordered
+  fallback set, then sets `DFKV_RDMA_DEV`, `DFKV_RDMA_PRIMARY_DEV`, and
+  `DFKV_RDMA_NUMA=0`.
+- Moved the rail-list parsing, fallback bounds, duplicate rejection, and
+  environment update contract into `dfkv-common`; SGLang HiCache and vLLM now
+  share one implementation while retaining their framework-specific physical
+  rank resolution.
+
 ### RDMA connection capacity
 
 - Unified scalar and scatter-gather data operations on one exclusive-ownership

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,18 @@ if(DFKV_BUILD_TESTS)
               -p test_client_metrics.py)
     set_tests_properties(python_client_metrics PROPERTIES
       ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/integration/common/src")
+    add_test(NAME python_common_rail_affinity
+      COMMAND ${PYTHON3} -m unittest discover
+              -s ${CMAKE_CURRENT_SOURCE_DIR}/integration/common/tests
+              -p test_rail_affinity.py)
+    set_tests_properties(python_common_rail_affinity PROPERTIES
+      ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/integration/common/src")
+    add_test(NAME python_vllm_rail_affinity
+      COMMAND ${PYTHON3} -m unittest discover
+              -s ${CMAKE_CURRENT_SOURCE_DIR}/integration/vllm/tests
+              -p test_rail_affinity.py)
+    set_tests_properties(python_vllm_rail_affinity PROPERTIES
+      ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/integration/common/src:${CMAKE_CURRENT_SOURCE_DIR}/integration/vllm/src")
     # Shared telemetry layer: pure-python, no build/lib needed (OTel-push test
     # self-skips when the SDK is absent). Includes the vendored-copy drift guard.
     add_test(NAME python_telemetry

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -184,11 +184,12 @@ capability；HCA `max_sge` 低于 dfkv 上限时会缩小宽度，高于上限�
 > 而不是悄悄按小的开——后者会让客户端按自己声明的大小发包、打爆对端 recv buffer（RNR/QP 断）。
 > 大集群建议显式设定，否则服务端的内存预算完全由客户端决定，而客户端常由别的团队部署、版本不一。
 
-> `rail_affinity=true` 按物理 attention rank（PCP>1 时用 `pcp_rank`，
-> 否则用 `tp_rank`）绑定一条主 rail，并默认加入相邻 1 条 fallback rail。
-> `rail_affinity_fallbacks=0` 可恢复严格 one-rank/one-rail；更大值不会超过
-> `DFKV_RDMA_DEV` 列表。connector 设置 `DFKV_RDMA_PRIMARY_DEV=<primary>`；
-> native transport 优先 primary，仅在其不可准入/失败时使用 fallback。
+> `rail_affinity=true` 在 native client 创建前把完整 `DFKV_RDMA_DEV` 收窄为
+> 一条 primary 和默认相邻 1 条 fallback。SGLang HiCache 使用其物理 attention
+> coordinate（PCP>1 时 `pcp_rank`，否则 `tp_rank`）；vLLM 使用 world-group
+> per-host `local_rank`，不把可重复的 TP/DCP/PCP/PP 存储坐标误当 HCA 序号。
+> `rail_affinity_fallbacks=0` 恢复严格 one-rank/one-rail；connector 设置
+> `DFKV_RDMA_PRIMARY_DEV=<primary>` 和 `DFKV_RDMA_NUMA=0`。
 
 ### 1.3 wire 协议版本
 
@@ -647,7 +648,7 @@ PYTHONHASHSEED=0 \
 DFKV_RDMA=1 \
 DFKV_RDMA_DEV=ib7s400p0,ib7s400p1,ib7s400p2,ib7s400p3,ib7s400p4,ib7s400p5,ib7s400p6,ib7s400p7 \
 DFKV_RDMA_DEPTH=1 \
-DFKV_RDMA_NUMA=1 \
+DFKV_RDMA_NUMA=0 \
 DFKV_LIB=/opt/dfkv/libdfkv.so \
 vllm serve <model> \
   --tensor-parallel-size 2 --data-parallel-size 4 \
@@ -659,7 +660,9 @@ vllm serve <model> \
     "kv_connector_extra_config": {
       "mds_endpoints": "192.168.0.8:28150,192.168.0.9:28150,192.168.0.10:28150",
       "mds_group": "glm",
-      "batch_concurrency": "8"
+      "batch_concurrency": "8",
+      "rail_affinity": true,
+      "rail_affinity_fallbacks": 1
     }
   }'
 ```
@@ -693,9 +696,9 @@ extra-config 键。namespace 始终绑定该 model identity 与 `vllm/raw-v1`；
 |---|---|---|
 | engine 参数 | `--prefix-caching-hash-algo sha256` | object key 必须是内容定义 hash；`builtin` 被连接器拒绝 |
 | engine 环境 | `PYTHONHASHSEED=0`（所有共享实例同值） | 稳定首块 parent hash；缺失会在每次进程重启后全量 cold miss |
-| engine 环境 | `DFKV_RDMA=1`、`DFKV_RDMA_DEV=<本机 ACTIVE HCA 列表>` | 强制 RDMA；PUT 使用 GPUDirect，GET 使用 host retry staging；网卡名必须按节点实际拓扑配置 |
+| engine 环境 | `DFKV_RDMA=1`、`DFKV_RDMA_DEV=<本机 ACTIVE HCA 有序全轨列表>` | 强制 RDMA；affinity 开启时 connector 在每个 worker 进程中按 world-group local rank 收窄为 primary + fallback |
+| connector extra-config | `rail_affinity=true`、`rail_affinity_fallbacks=1` | bounded failover；native open 前自动设置 per-process `DFKV_RDMA_PRIMARY_DEV` 和 `DFKV_RDMA_NUMA=0` |
 | engine 环境 | `DFKV_RDMA_DEPTH=1` | 每条 QP 限制一个在途 range；吞吐靠连接 fanout，不靠同 QP depth |
-| engine 环境 | `DFKV_RDMA_NUMA=1` | 每条连接选择 NUMA-local rail 和内存，避免跨 socket 路径 |
 | 容器资源 | Docker/nerdctl `--ulimit memlock=-1:-1`；Kubernetes `ulimits` 等价配置；systemd `LimitMEMLOCK=infinity` | 允许 GPU MR 及 CUDA GET 临时 pinned host staging；按并发 GET payload 验证 pinned-memory 与 memlock 容量，8 MiB 默认值可能触发 `ibv_reg_mr` 失败或临时注册退化 |
 | 宿主机 | `nvidia-peermem` 已加载 | GPUDirect MR 注册前提 |
 
@@ -708,7 +711,7 @@ nerdctl run --ulimit memlock=-1:-1 \
   -e DFKV_RDMA=1 \
   -e DFKV_RDMA_DEV=ib7s400p0,ib7s400p1 \
   -e DFKV_RDMA_DEPTH=1 \
-  -e DFKV_RDMA_NUMA=1 \
+  -e DFKV_RDMA_NUMA=0 \
   ... <image> \
   vllm serve <model> --prefix-caching-hash-algo sha256 ...
 ```
@@ -747,9 +750,9 @@ namespace/key 不一致是预期 cold miss。**空环 / MDS 不可达**可直接
 
 | env | 默认 | 推荐 | 说明 |
 |---|---|---|---|
-| `DFKV_RDMA` / `DFKV_RDMA_DEV` | **无；`DFKV_RDMA=1` 必填** | `1` / 全轨列表 | vLLM GPU 指针连接器仅支持 RDMA；PUT 为 GPUDirect，GET 为 pinned host retry staging + 同步 H2D publication；unset/TCP 在构造期关闭并拒绝，无 fallback。见 §1.2 |
-| `DFKV_RDMA_DEPTH` | `4` | 保持 4 | depth-flat（§1.2） |
-| `DFKV_RDMA_NUMA` | `0` | 多 NUMA 大机 `1` | §1.2 |
+| `DFKV_RDMA` / `DFKV_RDMA_DEV` | **无；`DFKV_RDMA=1` 必填** | `1` / 本机有序全轨列表 | vLLM GPU 指针连接器仅支持 RDMA；`rail_affinity=true` 时 connector 在每个 worker 内收窄列表 |
+| `DFKV_RDMA_DEPTH` | `4` | 保持生产已验证值 | depth-flat（§1.2） |
+| `DFKV_RDMA_NUMA` | `0` | affinity 开启时保持 `0` | connector 为严格 primary/fallback 映射显式设置 0；affinity 关闭时才按需启用 NUMA 动态选轨 |
 | `DFKV_LIB` / `DFKV_BUILD` | — | so 路径 | 被 extra_config `lib` 覆盖 |
 | `DFKV_ACCESS_LOG_*` | 关 | 排查时开 | §1.6；vLLM 侧记 `batch_get_auto_sg`/`batch_put_sg`/`batch_exist`/`register_memory` |
 | `DFKV_CLIENT_STATS_POLL_S` | `15` | 默认即可 | 后台轮询把环/MDS 健康镜像到 vLLM `/metrics`（`vllm:dfkv_client_ring_members`/`mds_reachable`/`mds_unreachable_polls_total`/`transport_info`）；`0`=关。见 [METRICS.md](METRICS.md) §3.5 |
@@ -767,6 +770,8 @@ namespace/key 不一致是预期 cold miss。**空环 / MDS 不可达**可直接
 | `members` | —（与 mds_endpoints 二选一） | `n=ip:rdma-port,...` | **端口 = server `--rdma-port`** |
 | `lib` | env 兜底 | so 绝对路径 | |
 | `batch_concurrency` | `8` | **大池可调高到 ≈ 节点数** | 跨节点 fan-out，**真正的吞吐杠杆**（depth 是平的） |
+| `rail_affinity` | `False` | 多 rank、多 rail 生产设 `true` | 按 vLLM world-group per-host `local_rank` 选择 primary；在 native client 创建前设置每进程独立 rail 环境 |
+| `rail_affinity_fallbacks` | `1` | `1` | 相邻有序 fallback 数；`0`=严格单 rail，超出可用 rail 数时自动收敛 |
 | `load_async` | `True` | 保持 True | 异步 load，走 `WAITING_FOR_REMOTE_KVS`、不占关键路径 |
 | `transfer_queue_capacity` | `256` | 保持默认，按压测调 | 每个 worker、每个方向的排队上限（`1..65536`）。满队列时非阻塞拒绝新任务：save 立即释放 finish/free fence，load 标记失败并重算；非法值启动即失败。 |
 | `enable_cross_layers_blocks` | `False` | 默认 False | 仅当引擎分页布局层内交错时开 |

--- a/integration/common/src/dfkv_common/__init__.py
+++ b/integration/common/src/dfkv_common/__init__.py
@@ -22,6 +22,10 @@ from .identity import (
     sg_key,
     tenant_hash,
 )
+from .rail_affinity import (
+    RailAffinitySelection,
+    apply_rank_local_rail_affinity,
+)
 
 __all__ = [
     "DFKV_CLIENT_ABI_VERSION_V2",
@@ -44,4 +48,6 @@ __all__ = [
     "pool_key",
     "sg_key",
     "tenant_hash",
+    "RailAffinitySelection",
+    "apply_rank_local_rail_affinity",
 ]

--- a/integration/common/src/dfkv_common/rail_affinity.py
+++ b/integration/common/src/dfkv_common/rail_affinity.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping, Optional
+
+
+@dataclass(frozen=True)
+class RailAffinitySelection:
+    enabled: bool
+    applied: bool
+    rank: int
+    available: tuple[str, ...]
+    selected: tuple[str, ...]
+    primary: Optional[str]
+    fallback_count: int
+    reason: str
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in ("", "0", "false", "no", "off")
+    return bool(value)
+
+
+def _fallback_count(value: Any, maximum: int) -> int:
+    if isinstance(value, bool):
+        raise ValueError("rail_affinity_fallbacks must be an integer, not boolean")
+    try:
+        count = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("rail_affinity_fallbacks must be an integer") from exc
+    return max(0, min(count, maximum))
+
+
+def apply_rank_local_rail_affinity(
+    cfg: Mapping[str, Any],
+    rank: int,
+    environ: MutableMapping[str, str],
+) -> RailAffinitySelection:
+    """Apply one primary plus bounded ordered fallback rails before native open.
+
+    ``rank`` is a connector-owned physical process/GPU coordinate.  This helper
+    deliberately does not derive it from TP/DCP/PCP/PP metadata: HiCache and
+    vLLM expose different parallel layouts, while HCA affinity is a per-host
+    physical property.
+    """
+    try:
+        physical_rank = int(rank)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("rail affinity rank must be an integer") from exc
+    if physical_rank < 0:
+        raise ValueError("rail affinity rank must be non-negative")
+
+    enabled = _truthy(cfg.get("rail_affinity"))
+    rails = tuple(
+        rail.strip()
+        for rail in environ.get("DFKV_RDMA_DEV", "").split(",")
+        if rail.strip()
+    )
+
+    if not enabled:
+        return RailAffinitySelection(
+            False, False, physical_rank, rails, rails, None, 0, "disabled"
+        )
+    if len(set(rails)) != len(rails):
+        raise ValueError("DFKV_RDMA_DEV contains duplicate rail names")
+    if len(rails) <= 1:
+        return RailAffinitySelection(
+            True,
+            False,
+            physical_rank,
+            rails,
+            rails,
+            rails[0] if rails else None,
+            0,
+            "fewer_than_two_rails",
+        )
+
+    fallback_count = _fallback_count(
+        cfg.get("rail_affinity_fallbacks", 1), len(rails) - 1
+    )
+    primary_index = physical_rank % len(rails)
+    selected = tuple(
+        rails[(primary_index + offset) % len(rails)]
+        for offset in range(fallback_count + 1)
+    )
+
+    environ["DFKV_RDMA_DEV"] = ",".join(selected)
+    environ["DFKV_RDMA_PRIMARY_DEV"] = selected[0]
+    environ["DFKV_RDMA_NUMA"] = "0"
+    environ.pop("DFKV_RDMA_RAIL_TIERS", None)
+
+    return RailAffinitySelection(
+        True,
+        True,
+        physical_rank,
+        rails,
+        selected,
+        selected[0],
+        fallback_count,
+        "applied",
+    )

--- a/integration/common/tests/test_rail_affinity.py
+++ b/integration/common/tests/test_rail_affinity.py
@@ -1,0 +1,87 @@
+import unittest
+
+from dfkv_common import apply_rank_local_rail_affinity
+
+
+class RailAffinityTest(unittest.TestCase):
+    def test_disabled_leaves_environment_unchanged(self):
+        env = {
+            "DFKV_RDMA_DEV": "ib0,ib1,ib2,ib3",
+            "DFKV_RDMA_NUMA": "1",
+            "DFKV_RDMA_RAIL_TIERS": "ib0|ib1;ib2|ib3",
+        }
+        before = dict(env)
+        result = apply_rank_local_rail_affinity({}, 2, env)
+        self.assertFalse(result.enabled)
+        self.assertFalse(result.applied)
+        self.assertEqual(env, before)
+
+    def test_primary_and_default_fallback_wrap_by_physical_rank(self):
+        env = {
+            "DFKV_RDMA_DEV": "ib0,ib1,ib2,ib3",
+            "DFKV_RDMA_NUMA": "1",
+            "DFKV_RDMA_RAIL_TIERS": "ib0|ib1;ib2|ib3",
+        }
+        result = apply_rank_local_rail_affinity({"rail_affinity": True}, 3, env)
+        self.assertEqual(result.selected, ("ib3", "ib0"))
+        self.assertEqual(result.primary, "ib3")
+        self.assertEqual(result.fallback_count, 1)
+        self.assertEqual(env["DFKV_RDMA_DEV"], "ib3,ib0")
+        self.assertEqual(env["DFKV_RDMA_PRIMARY_DEV"], "ib3")
+        self.assertEqual(env["DFKV_RDMA_NUMA"], "0")
+        self.assertNotIn("DFKV_RDMA_RAIL_TIERS", env)
+
+    def test_explicit_zero_disables_fallback_not_affinity(self):
+        env = {"DFKV_RDMA_DEV": "ib0,ib1,ib2,ib3"}
+        result = apply_rank_local_rail_affinity(
+            {"rail_affinity": "1", "rail_affinity_fallbacks": 0}, 6, env
+        )
+        self.assertTrue(result.applied)
+        self.assertEqual(result.selected, ("ib2",))
+        self.assertEqual(env["DFKV_RDMA_PRIMARY_DEV"], "ib2")
+
+    def test_fallback_count_is_bounded_to_available_rails(self):
+        env = {"DFKV_RDMA_DEV": "ib0,ib1,ib2"}
+        result = apply_rank_local_rail_affinity(
+            {"rail_affinity": True, "rail_affinity_fallbacks": 99}, 1, env
+        )
+        self.assertEqual(result.selected, ("ib1", "ib2", "ib0"))
+        self.assertEqual(result.fallback_count, 2)
+
+    def test_single_or_empty_rail_is_a_clean_noop(self):
+        for devs, expected_primary in (("ib0", "ib0"), ("", None)):
+            env = {"DFKV_RDMA_DEV": devs, "DFKV_RDMA_NUMA": "1"}
+            before = dict(env)
+            result = apply_rank_local_rail_affinity({"rail_affinity": True}, 0, env)
+            self.assertFalse(result.applied)
+            self.assertEqual(result.primary, expected_primary)
+            self.assertEqual(env, before)
+
+    def test_invalid_configuration_fails_before_native_open(self):
+        bad_cases = [
+            (
+                {"rail_affinity": True, "rail_affinity_fallbacks": True},
+                {"DFKV_RDMA_DEV": "ib0,ib1"},
+            ),
+            (
+                {"rail_affinity": True, "rail_affinity_fallbacks": "bad"},
+                {"DFKV_RDMA_DEV": "ib0,ib1"},
+            ),
+            ({"rail_affinity": True}, {"DFKV_RDMA_DEV": "ib0,ib0"}),
+        ]
+        for cfg, env in bad_cases:
+            with self.subTest(cfg=cfg, env=env):
+                with self.assertRaises(ValueError):
+                    apply_rank_local_rail_affinity(cfg, 0, env)
+
+    def test_negative_rank_is_rejected(self):
+        with self.assertRaises(ValueError):
+            apply_rank_local_rail_affinity(
+                {"rail_affinity": True},
+                -1,
+                {"DFKV_RDMA_DEV": "ib0,ib1"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -25,6 +25,7 @@ from sglang.srt.mem_cache.hicache_storage import HiCacheStorage, HiCacheStorageC
 from dfkv_common import (
     DfkvClientOptionsV2,
     SGLANG_HICACHE_RAW_V1,
+    apply_rank_local_rail_affinity,
     canonical_namespace,
     reject_namespace_override,
     make_client_options_v2,
@@ -370,29 +371,14 @@ class DfkvHiCache(HiCacheStorage):
             if _truthy(cfg.get("require_rdma")):
                 if not _truthy(os.environ.get("DFKV_RDMA")):
                     os.environ["DFKV_RDMA"] = "1"
-            # Optional rank-local rail affinity bounds CUDA-pool registrations.
-            # A small explicit fallback count keeps failure recovery without
-            # returning to every-rank/every-HCA registration: with one fallback,
-            # each HCA sees two rank pools (one primary, one neighbor fallback).
-            if _truthy(cfg.get("rail_affinity")):
-                rails = [x.strip() for x in
-                         os.environ.get("DFKV_RDMA_DEV", "").split(",")
-                         if x.strip()]
-                if len(rails) > 1:
-                    rank = self.pcp_rank if self.pcp_size > 1 else self.tp_rank
-                    primary = rank % len(rails)
-                    fallback_count = max(
-                        0, min(int(cfg.get("rail_affinity_fallbacks", 1)),
-                               len(rails) - 1))
-                    selected = [
-                        rails[(primary + offset) % len(rails)]
-                        for offset in range(fallback_count + 1)
-                    ]
-                    os.environ["DFKV_RDMA_DEV"] = ",".join(selected)
-                    os.environ["DFKV_RDMA_PRIMARY_DEV"] = selected[0]
-                    os.environ["DFKV_RDMA_NUMA"] = "0"
-                    os.environ.pop("DFKV_RDMA_RAIL_TIERS", None)
-            elif cfg.get("rdma_numa"):
+            # Resolve rank-local affinity before dfkv_open_v2 so each process
+            # registers CUDA pools only on its primary and bounded fallbacks.
+            # DP-attention exposes the physical rank through PCP; plain TP
+            # uses tp_rank.
+            affinity_rank = self.pcp_rank if self.pcp_size > 1 else self.tp_rank
+            self._rail_affinity = apply_rank_local_rail_affinity(
+                cfg, affinity_rank, os.environ)
+            if not self._rail_affinity.enabled and cfg.get("rdma_numa"):
                 os.environ.setdefault("DFKV_RDMA_NUMA", "1")
             # Same-host GET rendezvous (phase 5): dedups TP-replicated L3 loads
             # across the rank processes of one node (HiCache destinations are

--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -29,7 +29,9 @@ that single object operation; it does not split the chunk into physical keys.
   "kv_role": "kv_both",
   "kv_connector_extra_config": {
     "members": "c1=<server-ip>:<rdma-port>",
-    "lib": "/path/to/libdfkv.so"
+    "lib": "/path/to/libdfkv.so",
+    "rail_affinity": true,
+    "rail_affinity_fallbacks": 1
   }
 }'
 ```
@@ -55,7 +57,7 @@ traffic if either requirement is missing.
 |---|---|---|
 | `DFKV_RDMA` | **required: `1`** | Selects the required GPUDirect RDMA transport. Unset/TCP is rejected during connector construction; there is no TCP fallback. |
 | `PYTHONHASHSEED` | **required: fixed value** | Stabilizes vLLM's root block hash across processes and restarts. Use the same value (for example `0`) on every producer and consumer sharing a store. |
-| `DFKV_RDMA_DEV` | first local `ACTIVE` HCA | Optional device/fabric selector. Leave unset for one local rail even when `DFKV_RDMA=1`; use a comma-list only to opt into multi-rail, and verify the same listed names/fabric at both endpoints. |
+| `DFKV_RDMA_DEV` | first local `ACTIVE` HCA | Optional ordered device/fabric list. With `rail_affinity=true`, the connector narrows this full per-host list to the worker's world-group local-rank primary plus bounded fallbacks before native open. |
 | `DFKV_RDMA_DEPTH` | `4` | Negotiated request window (`min(client, server)`). Keep the defaults aligned for production connector batches. Per-connection bandwidth is depth-flat after connection setup; scale read throughput with sharded pooled connections, not by increasing depth. |
 | `DFKV_RDMA_NUMA` | `0` | `1` pins buffers/threads to the rail's NUMA node and picks a NUMA-local rail per connection. Optional. |
 | `DFKV_READ_SHARD_KEYS` | `16` | Target keys per read shard: splits one node's batched GET into parallel shards. The real read-throughput lever on few-node rings / large batches landing on one node (single connection drains ~166 MB/s serially); no-op on wide rings. |
@@ -79,6 +81,8 @@ LMCache connector access logs, so one setting covers every integration. Format:
 | `members` | (required) | dfkv member string. **The port MUST be the server's `--rdma-port`** (the RDMA bootstrap listener), not the main `--port`, when RDMA is enabled. |
 | `lib` | env `DFKV_LIB` / `$DFKV_BUILD/libdfkv.so` | path to `libdfkv.so`. |
 | `batch_concurrency` | `0`=auto | client fan-out for batch ops; the real throughput lever (depth is flat). Auto = `min(max(nodes, 8), 32)`: 8-way parallel on single-node, one-per-node on multi-node. Set >0 to pin a fixed value. |
+| `rail_affinity` | `False` | Bind each vLLM worker process to a primary rail selected by world-group local rank; requires an ordered multi-rail `DFKV_RDMA_DEV`. |
+| `rail_affinity_fallbacks` | `1` | Number of ordered neighboring fallback rails when affinity is enabled. `0` keeps strict one-rank/one-rail; values above the available rail count are bounded. |
 | `load_async` | `True` | async KV load: the scheduler returns `WAITING_FOR_REMOTE_KVS` and the load runs off the critical path. Keep `True`. |
 | `transfer_queue_capacity` | `256` | Maximum queued requests in each direction (`1..65536`). All receive workers consume one shared receive queue of this capacity; capacity is not multiplied by `recv_workers`. Submission is non-blocking: a full queue rejects new saves as completed (releasing finish/free fences) and rejects new loads as load errors (forcing recompute), so overload cannot grow memory or pin blocks indefinitely. Invalid or out-of-range values abort connector construction. |
 | `recv_workers` | `1` | Receive/load worker count (`1..32`). Workers consume the shared bounded receive queue and may execute independent native GETs concurrently. Invalid, boolean, or out-of-range values abort connector construction. |

--- a/integration/vllm/src/dfkv_vllm/rail_affinity.py
+++ b/integration/vllm/src/dfkv_vllm/rail_affinity.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def physical_affinity_rank(
+    *,
+    local_rank: int,
+    tp_rank: int,
+    pcp_rank: int,
+    dcp_rank: int,
+    pp_rank: int,
+) -> int:
+    """Return the per-host process/GPU coordinate used for HCA affinity.
+
+    TP/PCP/DCP/PP are storage and communication coordinates and can repeat
+    across stages or subgroups. vLLM's world-group ``local_rank`` is the
+    physical per-host process coordinate, so it alone anchors the ordered HCA
+    list. The logical ranks are accepted explicitly to keep their
+    non-participation visible and testable.
+    """
+    physical = int(local_rank)
+    logical = (int(tp_rank), int(pcp_rank), int(dcp_rank), int(pp_rank))
+    if physical < 0 or any(rank < 0 for rank in logical):
+        raise ValueError("vLLM rail affinity ranks must be non-negative")
+    return physical

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -28,6 +28,7 @@ from typing import Any, TypeVar
 
 import torch
 from dfkv_common import (
+    apply_rank_local_rail_affinity,
     canonical_namespace,
     reject_namespace_override,
 )
@@ -38,6 +39,7 @@ from vllm.config import VllmConfig
 from vllm.distributed import (
     get_dcp_group,
     get_pcp_group,
+    get_world_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
@@ -74,6 +76,7 @@ from .data import (
 from .dfkv_client import DfkvDeviceClient, SgDescriptorBatch
 from .dfkv_utils import get_dp_engine_index
 from .metrics import DfkvStoreConnectorStats
+from .rail_affinity import physical_affinity_rank
 from ._telemetry import config as _tcfg  # connector identity + client_register switch
 from .protocol import (
     LOOKUP_MSG,
@@ -1263,14 +1266,47 @@ class DfkvStoreWorker:
         self.tp_size = get_tensor_model_parallel_world_size()
         self.pp_size = parallel_config.pipeline_parallel_size
         self.pp_rank = (parallel_config.rank // self.tp_size) % self.pp_size
+        self.local_rank = int(get_world_group().local_rank)
 
         self.pcp_size = get_pcp_group().world_size
         self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
         self.dcp_size = get_dcp_group().world_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
+        self.affinity_rank = physical_affinity_rank(
+            local_rank=self.local_rank,
+            tp_rank=self.tp_rank,
+            pcp_rank=self.pcp_rank,
+            dcp_rank=self.dcp_rank,
+            pp_rank=self.pp_rank,
+        )
 
         assert vllm_config.kv_transfer_config is not None
         extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+        self._rail_affinity = apply_rank_local_rail_affinity(
+            extra, self.affinity_rank, os.environ
+        )
+        if self._rail_affinity.enabled:
+            logger.info(
+                "dfkv rail affinity: status=%s physical_rank=%d "
+                "dp=%d/%d pp=%d/%d tp=%d/%d pcp=%d/%d dcp=%d/%d "
+                "available=%s selected=%s primary=%s fallbacks=%d",
+                self._rail_affinity.reason,
+                self.affinity_rank,
+                self.dp_rank,
+                self.dp_size,
+                self.pp_rank,
+                self.pp_size,
+                self.tp_rank,
+                self.tp_size,
+                self.pcp_rank,
+                self.pcp_size,
+                self.dcp_rank,
+                self.dcp_size,
+                ",".join(self._rail_affinity.available) or "<none>",
+                ",".join(self._rail_affinity.selected) or "<none>",
+                self._rail_affinity.primary or "<none>",
+                self._rail_affinity.fallback_count,
+            )
         self.transfer_queue_capacity = _parse_transfer_queue_capacity(
             extra.get(
                 "transfer_queue_capacity",

--- a/integration/vllm/tests/test_rail_affinity.py
+++ b/integration/vllm/tests/test_rail_affinity.py
@@ -1,0 +1,76 @@
+import unittest
+
+from dfkv_common import apply_rank_local_rail_affinity
+from dfkv_vllm.rail_affinity import physical_affinity_rank
+
+
+class VllmRailAffinityTest(unittest.TestCase):
+    def test_physical_affinity_is_anchored_to_world_local_rank(self):
+        layouts = [
+            (0, 0, 0, 0, 0),
+            (7, 7, 0, 7, 0),  # TP8 / DCP8 / PP1
+            (5, 1, 1, 3, 1),  # PCP/DCP/PP coordinates differ
+            (2, 6, 0, 2, 0),  # DP engine reuses logical TP coordinates
+        ]
+        for local_rank, tp_rank, pcp_rank, dcp_rank, pp_rank in layouts:
+            with self.subTest(
+                layout=(local_rank, tp_rank, pcp_rank, dcp_rank, pp_rank)
+            ):
+                self.assertEqual(
+                    physical_affinity_rank(
+                        local_rank=local_rank,
+                        tp_rank=tp_rank,
+                        pcp_rank=pcp_rank,
+                        dcp_rank=dcp_rank,
+                        pp_rank=pp_rank,
+                    ),
+                    local_rank,
+                )
+
+    def test_negative_logical_or_physical_rank_is_rejected(self):
+        for field in ("local_rank", "tp_rank", "pcp_rank", "dcp_rank", "pp_rank"):
+            ranks = dict(
+                local_rank=0,
+                tp_rank=0,
+                pcp_rank=0,
+                dcp_rank=0,
+                pp_rank=0,
+            )
+            ranks[field] = -1
+            with self.subTest(field=field):
+                with self.assertRaisesRegex(ValueError, "must be non-negative"):
+                    physical_affinity_rank(**ranks)
+
+    def test_tp8_dcp8_rank_to_primary_and_fallback_mapping(self):
+        rails = ",".join(f"ib7s400p{i}" for i in range(8))
+        for rank in range(8):
+            env = {
+                "DFKV_RDMA_DEV": rails,
+                "DFKV_RDMA_NUMA": "1",
+                "DFKV_RDMA_RAIL_TIERS": "unused",
+            }
+            physical = physical_affinity_rank(
+                local_rank=rank,
+                tp_rank=rank,
+                pcp_rank=0,
+                dcp_rank=rank,
+                pp_rank=0,
+            )
+            selection = apply_rank_local_rail_affinity(
+                {"rail_affinity": True, "rail_affinity_fallbacks": 1},
+                physical,
+                env,
+            )
+            expected = (
+                f"ib7s400p{rank}",
+                f"ib7s400p{(rank + 1) % 8}",
+            )
+            self.assertEqual(selection.selected, expected)
+            self.assertEqual(env["DFKV_RDMA_DEV"], ",".join(expected))
+            self.assertEqual(env["DFKV_RDMA_PRIMARY_DEV"], expected[0])
+            self.assertEqual(env["DFKV_RDMA_NUMA"], "0")
+            self.assertNotIn("DFKV_RDMA_RAIL_TIERS", env)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Every vLLM worker inherited the full `DFKV_RDMA_DEV` list. On an 8-GPU/8-HCA host that made each process initialize and register its CUDA KV pool against every local rail, multiplying MR/QP pressure and erasing rank/HCA locality. SGLang HiCache had an inline affinity implementation, but vLLM had none and the policy was duplicated.

## Change

- add a shared `dfkv_common.apply_rank_local_rail_affinity` policy
- map vLLM workers by world-group per-host `local_rank`, not reusable TP/DCP/PCP/PP storage coordinates
- keep one ordered neighboring fallback by default; `rail_affinity_fallbacks=0` is strict one-rank/one-rail
- apply affinity before native client construction, including lazy-open paths
- migrate HiCache to the same shared policy
- document `rail_affinity`, `rail_affinity_fallbacks`, and `DFKV_RDMA_DEV` behavior
- register focused common/vLLM tests in CTest

Defaults remain unchanged: affinity is opt-in with `rail_affinity=true`.

## Validation

Local:
- `ctest --test-dir build-affinity --output-on-failure -j 9`: 786/786 completed, 0 failures (environment-gated tests skipped)
- focused Python contracts: 7 common + 3 vLLM, all passed
- final `dfkv-common` and `dfkv-vllm` wheels built; both affinity modules present and import-smoked

xb01 `xb01-gpu-200b-0064` (8x B200, 8x `ib7s400p*`, GLM-5.2-NVFP4, TP8/DCP8):
- all 8 workers resolved the expected ring mapping: rank N -> primary pN + fallback p(N+1 mod 8)
- official v2.23.0 baseline after one hot request: 240 RDMA QP lines, 7,559 MR lines
- candidate after the same hot request: 130 QP lines (-45.8%), 2,184 MR lines (-71.1%)
- latency-neutral same-prompt hot probe: baseline 1.731s, candidate 1.738s
- four concurrent 21,604-token prompts: cold 4/4 in 3.927s; hot 4/4 in 0.722s and 0.720s; 0 RDMA completion errors
- controlled primary-server-rail failure: p0 advertised `DOWN/DISABLED`, request still succeeded in 0.683s; completion delta p0=0, p1=237; member recovered from PARTIAL to ACTIVE after health restoration
- native real-RDMA probes passed for rank-local mapping/resource budget and sibling-rail cooldown fallback

The isolated services, container, test data, and temporary scripts on 0064 were removed after validation; all GPUs returned to 0 MiB used.