### PR TITLE
feat(lmcache): add rank-local RDMA rail affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### LMCache rank-local rail affinity
+
+- Added opt-in `rail_affinity` and `rail_affinity_fallbacks` plugin settings to
+  the in-process LMCache dfkv connector. Each worker now uses LMCache's explicit
+  per-host `local_worker_id` to apply the shared primary/fallback policy before
+  opening the native client; missing or invalid local metadata fails closed.
+- Kept the MP-server L2 adapter unchanged because it owns one shared dfkv
+  client and has no single physical GPU rank at construction.
+
 ### vLLM rank-local rail affinity
 
 - Added `rail_affinity` and `rail_affinity_fallbacks` to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,12 @@ if(DFKV_BUILD_TESTS)
               -p test_rail_affinity.py)
     set_tests_properties(python_common_rail_affinity PROPERTIES
       ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/integration/common/src")
+    add_test(NAME python_lmcache_rail_affinity
+      COMMAND ${PYTHON3} -m unittest discover
+              -s ${CMAKE_CURRENT_SOURCE_DIR}/integration/lmcache/tests
+              -p test_rail_affinity.py)
+    set_tests_properties(python_lmcache_rail_affinity PROPERTIES
+      ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/integration/common/src")
     add_test(NAME python_vllm_rail_affinity
       COMMAND ${PYTHON3} -m unittest discover
               -s ${CMAKE_CURRENT_SOURCE_DIR}/integration/vllm/tests

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -917,8 +917,9 @@ extra_config:
 
 **RDMA 版**：URL 用 **RDMA 端口**（server `--rdma-port`），并给 vLLM
 进程加 `export DFKV_RDMA=1`。单 fabric 节点可直接使用自动 active-HCA 发现；
-生产多 fabric 节点必须用 `DFKV_RDMA_DEV` 过滤出与 cache server 同 fabric
-的本机设备（同型号节点可逗号列全轨，见 §1.2）。
+生产多 fabric 节点必须用 `DFKV_RDMA_DEV` 配置同一份有序全轨列表。in-process
+LMCache 可启用 `rail_affinity=true`，connector 在各 worker native open 前按
+`metadata.local_worker_id` 收窄为 primary + fallback；缺少本地 rank 元数据时启动失败。
 
 **🔴 生产多模型 / 多租户隔离（in-process 隔离能力的天花板）**
 
@@ -968,7 +969,9 @@ vllm serve <model_path> \
 
 **验证**：
 1. **连接器已加载**（vLLM 启动日志，且没回退 blackhole）：
-   `Discovered adapter: DfkvConnectorAdapter` / `DfkvConnector ready: membership=... endpoint=... rdma_pools=1 ...`
+   `Discovered adapter: DfkvConnectorAdapter` / `DfkvConnector ready: membership=... endpoint=... rdma_pools=1 ...`。
+   affinity 启用时还必须逐 worker 出现
+   `LMCache dfkv rail affinity: ... local_rank=N/... selected=... primary=...`。
 2. **缓存命中**：同一请求发两遍（或同 `--seed` 的 bench 跑两遍），第二遍
    `External prefix cache hit rate` > 0、TTFT 明显下降；也可开 `DFKV_ACCESS_LOG_ENABLED=1`
    看 `batch_set`/`batch_get` 命中。
@@ -994,6 +997,8 @@ vllm bench serve --backend openai-chat --endpoint /v1/chat/completions \
 | `membership` | 否 | **`mds`（默认）** 或 `static` |
 | `lib` | 否 | `libdfkv.so` 路径（覆盖 `DFKV_LIB`） |
 | `mds_poll_ms` | 否 | mds 模式轮询间隔，默认 3000 |
+| `rail_affinity` | 否 | 默认 `false`；仅 in-process 路径按 LMCache `local_worker_id` 选择 per-worker primary |
+| `rail_affinity_fallbacks` | 否 | 默认 `1`；相邻有序 fallback 数，`0` 为严格 one-rank/one-rail |
 
 也支持简写 URL 直连（`plugin://dfkv` 场景 URL 即成员串），此时 knob 全走默认
 （membership=mds、lib 走 env）。
@@ -1105,6 +1110,10 @@ server 的 pinned L1 arena 在 LMCache 传入 `l1_memory_desc` 时自动注册 R
 已在 GLM-5.2（vLLM 0.23.0 + LMCache 0.4.7）真机验证：store → 重启（L1 清空）→ 从 dfkv
 回载、prefill 跳过。单测 `integration/lmcache/tests/test_l2_adapter.py`（fake client）+
 集成测试 `test_l2_adapter_integration.py`（`DFKV_L2_URL`/`DFKV_L2_MEMBERSHIP` 指向真环）。
+
+MP-server L2 adapter 只有一个共享 dfkv client，构造时没有单一物理 GPU local
+rank，因此不应用 rank-local affinity；`adapter_params` 中也不接受这两个键。
+需要 per-worker/HCA 映射时使用 §4.1–4.4 的 in-process 路径。
 
 ### 4.6 设计与实现
 

--- a/integration/lmcache/README.md
+++ b/integration/lmcache/README.md
@@ -46,6 +46,8 @@ extra_config:
   remote_storage_plugin.dfkv.url:         dfkv://<mds_ip:port,...>/<group>
   remote_storage_plugin.dfkv.membership:  mds            # or "static"
   remote_storage_plugin.dfkv.lib:         /path/to/libdfkv.so
+  remote_storage_plugin.dfkv.rail_affinity: true
+  remote_storage_plugin.dfkv.rail_affinity_fallbacks: 1
 ```
 
 - **mds membership** (default): the URL host part is a comma-separated list of
@@ -55,6 +57,14 @@ extra_config:
 
 The library is found via (highest first) `remote_storage_plugin.dfkv.lib` →
 env `DFKV_LIB` → `$DFKV_BUILD/libdfkv.so`.
+
+For in-process LMCache, rank-local affinity is opt-in. Set the engine process
+environment to the same ordered full per-host rail list, for example
+`DFKV_RDMA_DEV=ib0,...,ib7`. Each LMCache worker reads the explicit
+`metadata.local_worker_id` before native open, narrows its process-local list to
+one primary plus the configured neighboring fallbacks, and sets
+`DFKV_RDMA_PRIMARY_DEV`. Missing or invalid local-rank metadata fails startup
+rather than falling back to the global `worker_id`.
 
 ## Configure LMCache (MP-server mode — L2 adapter)
 
@@ -140,6 +150,7 @@ payloads.
 | `DFKV_CONNECTOR_ASSUME_EXISTS` | 0 | skip remote contains checks (debug) |
 | `DFKV_ACCESS_LOG_ENABLED` | 0 | per-op access log |
 | `DFKV_ACCESS_LOG_PATH` | (stderr) | access-log file path |
+| `DFKV_RDMA_DEV` | first local ACTIVE HCA | ordered full per-host list; narrowed per worker when in-process affinity is enabled |
 
 ## Limitations
 
@@ -150,6 +161,10 @@ payloads.
   synchronous ctypes client to LMCache's eventfd model with a background asyncio
   loop (dfkv has no native eventfd, so no pybind/`NativeConnectorL2Adapter`
   path is used).
+- Rank-local rail affinity applies only to the in-process `RemoteConnector`,
+  where LMCache supplies one `local_worker_id` per engine process. The MP-server
+  L2 adapter owns one shared dfkv client and does not expose a single physical
+  GPU rank at construction, so it deliberately does not apply this policy.
 - **L2 eviction is supported** (dfkv gained a `remove` RPC): set
   `max_capacity_gb > 0` on the L2 adapter to enable LMCache's L2EvictionController,
   which calls `DfkvL2Adapter.delete()` → `dfkv_batch_remove` to drop blocks when

--- a/integration/lmcache/src/dfkv_connector/adapter.py
+++ b/integration/lmcache/src/dfkv_connector/adapter.py
@@ -13,6 +13,8 @@ Wire-up in LMCache config (plugin mode, recommended):
       remote_storage_plugin.dfkv.membership:  mds      # "mds" (default) | "static"
       remote_storage_plugin.dfkv.lib:         /path/to/libdfkv.so   # overrides $DFKV_LIB
       remote_storage_plugin.dfkv.mds_poll_ms: 3000
+      remote_storage_plugin.dfkv.rail_affinity: true
+      remote_storage_plugin.dfkv.rail_affinity_fallbacks: 1
 
 For static membership the URL carries the member string directly, e.g.
     remote_storage_plugin.dfkv.url:        dfkv://n1=10.0.0.1:12000,n2=10.0.0.2:12000/x
@@ -41,6 +43,7 @@ from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 
 from .access_log import access_log
 from .remote_connector import DfkvConnector
+from .rail_affinity import parse_plugin_rail_affinity
 
 logger = init_logger(__name__)
 
@@ -61,6 +64,8 @@ class _PluginOverrides:
     membership: str
     lib_path: Optional[str]
     mds_poll_ms: int
+    rail_affinity: bool
+    rail_affinity_fallbacks: int
 
 
 class DfkvConnectorAdapter(ConnectorAdapter):
@@ -88,9 +93,11 @@ class DfkvConnectorAdapter(ConnectorAdapter):
             ov = self._resolve_overrides(context)
             logger.info(
                 "Creating DfkvConnector: context_url=%s target_url=%s "
-                "membership=%s lib=%s mds_poll_ms=%d",
+                "membership=%s lib=%s mds_poll_ms=%d rail_affinity=%s "
+                "fallbacks=%d",
                 context.url, ov.target_url, ov.membership,
-                ov.lib_path or "-", ov.mds_poll_ms,
+                ov.lib_path or "-", ov.mds_poll_ms, ov.rail_affinity,
+                ov.rail_affinity_fallbacks,
             )
             return DfkvConnector(
                 url=ov.target_url,
@@ -99,6 +106,8 @@ class DfkvConnectorAdapter(ConnectorAdapter):
                 lib_path=ov.lib_path,
                 membership=ov.membership,
                 mds_poll_ms=ov.mds_poll_ms,
+                rail_affinity=ov.rail_affinity,
+                rail_affinity_fallbacks=ov.rail_affinity_fallbacks,
             )
 
     @staticmethod
@@ -109,6 +118,7 @@ class DfkvConnectorAdapter(ConnectorAdapter):
             return _PluginOverrides(
                 target_url=url, membership=_DEFAULT_MEMBERSHIP,
                 lib_path=None, mds_poll_ms=_DEFAULT_MDS_POLL_MS,
+                rail_affinity=False, rail_affinity_fallbacks=1,
             )
 
         plugin_name = getattr(context, "plugin_name", None) or url[
@@ -166,10 +176,13 @@ class DfkvConnectorAdapter(ConnectorAdapter):
                     f"extra_config['{prefix}.mds_poll_ms']={mds_poll_ms} must be "
                     "positive"
                 )
+        affinity = parse_plugin_rail_affinity(extra_config, prefix)
 
         return _PluginOverrides(
             target_url=target_url,
             membership=membership,
             lib_path=lib_path or None,
             mds_poll_ms=mds_poll_ms,
+            rail_affinity=affinity.enabled,
+            rail_affinity_fallbacks=affinity.fallback_count,
         )

--- a/integration/lmcache/src/dfkv_connector/rail_affinity.py
+++ b/integration/lmcache/src/dfkv_connector/rail_affinity.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class LMCacheRailAffinityConfig:
+    enabled: bool = False
+    fallback_count: int = 1
+
+
+def parse_plugin_rail_affinity(
+    extra_config: Mapping[str, Any], prefix: str
+) -> LMCacheRailAffinityConfig:
+    enabled_key = f"{prefix}.rail_affinity"
+    fallback_key = f"{prefix}.rail_affinity_fallbacks"
+
+    enabled = extra_config.get(enabled_key, False)
+    if not isinstance(enabled, bool):
+        raise ValueError(f"extra_config[{enabled_key!r}] must be a boolean")
+
+    fallback_count = extra_config.get(fallback_key, 1)
+    if isinstance(fallback_count, bool) or not isinstance(fallback_count, int):
+        raise ValueError(f"extra_config[{fallback_key!r}] must be an integer")
+    if fallback_count < 0:
+        raise ValueError(f"extra_config[{fallback_key!r}] must be non-negative")
+
+    return LMCacheRailAffinityConfig(enabled, fallback_count)
+
+
+def physical_affinity_rank(metadata: Any) -> int:
+    """Return LMCache's explicit per-host worker/GPU coordinate.
+
+    ``worker_id`` is the global/logical rank used in object identity. It can
+    exceed the host-local GPU count and must never drive HCA affinity. Current
+    LMCache v0.4.7+ metadata exposes both ``local_worker_id`` and
+    ``local_world_size``; fail closed instead of guessing when either is absent.
+    """
+    if not hasattr(metadata, "local_worker_id") or not hasattr(
+        metadata, "local_world_size"
+    ):
+        raise ValueError(
+            "LMCache rail affinity requires metadata.local_worker_id and "
+            "metadata.local_world_size"
+        )
+
+    local_rank = getattr(metadata, "local_worker_id")
+    local_world_size = getattr(metadata, "local_world_size")
+    if isinstance(local_rank, bool) or isinstance(local_world_size, bool):
+        raise ValueError("LMCache local rank metadata must be integer-valued")
+    try:
+        local_rank = int(local_rank)
+        local_world_size = int(local_world_size)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("LMCache local rank metadata must be integer-valued") from exc
+
+    if local_world_size <= 0:
+        raise ValueError("LMCache metadata.local_world_size must be positive")
+    if local_rank < 0 or local_rank >= local_world_size:
+        raise ValueError(
+            "LMCache metadata.local_worker_id must be within local_world_size"
+        )
+    return local_rank

--- a/integration/lmcache/src/dfkv_connector/remote_connector.py
+++ b/integration/lmcache/src/dfkv_connector/remote_connector.py
@@ -26,7 +26,11 @@ import hashlib
 import os
 from typing import Any, List, Optional, Tuple
 
-from dfkv_common import LMCACHE_RAW_V1, canonical_namespace
+from dfkv_common import (
+    LMCACHE_RAW_V1,
+    apply_rank_local_rail_affinity,
+    canonical_namespace,
+)
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj
@@ -38,6 +42,7 @@ from .config import parse_dfkv_url
 from .exists_cache import ExistsLRU
 from .key_mapper import cache_engine_key_to_dfkv_key
 from .native_client import DfkvNativeClient
+from .rail_affinity import physical_affinity_rank
 
 logger = init_logger(__name__)
 
@@ -72,6 +77,8 @@ class DfkvConnector(RemoteConnector):
         lib_path: Optional[str] = None,
         membership: str = "mds",
         mds_poll_ms: int = 3000,
+        rail_affinity: bool = False,
+        rail_affinity_fallbacks: int = 1,
     ) -> None:
         with access_log("__init__", lambda: f"url={url}") as r:
             super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
@@ -91,6 +98,31 @@ class DfkvConnector(RemoteConnector):
             world_size = max(1, int(getattr(_md, "world_size", 1)))
             worker_id = int(getattr(_md, "worker_id", 0))
             model_identity = str(getattr(_md, "model_name", ""))
+            self._rail_affinity = None
+            if rail_affinity:
+                affinity_rank = physical_affinity_rank(_md)
+                self._rail_affinity = apply_rank_local_rail_affinity(
+                    {
+                        "rail_affinity": True,
+                        "rail_affinity_fallbacks": rail_affinity_fallbacks,
+                    },
+                    affinity_rank,
+                    os.environ,
+                )
+                logger.info(
+                    "LMCache dfkv rail affinity: status=%s local_rank=%d/%d "
+                    "worker_id=%d/%d available=%s selected=%s primary=%s "
+                    "fallbacks=%d",
+                    self._rail_affinity.reason,
+                    affinity_rank,
+                    int(getattr(_md, "local_world_size")),
+                    worker_id,
+                    world_size,
+                    ",".join(self._rail_affinity.available) or "<none>",
+                    ",".join(self._rail_affinity.selected) or "<none>",
+                    self._rail_affinity.primary or "<none>",
+                    self._rail_affinity.fallback_count,
+                )
             _dtype_identity = ",".join(str(dtype) for dtype in self.meta_dtypes)
             _shape_identity = "|".join(str(tuple(shape)) for shape in self.meta_shapes)
             namespace = canonical_namespace(

--- a/integration/lmcache/tests/test_rail_affinity.py
+++ b/integration/lmcache/tests/test_rail_affinity.py
@@ -1,0 +1,105 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+_TEST_DIR = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(_TEST_DIR, "..", "..", "common", "src"))
+
+_MODULE_PATH = os.path.join(
+    _TEST_DIR, "..", "src", "dfkv_connector", "rail_affinity.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "_dfkv_lmcache_rail_affinity", _MODULE_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+from dfkv_common import apply_rank_local_rail_affinity  # noqa: E402
+
+parse_plugin_rail_affinity = _MODULE.parse_plugin_rail_affinity
+physical_affinity_rank = _MODULE.physical_affinity_rank
+
+
+class LMCacheRailAffinityTest(unittest.TestCase):
+    def test_plugin_config_defaults_to_disabled_with_one_fallback(self):
+        config = parse_plugin_rail_affinity({}, "remote_storage_plugin.dfkv")
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.fallback_count, 1)
+
+    def test_plugin_config_parses_explicit_affinity(self):
+        config = parse_plugin_rail_affinity(
+            {
+                "remote_storage_plugin.dfkv.rail_affinity": True,
+                "remote_storage_plugin.dfkv.rail_affinity_fallbacks": 2,
+            },
+            "remote_storage_plugin.dfkv",
+        )
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.fallback_count, 2)
+
+    def test_invalid_plugin_config_fails_closed(self):
+        bad_configs = [
+            {"remote_storage_plugin.dfkv.rail_affinity": "true"},
+            {"remote_storage_plugin.dfkv.rail_affinity_fallbacks": True},
+            {"remote_storage_plugin.dfkv.rail_affinity_fallbacks": -1},
+            {"remote_storage_plugin.dfkv.rail_affinity_fallbacks": "1"},
+        ]
+        for config in bad_configs:
+            with self.subTest(config=config):
+                with self.assertRaises(ValueError):
+                    parse_plugin_rail_affinity(
+                        config, "remote_storage_plugin.dfkv"
+                    )
+
+    def test_physical_rank_uses_local_worker_not_global_worker(self):
+        metadata = types.SimpleNamespace(
+            worker_id=13,
+            world_size=16,
+            local_worker_id=5,
+            local_world_size=8,
+        )
+        self.assertEqual(physical_affinity_rank(metadata), 5)
+
+    def test_missing_or_invalid_local_metadata_fails_closed(self):
+        bad_metadata = [
+            types.SimpleNamespace(worker_id=0, world_size=8),
+            types.SimpleNamespace(local_worker_id=-1, local_world_size=8),
+            types.SimpleNamespace(local_worker_id=8, local_world_size=8),
+            types.SimpleNamespace(local_worker_id=0, local_world_size=0),
+            types.SimpleNamespace(local_worker_id=True, local_world_size=8),
+        ]
+        for metadata in bad_metadata:
+            with self.subTest(metadata=metadata):
+                with self.assertRaises(ValueError):
+                    physical_affinity_rank(metadata)
+
+    def test_two_node_tp16_maps_each_hosts_local_workers_to_eight_rails(self):
+        rails = ",".join(f"ib7s400p{i}" for i in range(8))
+        for global_rank in range(16):
+            local_rank = global_rank % 8
+            metadata = types.SimpleNamespace(
+                worker_id=global_rank,
+                world_size=16,
+                local_worker_id=local_rank,
+                local_world_size=8,
+            )
+            env = {"DFKV_RDMA_DEV": rails}
+            selection = apply_rank_local_rail_affinity(
+                {"rail_affinity": True, "rail_affinity_fallbacks": 1},
+                physical_affinity_rank(metadata),
+                env,
+            )
+            expected = (
+                f"ib7s400p{local_rank}",
+                f"ib7s400p{(local_rank + 1) % 8}",
+            )
+            self.assertEqual(selection.selected, expected)
+            self.assertEqual(env["DFKV_RDMA_PRIMARY_DEV"], expected[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The in-process LMCache dfkv connector inherited the same full `DFKV_RDMA_DEV` list in every worker. On an 8-worker/8-HCA host each 5 GiB LMCache pinned arena was therefore registered against all eight HCAs, multiplying MR/QP resources and losing worker/HCA locality.

## Change

- add opt-in `remote_storage_plugin.dfkv.rail_affinity`
- add `remote_storage_plugin.dfkv.rail_affinity_fallbacks` (default 1)
- use LMCache's explicit `metadata.local_worker_id` / `local_world_size`, never global `worker_id`, before native open
- apply the existing shared primary/fallback policy and emit per-worker mapping evidence
- fail closed when local-rank metadata is missing or invalid
- leave the MP-server L2 adapter unchanged: it owns one shared dfkv client and has no single physical GPU rank at construction
- add a pure-Python LMCache contract suite to CTest and update connector docs

Defaults remain unchanged; affinity is opt-in.

## Validation

Local:
- RDMA-enabled Release build succeeded
- CTest: 787/787 completed, 0 failures (environment-gated tests skipped)
- LMCache affinity contract: 6/6
- ruff and py_compile passed
- common/LMCache wheels built; new module present in wheel

xb01 `xb01-gpu-200b-0064`:
- vLLM 0.27.1 + LMCache 0.5.3 + Qwen3-8B, TP8, eight active `ib7s400p*` HCAs
- all workers resolved rank N -> primary pN + fallback p(N+1 mod 8); native effective config matched
- official v2.23.1 baseline after L3 hot read: 383 QP lines / 2,509 MR lines
- candidate: 66 QP lines (-82.8%) / 72 MR lines (-97.1%)
- cross-process L3 hot latency: baseline 4.187s, candidate 4.171s (-0.4%, neutral)
- candidate cold: 4/4 requests, 96,024 input tokens, 2.875s, 13,386,645,504 bytes written
- candidate restart hot: 4/4, 4.171s, 95,232/96,024 external prefix hits, 2,976 dfkv GET hits, 14,042,529,792 bytes read, zero writes/errors
- controlled p0 server-rail failure: 4/4 restart-hot requests, p0 completions=0, p1=1,488, p2..p7=744 each, same 95,232 external hits and zero errors; member recovered PARTIAL -> ACTIVE
- baseline rail completions were uneven; candidate healthy hot read was exactly 744 completions on every rail

All isolated services, container, data, staging, and scripts were removed after validation; all eight GPUs returned to 0 MiB.