### PR TITLE
fix: alert on RDMA hard receive budget

### DIFF
--- a/deploy/observability/alerts.yml
+++ b/deploy/observability/alerts.yml
@@ -58,13 +58,13 @@ groups:
           summary: "dfkv server RDMA completion errors"
           description: "{{ $labels.instance }} has failing RDMA completions."
       - alert: DfkvRdmaReceiveSegmentLow
-        expr: dfkv_rdma_recv_segment_bytes > 0 and (dfkv_rdma_recv_segment_free_bytes / dfkv_rdma_recv_segment_bytes) < 0.1
+        expr: ((dfkv_rdma_recv_segment_max_bytes - dfkv_rdma_recv_segment_used_bytes) / dfkv_rdma_recv_segment_max_bytes) < 0.1 and dfkv_rdma_recv_segment_max_bytes > 0
         for: 2m
         labels:
           severity: warning
         annotations:
-          summary: "dfkv RDMA receive segment has less than 10% free"
-          description: "{{ $labels.instance }} may reject new data QPs."
+          summary: "dfkv RDMA receive hard budget has less than 10% free"
+          description: "{{ $labels.instance }} is close to the hard receive-pool budget and may reject new data QPs."
       - alert: DfkvServerMdsHeartbeatDegraded
         expr: dfkv_mds_heartbeat_healthy == 0 or dfkv_mds_last_success_age_seconds > 30
         for: 1m

--- a/deploy/observability/grafana/dashboards/dfkv-cluster.json
+++ b/deploy/observability/grafana/dashboards/dfkv-cluster.json
@@ -1592,7 +1592,7 @@
     {
       "id": 23,
       "type": "timeseries",
-      "title": "Receive segment free ratio",
+      "title": "Receive hard-budget free ratio",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -1634,7 +1634,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(dfkv_rdma_recv_segment_free_bytes{instance=~\"$node\"} / dfkv_rdma_recv_segment_bytes{instance=~\"$node\"})",
+          "expr": "((dfkv_rdma_recv_segment_max_bytes{instance=~\"$node\"} - dfkv_rdma_recv_segment_used_bytes{instance=~\"$node\"}) / dfkv_rdma_recv_segment_max_bytes{instance=~\"$node\"})",
           "legendFormat": "{{instance}}"
         }
       ]

--- a/test/python/test_observability_contract.py
+++ b/test/python/test_observability_contract.py
@@ -243,6 +243,33 @@ class ObservabilityContractTest(unittest.TestCase):
             unknown = metric_families(expression) - PUBLIC_FAMILIES
             self.assertFalse(unknown, f"alert references unknown metrics {sorted(unknown)}")
 
+    def test_receive_segment_capacity_uses_hard_budget(self):
+        alerts = ALERTS.read_text(encoding="utf-8")
+        self.assertIn(
+            "((dfkv_rdma_recv_segment_max_bytes - "
+            "dfkv_rdma_recv_segment_used_bytes) / "
+            "dfkv_rdma_recv_segment_max_bytes) < 0.1",
+            alerts,
+        )
+        self.assertNotIn(
+            "dfkv_rdma_recv_segment_free_bytes / "
+            "dfkv_rdma_recv_segment_bytes",
+            alerts,
+        )
+        dashboard = json.loads(
+            (DASHBOARDS / "dfkv-cluster.json").read_text(encoding="utf-8")
+        )
+        panel = next(panel for panel in dashboard["panels"] if panel["id"] == 23)
+        self.assertEqual(panel["title"], "Receive hard-budget free ratio")
+        self.assertIn(
+            "dfkv_rdma_recv_segment_max_bytes",
+            panel["targets"][0]["expr"],
+        )
+        self.assertIn(
+            "dfkv_rdma_recv_segment_used_bytes",
+            panel["targets"][0]["expr"],
+        )
+
     def test_prometheus_mounts_the_checked_rule_file(self):
         prometheus = (ROOT / "deploy" / "observability" / "prometheus.yml").read_text()
         compose = (ROOT / "deploy" / "observability" / "docker-compose.yml").read_text()


### PR DESCRIPTION
## Problem
`DfkvRdmaReceiveSegmentLow` divides unleased bytes by currently committed lazy chunks. Healthy pools therefore fire whenever a committed chunk is >90% occupied, even with most of the hard budget still available.

INC #C5ECD7 observed 6.39%-9.38% committed-chunk free while the affected xb01 ring retained 89.78%-92.54% hard-budget headroom, with zero growth/allocation failures.

## Change
- alert on `(max_bytes - used_bytes) / max_bytes`
- align the Grafana panel with hard-budget headroom
- add a regression contract for the alert and dashboard expressions

## Verification
- `python3 test/python/test_observability_contract.py` (5 tests, OK)
- `promtool check rules` against the hotfixed xb01 rule file (26 rules, SUCCESS)
- live rule state changed from firing/8 active to inactive/0 active