### PR TITLE
fix(hicache): support legacy SGLang CP context

### DIFF
--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -127,13 +127,22 @@ def _resolve_parallel_coordinates(
         if f"{name}_size" in cfg or f"{name}_rank" in cfg:
             resolved[name] = _physical_axis(cfg, name)
         elif parallel is not None:
-            resolved[name] = _physical_axis(
-                {
-                    f"{name}_size": getattr(parallel, size_attr),
-                    f"{name}_rank": getattr(parallel, rank_attr),
-                },
-                name,
-            )
+            size_value = getattr(parallel, size_attr, None)
+            rank_value = getattr(parallel, rank_attr, None)
+            if name == "dcp" and size_value is None and rank_value is None:
+                # Legacy SGLang exposes only attn_cp_*: that single axis is
+                # already represented by PCP above. It has no independent DCP
+                # shard, so duplicating attn_cp_* here would corrupt keys and
+                # replica-writer election.
+                resolved[name] = (1, 0)
+            else:
+                resolved[name] = _physical_axis(
+                    {
+                        f"{name}_size": size_value,
+                        f"{name}_rank": rank_value,
+                    },
+                    name,
+                )
         else:
             resolved[name] = (1, 0)
 

--- a/integration/hicache/tests/test_sg_width_namespace.py
+++ b/integration/hicache/tests/test_sg_width_namespace.py
@@ -174,6 +174,16 @@ class TestParallelCoordinates(unittest.TestCase):
         self.assertEqual(dcp, (2, 1))
         self.assertEqual(attn_tp_rank, 0)
 
+    def test_legacy_sglang_without_dcp_coordinates(self):
+        with _parallel_runtime(
+            attn_cp_size=8,
+            attn_cp_rank=3,
+        ):
+            pcp, dcp, attn_tp_rank = H._resolve_parallel_coordinates({})
+        self.assertEqual(pcp, (8, 3))
+        self.assertEqual(dcp, (1, 0))
+        self.assertIsNone(attn_tp_rank)
+
     def test_explicit_coordinates_override_runtime_axes(self):
         with _parallel_runtime(
             attn_cp_size=8,


### PR DESCRIPTION
## Problem
xb01 production rolled back the v2.24.3 client after the first Spinfield-managed GLM-5.2 worker crashed in `_resolve_parallel_coordinates`: its older SGLang `ParallelContext` exposes `attn_cp_size/rank` but no `attn_dcp_size/rank`.

LWS stopped after the first unready worker, limiting impact to one of 17 workers.

## Fix
- preserve the legacy `attn_cp_*` axis as PCP
- treat a completely absent independent DCP axis as `(1, 0)`
- do not copy the same legacy CP coordinate into both PCP and DCP, which would duplicate key dimensions and alter replica-writer election
- retain strict validation when only part of an axis is present

## Verification
- added a legacy `ParallelContext` regression that lacks both DCP fields
- `python3 integration/hicache/tests/test_sg_width_namespace.py`: 17/17 passed

The broader unittest discovery also reaches the same 17 passing tests; its unrelated `test_client_stats` module cannot import locally because this workstation lacks pytest. CI supplies the pinned test environment.