### PR TITLE
fix: publish RamTier failure before completion

### DIFF
--- a/src/cache/ram_tier.cc
+++ b/src/cache/ram_tier.cc
@@ -1146,17 +1146,21 @@ void RamTier::FlushLoop(Shard& s) {
           s.flushq.push_back(std::move(batch[i]));  // retry later
           s.cv.notify_one();
         } else {
+          const auto completion = entry.completion;
+          const bool client_acked = entry.client_acked;
           if (entry.flush_pin) {
             if (entry.in_arena())
               s.alloc->Unpin(entry.key, entry.slot_handle);
             entry.flush_pin = false;
           }
-          CompletePut(entry.completion, false);
-          if (entry.client_acked)
+          if (client_acked)
             post_ack_flush_failures_.fetch_add(1, std::memory_order_relaxed);
           DropLocked(s, batch[i].key);
           healthy_.store(false, std::memory_order_release);
           flush_dropped_.fetch_add(1, std::memory_order_relaxed);
+          // Publish every terminal side effect before waking PutCommitted()
+          // leaders and duplicate followers.
+          CompletePut(completion, false);
         }
       }
       s.flush_inflight -= B;


### PR DESCRIPTION
## Problem
Final-main CI run 33398128478 exposed a real completion-order race in `RamTier.InflightDuplicateSharesTerminalLeaderFailure`: both `PutCommitted` waiters could return `kIOError` before the terminal flush path published `healthy=false` and dropped the failed entry.

The failed assertion observed `rt.healthy()==true` after both waiters joined.

## Fix
Capture the shared completion, publish all terminal side effects under the shard lock, then wake leader/follower waiters with `CompletePut(false)`.

This preserves the contract that a completed terminal failure is fully visible when `PutCommitted` returns.

## Verification
- full `ram_tier_test`: 36/36 passed
- failing test repeated 100 times with `--gtest_break_on_failure`: 100/100 passed