### PR TITLE
feat(rdma): in-flight staged-lease PUT datapath (server receive memory tracks data, not connections)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Build (RDMA + tests)
         run: |
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDFKV_WITH_RDMA=ON
-          cmake --build build -j --target rdma_loopback_test
+          cmake --build build -j --target rdma_loopback_test rdma_lease_loopback_test rdma_lease_client_test
       # Probe-then-gate: blanket continue-on-error masked real assertion failures
       # for weeks (two broken tests stayed green). Instead, first check that rxe
       # can actually round-trip RC traffic with the simplest datapath case; only
@@ -222,17 +222,21 @@ jobs:
         id: rxe_probe
         run: |
           ulimit -l unlimited 2>/dev/null || true
-          if ./build/rdma_loopback_test --gtest_filter=RdmaLoopback.PutGetExistMissOverRdma; then
+          if ./build/rdma_loopback_test --gtest_filter=RdmaLoopback.PutGetExistMissOverRdma --gtest_output=xml:rdma-probe.xml \
+             && python3 -c 'import xml.etree.ElementTree as E; r=E.parse("rdma-probe.xml").getroot(); assert int(r.attrib["tests"]) == 1 and not list(r.iter("skipped")) and not list(r.iter("failure"))'; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::rxe loopback cannot round-trip RC traffic on this runner; datapath suite skipped"
+            echo "::warning::RDMA NOT EXERCISED: no successful non-skipped loopback probe; a real-HCA acceptance run is still required"
           fi
       - name: Run RDMA datapath test (hard gate when rxe works)
         if: steps.rxe_probe.outputs.ok == 'true'
         run: |
           ulimit -l unlimited 2>/dev/null || true
           ./build/rdma_loopback_test
+          ./build/rdma_lease_loopback_test --gtest_output=xml:lease.xml
+          ./build/rdma_lease_client_test --gtest_output=xml:lease-client.xml
+          python3 -c 'import xml.etree.ElementTree as E; roots=[E.parse(p).getroot() for p in ("lease.xml","lease-client.xml")]; assert all(int(r.attrib["tests"]) > 0 and not list(r.iter("skipped")) and not list(r.iter("failure")) for r in roots)'
       - name: Build + run RDMA datapath test under ThreadSanitizer (hard gate when rxe works)
         if: steps.rxe_probe.outputs.ok == 'true'
         run: |
@@ -240,9 +244,12 @@ jobs:
             -DCMAKE_CXX_FLAGS="-fsanitize=thread -g -O1" \
             -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread \
             -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=thread
-          cmake --build build-tsan -j --target rdma_loopback_test
+          cmake --build build-tsan -j --target rdma_loopback_test rdma_lease_loopback_test rdma_lease_client_test
           ulimit -l unlimited 2>/dev/null || true
           TSAN_OPTIONS=halt_on_error=1 ./build-tsan/rdma_loopback_test
+          TSAN_OPTIONS=halt_on_error=1 ./build-tsan/rdma_lease_loopback_test --gtest_output=xml:lease-tsan.xml
+          TSAN_OPTIONS=halt_on_error=1 ./build-tsan/rdma_lease_client_test --gtest_output=xml:lease-client-tsan.xml
+          python3 -c 'import xml.etree.ElementTree as E; roots=[E.parse(p).getroot() for p in ("lease-tsan.xml","lease-client-tsan.xml")]; assert all(int(r.attrib["tests"]) > 0 and not list(r.iter("skipped")) and not list(r.iter("failure")) for r in roots)'
 
   portable-static-build:
     name: portable static artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++ git ca-certificates \
-            libibverbs-dev rdma-core iproute2
+            libibverbs-dev liburing-dev rdma-core iproute2
       - name: Set up Soft-RoCE (rdma_rxe) over loopback
         run: |
           # rxe over 'lo' keeps packets in-host, so RC self-loopback actually
@@ -211,7 +211,7 @@ jobs:
           rdma link show || true
       - name: Build (RDMA + tests)
         run: |
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDFKV_WITH_RDMA=ON
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDFKV_WITH_RDMA=ON -DDFKV_WITH_URING=ON
           cmake --build build -j --target rdma_loopback_test rdma_lease_loopback_test rdma_lease_client_test
       # Probe-then-gate: blanket continue-on-error masked real assertion failures
       # for weeks (two broken tests stayed green). Instead, first check that rxe
@@ -234,22 +234,24 @@ jobs:
         run: |
           ulimit -l unlimited 2>/dev/null || true
           ./build/rdma_loopback_test
-          ./build/rdma_lease_loopback_test --gtest_output=xml:lease.xml
+          DFKV_SERVER_URING=0 ./build/rdma_lease_loopback_test --gtest_output=xml:lease-sync.xml
+          DFKV_SERVER_URING=1 ./build/rdma_lease_loopback_test --gtest_output=xml:lease-uring.xml
           ./build/rdma_lease_client_test --gtest_output=xml:lease-client.xml
-          python3 -c 'import xml.etree.ElementTree as E; roots=[E.parse(p).getroot() for p in ("lease.xml","lease-client.xml")]; assert all(int(r.attrib["tests"]) > 0 and not list(r.iter("skipped")) and not list(r.iter("failure")) for r in roots)'
+          python3 -c 'import xml.etree.ElementTree as E; roots=[E.parse(p).getroot() for p in ("lease-sync.xml","lease-uring.xml","lease-client.xml")]; assert all(int(r.attrib["tests"]) > 0 and not list(r.iter("skipped")) and not list(r.iter("failure")) for r in roots)'
       - name: Build + run RDMA datapath test under ThreadSanitizer (hard gate when rxe works)
         if: steps.rxe_probe.outputs.ok == 'true'
         run: |
-          cmake -S . -B build-tsan -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDFKV_WITH_RDMA=ON \
+          cmake -S . -B build-tsan -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDFKV_WITH_RDMA=ON -DDFKV_WITH_URING=ON \
             -DCMAKE_CXX_FLAGS="-fsanitize=thread -g -O1" \
             -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread \
             -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=thread
           cmake --build build-tsan -j --target rdma_loopback_test rdma_lease_loopback_test rdma_lease_client_test
           ulimit -l unlimited 2>/dev/null || true
           TSAN_OPTIONS=halt_on_error=1 ./build-tsan/rdma_loopback_test
-          TSAN_OPTIONS=halt_on_error=1 ./build-tsan/rdma_lease_loopback_test --gtest_output=xml:lease-tsan.xml
+          TSAN_OPTIONS=halt_on_error=1 DFKV_SERVER_URING=0 ./build-tsan/rdma_lease_loopback_test --gtest_output=xml:lease-sync-tsan.xml
+          TSAN_OPTIONS=halt_on_error=1 DFKV_SERVER_URING=1 ./build-tsan/rdma_lease_loopback_test --gtest_output=xml:lease-uring-tsan.xml
           TSAN_OPTIONS=halt_on_error=1 ./build-tsan/rdma_lease_client_test --gtest_output=xml:lease-client-tsan.xml
-          python3 -c 'import xml.etree.ElementTree as E; roots=[E.parse(p).getroot() for p in ("lease-tsan.xml","lease-client-tsan.xml")]; assert all(int(r.attrib["tests"]) > 0 and not list(r.iter("skipped")) and not list(r.iter("failure")) for r in roots)'
+          python3 -c 'import xml.etree.ElementTree as E; roots=[E.parse(p).getroot() for p in ("lease-sync-tsan.xml","lease-uring-tsan.xml","lease-client-tsan.xml")]; assert all(int(r.attrib["tests"]) > 0 and not list(r.iter("skipped")) and not list(r.iter("failure")) for r in roots)'
 
   portable-static-build:
     name: portable static artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+### Operation-scoped RDMA staging
+
+- Large scalar and scatter/gather PUTs negotiate exact operation-scoped
+  staging leases. Successful STORE revokes the remote MR before recycling
+  storage; failed connections keep storage until QP/MR teardown completes.
+- Direct scalar/SG GETs negotiate dynamic pull descriptors and explicitly
+  acknowledge release after local READ completions. Supported endpoints no
+  longer reserve a connection-lifetime pull arena.
+- `DFKV_RDMA_MAX_BLOCK_BYTES` remains the common PUT/GET object ceiling.
+  `DFKV_RDMA_INLINE_PUT_MAX_BYTES` defaults to 4 MiB (0 disables leased PUT);
+  `DFKV_RDMA_DYNAMIC_PULL` defaults to enabled (0 retains legacy pull).
+  Both capabilities are optional and negotiated before connection sizing.
+- Preserve mixed-batch invalid results and first-write-wins ordering; reuse
+  pooled legacy endpoints without repeated capability-probe/QP churn.
+  Insufficient GET capacity returns `kInvalid` without cooling a healthy peer.
+- Add delayed-DMA, MR/chunk reclamation, pressure, generation, old-peer and
+  posted-READ abandonment regressions. Hardware CI invokes the lease suites
+  in SYNC/io_uring and TSan modes and distinguishes skipped hardware probes.
+- Replace the in-process memory benchmark with an external-server client:
+  retain clients during idle sampling, record sampled server RSS/committed/
+  leased peaks, and validate every successful PUT with byte-exact GET.
+  Samples are not exact hardware high-water counters.
+
+### Hybrid inference cache correctness
+
+- Revalidate vLLM's length-dependent state mask after shortening a lookup
+  prefix, and reserve the sampling tail before lookup rather than truncating
+  an already validated hit.
+- Preserve each cache group's effective physical block coverage instead of
+  treating a small attention block as a whole scheduler-LCM region. Respect
+  nonpersistent scratch pools without forcing them into the hash geometry.
+- Store every TP-sharded recurrent checkpoint under its physical rank in the
+  `mamba` pool; retain attention replica striping without eliding required
+  state-shard clients. Old collapsed state keys and affected underfilled
+  heterogeneous layouts cold-miss after the identity correction; native wire,
+  raw payload and C ABI formats remain compatible.
+- Include the tested SGLang engine patch registering the missing DSA indexer
+  sidecar in hybrid Mamba stacks. Correct recurrent bytes alone do not make a
+  complete DSA cache; the indexer must survive the same fresh-process reload.
+
+
 ### SGLang Prefill-CP storage identity and physical rail affinity
 
 - Fixed SGLang DP-attention rail affinity to use the world-group node-local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@
   sidecar in hybrid Mamba stacks. Correct recurrent bytes alone do not make a
   complete DSA cache; the indexer must survive the same fresh-process reload.
 
+### GPUDirect load memory ordering
+
+- Fence device-direct GET completions with a post-batch device
+  synchronization so kernels launched after the load observe the RDMA BAR
+  writes; arming `CU_POINTER_ATTRIBUTE_SYNC_MEMOPS` at registration where the
+  driver accepts it (VMM/cuMemMap pools reject it with a one-shot warning).
+  Observed live as exact-hit loads whose generation degraded into empty
+  reasoning until reordered. `DFKV_GPU_LOAD_FENCE=0` disables the fence.
+
 
 ### SGLang Prefill-CP storage identity and physical rail affinity
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,13 @@ add_executable(dfkv_bench ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_bench_main.
 target_link_libraries(dfkv_bench PRIVATE dfkv_core)
 add_executable(dfkv_discover_smoke ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_discover_smoke_main.cc)
 target_link_libraries(dfkv_discover_smoke PRIVATE dfkv_core)
-add_executable(dfkvleasebench
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkvleasebench_main.cc)
-target_link_libraries(dfkvleasebench PRIVATE dfkv_core)
+if(DFKV_WITH_RDMA)
+  # In-process server+fan-out client memory benchmark; needs real verbs.
+  add_executable(dfkvleasebench
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkvleasebench_main.cc)
+  target_link_libraries(dfkvleasebench PRIVATE dfkv_core)
+  install(TARGETS dfkvleasebench RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 # Real-HW lockstep repro for the GPU rendezvous (needs CUDA devices at
 # runtime; builds everywhere — CUDA is dlopen'd).
@@ -113,7 +117,7 @@ target_link_libraries(dfkv_gpu_dedup_repro PRIVATE dfkv_core)
 
 include(GNUInstallDirs)
 install(TARGETS dfkv dfkv_server dfkv_mds dfkv_smoke dfkvctl dfkv_bench
-        dfkv_discover_smoke dfkv_gpu_dedup_repro dfkvleasebench dfkv_core
+        dfkv_discover_smoke dfkv_gpu_dedup_repro dfkv_core
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -166,6 +170,7 @@ if(DFKV_BUILD_TESTS)
   file(GLOB_RECURSE DFKV_TESTS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/test/*_test.cc)
   # rdma_loopback_test needs the RDMA transport/server symbols -> RDMA build only.
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
+  list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_lease_loopback_test.cc)
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_topology_test.cc)
   # Backend semantics have dedicated tests below. Keep unrelated functional
@@ -194,8 +199,14 @@ if(DFKV_BUILD_TESTS)
   endforeach()
   if(DFKV_WITH_RDMA)  # exercised in CI under Soft-RoCE (rdma_rxe); skips if no device
     add_executable(rdma_loopback_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
+    add_executable(rdma_lease_loopback_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_lease_loopback_test.cc)
     target_link_libraries(rdma_loopback_test PRIVATE dfkv_core GTest::gtest_main)
+    target_link_libraries(rdma_lease_loopback_test PRIVATE dfkv_core GTest::gtest_main)
     gtest_discover_tests(rdma_loopback_test PROPERTIES
+      RESOURCE_LOCK gpu_rdma_hw
+      ENVIRONMENT "${DFKV_UNIT_TEST_ENV}")
+    gtest_discover_tests(rdma_lease_loopback_test PROPERTIES
       RESOURCE_LOCK gpu_rdma_hw
       ENVIRONMENT "${DFKV_UNIT_TEST_ENV}")
     add_executable(qp_depth_negotiation_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ add_executable(dfkv_bench ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_bench_main.
 target_link_libraries(dfkv_bench PRIVATE dfkv_core)
 add_executable(dfkv_discover_smoke ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_discover_smoke_main.cc)
 target_link_libraries(dfkv_discover_smoke PRIVATE dfkv_core)
+add_executable(dfkvleasebench
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkvleasebench_main.cc)
+target_link_libraries(dfkvleasebench PRIVATE dfkv_core)
 
 # Real-HW lockstep repro for the GPU rendezvous (needs CUDA devices at
 # runtime; builds everywhere — CUDA is dlopen'd).
@@ -110,7 +113,7 @@ target_link_libraries(dfkv_gpu_dedup_repro PRIVATE dfkv_core)
 
 include(GNUInstallDirs)
 install(TARGETS dfkv dfkv_server dfkv_mds dfkv_smoke dfkvctl dfkv_bench
-        dfkv_discover_smoke dfkv_gpu_dedup_repro dfkv_core
+        dfkv_discover_smoke dfkv_gpu_dedup_repro dfkvleasebench dfkv_core
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(dfkv_bench ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_bench_main.
 target_link_libraries(dfkv_bench PRIVATE dfkv_core)
 add_executable(dfkv_discover_smoke ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_discover_smoke_main.cc)
 target_link_libraries(dfkv_discover_smoke PRIVATE dfkv_core)
+include(GNUInstallDirs)
 if(DFKV_WITH_RDMA)
   # In-process server+fan-out client memory benchmark; needs real verbs.
   add_executable(dfkvleasebench
@@ -115,7 +116,6 @@ endif()
 add_executable(dfkv_gpu_dedup_repro ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/dfkv_gpu_dedup_repro_main.cc)
 target_link_libraries(dfkv_gpu_dedup_repro PRIVATE dfkv_core)
 
-include(GNUInstallDirs)
 install(TARGETS dfkv dfkv_server dfkv_mds dfkv_smoke dfkvctl dfkv_bench
         dfkv_discover_smoke dfkv_gpu_dedup_repro dfkv_core
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -171,6 +171,7 @@ if(DFKV_BUILD_TESTS)
   # rdma_loopback_test needs the RDMA transport/server symbols -> RDMA build only.
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_lease_loopback_test.cc)
+  list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_lease_client_test.cc)
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)
   list(REMOVE_ITEM DFKV_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_topology_test.cc)
   # Backend semantics have dedicated tests below. Keep unrelated functional
@@ -201,12 +202,18 @@ if(DFKV_BUILD_TESTS)
     add_executable(rdma_loopback_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_loopback_test.cc)
     add_executable(rdma_lease_loopback_test
       ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_lease_loopback_test.cc)
+    add_executable(rdma_lease_client_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/rdma_lease_client_test.cc)
     target_link_libraries(rdma_loopback_test PRIVATE dfkv_core GTest::gtest_main)
     target_link_libraries(rdma_lease_loopback_test PRIVATE dfkv_core GTest::gtest_main)
+    target_link_libraries(rdma_lease_client_test PRIVATE dfkv_core GTest::gtest_main)
     gtest_discover_tests(rdma_loopback_test PROPERTIES
       RESOURCE_LOCK gpu_rdma_hw
       ENVIRONMENT "${DFKV_UNIT_TEST_ENV}")
     gtest_discover_tests(rdma_lease_loopback_test PROPERTIES
+      RESOURCE_LOCK gpu_rdma_hw
+      ENVIRONMENT "${DFKV_UNIT_TEST_ENV}")
+    gtest_discover_tests(rdma_lease_client_test PROPERTIES
       RESOURCE_LOCK gpu_rdma_hw
       ENVIRONMENT "${DFKV_UNIT_TEST_ENV}")
     add_executable(qp_depth_negotiation_test ${CMAKE_CURRENT_SOURCE_DIR}/test/transport/qp_depth_negotiation_test.cc)

--- a/deploy/observability/CONNECTOR-USAGE.md
+++ b/deploy/observability/CONNECTOR-USAGE.md
@@ -102,7 +102,7 @@ vllm serve <model> \
 ```
 
 vLLM supplies the exact runtime `model_name` and combines it with the
-source-controlled `vllm/raw-v1` namespace.
+source-controlled `vllm-multiwr-v3` namespace.
 
 ### 2.2 打开 telemetry
 **只认环境变量**(连接器内部 `configure({})`,**不会**去读 `kv_connector_extra_config`),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,7 +99,7 @@ block-token and layer geometry, group, and replicated topology sizes.
 Connector-specific shape/stride fields feed the deterministic 64-bit layout
 fingerprint.
 
-The source-controlled layout IDs are `sglang-hicache/raw-v1`, `vllm/raw-v1`,
+The source-controlled layout IDs are `sglang-hicache/raw-v1`, `vllm-multiwr-v3`,
 and `lmcache/raw-v1`. Model/revision strings are preserved verbatim. Operators
 cannot alias namespaces through configuration: an identity-bearing schema
 change requires code review and a layout-ID bump, which deliberately starts a
@@ -162,20 +162,31 @@ Production discovery uses MDS.
 ### 4.1 RDMA v2 resource and failure invariants
 
 - `RdmaServer::Start` commits one aligned receive chunk. Additional chunks are
-  committed on allocation misses up to `DFKV_RDMA_RECV_SEGMENT_SIZE`; only the
-  chunk leased by a connection is registered on that endpoint's rail.
-- `DFKV_RDMA_MAX_BLOCK_BYTES` is the logical object safety ceiling. Each data
-  connection advertises `next_power_of_two(max(actual operation bytes,
-  DFKV_RDMA_CONNECTION_MIN_BLOCK_BYTES))`, capped by that ceiling.
+  committed on allocation misses up to `DFKV_RDMA_RECV_SEGMENT_SIZE`.
+  Resident receive slots pin their chunk through endpoint lifetime; operation
+  leases use exact MRs rather than retaining growth-chunk MRs in endpoint caches.
+- `DFKV_RDMA_MAX_BLOCK_BYTES` remains the logical safety ceiling for every API.
+  Inline operations select a power-of-two resident class. Leased PUT excludes
+  oversized objects from that resident geometry; dynamic direct GET uses the
+  minimum class independently of its operation's logical capacity.
 - The client selects a second power-of-two class from the operation's requested
   window: scalar QPs open at depth 1, while batches reuse/open the smallest
   sufficient depth up to the client/server ceiling.
-- The server validates the block class, negotiates the depth class, and leases
-  that many receive plus pull slots from rail-affinitized chunks. Pull arenas
-  use type-2 Memory Windows over a shared chunk MR, with exact-MR fallback.
-- A data slot is `align4K(4096 + connection_class)`. The hard receive budget
-  covers worst-case live/pooled QPs; resident memory grows by chunk and empty
+- Optional PUT and dynamic-pull capabilities are negotiated before geometry
+  selection and cached by peer identity/publication. Legacy peers retain
+  receive plus pull slots and their 73-byte readiness frame. Dynamic peers
+  omit the resident pull arena and use the 33-byte retirement readiness frame.
+- A resident slot is `align4K(4096 + connection_class)`. Both resident slots
+  and transient PUT/GET leases consume the same process hard budget. Empty
   non-initial chunks return after `DFKV_RDMA_RECV_CHUNK_IDLE_MS`.
+- Successful PUT deregisters its exact remote-WRITE MR before recycling the
+  range. Dynamic GET publishes an exact READ MR and waits for an explicit
+  generation-checked RELEASE; the client sends RELEASE only after local READ
+  completions and waits for ACK before idling. Failed connections destroy the
+  QP and revoke MRs before RAII returns backing ranges and decrements gauges.
+- Numeric rkeys can be recycled by providers after fresh registration; they
+  are not permanent nonces. Correctness relies on completion/release ordering,
+  generation checks for control messages, and endpoint fencing on failures.
 - Client host/device pools are registered once per rail at declaration time.
   Re-declaring the same base with a larger size registers the larger extent; the
   registration call returns false/nonzero unless the full range is ready. Buffers

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -106,6 +106,16 @@ readiness 与连接级 arena。字符串 Range/RangeMany 保持已有 staged-WRI
 及 offset/length 语义。所有路径共用显式 `DFKV_RDMA_MAX_BLOCK_BYTES` 上限；
 不能用提高 inline 阈值绕过它。control response 上限仍为 32 KiB。
 
+**GPUDirect RDMA 内存顺序（所有 device-direct GET）**：RDMA 写入 GPU 显存
+的完成队列应答只证明“已发出”，不证明数据已抵达 GPU BAR；设计指南
+（Synchronization and Memory Ordering）明确要求在任何后续 CUDA kernel
+启动前完成排序，否则 kernel 可能读到旧数据——实测表现为：对象全命中、
+字节量全对，但生成退化成空转推理。注册期会尝试置
+`CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`（普通 cudaMalloc 分配可用；vLLM 的
+LBHNC/VMM `cuMemMap` 池会被驱动拒绝并告警一次），连接器在每次命中
+scatter 后执行设备同步作为排序栅栏；`DFKV_GPU_LOAD_FENCE=0` 可关闭
+栅栏，仅建议在确认无 GPUDirect 直载读路径时使用。
+
 **CUDA GET publication 要区分传输路径**：原生 RDMA scalar/SG GET 可直接 READ
 到调用方已注册的 CUDA buffer。READ 完成后才报告命中；失败会 fence QP/MR，
 防止返回后仍有 DMA，但不会撤销已完成的部分写入。调用方必须忽略 miss/error
@@ -500,7 +510,8 @@ sglang serve /models/glm-5.2-nvfp4 --served-model-name glm-5.2 \
   应在对应 SGLang 源码树先执行 `git apply --check`，再应用、重建或部署受控
   overlay。不要盲目覆盖其它引擎版本。启动池描述必须包含 `INDEXER`，并对原始
   长提示执行完整进程重启后的 L3 回载与答案校验；旧的缺 indexer 缓存不能视为
-  完整命中。本轮验收使用了这项引擎修复，不能声称未修改的混合引擎已通过。
+  上游 SGLang main（2026-09-08 核对）仍未在 `build_hybrid_mamba_stack` 注册
+  INDEXER，该补丁对当前上游同样适用，并非仅限旧镜像。
 - **identity/layout 必须协同发布。** namespace 使用 SGLang runtime 给出的精确
   `model_name` + `sglang-hicache/raw-v1`；同一模型的 pool/hash/并行坐标/component
   进入 canonical object key。dfkv value 只有 raw bytes，不会检查 page size、

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -87,6 +87,8 @@ tp_rank=..,ver=<lib>`（无 `role`——HiCache 是前缀 L3 缓存，无生产/
 | `DFKV_RDMA_DEPTH` | `4` ceiling | 两侧保持上限一致 | scalar QP=depth1；batch按实际window选择最小power-of-two depth class，再由server cap钳制。 |
 | `DFKV_RDMA_MAX_BLOCK_BYTES` | 4 MiB 逻辑上限 | 覆盖最大合法对象 | 只做 deterministic oversize guard；不再让所有连接按最大值预留。 |
 | `DFKV_RDMA_CONNECTION_MIN_BLOCK_BYTES` | 256 KiB | 覆盖常见小块，保持默认起步 | 当前操作最大对象按 power-of-two 向上取 connection class；idle pool 选最小可满足 QP。 |
+| `DFKV_RDMA_INLINE_PUT_MAX_BYTES` | 4 MiB | 保持默认 | 超阈 scalar/SG PUT 协商操作级 staging lease；`0` 或空值禁用。不会放宽 `MAX_BLOCK_BYTES` 的业务上限。 |
+| `DFKV_RDMA_DYNAMIC_PULL` | `1` | 保持默认 | 支持的新 peer 逐 GET 申请 pull lease，READ 完成后显式释放并等待 ACK；`0` 保留旧连接级 pull arena。 |
 | `DFKV_RDMA_RECV_SEGMENT_SIZE` | 128 GiB | 按 peak live/pooled QP 设 hard budget | server receive-pool 最大提交量；不再启动期全量申请。 |
 | `DFKV_RDMA_RECV_CHUNK_BYTES` | 256 MiB | 保持默认，除非常见 connection class 更大 | server 启动只提交一个 chunk，后续 allocation miss 按需增长，不超过 hard budget。 |
 | `DFKV_RDMA_RECV_CHUNK_IDLE_MS` | 60 s | 保持默认 | 空闲非初始chunk到期返还；`0`关闭。增长chunk绑定首次使用rail/NUMA。 |
@@ -95,25 +97,28 @@ tp_rank=..,ver=<lib>`（无 `role`——HiCache 是前缀 L3 缓存，无生产/
 | `DFKV_CUDA_PINNED_POOL_BYTES` | 64 MiB（67108864） | 按进程允许的 CUDA pinned host memory / memlock 设置 | vLLM CUDA GET publication 的进程级 bounce pool 预算。取正十进制字节数，最大 4 GiB；预算向下取整为完整 slot，且至少容纳一个 slot、最多 4096 个。非法或与 slot 不兼容的组合告警并回退整组默认值。slot 按需创建，因此实际 pinned high-water 不超过取整后的预算。 |
 | `DFKV_CUDA_PINNED_SLOT_BYTES` | 4 MiB（4194304） | 保持能容纳常见单块；不必按最大 payload 预分配 | 固定 publication slot 大小，取 4 KiB–64 MiB 的正十进制字节数。非法值告警并回退默认 sizing。大 payload 按 slot 大小分块发布，不要求一个 payload 对应一个 slot。 |
 
-**v2 数据面**：PUT 把 `[request prefix | raw payload]` 以
-`RDMA_WRITE_WITH_IMM` 直接写入 server 租出的 slot；GET 先用 SEND 提交
-`{addr,rkey,len}` 目标描述符，server 再以 RDMA WRITE 直接散射到调用方
-buffer，最后只 SEND 状态与 authoritative stored length。两向 block payload
-都不经过 control buffer。`kMembers` 在隔离的 control lane 上使用显式
-`18-byte prefix + 32-KiB data` 容量；边界值完整返回，更大响应失败而不截断。
+**当前协商数据面**：inline PUT 仍使用 `RDMA_WRITE_WITH_IMM`；
+超阈 PUT 在 `kLeasePut` 返回 exact-MR 描述符后，将完整对象写入操作级租约。
+直接 scalar/SG GET 使用 `kPullRange` 返回的地址/rkey 发起 RDMA READ，
+随后发送 `kPullRelease` 并等待 ACK，才将连接归入 idle pool。
+新 peer 的 bootstrap 不再发布常驻 pull arena；旧 peer 保持原 73-byte
+readiness 与连接级 arena。字符串 Range/RangeMany 保持已有 staged-WRITE
+及 offset/length 语义。所有路径共用显式 `DFKV_RDMA_MAX_BLOCK_BYTES` 上限；
+不能用提高 inline 阈值绕过它。control response 上限仍为 32 KiB。
 
-**CUDA GET publication**：RDMA 仍写入每次请求自有的 pageable retry
-staging，而不是直接写调用方 CUDA 地址。这样失败 rail 的部分写入不会污染调用方
-buffer；只有最终获胜的完整尝试才进入 publication。进程级 pool 对固定大小 slot
-进行独占租赁；无空闲 slot 且预算已用尽时调用会阻塞等待（backpressure），不会
-继续分配。每个 slot 首次按需创建时使用 portable CUDA pinned host allocation；
-若该分配路径不可用，则以对齐 host allocation 加 portable CUDA host registration
-作为回退。slot 在其生命周期内只分配并 pin/register 一次。publication 对每块先
-从 pageable staging 复制到当次 leased slot，再在保留调用线程 CUDA context 的前提下
-排入异步 H2D copy；该块 stream 同步完成后才归还 slot。大 payload 逐块重复
-lease/copy/sync/release 流程。因此 CUDA GET 仍是 staged H2D，而不是 direct
-GPUDirect GET：后者无法满足“失败重试不得改动 caller buffer”的 publication
-fence。PUT 的 GPUDirect 路径不变。
+**CUDA GET publication 要区分传输路径**：原生 RDMA scalar/SG GET 可直接 READ
+到调用方已注册的 CUDA buffer。READ 完成后才报告命中；失败会 fence QP/MR，
+防止返回后仍有 DMA，但不会撤销已完成的部分写入。调用方必须忽略 miss/error
+对应的整个对象，不能把失败目标当作有效缓存。
+
+使用 `DestinationPublisher` 的 staged 读取路径则先写入请求自有的 pageable
+staging，只在选定完整结果后发布到 CUDA 目标。publication 从进程级有界 pool
+独占租赁 pinned slot；预算耗尽时等待，而不是继续分配。slot 首次按需创建时
+使用 portable CUDA pinned host allocation；必要时采用对齐 host allocation
+加 portable CUDA host registration。每个 slot 只 pin/register 一次。publication
+先复制到 slot，再在保留调用线程 CUDA context 的前提下执行异步 H2D copy；
+stream 同步完成后才归还 slot。大 payload 分块重复此流程。这一 staged 路径的
+原子发布保证不能套用到上面的原生 GPUDirect READ。
 
 容器和进程的 pinned-memory / `RLIMIT_MEMLOCK` 必须覆盖 pool **实际按需分配的
 high-water**（上限是向 slot 取整后的 pool budget），还要为进程内其他 locked
@@ -136,12 +141,27 @@ connection_class =
 depth_class = min(server_depth,
                   next_power_of_two(max(actual_window, 1)))
 S_data = align4K(4096 + connection_class)
-B_connection = 2 × depth_class × S_data
+B_connection_legacy = 2 × depth_class × S_data
+B_connection_dynamic = depth_class × S_data
 ```
 
 同一 peer/rail 的 idle pool 选择最小可满足 class；没有才建新 QP。pool 满时，
 较小返回连接可替换最大的 idle QP。偶发大对象因此只放大自己的连接，不放大所有
 rank/process 的常驻连接。
+
+动态 GET 的连接只需要 minimum-class resident receive slot；直接 GET 的
+数据缓冲按请求容量从 server receive pool 申请。超阈 PUT 的 resident class
+只需覆盖当前批次的 inline 部分。两类操作级租约也占用同一个 hard budget。
+MR 为 exact operation region：成功路径先注销再还内存；异常路径先销毁
+QP/MR，再由 RAII 归还区间。数值 rkey 可能被 provider 在新授权中复用，
+不是永久唯一 nonce；release generation 防止控制消息误释放新租约。
+
+滚动升级推荐 server-first；新 client 连接旧 server 时保留旧 wire 和连接池
+复用，不要求同步切换所有客户端。RDMA 能力升级不改变 raw value、slab 或
+原生 namespace/key codec；本版 vLLM 混合模型修复另有下述缓存身份切换，不能
+把 wire 兼容等同于所有旧 Python 缓存对象仍可复用。
+`DFKV_RDMA_DYNAMIC_PULL=0` 与 `DFKV_RDMA_INLINE_PUT_MAX_BYTES=0` 可分别
+关闭两项可选能力，不能替代真实旧版本混跑验收。
 
 server receive pool 以 `DFKV_RDMA_RECV_CHUNK_BYTES` 惰性提交，累计不超过
 `DFKV_RDMA_RECV_SEGMENT_SIZE`。预算仍按所有 rank/process 的 peak live +
@@ -225,7 +245,7 @@ connector-produced binary namespace bytes, batch concurrency, and optional
 client registration identity. Unknown flags/version/short structs fail closed.
 There are no post-open membership mutators, operator namespace aliases, or
 geometry parameters. The namespace binds the exact runtime model identity and
-connector raw-layout ID (`sglang-hicache/raw-v1`, `vllm/raw-v1`,
+connector raw-layout ID (`sglang-hicache/raw-v1`, `vllm-multiwr-v3`,
 `lmcache/raw-v1`). 可调字段只有 `tenant_id`（默认 `default`）与
 `model_revision`（默认取 model identity），走各连接器的 extra_config/config 键
 （§2.2 / §3.4 / §4.5）——多租户隔离或模型版本滚动时显式分开
@@ -467,6 +487,20 @@ sglang serve /models/glm-5.2-nvfp4 --served-model-name glm-5.2 \
 - **多池模型**（Mamba/SWA/DeepSeek-V4）用 v2 PoolTransfer 接口（插件已实现）。
   DSA/DeepSeekV4 主 `kv` 池是无数据的 LogicalHostPool（`get_page_buffer_meta→None`），
   插件对其 `batch_set_v1` 写空 marker 锚定命中前缀、`batch_get_v1` no-op，真实 KV 走 v2 侧池。
+- **Mamba＋DSA 混合模型必须同时注册 `KV`、`MAMBA`、`INDEXER`。**
+  只恢复 latent 与 recurrent state、遗漏历史 indexer 数据，会出现“所有已请求
+  对象均命中，但长提示答案错误”；不能通过增加生成长度或把命中计数当作正确性
+  来跳过检查。SGLang 的普通 DSA 路径正确注册 sidecar，不代表混合路径也已注册。
+  对尚缺该接线的引擎，随包提供
+  [混合 DSA indexer 修复补丁](../integration/hicache/patches/sglang-hybrid-mamba-dsa-indexer.patch)。
+  它修复引擎的 host-pool entry 与 `SidecarPoolSpec` 两处声明，不改变 dfkv
+  value/wire 格式。补丁的实测源文件是
+  `python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py`，
+  原始 SHA256 为 `48456e7ce2cf20f839d100333404c90ba1d65b370a7f8265e9bc044ec18c2216`；
+  应在对应 SGLang 源码树先执行 `git apply --check`，再应用、重建或部署受控
+  overlay。不要盲目覆盖其它引擎版本。启动池描述必须包含 `INDEXER`，并对原始
+  长提示执行完整进程重启后的 L3 回载与答案校验；旧的缺 indexer 缓存不能视为
+  完整命中。本轮验收使用了这项引擎修复，不能声称未修改的混合引擎已通过。
 - **identity/layout 必须协同发布。** namespace 使用 SGLang runtime 给出的精确
   `model_name` + `sglang-hicache/raw-v1`；同一模型的 pool/hash/并行坐标/component
   进入 canonical object key。dfkv value 只有 raw bytes，不会检查 page size、
@@ -684,7 +718,7 @@ vllm serve <model> \
 ```
 
 `model_name` 取 vLLM 的精确 `model_config.model`（即上面的 `<model>`），不是
-extra-config 键。namespace 始终绑定该 model identity 与 `vllm/raw-v1`；没有可配置
+extra-config 键。namespace 始终绑定该 model identity 与 `vllm-multiwr-v3`；没有可配置
 的 namespace alias。
 
 **备选（单节点/简单部署）：静态成员表** —— 无 MDS 时改用 `members`，节点增减需重启：
@@ -744,6 +778,43 @@ lsmod | grep nvidia_peermem
 功能验收不能只测同进程第二次请求：必须写入长 prompt，**重启整个 engine
 进程**后重复相同 prompt，确认 key 存在、cached tokens 接近完整 prompt，
 且 `dfkv_rdma_completion_errors_total` 无增量。
+
+#### 混合模型的存储完整性与升级边界
+
+- 每个持久化 group 保留自己的有效 block size；attention 按引擎的 DCP
+  规则换算逻辑覆盖，Mamba 状态不乘 DCP。scheduler LCM 只约束请求边界，
+  不能把一块较小的物理 attention 数据冒充整个 LCM 区间。
+- 明确 `participates_in_prefix_caching=False` 的 scratch pool 不生成缓存对象，
+  不约束 hash 粒度，也不会在回载时覆盖新请求的 scratch buffer。
+- Mamba/KDA 使用独立 `mamba` pool 和物理 TP rank，所有状态分片都必须存在。
+  MLA latent 的复制语义不能用于 recurrent state；混合模型不能通过客户端
+  收敛或 elision 丢弃状态分片。复制型 attention 保持原来的 writer striping。
+- lookup 缩短候选前缀后，必须重验该边界的 state mask。采样保留尾部在 lookup
+  前处理，不能在验证后再次把命中长度截短为另一个未经验证的 checkpoint。
+- 本版使用新的 `vllm-multiwr-v3` raw-layout ID，统一隔离可能欠填充或丢失 TP
+  分片的旧对象；不双读、不双写、不保留旧格式 alias。所有 vLLM Python
+  writer/reader 应协同升级并接受一次冷缓存。原生 C ABI、slab 和 RDMA wire
+  仍兼容；这不代表旧 Python payload layout 可以继续解码。
+- 引擎可能把一个逻辑 block 降为多个 kernel tile；注册时必须按 allocator 的
+  逻辑 block 数折叠物理 tile 轴，完整收集每个逻辑 block 的所有 bytes，不能
+  直接把逻辑 block ID 用作 kernel-tile 索引。
+
+
+#### 混合模型的 KV 加载故障恢复
+
+- vLLM 上游 `_handle_invalid_blocks` 的 `(req_block_ids,) = ...` 解包在多 KV-group
+  模型上必然抛 `ValueError`，导致 EngineCore 死亡。随包提供
+  [混合 invalid-blocks 修复补丁](../integration/vllm/patches/vllm-hybrid-invalid-blocks.patch)：
+  hybrid 请求按 per-group 外层 spec（AttentionSpec 乘 DCP）计算受影响前缀，
+  命中失败时使所有参与 group 的相关 block hash 失效（仅 hash，不释放 DMA 中
+  buffer），`skip_reading_prefix_cache=True` 后复用 `_preempt_request` 回到
+  waiting 队列本地重算；async 请求在 finished_recving 之后由既有
+  `_update_waiting_for_remote_kv` 释放。单 group 请求保留原最长有效前缀与
+  共享 block 优化。fail 策略仅上报受影响请求与 eviction 集合，不做重放。
+  dfkv 调度器同步配合：重放请求查询前丢弃残余 lookup/load_spec 并返回
+  `(0, False)`，不会反复撞同一外部缓存。补丁针对实测镜像
+  `vllm/vllm-openai:glm53-flash` 的 `vllm/v1/core/sched/scheduler.py`，应用前先
+  `git apply --check`；不可盲目覆盖其它引擎版本。
 
 ### 3.2 验证
 
@@ -1389,7 +1460,7 @@ prompt ≈4 GB KV」的 TTFT）：
 control plane；不同模型和 runtime 共用节点与 LRU，不等于共用 cache identity。
 
 默认自动 namespace 同时包含精确 runtime model identity 和 connector layout ID：
-`sglang-hicache/raw-v1`、`vllm/raw-v1` 或 `lmcache/raw-v1`。因此同名模型在不同
+`sglang-hicache/raw-v1`、`vllm-multiwr-v3` 或 `lmcache/raw-v1`。因此同名模型在不同
 runtime 默认也隔离。object key 再编码 pool、完整内容 hash、DP/TP/PCP/DCP/PP
 坐标、cache group、component 和可选 binary SG 坐标。
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -16,7 +16,7 @@ v1.35 two-sided 数据面实测，v2 one-sided 需重测）。
 dfkv 把**控制面**与**数据面**解耦：
 
 - **控制面 = TCP + 两边 SEND/RECV**：bootstrap TCP 只交换设备/QP/receive-segment 描述；RDMA QP 的 request descriptor 有界，response buffer 显式预留 `18-byte prefix + 32 KiB`，使 32-KiB `Members` 在 control lane 完整返回；更大响应直接失败、不截断。
-- **payload = one-sided RDMA**：v2 PUT 用 `RDMA_WRITE_WITH_IMM` 直落 server 共享 receive-segment slot，GET 由 server `RDMA_WRITE` 到 client 提交的 `{addr,rkey,len}`。数据 fabric 无需 IP。
+- **payload = one-sided RDMA**：inline PUT 用 `RDMA_WRITE_WITH_IMM`；大对象通过操作级 lease 接收。直接 GET 由 client RDMA READ 拉取，支持动态 pull 的新 peer 不再保留连接级 pull arena。两项能力均独立协商，旧 peer 保留原数据面。数据 fabric 无需 IP。
 - **设备发现与拓扑**：留空时自动发现保持 `ACTIVE`-only（两端各选本地首个 port 1 `ACTIVE` HCA）；显式逗号白名单定义固定 topology，按首次出现顺序去重，server 会接纳**存在但启动时 DOWN** 的设备完成 anchor/MR 初始化并持续监控。运行期至少一条 initialized rail 健康即可承载 placement；最后一条健康 rail 丢失立即退环，0→非 0 恢复仍通过连续采样门。
 - **失败策略**：未设 `DFKV_RDMA` 时选择 TCP；一旦选择 RDMA，显式设备缺失、open/port/GID query 失败，或任一 configured rail 的 anchor、共享 receive-segment MR、RAM/user MR 初始化失败，均拒绝启动而不缩小 topology。client 配置 `DFKV_RDMA_RAIL_TIERS` 后还要求 MDS 返回完整 HLT1 peer topology；缺失/不完整或无兼容健康轨以 client-local `kNoCompatibleRail` fail closed，不切 TCP、不惩罚 peer。
 
@@ -362,11 +362,12 @@ journalctl -u dfkv -n 10 --no-pager
 > `kNoCompatibleRail` 均不增加 local rail error。cooldown 到期仍只准入一个真实
 > recovery probe。
 >
-> **v2 receive-pool 预算**：每条data QP按实际block/depth二维class计算
-> `slot=align4K(4096 + block_class)`，pull-read lease为
-> `2 × depth_class × slot`。`DFKV_RDMA_RECV_SEGMENT_SIZE`是hard budget，
-> `_CHUNK_BYTES`是惰性提交粒度，`_CHUNK_IDLE_MS`控制空chunk返还。
-> 上线看committed/max/chunks、used/free、growth/shrink/failure和MW/fallback。
+> **receive-pool 预算**：`slot=align4K(4096 + block_class)`。
+> 旧 peer 的 resident lease 是 `2 × depth_class × slot`；动态 pull peer
+> 只保留 `depth_class × slot` 的 receive slots，直接 GET 使用 minimum class。
+> 在飞 PUT/GET 租约也计入 `DFKV_RDMA_RECV_SEGMENT_SIZE` hard budget。
+> 上线同时观察 committed/used/真实 RSS 与动态租约归还；不能把操作结束后的
+> used_bytes 当作整个运行过程的峰值或 pinned memory。
 
 ### 3a. 每节点 tenant quota
 
@@ -467,6 +468,8 @@ flag 为 env facade）；未列 flag 的全部 env 均从源码排查就不误�
 | `DFKV_RDMA_RECV_CHUNK_BYTES` | `256 MiB` | server 启动与增量提交粒度 |
 | `DFKV_RDMA_RECV_CHUNK_IDLE_MS` | `60000` | 空闲非初始chunk返还延迟；`0`关闭缩容 |
 | `DFKV_RDMA_CONNECTION_MIN_BLOCK_BYTES` | `256 KiB` | client adaptive data-QP 最小 class；实际对象向上取 power-of-two |
+| `DFKV_RDMA_INLINE_PUT_MAX_BYTES` | `4 MiB` | client 超阈 PUT 使用操作级 lease；`0`/空值禁用，不改变业务对象上限 |
+| `DFKV_RDMA_DYNAMIC_PULL` | `1` | client 协商动态 direct GET 与显式 release ACK；`0`保留旧 pull arena |
 | `DFKV_RDMA_CONNECT_MS` | — | client：IB QP 建连超时 |
 | `DFKV_RDMA_IO_MS` | — | client：控制面帧读写超时 |
 | `DFKV_RDMA_BATCH_OP_TIMEOUT_MS` | 0=跟随 RDMA_OP | client：multi-item Cache/Range/Exist、SG 窗口总期限 |

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -45,6 +45,7 @@ from dfkv_metrics import Metrics as _Metrics, ClientStatsPoller as _ClientStatsP
 from dfkv_telemetry import metrics as _push_metrics, config as _tcfg
 from dfkv_telemetry import tracing as _tracing
 
+
 # The module carries no logger of its own historically (observability rides the
 # access log / tracing spans). One is added here for the read-reject diagnostic,
 # which must land in the ENGINE log next to SGLang's "0 pages verified across

--- a/integration/hicache/dfkv_hicache.py
+++ b/integration/hicache/dfkv_hicache.py
@@ -52,6 +52,25 @@ from dfkv_telemetry import tracing as _tracing
 # ranks" line to be readable as a pair.
 _log = logging.getLogger(__name__)
 
+
+def _gpu_load_fence() -> None:
+    """Order GPUDirect RDMA writes before subsequent CUDA kernels.
+
+    The GPUDirect RDMA design guide (Synchronization and Memory Ordering)
+    requires that writes landing via the GPU BAR complete before the CPU
+    thread returns to launch dependent kernels; a completion reaped from the
+    CQ proves transmission, not arrival in device memory. Drivers reject
+    CU_POINTER_ATTRIBUTE_SYNC_MEMOPS on VMM/cuMemMap pools (vLLM LBHNC), so
+    the connector issues a device synchronization as the ordering fence
+    after any hit scatter. Disable with DFKV_GPU_LOAD_FENCE=0.
+    """
+    if os.environ.get("DFKV_GPU_LOAD_FENCE", "1") != "1":
+        return
+    import torch
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
 _FLAG_IS_MLA = 0x1
 
 # Historical/default width: ConnectX-era max_sge=30 and SGE[0] carries the wire
@@ -1514,7 +1533,9 @@ class DfkvHiCache(HiCacheStorage):
             self._h, karr, klens, parr, carr, narr, n, out_hit, out_len)
         if rc != 0:
             return [0] * n, [0] * n
-        del key_owners
+        del inner_p; del inner_c; del parr; del carr; del narr
+        if any(h == 1 for h in out_hit):
+            _gpu_load_fence()
         return [out_hit[i] for i in range(n)], [int(out_len[i]) for i in range(n)]
 
     def batch_get_v1_device(self, keys, device_indices, extra_info=None) -> List[bool]:

--- a/integration/hicache/patches/sglang-hybrid-mamba-dsa-indexer.patch
+++ b/integration/hicache/patches/sglang-hybrid-mamba-dsa-indexer.patch
@@ -1,0 +1,60 @@
+--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
++++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+@@ -695,6 +695,8 @@
+     storage_backend_extra_config: Optional[dict] = None,
+     enable_storage_metrics: bool = False,
+ ) -> tuple[HostPoolGroup, HybridCacheController]:
++    from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
++
+     transfer_layer_num = len(full_layer_mapping | mamba_layer_mapping)
+     mamba_allocator = params.req_to_token_pool.mamba_allocator
+     mtp_draft_device_pools = tuple(
+@@ -748,6 +750,24 @@
+             device_free_fn=mamba_allocator.free,
+         ),
+     ]
++    if isinstance(kv_pool, DSATokenToKVPool) and kv_pool.index_k_with_scale_buffer:
++        # Hybrid attention still needs its DSA selection keys after a cache
++        # restore; recovering the latent and recurrent state alone is unsafe.
++        indexer_host_pool = DSAIndexerPoolHost(
++            kv_pool,
++            kv_host_pool,
++            get_memory().hicache_mem_layout,
++            allocator_type=_get_allocator_type(server_args),
++        )
++        entries.append(
++            build_pool_entry(
++                name=PoolName.INDEXER,
++                host_pool=indexer_host_pool,
++                device_pool=kv_pool,
++                layer_mapping=full_layer_mapping,
++                transfer_layer_num=transfer_layer_num + len(mtp_draft_device_pools),
++            )
++        )
+     host_pool_group = HostPoolGroup(entries)
+     cache_controller = HybridCacheController(
+         params.token_to_kv_pool_allocator,
+@@ -1311,6 +1331,11 @@
+             storage_backend_extra_config=storage_backend_extra_config,
+             enable_storage_metrics=enable_storage_metrics,
+         )
++        sidecars = (
++            [SidecarPoolSpec(pool_name=PoolName.INDEXER, indices_from_pool=PoolName.KV)]
++            if PoolName.INDEXER in host_pool_group.entry_map
++            else []
++        )
+         return StackBuildResult(
+             host_pool_group=host_pool_group,
+             cache_controller=cache_controller,
+@@ -1318,9 +1343,10 @@
+                 ComponentType.FULL: host_pool_group.get_pool(PoolName.KV),
+                 ComponentType.MAMBA: host_pool_group.get_pool(PoolName.MAMBA),
+             },
++            sidecars=sidecars,
+             register_req_to_token_counter=True,
+             transfer_layer_num=len(full_layer_mapping | mamba_layer_mapping),
+-            pools_desc="KV + MAMBA",
++            pools_desc="KV + MAMBA + INDEXER" if sidecars else "KV + MAMBA",
+         )
+ 
+ 

--- a/integration/vllm/README.md
+++ b/integration/vllm/README.md
@@ -233,12 +233,12 @@ contains before/after metric evidence.
 
 `model_name` is the exact vLLM `model_config.model`, not an extra-config key.
 The binary namespace and every object key bind it to the source-controlled
-`vllm-multiwr-v2` storage-layout ID; operator-supplied aliases are rejected.
+`vllm-multiwr-v3` storage-layout ID; operator-supplied aliases are rejected.
 
 Object keys are self-delimiting binary bytes: `DFKVPOOL\x02`, uint32-LE
 length-framed pool and full page hash, fixed `(uint32 size, int32 rank)` pairs
 for DP/TP/PCP/DCP/PP, uint32 KV-cache group, and the length-framed
-`vllm-multiwr-v2` component. There is exactly one key per logical chunk,
+`vllm-multiwr-v3` component. There is exactly one key per logical chunk,
 independent of its GPU segment count or the negotiated HCA `max_sge`. Every
 native operation receives a pointer plus its exact uint64 length (parallel
 pointer/length arrays for batch and SG); no C-string, decode/re-encode,
@@ -250,11 +250,15 @@ envelope. A read is accepted only when the object hits and its returned length
 exactly equals the complete destination-vector capacity; otherwise that logical
 chunk is failed closed and recomputed.
 
-`multiwr-v2` is a clean cutover from the former `sg-v1` physical-key layout.
-Old objects are cold misses by namespace/key identity: readers do not probe,
-assemble, or clean up v1 scatter-group siblings. Roll producers and consumers
-together; expect a cold external cache after rollout. Do not mix connector
-versions in one deployment.
+`multiwr-v3` is a clean cutover from `multiwr-v2` and `sg-v1`. Earlier
+payloads can contain only one physical kernel tile for an entire logical
+block or an incomplete set of TP state shards; those objects cannot be
+safely reused. Writers now gather every kernel tile belonging to a logical
+block, and Mamba state uses the `mamba` pool with physical TP coordinates.
+Old objects cold-miss by namespace/key identity; there is no legacy read,
+dual write, alias, or sibling cleanup. Roll Python producers and consumers
+together and expect a cold external cache. Native C ABI and server protocol
+compatibility are separate from this corrected Python raw-layout identity.
 
 Different namespace/key bytes are a cold miss. The same namespace+key with a
 different dtype, page/block size, shape, layer order, or KV memory layout is a

--- a/integration/vllm/patches/vllm-hybrid-invalid-blocks.patch
+++ b/integration/vllm/patches/vllm-hybrid-invalid-blocks.patch
@@ -1,0 +1,62 @@
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -2839,7 +2839,58 @@
+             req_num_computed_tokens = (
+                 request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
+             )
+-            # TODO (davidb): add support for hybrid memory allocator
++            if len(group_block_ids) > 1:
++                req_num_computed_tokens = max(0, req_num_computed_tokens)
++                dependent_groups = []
++                for block_ids, group in zip(
++                    group_block_ids,
++                    self.kv_cache_config.kv_cache_groups,
++                    strict=True,
++                ):
++                    spec = group.kv_cache_spec
++                    if not spec.participates_in_prefix_caching:
++                        continue
++                    # Match the engine's outer-spec DCP coverage rule.
++                    block_size = spec.block_size
++                    if isinstance(spec, AttentionSpec):
++                        block_size *= self.dcp_world_size
++                    dependent_groups.append(block_ids)
++                    num_computed_blocks = (
++                        req_num_computed_tokens + block_size - 1
++                    ) // block_size
++                    if any(
++                        block_id in invalid_block_ids
++                        for _, block_id in zip(range(num_computed_blocks), block_ids)
++                    ):
++                        is_affected = True
++
++                if not is_affected:
++                    continue
++                affected_req_ids.add(req_id)
++                total_affected_tokens += req_num_computed_tokens
++                # A failed group invalidates all dependent group states, not
++                # just the failed group's suffix. evict_blocks removes hashes
++                # only: it must not return DMA-owned buffers to the pool.
++                dependent_block_ids = {
++                    block_id for block_ids in dependent_groups for block_id in block_ids
++                }
++                if evict_blocks:
++                    blocks_to_evict.update(dependent_block_ids)
++                if self.recompute_kv_load_failures:
++                    self.kv_cache_manager.evict_blocks(dependent_block_ids)
++                    request.skip_reading_prefix_cache = True
++                    if request.status == RequestStatus.RUNNING:
++                        self.running.remove(request)
++                        self._preempt_request(
++                            request, time.monotonic(), drop_stale_output=True
++                        )
++                    else:
++                        assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
++                        # Keep async receive buffers until finished_recving;
++                        # _update_waiting_for_remote_kv then frees all groups.
++                        request.num_computed_tokens = 0
++                continue
++
+             (req_block_ids,) = group_block_ids
+ 
+             req_num_computed_blocks = (

--- a/integration/vllm/src/dfkv_vllm/__init__.py
+++ b/integration/vllm/src/dfkv_vllm/__init__.py
@@ -9,7 +9,7 @@
         "lib":"/path/to/libdfkv.so"}}'
 
 The exact model identity comes from vLLM and is bound to the source-controlled
-``vllm/raw-v1`` layout ID; operator namespace aliases are rejected.
+``vllm-multiwr-v3`` layout ID; operator namespace aliases are rejected.
 """
 from .dfkv_client import DfkvDeviceClient
 

--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -44,7 +44,7 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
-from .data import DfkvStoreConnectorMetadata, VLLM_MULTIWR_V2
+from .data import DfkvStoreConnectorMetadata, VLLM_RAW_LAYOUT
 from .metrics import DfkvStoreConnectorStats, DfkvStorePromMetrics
 from .scheduler import DfkvStoreScheduler
 from .worker import DfkvStoreWorker
@@ -89,7 +89,7 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
     """KV connector using DfkvDistributedStore as shared KV pool."""
 
     # Wire/storage schema, intentionally not operator-configurable.
-    storage_layout_id = VLLM_MULTIWR_V2
+    storage_layout_id = VLLM_RAW_LAYOUT
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:

--- a/integration/vllm/src/dfkv_vllm/coordinator.py
+++ b/integration/vllm/src/dfkv_vllm/coordinator.py
@@ -89,7 +89,9 @@ class DfkvStoreCoordinator:
         use_eagle: bool = False,
     ) -> None:
         assert all(
-            g.kv_cache_spec.block_size % hash_block_size == 0 for g in kv_cache_groups
+            g.kv_cache_spec.block_size % hash_block_size == 0
+            for g in kv_cache_groups
+            if getattr(_unwrap_spec(g.kv_cache_spec), "participates_in_prefix_caching", True)
         ), "block_size must be divisible by hash_block_size"
         assert scheduler_block_size % hash_block_size == 0, (
             f"scheduler_block_size ({scheduler_block_size}) must be a multiple of "
@@ -114,6 +116,8 @@ class DfkvStoreCoordinator:
         ] = []
         for i, g in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(g.kv_cache_spec)
+            if not getattr(spec, "participates_in_prefix_caching", True):
+                continue
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None, (
                 f"No manager registered for KVCacheSpec {spec}"

--- a/integration/vllm/src/dfkv_vllm/coordinator.py
+++ b/integration/vllm/src/dfkv_vllm/coordinator.py
@@ -77,10 +77,18 @@ class ExternalCachedBlockPool:
         return None
 
 
+def _prefix_cacheable(spec):
+    """Older engines name this participates_in_prefix_caching."""
+    for name in ("prefix_cacheable", "participates_in_prefix_caching"):
+        value = getattr(spec, name, None)
+        if value is not None:
+            return bool(value)
+    return True
+
+
 class DfkvStoreCoordinator:
     """Mirror of ``HybridKVCacheCoordinator.find_longest_cache_hit`` over an
     ``ExternalCachedBlockPool``."""
-
     def __init__(
         self,
         kv_cache_groups: list[KVCacheGroupSpec],
@@ -88,11 +96,20 @@ class DfkvStoreCoordinator:
         hash_block_size: int,
         use_eagle: bool = False,
     ) -> None:
-        assert all(
-            g.kv_cache_spec.block_size % hash_block_size == 0
+
+        participating = [
+            (_prefix_cacheable(g.kv_cache_spec), g.kv_cache_spec.block_size)
             for g in kv_cache_groups
-            if getattr(_unwrap_spec(g.kv_cache_spec), "participates_in_prefix_caching", True)
-        ), "block_size must be divisible by hash_block_size"
+        ]
+        assert all(
+            size % hash_block_size == 0
+            for participates, size in participating
+            if participates
+        ), (
+            f"block_size must be divisible by hash_block_size "
+            f"(hash={hash_block_size}, scheduler={scheduler_block_size}, "
+            f"groups={participating})"
+        )
         assert scheduler_block_size % hash_block_size == 0, (
             f"scheduler_block_size ({scheduler_block_size}) must be a multiple of "
             f"hash_block_size ({hash_block_size})"
@@ -116,7 +133,7 @@ class DfkvStoreCoordinator:
         ] = []
         for i, g in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(g.kv_cache_spec)
-            if not getattr(spec, "participates_in_prefix_caching", True):
+            if not _prefix_cacheable(g.kv_cache_spec):
                 continue
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None, (

--- a/integration/vllm/src/dfkv_vllm/data.py
+++ b/integration/vllm/src/dfkv_vllm/data.py
@@ -26,10 +26,10 @@ from vllm.v1.core.kv_cache_utils import (
 
 logger = init_logger(__name__)
 
-# Source-controlled object-layout discriminator. It is framed into every pool
-# key and also binds the native namespace, so sg-v1 and multiwr-v2 objects can
-# never collide or be read through a compatibility fallback.
-VLLM_MULTIWR_V2 = b"vllm-multiwr-v2"
+# Bind complete logical-block payloads and per-TP state to a new identity.
+# Older layouts may contain only one kernel tile for a whole logical block;
+# they must cold-miss, never be decoded through a compatibility fallback.
+VLLM_RAW_LAYOUT = b"vllm-multiwr-v3"
 
 def key_diagnostic_label(key: bytes) -> str:
     """Return the standard non-reversible diagnostic label for a store key."""
@@ -45,12 +45,13 @@ def split_block_contiguous_runs(
     shape: Sequence[int],
     strides: Sequence[int],
     element_size: int,
+    logical_blocks: int | None = None,
 ) -> tuple[int, list[tuple[int, int]]]:
     """Return ``(block_stride, [(offset, size), ...])`` in bytes.
 
-    Dimension 0 indexes KV blocks. Expand padded or transposed in-block
-    dimensions into deterministic contiguous runs; overlapping views fail
-    closed instead of transferring the whole block stride.
+    Dimension 0 indexes kernel blocks. If their count is a multiple of the
+    allocator's logical block count, fold those kernel tiles into each logical
+    block before deriving runs. Padded/transposed dimensions remain explicit.
     """
     if len(shape) != len(strides) or not shape:
         raise ValueError("shape and strides must have the same non-zero rank")
@@ -58,6 +59,16 @@ def split_block_contiguous_runs(
         raise ValueError("shape dimensions and element_size must be positive")
     if any(int(s) < 0 for s in strides):
         raise ValueError("negative KV-cache strides are not supported")
+    if logical_blocks is not None:
+        if logical_blocks <= 0 or int(shape[0]) % logical_blocks:
+            raise ValueError(
+                f"kernel block count {shape[0]} does not divide into "
+                f"{logical_blocks} logical blocks"
+            )
+        tiles = int(shape[0]) // logical_blocks
+        if tiles != 1:
+            shape = (logical_blocks, tiles, *shape[1:])
+            strides = (int(strides[0]) * tiles, int(strides[0]), *strides[1:])
 
     block_stride = int(strides[0]) * element_size
     if block_stride <= 0:
@@ -143,6 +154,7 @@ class KeyMetadata:
     pp_size: int
     pp_rank: int
     group_id: int = 0
+    pool_name: str = "kv"
 
 
 @dataclass(order=True)
@@ -167,6 +179,7 @@ class PoolKey:
                 self.key_metadata.pp_size,
                 self.key_metadata.pp_rank,
                 self.key_metadata.group_id,
+                self.key_metadata.pool_name,
                 self.chunk_hash,
             )
         )
@@ -174,7 +187,7 @@ class PoolKey:
     def to_bytes(self) -> bytes:
         return pool_key(
             self.chunk_hash,
-            pool="kv",
+            pool=self.key_metadata.pool_name,
             dp_size=self.key_metadata.dp_size,
             dp_rank=self.key_metadata.dp_rank,
             tp_size=self.key_metadata.tp_size,
@@ -186,7 +199,7 @@ class PoolKey:
             pp_size=self.key_metadata.pp_size,
             pp_rank=self.key_metadata.pp_rank,
             group_id=self.key_metadata.group_id,
-            component=VLLM_MULTIWR_V2.decode("ascii"),
+            component=VLLM_RAW_LAYOUT.decode("ascii"),
         )
 
 
@@ -198,11 +211,13 @@ class ChunkedTokenDatabase:
         metadata: KeyMetadata,
         block_size: int,
         hash_block_size: int | None = None,
+        cacheable: bool = True,
     ):
         self.metadata = metadata
         self.block_size = block_size
         self.hash_block_size = hash_block_size or block_size
-        if self.block_size % self.hash_block_size != 0:
+        self.cacheable = cacheable
+        if cacheable and self.block_size % self.hash_block_size != 0:
             raise ValueError(
                 f"block_size ({self.block_size}) must be a multiple of "
                 f"hash_block_size ({self.hash_block_size})"
@@ -345,7 +360,7 @@ class ChunkedTokenDatabase:
                 up to the group's ``block_size`` via ``BlockHashListWithBlockSize``.
             mask_num: Number of tokens to skip from the beginning.
         """
-        if not block_hashes:
+        if not self.cacheable or not block_hashes:
             return
         if self.block_size == self.hash_block_size:
             chunk_hashes: Iterable[BlockHash] = block_hashes

--- a/integration/vllm/src/dfkv_vllm/dfkv_client.py
+++ b/integration/vllm/src/dfkv_vllm/dfkv_client.py
@@ -23,6 +23,9 @@ c_void_p = ctypes.c_void_p
 c_uint64 = ctypes.c_uint64
 c_int = ctypes.c_int
 
+
+
+
 class _FlatSgVectorView(Sequence[int]):
     """Read-only view of one key's slice in a flat ctypes descriptor array."""
 

--- a/integration/vllm/src/dfkv_vllm/scheduler.py
+++ b/integration/vllm/src/dfkv_vllm/scheduler.py
@@ -92,8 +92,14 @@ class DfkvStoreScheduler:
         Returns ``(None, False)`` while an asynchronous lookup is pending so
         vLLM retries the request on a later scheduler step.
         """
-        # Look up against the full prefill range, not just the prompt.
-        token_len = request.num_tokens // self._block_size * self._block_size
+        if getattr(request, "skip_reading_prefix_cache", False):
+            self.client.discard(request.request_id)
+            self.load_specs.pop(request.request_id, None)
+            return 0, False
+
+        # Leave the sampling tail before lookup: shortening an already
+        # validated hit can select different recurrent-state checkpoint keys.
+        token_len = (request.num_tokens - 1) // self._block_size * self._block_size
         if token_len < self._block_size:
             return 0, False
 
@@ -111,13 +117,6 @@ class DfkvStoreScheduler:
             request.request_id, request.num_tokens, num_computed_tokens,
             (time.perf_counter() - _lk0) * 1000.0, num_external_hit_tokens,
         )
-        if num_external_hit_tokens == request.num_tokens:
-            # Leave a sub-block tail uncomputed for sampling, on a block
-            # boundary so the recv-side load mask covers every yielded chunk.
-            num_external_hit_tokens = max(
-                0,
-                (request.num_tokens - 1) // self._block_size * self._block_size,
-            )
 
         if num_external_hit_tokens < num_computed_tokens:
             need_to_allocate = 0

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -51,7 +51,9 @@ from vllm.v1.core.kv_cache_utils import (
     maybe_convert_block_hash,
     resolve_kv_cache_block_sizes,
 )
-from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec, KVCacheConfig, KVCacheGroupSpec, MambaSpec,
+)
 
 # dfkv: get_dp_engine_index replaces mooncake_utils.get_mooncake_dp_engine_index;
 # dfkv handles its own RDMA bootstrap so the transfer-engine helpers are dropped.
@@ -64,9 +66,9 @@ from .client_ranks import (
     resolve_client_ranks,
     should_create_client,
 )
-from .coordinator import DfkvStoreCoordinator
+from .coordinator import DfkvStoreCoordinator, _unwrap_spec
 from .data import (
-    VLLM_MULTIWR_V2,
+    VLLM_RAW_LAYOUT,
     ChunkedTokenDatabase,
     DfkvStoreConnectorMetadata,
     KeyMetadata,
@@ -146,6 +148,13 @@ class _KeyStripeIdentity:
     stripe_step: int
 
 
+def _effective_cache_spec(spec, dcp_size: int):
+    """Use the same outer-spec DCP rule as resolve_kv_cache_block_sizes."""
+    if dcp_size == 1 or not isinstance(spec, AttentionSpec):
+        return spec
+    return dataclasses.replace(spec, block_size=spec.block_size * dcp_size)
+
+
 def _key_stripe_identity(
     *,
     tp_rank: int,
@@ -222,8 +231,16 @@ def _logical_block_ids(
     mask: Sequence[bool],
     block_ids: Sequence[int],
 ) -> list[int]:
+    # Full allocator tables may include future, uncomputed blocks. Select by
+    # logical position, not from their tail. Only an actually compact state
+    # table maps its entries consecutively onto selected mask positions.
+    if len(block_ids) >= len(mask):
+        return [
+            int(block_ids[index]) if selected else -1
+            for index, selected in enumerate(mask)
+        ]
     positions = [index for index, selected in enumerate(mask) if selected]
-    if len(block_ids) < len(positions):
+    if len(block_ids) != len(positions):
         raise ValueError(
             f"block table has {len(block_ids)} ids for "
             f"{len(positions)} selected state slots"
@@ -231,7 +248,7 @@ def _logical_block_ids(
     logical = [-1] * len(mask)
     for position, block_id in zip(
         positions,
-        block_ids[-len(positions) :] if positions else (),
+        block_ids,
         strict=True,
     ):
         logical[position] = int(block_id)
@@ -569,6 +586,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         enable_kv_event: bool = False,
         record_operation: Callable[..., None] | None = None,
         queue_capacity: int = DEFAULT_TRANSFER_QUEUE_CAPACITY,
+        tp_sharded_groups: frozenset[int] = frozenset(),
     ):
         super().__init__(
             client,
@@ -585,6 +603,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         # stripe_idx=None for a non-participant.
         self.stripe_idx: int | None = stripe_idx
         self.stripe_step = stripe_step
+        self.tp_sharded_groups = tp_sharded_groups
         self.coord = coord
         self.kv_role = kv_role
         self.stored_requests: defaultdict[str, int] = defaultdict(int)
@@ -665,6 +684,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             block_hashes: list[BlockHash] = []
             group_indices: list[int] = []
             logical_block_ids_per_group: list[list[int]] = []
+            stripe_position = 0
             for g_idx, db in enumerate(self.token_databases):
                 mask = store_masks[g_idx]
                 logical_block_ids_per_group.append(
@@ -675,24 +695,23 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 ):
                     if chunk_idx >= len(mask) or not mask[chunk_idx]:
                         continue
+                    # State checkpoints contain this physical TP rank's shard;
+                    # every rank must save them. Only payload replicas stripe.
+                    # Count all selected chunks to retain the attention stripe
+                    # positions used before introducing per-group ownership.
+                    selected = g_idx in self.tp_sharded_groups or (
+                        self.stripe_idx is not None
+                        and stripe_position % self.stripe_step == self.stripe_idx
+                    )
+                    stripe_position += 1
+                    if not selected:
+                        continue
                     starts.append(start)
                     ends.append(end)
                     keys.append(key.to_bytes())
                     block_hashes.append(BlockHash(bytes.fromhex(key.chunk_hash)))
                     group_indices.append(g_idx)
 
-            # Split chunks across the workers that share this exact key
-            # coordinate. A converged CLIENT_RANKS non-participant selects
-            # nothing while preserving request bookkeeping and completion.
-            if self.stripe_idx is None:
-                sl = slice(0, 0)
-            else:
-                sl = slice(self.stripe_idx, None, self.stripe_step)
-            starts = starts[sl]
-            ends = ends[sl]
-            keys = keys[sl]
-            block_hashes = block_hashes[sl]
-            group_indices = group_indices[sl]
 
             if not keys:
                 return
@@ -1503,12 +1522,26 @@ class DfkvStoreWorker:
         self.dcp_rank = key_stripe.dcp_rank
         self.stripe_idx = key_stripe.stripe_idx
         self.stripe_step = key_stripe.stripe_step
+        # Mamba/KDA states are TP-sharded even when attention uses a replicated
+        # MLA latent. UniformTypeKVCacheSpecs must be classified by inner spec.
+        self._tp_sharded_groups = frozenset(
+            g_idx
+            for g_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+            if isinstance(_unwrap_spec(group.kv_cache_spec), MambaSpec)
+            and getattr(_unwrap_spec(group.kv_cache_spec), "participates_in_prefix_caching", True)
+        )
+        self._kv_cache_groups: list[KVCacheGroupSpec] = [
+            dataclasses.replace(
+                group, kv_cache_spec=_effective_cache_spec(group.kv_cache_spec, self.dcp_size)
+            )
+            for group in kv_cache_config.kv_cache_groups
+        ]
 
         # CLIENT_RANKS (issue #111): converge store-side dfkv clients onto a
         # subset of ranks when the KV object is fully TP-replicated.
         # Layout-clamped, never rejects (one fleet-wide env template must be
         # safe everywhere).
-        replicated = self.head_or_tp_rank < 0
+        replicated = self.head_or_tp_rank < 0 and not self._tp_sharded_groups
         requested = os.environ.get(CLIENT_RANKS_ENV)
         self.client_ranks, cr_reason = resolve_client_ranks(
             requested, self.tp_size, replicated
@@ -1586,7 +1619,7 @@ class DfkvStoreWorker:
         )
         key_namespace = canonical_namespace(
             model_identity,
-            VLLM_MULTIWR_V2.decode("ascii"),
+            VLLM_RAW_LAYOUT.decode("ascii"),
             tenant_id=str(extra.get("tenant_id", "default")),
             model_revision=str(_model_revision),
             dtype=_cache_dtype,
@@ -1596,7 +1629,7 @@ class DfkvStoreWorker:
             dp_size=self.dp_size,
             pp_size=self.pp_size,
             layout_fields={
-                "storage_layout": VLLM_MULTIWR_V2.decode("ascii"),
+                "storage_layout": VLLM_RAW_LAYOUT.decode("ascii"),
                 "cache_dtype": _cache_dtype,
                 "model_dtype": str(getattr(model_config, "dtype", "unknown")),
                 "block_size": self.block_size,
@@ -1694,46 +1727,6 @@ class DfkvStoreWorker:
         self.kv_connector_stats = DfkvStoreConnectorStats()
 
         self._kv_cache_config = kv_cache_config
-        # PCP/DCP > 1 (single- OR multi-group): scale EACH group's
-        # spec.block_size to self.block_size (= scheduler_block_size) so the
-        # coordinator's ``block_size % hash_block_size == 0`` and
-        # ``scheduler_block_size % block_size == 0`` invariants hold. Under CP
-        # different groups shard differently (e.g. GLM-5.2 DSA: the MLA group is
-        # DCP-sharded while the indexer group is not), but normalizing every
-        # group to scheduler_block_size keeps the per-group hashing / store-load
-        # masks uniform; each rank still only holds (and stores under its
-        # @pcp{r}@dcp{r} key) its own physical shard of the cache.
-        from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
-
-        def _scale_spec(spec):
-            # UniformTypeKVCacheSpecs wraps inner per-layer specs; the
-            # coordinator unwraps to the inner spec (see _unwrap_spec), so the
-            # inner block_size(s) must be scaled too, not just the wrapper's.
-            if isinstance(spec, UniformTypeKVCacheSpecs):
-                inner = {
-                    name: (
-                        dataclasses.replace(s, block_size=self.block_size)
-                        if s.block_size != self.block_size
-                        else s
-                    )
-                    for name, s in spec.kv_cache_specs.items()
-                }
-                if spec.block_size == self.block_size and all(
-                    s.block_size == self.block_size for s in inner.values()
-                ):
-                    return spec
-                return dataclasses.replace(
-                    spec, block_size=self.block_size, kv_cache_specs=inner
-                )
-            if spec.block_size != self.block_size:
-                return dataclasses.replace(spec, block_size=self.block_size)
-            return spec
-
-        groups = [
-            dataclasses.replace(g, kv_cache_spec=_scale_spec(g.kv_cache_spec))
-            for g in kv_cache_config.kv_cache_groups
-        ]
-        self._kv_cache_groups: list[KVCacheGroupSpec] = groups
         spec_cfg = getattr(vllm_config, "speculative_config", None)
         use_eagle = bool(
             spec_cfg.use_eagle()
@@ -1750,9 +1743,24 @@ class DfkvStoreWorker:
         # register_kv_caches once the kv-cache layout is known.
         self.token_dbs: list[ChunkedTokenDatabase] = [
             ChunkedTokenDatabase(
-                dataclasses.replace(self.metadata, group_id=g_idx),
+                dataclasses.replace(
+                    self.metadata,
+                    group_id=g_idx,
+                    # Old state objects used attention's collapsed rank
+                    # coordinates. Keep them outside the corrected state pool,
+                    # including legacy numeric GQA/DCP coordinate collisions.
+                    pool_name="mamba" if g_idx in self._tp_sharded_groups else "kv",
+                    tp_rank=(
+                        self.tp_rank
+                        if g_idx in self._tp_sharded_groups
+                        else self.head_or_tp_rank
+                    ),
+                ),
                 g.kv_cache_spec.block_size,
                 hash_block_size=self.hash_block_size,
+                cacheable=getattr(
+                    _unwrap_spec(g.kv_cache_spec), "participates_in_prefix_caching", True
+                ),
             )
             for g_idx, g in enumerate(self._kv_cache_groups)
         ]
@@ -1862,6 +1870,9 @@ class DfkvStoreWorker:
         # semantic layer name so independently constructed producer/consumer
         # mappings gather and scatter the same ordered byte stream.
         for layer_name in sorted(kv_caches):
+            g_idx = layer_to_group[layer_name]
+            if not self.token_dbs[g_idx].cacheable:
+                continue
             cache = _repr_tensor(kv_caches[layer_name])
             cache_storage = cache.untyped_storage()
             base_addr = cache_storage.data_ptr()
@@ -1879,7 +1890,6 @@ class DfkvStoreWorker:
                 if self.client is not None:
                     self.client.register_memory(base_addr, region_len)
 
-            g_idx = layer_to_group[layer_name]
             layer_addr = cache.data_ptr()
             el = cache.element_size()
             page_size_bytes = region_len // self.num_blocks
@@ -1895,7 +1905,7 @@ class DfkvStoreWorker:
                 # transpose); represent every run explicitly rather than
                 # silently transferring the whole stride and crossing slots.
                 block_stride, runs = split_block_contiguous_runs(
-                    cache.shape, cache.stride(), el
+                    cache.shape, cache.stride(), el, logical_blocks=self.num_blocks
                 )
                 for offset, content in runs:
                     group_seg_layouts[g_idx].append(
@@ -1950,6 +1960,7 @@ class DfkvStoreWorker:
                 queue_capacity=getattr(
                     self, "transfer_queue_capacity", DEFAULT_TRANSFER_QUEUE_CAPACITY
                 ),
+                tp_sharded_groups=self._tp_sharded_groups,
             )
             if self.client_ranks < self.tp_size:
                 # Converged mode: re-stripe stores over the participant set.
@@ -2184,159 +2195,185 @@ class DfkvStoreWorker:
         return finished_sending
 
     def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
-        """Check how many prefix tokens exist in the store.
-
-        Checks across all TP ranks at this worker's own PP rank.
-        """
-        if not block_hashes or token_len <= 0:
-            return 0
-
-        # Build every physical object required by each logical LCM chunk.
-        # Object metadata retains the logical chunk index so repeated hashes
-        # cannot collapse accounting across distinct prefix positions.
-        candidate_keys: list[bytes] = []
-        candidate_meta: list[tuple[int, int, int, bytes]] = []
-        expected_per_object: dict[tuple[int, int, int, bytes], int] = {}
-        tp_count = min(self.tp_size, self.num_kv_head)
-        # dfkv: gate candidates by store_mask -- the SAME per-(group,chunk) set
-        # the SAVE path stores (worker.py save gate) and the LOAD path reads
-        # (load_mask delegates to store_mask). For SlidingWindow groups (V4-Flash
-        # has 4 of them besides the full-MLA group) store_mask keeps only the
-        # in-window tail chunks; without this gate the lookup enumerated every
-        # chunk (4830 vs the 1058 actually stored), so find_longest_cache_hit's
-        # SWA walk demanded never-stored pre-window chunks and collapsed to 0.
-        aligned_token_len = (
-            token_len // self.coord.lcm_block_size * self.coord.lcm_block_size
-        )
-        store_masks = self.coord.store_mask(aligned_token_len)
-        if aligned_token_len == 0:
-            return 0
-        num_prefix_chunks = aligned_token_len // self.coord.lcm_block_size
-        required_objects_per_chunk = [0] * num_prefix_chunks
-        missing_required_per_chunk = [False] * num_prefix_chunks
-        for g_idx, db in enumerate(self.token_dbs):
-            spec_block_size = db.block_size
-            mask = store_masks[g_idx]
-            group_hashes = self.coord.block_hashes_for_spec(
-                block_hashes, self._kv_cache_groups[g_idx].kv_cache_spec
+        """Return a prefix whose length-dependent load objects all exist."""
+        def lookup_candidate(token_len: int) -> int:
+            """Check how many prefix tokens exist in the store.
+    
+            Checks across all TP ranks at this worker's own PP rank.
+            """
+            if not block_hashes or token_len <= 0:
+                return 0
+    
+            # Build every physical object required by each logical LCM chunk.
+            # Object metadata retains the logical chunk index so repeated hashes
+            # cannot collapse accounting across distinct prefix positions.
+            candidate_keys: list[bytes] = []
+            candidate_meta: list[tuple[int, int, int, bytes]] = []
+            expected_per_object: dict[tuple[int, int, int, bytes], int] = {}
+            tp_count = min(self.tp_size, self.num_kv_head)
+            # dfkv: gate candidates by store_mask -- the SAME per-(group,chunk) set
+            # the SAVE path stores (worker.py save gate) and the LOAD path reads
+            # (load_mask delegates to store_mask). For SlidingWindow groups (V4-Flash
+            # has 4 of them besides the full-MLA group) store_mask keeps only the
+            # in-window tail chunks; without this gate the lookup enumerated every
+            # chunk (4830 vs the 1058 actually stored), so find_longest_cache_hit's
+            # SWA walk demanded never-stored pre-window chunks and collapsed to 0.
+            aligned_token_len = (
+                token_len // self.coord.lcm_block_size * self.coord.lcm_block_size
             )
-            # Replicated MLA stores every SAVE under the single canonical
-            # tp_rank=-1 coordinate (see metadata init): expanding to
-            # tp_rank=0..tp_count-1 would never match it. Probe the stored
-            # coordinate as-is when negative; else expand across the per-TP
-            # head coordinates used by GQA/DCP saves.
-            tp_candidates = (
-                [db.metadata.tp_rank] if db.metadata.tp_rank < 0 else range(tp_count)
-            )
-            rank_probes = max(1, len(tp_candidates))
-            processed_chunks = 0
-            for chunk_id, h in enumerate(group_hashes):
-                start_idx = chunk_id * spec_block_size
-                if start_idx >= aligned_token_len:
-                    break
-                processed_chunks = chunk_id + 1
-                if chunk_id >= len(mask) or not mask[chunk_id]:
+            store_masks = self.coord.store_mask(aligned_token_len)
+            if aligned_token_len == 0:
+                return 0
+            num_prefix_chunks = aligned_token_len // self.coord.lcm_block_size
+            required_objects_per_chunk = [0] * num_prefix_chunks
+            missing_required_per_chunk = [False] * num_prefix_chunks
+            for g_idx, db in enumerate(self.token_dbs):
+                spec_block_size = db.block_size
+                mask = store_masks[g_idx]
+                if not mask:
                     continue
-                logical_chunk_idx = start_idx // self.coord.lcm_block_size
-                object_meta = (logical_chunk_idx, g_idx, chunk_id, bytes(h))
-                expected_per_object[object_meta] = rank_probes
-                required_objects_per_chunk[logical_chunk_idx] += 1
-                for tp in tp_candidates:
-                    # Keep this worker's own pp_rank (db.metadata.pp_rank): PP
-                    # partitions layers, so each (group, chunk) lives under a
-                    # single stage's pp_rank, matching the SAVE/LOAD keys. Probing
-                    # every pp_rank matched nothing and forced present=0 on PP>1.
-                    md = dataclasses.replace(db.metadata, tp_rank=tp)
-                    candidate_keys.append(PoolKey(md, h.hex()).to_bytes())
-                    candidate_meta.append(object_meta)
-            # A truncated hash vector is malformed metadata. Mark only its
-            # ungenerated required suffix chunks incomplete; the normal path
-            # has no second full mask scan.
-            for chunk_id in range(
-                processed_chunks,
-                min(len(mask), aligned_token_len // spec_block_size),
-            ):
-                if mask[chunk_id]:
-                    logical_chunk_idx = (
-                        chunk_id * spec_block_size // self.coord.lcm_block_size
-                    )
-                    missing_required_per_chunk[logical_chunk_idx] = True
-
-        if not candidate_keys:
-            return 0
-
-        lookup_start = time.perf_counter()
-        try:
-            res = self.client.batch_exist(candidate_keys)
-            if len(res) != len(candidate_keys):
-                raise RuntimeError(
-                    "batch_exist returned incomplete per-key results: "
-                    f"keys={len(candidate_keys)} statuses={len(res)}"
+                group_hashes = self.coord.block_hashes_for_spec(
+                    block_hashes, self._kv_cache_groups[g_idx].kv_cache_spec
                 )
-        except Exception as e:
+                # State pools need every physical TP shard, independently of
+                # attention head replication. MLA retains its canonical -1;
+                # GQA/DCP attention retains its existing head coordinates.
+                tp_sharded = isinstance(
+                    _unwrap_spec(self._kv_cache_groups[g_idx].kv_cache_spec),
+                    MambaSpec,
+                )
+                if tp_sharded:
+                    tp_candidates = range(self.tp_size)
+                elif db.metadata.tp_rank < 0:
+                    tp_candidates = [db.metadata.tp_rank]
+                else:
+                    tp_candidates = range(tp_count)
+                rank_probes = max(1, len(tp_candidates))
+                processed_chunks = 0
+                for chunk_id, h in enumerate(group_hashes):
+                    start_idx = chunk_id * spec_block_size
+                    if start_idx >= aligned_token_len:
+                        break
+                    processed_chunks = chunk_id + 1
+                    if chunk_id >= len(mask) or not mask[chunk_id]:
+                        continue
+                    logical_chunk_idx = start_idx // self.coord.lcm_block_size
+                    object_meta = (logical_chunk_idx, g_idx, chunk_id, bytes(h))
+                    expected_per_object[object_meta] = rank_probes
+                    required_objects_per_chunk[logical_chunk_idx] += 1
+                    for tp in tp_candidates:
+                        # Keep this worker's own pp_rank (db.metadata.pp_rank): PP
+                        # partitions layers, so each (group, chunk) lives under a
+                        # single stage's pp_rank, matching the SAVE/LOAD keys. Probing
+                        # every pp_rank matched nothing and forced present=0 on PP>1.
+                        md = dataclasses.replace(
+                            db.metadata,
+                            tp_rank=tp,
+                            dcp_rank=(
+                                (tp * db.metadata.pcp_size + db.metadata.pcp_rank)
+                                % db.metadata.dcp_size
+                                if tp_sharded
+                                else db.metadata.dcp_rank
+                            ),
+                        )
+                        candidate_keys.append(PoolKey(md, h.hex()).to_bytes())
+                        candidate_meta.append(object_meta)
+                # A truncated hash vector is malformed metadata. Mark only its
+                # ungenerated required suffix chunks incomplete; the normal path
+                # has no second full mask scan.
+                for chunk_id in range(
+                    processed_chunks,
+                    min(len(mask), aligned_token_len // spec_block_size),
+                ):
+                    if mask[chunk_id]:
+                        logical_chunk_idx = (
+                            chunk_id * spec_block_size // self.coord.lcm_block_size
+                        )
+                        missing_required_per_chunk[logical_chunk_idx] = True
+    
+            if not candidate_keys:
+                return 0
+    
+            lookup_start = time.perf_counter()
+            try:
+                res = self.client.batch_exist(candidate_keys)
+                if len(res) != len(candidate_keys):
+                    raise RuntimeError(
+                        "batch_exist returned incomplete per-key results: "
+                        f"keys={len(candidate_keys)} statuses={len(res)}"
+                    )
+            except Exception as e:
+                self._record_kv_connector_operation(
+                    "lookup_exists",
+                    time.perf_counter() - lookup_start,
+                    len(candidate_keys),
+                    num_logical_keys=len(expected_per_object),
+                    status="error",
+                    num_failed_keys=len(candidate_keys),
+                )
+                logger.error("Remote connection failed in lookup: %s", e)
+                return 0
+    
             self._record_kv_connector_operation(
                 "lookup_exists",
                 time.perf_counter() - lookup_start,
                 len(candidate_keys),
                 num_logical_keys=len(expected_per_object),
-                status="error",
-                num_failed_keys=len(candidate_keys),
             )
-            logger.error("Remote connection failed in lookup: %s", e)
-            return 0
-
-        self._record_kv_connector_operation(
-            "lookup_exists",
-            time.perf_counter() - lookup_start,
-            len(candidate_keys),
-            num_logical_keys=len(expected_per_object),
-        )
-
-        # A semantic object exists only if every TP*PP coordinate exists. A
-        # logical LCM chunk is complete only if all of its semantic objects do.
-        # Scan logical chunks in order and cap the semantic coordinator at the
-        # first incomplete one, so an isolated later hit can never be loaded.
-        present_per_object: dict[tuple[int, int, int, bytes], int] = {}
-        for object_meta, exists in zip(candidate_meta, res, strict=True):
-            if exists == 1:
-                present_per_object[object_meta] = (
-                    present_per_object.get(object_meta, 0) + 1
-                )
-
-        complete_chunks = [
-            required > 0 and not missing_required_per_chunk[idx]
-            for idx, required in enumerate(required_objects_per_chunk)
-        ]
-        exists_set: set[tuple[int, bytes]] = set()
-        for object_meta, expected in expected_per_object.items():
-            logical_chunk_idx, g_idx, _chunk_id, chunk_hash = object_meta
-            if present_per_object.get(object_meta, 0) != expected:
-                complete_chunks[logical_chunk_idx] = False
-            else:
-                exists_set.add((g_idx, chunk_hash))
-
-        prefix_chunks = 0
-        for chunk_idx, complete in enumerate(complete_chunks):
-            if required_objects_per_chunk[chunk_idx] == 0 or not complete:
-                break
-            prefix_chunks += 1
-        complete_prefix_tokens = prefix_chunks * self.coord.lcm_block_size
-
-        # candidate_keys are derived from the same manager-selected store mask
-        # used by save and load. Once every required object for the contiguous
-        # prefix exists, re-running cross-group convergence can only discard
-        # intentionally sparse stateful groups.
-        hit_length = complete_prefix_tokens
-        logger.debug(
-            "dfkv lookup: token_len=%d candidates=%d complete_chunks=%d/%d "
-            "-> hit_length=%d",
-            token_len,
-            len(candidate_keys),
-            prefix_chunks,
-            num_prefix_chunks,
-            hit_length,
-        )
-        return hit_length
+    
+            # A semantic object exists only if every TP*PP coordinate exists. A
+            # logical LCM chunk is complete only if all of its semantic objects do.
+            # Scan logical chunks in order and cap the semantic coordinator at the
+            # first incomplete one, so an isolated later hit can never be loaded.
+            present_per_object: dict[tuple[int, int, int, bytes], int] = {}
+            for object_meta, exists in zip(candidate_meta, res, strict=True):
+                if exists == 1:
+                    present_per_object[object_meta] = (
+                        present_per_object.get(object_meta, 0) + 1
+                    )
+    
+            complete_chunks = [
+                required > 0 and not missing_required_per_chunk[idx]
+                for idx, required in enumerate(required_objects_per_chunk)
+            ]
+            exists_set: set[tuple[int, bytes]] = set()
+            for object_meta, expected in expected_per_object.items():
+                logical_chunk_idx, g_idx, _chunk_id, chunk_hash = object_meta
+                if present_per_object.get(object_meta, 0) != expected:
+                    complete_chunks[logical_chunk_idx] = False
+                else:
+                    exists_set.add((g_idx, chunk_hash))
+    
+            prefix_chunks = 0
+            for chunk_idx, complete in enumerate(complete_chunks):
+                if required_objects_per_chunk[chunk_idx] == 0 or not complete:
+                    break
+                prefix_chunks += 1
+            complete_prefix_tokens = prefix_chunks * self.coord.lcm_block_size
+    
+            # This is only a candidate boundary. The outer loop checks the
+            # mask at that exact length before admitting it for LOAD.
+            hit_length = complete_prefix_tokens
+            logger.debug(
+                "dfkv lookup: token_len=%d candidates=%d complete_chunks=%d/%d "
+                "-> hit_length=%d",
+                token_len,
+                len(candidate_keys),
+                prefix_chunks,
+                num_prefix_chunks,
+                hit_length,
+            )
+            return hit_length
+    
+        candidate = token_len // self.coord.lcm_block_size * self.coord.lcm_block_size
+        while candidate > 0:
+            hit = lookup_candidate(candidate)
+            if hit == candidate:
+                return hit
+            # Tail-only state masks move when the candidate prefix shrinks.
+            # Revalidate that boundary rather than loading unprobed checkpoints.
+            candidate = hit
+        return 0
 
     def get_kv_events(self) -> list[BlockStored]:
         if self.enable_kv_events and self.kv_send_thread is not None:

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -24,6 +24,7 @@ import zlib
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
+
 from typing import Any, TypeVar
 
 import torch
@@ -66,7 +67,7 @@ from .client_ranks import (
     resolve_client_ranks,
     should_create_client,
 )
-from .coordinator import DfkvStoreCoordinator, _unwrap_spec
+from .coordinator import DfkvStoreCoordinator, _prefix_cacheable, _unwrap_spec
 from .data import (
     VLLM_RAW_LAYOUT,
     ChunkedTokenDatabase,
@@ -875,7 +876,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         [key_diagnostic_label(key) for key in keys[:3]],
                         e,
                     )
-
             if self.enable_kv_event and successful_events:
                 self.update_kv_event(successful_events)
         finally:
@@ -1329,6 +1329,16 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 for i, (hit, got_len) in enumerate(zip(hits, lens, strict=True))
                 if hit != 1 or got_len != chunk_totals[i]
             ]
+            # GPUDirect RDMA ordering fence: the CQ completion proves
+            # transmission, not arrival of the BAR writes in device memory;
+            # drivers reject CU_POINTER_ATTRIBUTE_SYNC_MEMOPS on VMM pools, so
+            # synchronize the device before the scheduler launches kernels over
+            # the loaded blocks. DFKV_GPU_LOAD_FENCE=0 disables.
+            if (
+                os.environ.get("DFKV_GPU_LOAD_FENCE", "1") == "1"
+                and torch.cuda.is_available()
+            ):
+                torch.cuda.synchronize()
             failed_block_ids = [rotated_block_ids[i] for i in failed_indices]
             self._record_operation(
                 "load_get",
@@ -1528,7 +1538,7 @@ class DfkvStoreWorker:
             g_idx
             for g_idx, group in enumerate(kv_cache_config.kv_cache_groups)
             if isinstance(_unwrap_spec(group.kv_cache_spec), MambaSpec)
-            and getattr(_unwrap_spec(group.kv_cache_spec), "participates_in_prefix_caching", True)
+            and _prefix_cacheable(group.kv_cache_spec)
         )
         self._kv_cache_groups: list[KVCacheGroupSpec] = [
             dataclasses.replace(
@@ -1758,9 +1768,7 @@ class DfkvStoreWorker:
                 ),
                 g.kv_cache_spec.block_size,
                 hash_block_size=self.hash_block_size,
-                cacheable=getattr(
-                    _unwrap_spec(g.kv_cache_spec), "participates_in_prefix_caching", True
-                ),
+                cacheable=_prefix_cacheable(g.kv_cache_spec),
             )
             for g_idx, g in enumerate(self._kv_cache_groups)
         ]
@@ -1941,7 +1949,6 @@ class DfkvStoreWorker:
             ]
             if seg_layout:
                 db.set_seg_layout(seg_layout)
-
         # Start transfer threads
         if self.kv_role in ["kv_producer", "kv_both"]:
             ready_event_sending = threading.Event()

--- a/integration/vllm/tests/test_client_stats.py
+++ b/integration/vllm/tests/test_client_stats.py
@@ -63,7 +63,7 @@ def test_empty_ring_and_counter_deltas():
 
 def test_missing_metrics_are_absent_not_false_zeroes():
     poller = ClientStatsPoller(
-        lambda: "dfkv_client_ring_members 2\\n", tp_rank=0, interval_s=0)
+        lambda: "dfkv_client_ring_members 2\n", tp_rank=0, interval_s=0)
     poller.poll_once()
     assert poller.gauges() == {"dfkv_client_ring_members": 2.0}
 

--- a/integration/vllm/tests/test_dcp_lookup_geometry.py
+++ b/integration/vllm/tests/test_dcp_lookup_geometry.py
@@ -33,7 +33,6 @@ is faked, only the pure-python key/lookup math is exercised.
 
 import hashlib
 import sys
-import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -45,13 +44,8 @@ from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
 
 from dfkv_vllm.coordinator import DfkvStoreCoordinator
-from dfkv_vllm.data import ChunkedTokenDatabase, KeyMetadata, PoolKey, ReqMeta
-from dfkv_vllm.worker import (
-    DfkvStoreWorker,
-    KVCacheStoreSendingThread,
-    SG_MAX_SEGS,
-    _sg_group_key,
-)
+from dfkv_vllm.data import KeyMetadata, PoolKey
+from dfkv_vllm.worker import DfkvStoreWorker
 
 BLOCK = 64
 NCHUNK = 64
@@ -76,9 +70,9 @@ def _md(dcp_rank: int) -> KeyMetadata:
     return KeyMetadata(**{**_METADATA, "dcp_rank": dcp_rank})
 
 
-def _onewire_key(md: KeyMetadata, h: BlockHash) -> str:
-    # Same on-wire form lookup probes and the save path store: group-0 SG key.
-    return _sg_group_key(PoolKey(md, h.hex()).to_bytes(), 0, SG_MAX_SEGS)
+def _onewire_key(md: KeyMetadata, h: BlockHash) -> bytes:
+    # One logical object spans as many native WR windows as required.
+    return PoolKey(md, h.hex()).to_bytes()
 
 
 def _make_store(geometry: str, hashes: list[BlockHash]) -> set[bytes]:
@@ -94,8 +88,6 @@ def _lookup_hit_tokens(
     store: set[bytes], hashes: list[BlockHash], md: KeyMetadata | None = None
 ) -> int:
     class _FakeClient:
-        _sg_segs_cache = SG_MAX_SEGS
-
         def __init__(self, present: set[bytes]):
             self._present = present
 
@@ -200,311 +192,3 @@ def test_replicated_mla_lookup_misses_legacy_tp0_coordinate():
         f"lookup must not probe the legacy tp_rank=0 coordinate, got {hit}"
     )
 
-
-# ---------------------------------------------------------------------------
-# Partial scatter-group probe/heal (v2 review #14)
-#
-# A chunk is stored as G = ceil(per-layer segments / SG_MAX_SEGS) explicit
-# SG objects (_group_segments_sg): a 40-layer model with 29-wide RDMA spans
-# 2 groups (29 + 11). The pre-fix dedup/lookup probed group 0 only, so a
-# partial write (group 0 in, a sibling group lost to a failed put or
-# eviction) probed "stored": dedup skipped the rewrite, lookup counted it
-# cached, and every load of that chunk then failed wholesale -- recomputed
-# for the chunk's whole LRU lifetime while pinning ring capacity. The tests
-# below drive the REAL lookup and the REAL save thread against the fixed
-# all-group geometry.
-# ---------------------------------------------------------------------------
-
-_SG_LAYERS = SG_MAX_SEGS + 11  # segments/chunk -> exactly 2 SG groups
-_SAVE_CHUNKS = 4
-
-
-def _sg_onewire_key(md: KeyMetadata, h: BlockHash, grp: int) -> bytes:
-    return _sg_group_key(PoolKey(md, h.hex()).to_bytes(), grp, SG_MAX_SEGS)
-
-
-def _spec() -> FullAttentionSpec:
-    return FullAttentionSpec(
-        block_size=BLOCK,
-        num_kv_heads=1,
-        head_size=576,
-        dtype=torch.bfloat16,
-    )
-
-
-def _lookup_hit_tokens_sg(
-    store: set[bytes],
-    hashes: list[BlockHash],
-    md: KeyMetadata,
-    segs_per_block: int,
-) -> int:
-    # Same as _lookup_hit_tokens but the fake db carries a seg layout, so
-    # _num_sg_groups resolves multi-group chunks exactly like the real
-    # ChunkedTokenDatabase does after register_kv_caches.
-    class _FakeClient:
-        _sg_segs_cache = SG_MAX_SEGS
-
-        def __init__(self, present: set[bytes]):
-            self._present = present
-
-        def batch_exist(self, keys):
-            return [1 if k in self._present else 0 for k in keys]
-
-    groups = [
-        KVCacheGroupSpec([f"layer{i}" for i in range(segs_per_block)], _spec())
-    ]
-    coord = DfkvStoreCoordinator(
-        groups, scheduler_block_size=BLOCK, hash_block_size=BLOCK
-    )
-    self_ = SimpleNamespace(
-        coord=coord,
-        token_dbs=[
-            SimpleNamespace(
-                metadata=md,
-                block_size=BLOCK,
-                _seg_layout=[(0, 4096, 4096)] * segs_per_block,
-            )
-        ],
-        client=_FakeClient(store),
-        tp_size=8,
-        num_kv_head=1,
-        pp_size=1,
-        _kv_cache_groups=groups,
-        _record_kv_connector_operation=lambda *a, **k: None,
-    )
-    return DfkvStoreWorker.lookup(self_, NCHUNK * BLOCK, hashes)
-
-
-def test_multigroup_lookup_hits_when_all_groups_present():
-    """Both SG groups of every chunk stored -> full prefix hit. Guard: the
-    all-group probe must not LOSE coverage the group-0 probe used to see."""
-    hashes = _hashes()
-    md = _mla_md()
-    store = {_sg_onewire_key(md, h, grp) for h in hashes for grp in (0, 1)}
-    assert len(store) == 2 * NCHUNK
-    hit = _lookup_hit_tokens_sg(store, hashes, md, _SG_LAYERS)
-    assert hit == NCHUNK * BLOCK, (
-        f"all-group store must yield a full prefix, got {hit}/{NCHUNK * BLOCK}"
-    )
-
-
-def test_multigroup_lookup_misses_when_either_group_missing():
-    """Root regression (lookup side): with only ONE of the two SG groups
-    stored the chunk must NOT count as cached. The pre-fix group-0 probe
-    reported the group-0-only case as a full hit while every load of the
-    chunk failed."""
-    hashes = _hashes()
-    md = _mla_md()
-    for present_grp in (0, 1):
-        store = {_sg_onewire_key(md, h, present_grp) for h in hashes}
-        assert len(store) == NCHUNK
-        hit = _lookup_hit_tokens_sg(store, hashes, md, _SG_LAYERS)
-        assert hit == 0, (
-            f"group{present_grp}-only partial store must probe as uncached, "
-            f"got {hit}/{NCHUNK * BLOCK} tokens"
-        )
-
-
-class _FakeSaveClient:
-    """In-memory dfkv stand-in for the save thread: scripted per-key put
-    failures and a recording remove RPC."""
-
-    _sg_segs_cache = SG_MAX_SEGS
-
-    def __init__(
-        self,
-        present: set[bytes] | None = None,
-        fail_keys: set[bytes] | None = None,
-    ):
-        self._present = set(present or ())
-        self._fail_keys = set(fail_keys or ())
-        self.exist_calls: list[list[bytes]] = []
-        self.put_calls: list[list[bytes]] = []
-        self.removed: list[bytes] = []
-
-    def batch_exist(self, keys):
-        keys = list(keys)
-        self.exist_calls.append(keys)
-        return [1 if k in self._present else 0 for k in keys]
-
-    def batch_put_sg(self, keys, seg_ptrs, seg_sizes):
-        keys = list(keys)
-        self.put_calls.append(keys)
-        res = []
-        for k in keys:
-            if k in self._fail_keys:
-                res.append(1)
-            else:
-                res.append(0)
-                self._present.add(k)
-        return res
-
-    def supports_remove(self):
-        return True
-
-    def batch_remove(self, keys):
-        keys = list(keys)
-        self.removed.extend(keys)
-        for k in keys:
-            self._present.discard(k)
-        return [1] * len(keys)
-
-
-def _run_save_request(
-    client,
-    md: KeyMetadata,
-    hashes: list[BlockHash],
-    segs_per_block: int = _SG_LAYERS,
-    record_ops: list | None = None,
-) -> None:
-    """Drive the REAL KVCacheStoreSendingThread._handle_request over a real
-    1-group coordinator + a real ChunkedTokenDatabase whose legacy layout
-    tables emulate a ``segs_per_block``-layer model (prepare_value emits one
-    segment per entry per block, so _num_sg_groups sees the legacy branch)."""
-    groups = [
-        KVCacheGroupSpec([f"layer{i}" for i in range(segs_per_block)], _spec())
-    ]
-    coord = DfkvStoreCoordinator(
-        groups, scheduler_block_size=BLOCK, hash_block_size=BLOCK
-    )
-    db = ChunkedTokenDatabase(md, block_size=BLOCK, hash_block_size=BLOCK)
-    db.set_kv_caches_base_addr([0x1000 + i * 4096 * 1024 for i in range(segs_per_block)])
-    db.set_block_len([4096] * segs_per_block)
-    thread = KVCacheStoreSendingThread(
-        client=client,
-        coord=coord,
-        token_databases=[db],
-        block_size=BLOCK,
-        tp_rank=0,
-        stripe_idx=0,
-        stripe_step=1,
-        kv_role="kv_both",
-        ready_event=threading.Event(),
-        enable_kv_event=False,
-        record_operation=(
-            (lambda **kw: record_ops.append(kw))
-            if record_ops is not None
-            else None
-        ),
-    )
-    nblocks = len(hashes)
-    meta = ReqMeta(
-        req_id="req-sg",
-        token_len_chunk=nblocks * BLOCK,
-        block_ids=(list(range(nblocks)),),
-        block_hashes=list(hashes),
-    )
-    thread.add_stored_request("req-sg")
-    thread._handle_request(meta)
-    assert thread.stored_requests.get("req-sg", 0) == 0
-
-
-def test_save_dedup_rewrites_when_sibling_group_missing():
-    """Root regression (dedup side): group 0 of every chunk is stored but
-    its sibling group is gone. The pre-fix gate probed group 0 only and
-    skipped the save entirely, so the partial chunk was never rewritten.
-    The gate must now probe both groups and re-store the chunks."""
-    hashes = _hashes()[:_SAVE_CHUNKS]
-    md = _mla_md()
-    present = {_sg_onewire_key(md, h, 0) for h in hashes}
-    client = _FakeSaveClient(present=present)
-    _run_save_request(client, md, hashes)
-    assert client.exist_calls, "dedup gate must probe first"
-    assert len(client.exist_calls[0]) == 2 * len(hashes), (
-        f"probe must cover both SG groups per chunk: "
-        f"{len(client.exist_calls[0])} keys for {len(hashes)} chunks"
-    )
-    assert client.put_calls, (
-        "group-0-only partial chunks must be rewritten, not skipped"
-    )
-    expected_keys = {
-        _sg_onewire_key(md, h, grp) for h in hashes for grp in (0, 1)
-    }
-    assert set(client.put_calls[0]) == expected_keys
-    assert expected_keys <= client._present
-
-
-def test_save_dedup_skips_when_all_groups_present():
-    """Guard: with BOTH SG groups of every chunk stored the dedup gate keeps
-    its skip-fast behavior (no put at all)."""
-    hashes = _hashes()[:_SAVE_CHUNKS]
-    md = _mla_md()
-    present = {_sg_onewire_key(md, h, grp) for h in hashes for grp in (0, 1)}
-    client = _FakeSaveClient(present=present)
-    _run_save_request(client, md, hashes)
-    assert client.put_calls == [], (
-        f"fully-stored chunks must stay dedup-skipped, got puts {client.put_calls}"
-    )
-
-
-def test_save_partial_put_failure_removes_sibling_groups():
-    """Cleanup: when one group put fails, the chunk's sibling group keys
-    (including the successfully written one) must receive a best-effort
-    remove so no half-stored ghost lingers in the ring."""
-    hashes = _hashes()[:_SAVE_CHUNKS]
-    md = _mla_md()
-    victim_g1 = _sg_onewire_key(md, hashes[1], 1)
-    ops: list[dict] = []
-    client = _FakeSaveClient(fail_keys={victim_g1})
-    _run_save_request(client, md, hashes, record_ops=ops)
-    assert set(client.removed) == {
-        _sg_onewire_key(md, hashes[1], 0),
-        victim_g1,
-    }, (
-        "both group keys of the failed chunk must be removed, got "
-        f"{[k.hex()[-8:] for k in client.removed]}"
-    )
-    assert not {_sg_onewire_key(md, hashes[1], grp) for grp in (0, 1)} & client._present
-    rm_ops = [op for op in ops if op.get("operation") == "save_remove_partial"]
-    assert rm_ops and rm_ops[0].get("status") == "ok", (
-        f"cleanup metric missing or wrong: {ops}"
-    )
-
-
-def test_save_partial_put_failure_without_remove_rpc_is_inert():
-    """Degradation: a client/lib without the remove RPC (older libdfkv)
-    must skip cleanup silently -- never raise into the save path -- and the
-    metric records the unsupported skip."""
-
-    class _OldLibClient(_FakeSaveClient):
-        def supports_remove(self):
-            return False
-
-        def batch_remove(self, keys):  # pragma: no cover - must never run
-            raise AssertionError("old lib without remove RPC must be skipped")
-
-    hashes = _hashes()[:_SAVE_CHUNKS]
-    md = _mla_md()
-    ops: list[dict] = []
-    client = _OldLibClient(fail_keys={_sg_onewire_key(md, hashes[0], 1)})
-    _run_save_request(client, md, hashes, record_ops=ops)  # must not raise
-    assert client.put_calls, "put was attempted before the scripted failure"
-    rm_ops = [op for op in ops if op.get("operation") == "save_remove_partial"]
-    assert rm_ops and rm_ops[0].get("status") == "unsupported", (
-        f"unsupported-cleanup metric missing or wrong: {ops}"
-    )
-
-
-def test_single_group_chunk_probe_geometry_unchanged():
-    """G=1 guard: a chunk that fits ONE SG group keeps the byte-identical
-    pre-fix geometry -- exactly one group-0 key per chunk in the dedup probe
-    and in the rewrite, and unchanged skip behavior."""
-    hashes = _hashes()[:_SAVE_CHUNKS]
-    md = _mla_md()
-    single_layers = SG_MAX_SEGS - 9  # 20 segments -> exactly 1 SG group
-    # Fully present -> still skipped, probe list identical to the pre-fix
-    # group-0-only form.
-    present = {_sg_onewire_key(md, h, 0) for h in hashes}
-    client = _FakeSaveClient(present=present)
-    _run_save_request(client, md, hashes, segs_per_block=single_layers)
-    assert client.put_calls == []
-    old_probe_form = [_sg_onewire_key(md, h, 0) for h in hashes]
-    assert client.exist_calls[0] == old_probe_form, (
-        "single-group chunk probe list must be byte-identical to the "
-        "pre-fix group-0-only form"
-    )
-    # Absent -> rewrite puts exactly the old group-0 keys.
-    client2 = _FakeSaveClient()
-    _run_save_request(client2, md, hashes, segs_per_block=single_layers)
-    assert len(client2.put_calls) == 1
-    assert client2.put_calls[0] == old_probe_form

--- a/integration/vllm/tests/test_hybrid_pool_layout.py
+++ b/integration/vllm/tests/test_hybrid_pool_layout.py
@@ -20,6 +20,7 @@ from dfkv_vllm.data import (  # noqa: E402
     ChunkedTokenDatabase,
     KeyMetadata,
     PoolKey,
+    key_diagnostic_label,
     split_block_contiguous_runs,
 )
 from dfkv_vllm import worker as worker_module  # noqa: E402
@@ -54,17 +55,6 @@ def test_logical_block_ids_expand_compact_stateful_table():
         worker_module._logical_block_ids([True, True], [5])
 
 
-def test_pool_key_uses_cross_runtime_binary_schema():
-    assert PoolKey(_METADATA, "0123abcd").to_bytes() == (
-        b"DFKVPOOL\x02"
-        + struct.pack("<I", 2) + b"kv"
-        + struct.pack("<I", 8) + b"0123abcd"
-        + struct.pack(
-            "<IiIiIiIiIiI",
-            1, -1, 1, 0, 1, 0, 1, 0, 1, 0, 0,
-        )
-        + struct.pack("<I", 3) + b"all"
-    )
 
 
 def test_pool_key_preserves_embedded_nul_and_non_utf8_hash_bytes():
@@ -75,10 +65,12 @@ def test_pool_key_preserves_embedded_nul_and_non_utf8_hash_bytes():
 
 
 def test_binary_key_log_label_is_digest_only():
-    label = worker_module._key_label(b"\xff\x00raw-secret")
-    assert label.startswith("len=12 sha256=")
-    assert len(label.removeprefix("len=12 sha256=")) == 16
+    key = b"\xff\x00raw-secret"
+    label = key_diagnostic_label(key)
     assert "raw-secret" not in label
+    assert key.hex() not in label
+    assert label == key_diagnostic_label(key)
+    assert label != key_diagnostic_label(b"\xff\x00alt-secret")
 
 
 def test_prepare_value_uses_actual_noncontiguous_block_ids():

--- a/integration/vllm/tests/test_scheduler_full_block_ids.py
+++ b/integration/vllm/tests/test_scheduler_full_block_ids.py
@@ -41,3 +41,47 @@ def test_new_request_metadata_uses_complete_allocated_block_table():
     assert len(metadata.requests) == 1
     assert metadata.requests[0].block_ids == complete_block_ids
     assert metadata.requests[0].can_save is True
+
+
+def test_sampling_tail_does_not_authorize_an_absent_checkpoint():
+    scheduler = object.__new__(DfkvStoreScheduler)
+    scheduler._block_size = 64
+    scheduler.lookup_async = False
+    scheduler.load_async = False
+    scheduler.load_specs = {}
+    checkpoints = {128}
+    scheduler.client = SimpleNamespace(
+        lookup=lambda request_id, length, hashes, non_block: max(
+            (depth for depth in checkpoints if depth <= length), default=0
+        )
+    )
+    request = SimpleNamespace(
+        request_id="stateful-full-hit", num_tokens=128, block_hashes=[]
+    )
+    # The final token must be recomputed for sampling. A checkpoint at 128
+    # cannot be used to resume at 64 when the latter checkpoint is absent.
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+    assert request.request_id not in scheduler.load_specs
+    checkpoints.add(64)
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (64, False)
+
+
+def test_cache_bypass_discards_stale_external_admission():
+    scheduler = object.__new__(DfkvStoreScheduler)
+    scheduler._block_size = 64
+    scheduler.lookup_async = False
+    scheduler.load_async = False
+    cached = {"replay": 128}
+    other_spec = object()
+    scheduler.load_specs = {"replay": object(), "unrelated": other_spec}
+    scheduler.client = SimpleNamespace(
+        lookup=lambda request_id, *args, **kwargs: cached[request_id],
+        discard=lambda request_id: cached.pop(request_id, None),
+    )
+    request = SimpleNamespace(
+        request_id="replay", num_tokens=256, block_hashes=[],
+        skip_reading_prefix_cache=True,
+    )
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+    assert cached == {}
+    assert scheduler.load_specs == {"unrelated": other_spec}

--- a/integration/vllm/tests/test_stateful_lookup_admission.py
+++ b/integration/vllm/tests/test_stateful_lookup_admission.py
@@ -1,0 +1,502 @@
+"""Hybrid resume admission must validate the checkpoint at the returned depth."""
+import ctypes
+import hashlib
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_cache_interface import (
+    KVCacheGroupSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+)
+
+from dfkv_vllm import worker as worker_module
+from dfkv_vllm.data import KeyMetadata, LoadSpec, PoolKey, ReqMeta
+from dfkv_vllm.worker import DfkvStoreWorker
+
+BLOCK = 64
+_MLA_METADATA = {
+    "model_name": "stateful-admission", "dp_size": 1, "dp_rank": -1,
+    "tp_size": 1, "tp_rank": -1, "pcp_size": 1, "pcp_rank": 0,
+    "dcp_size": 1, "pp_size": 1, "pp_rank": 0,
+}
+
+
+def _hashes(count=2):
+    return [BlockHash(hashlib.sha256(str(i).encode()).digest()) for i in range(count)]
+
+
+
+def test_shorter_prefix_requires_its_own_state_checkpoints():
+    """A longer prefix's tail mask cannot authorize a shorter resume."""
+    hashes = _hashes()[:2]
+    metadata = [
+        KeyMetadata(**{**_MLA_METADATA, "dcp_rank": 0, "group_id": group})
+        for group in range(5)
+    ]
+    store = {
+        PoolKey(metadata[0], h.hex()).to_bytes() for h in hashes
+    }
+    # The original query finds four of six objects: two dense chunks and
+    # two of the four recurrent checkpoints at the final boundary.
+    store.update(
+        PoolKey(metadata[group], hashes[1].hex()).to_bytes()
+        for group in (1, 2)
+    )
+    coord = SimpleNamespace(
+        lcm_block_size=BLOCK,
+        store_mask=lambda length: [
+            [True] * (length // BLOCK),
+            *[
+                [False] * (length // BLOCK - 1) + [True]
+                for _ in range(4)
+            ],
+        ],
+        block_hashes_for_spec=lambda all_hashes, spec: all_hashes,
+    )
+    worker = SimpleNamespace(
+        coord=coord,
+        token_dbs=[
+            SimpleNamespace(metadata=md, block_size=BLOCK) for md in metadata
+        ],
+        client=SimpleNamespace(
+            batch_exist=lambda keys: [int(key in store) for key in keys]
+        ),
+        tp_size=1,
+        num_kv_head=1,
+        _kv_cache_groups=[
+            SimpleNamespace(kv_cache_spec=None) for _ in metadata
+        ],
+        _record_kv_connector_operation=lambda *args, **kwargs: None,
+    )
+    assert DfkvStoreWorker.lookup(worker, 2 * BLOCK, hashes) == 0
+    # An actual checkpoint at the earlier boundary makes that prefix safe.
+    store.update(
+        PoolKey(metadata[group], hashes[0].hex()).to_bytes()
+        for group in range(1, 5)
+    )
+    assert DfkvStoreWorker.lookup(worker, 2 * BLOCK, hashes) == BLOCK
+
+
+class _MemoryClient:
+    """Native-boundary substitute that gathers/scatters actual CPU buffers."""
+
+    def __init__(self, objects, namespace):
+        self.objects = objects
+        self.namespace = namespace
+
+    def register_memory(self, base, size):
+        pass
+
+    def batch_exist(self, keys):
+        return [int((self.namespace, key) in self.objects) for key in keys]
+
+    def batch_put_sg(self, keys, pointers, sizes):
+        for key, ptrs, lens in zip(keys, pointers, sizes, strict=True):
+            self.objects[self.namespace, key] = b"".join(
+                ctypes.string_at(ptr, length)
+                for ptr, length in zip(ptrs, lens, strict=True)
+            )
+        return [0] * len(keys)
+
+    def batch_get_auto_sg(self, keys, pointers, capacities):
+        hits, lengths = [], []
+        for key, ptrs, caps in zip(keys, pointers, capacities, strict=True):
+            value = self.objects.get((self.namespace, key))
+            hits.append(value is not None)
+            lengths.append(len(value) if value is not None else 0)
+            if value is None:
+                continue
+            assert len(value) == sum(caps)
+            offset = 0
+            for ptr, cap in zip(ptrs, caps, strict=True):
+                ctypes.memmove(ptr, value[offset:offset + cap], cap)
+                offset += cap
+        return hits, lengths
+
+    def close(self):
+        pass
+
+class _ScratchSpec(MLAAttentionSpec):
+    @property
+    def participates_in_prefix_caching(self):
+        return False
+
+
+
+@pytest.fixture
+def hybrid_workers(monkeypatch):
+    """Use real startup, group registration, send/load and lookup on CPU."""
+    objects = {}
+    workers = []
+    rank = [0]
+    dcp_size = [1]
+    monkeypatch.setattr(
+        worker_module, "DfkvDeviceClient",
+        lambda **kwargs: _MemoryClient(objects, kwargs["key_namespace"]),
+    )
+    monkeypatch.setattr(
+        worker_module, "LookupKeyServer",
+        lambda *args: SimpleNamespace(close=lambda: None),
+    )
+    monkeypatch.setattr(
+        worker_module, "apply_rank_local_rail_affinity",
+        lambda *args: SimpleNamespace(enabled=False),
+    )
+    monkeypatch.setattr(worker_module, "get_dp_engine_index", lambda config: 0)
+    monkeypatch.setattr(
+        worker_module, "get_tensor_model_parallel_rank", lambda: rank[0],
+    )
+    monkeypatch.setattr(
+        worker_module, "get_tensor_model_parallel_world_size", lambda: 4,
+    )
+    monkeypatch.setattr(
+        worker_module, "get_world_group",
+        lambda: SimpleNamespace(local_rank=rank[0]),
+    )
+    monkeypatch.setattr(
+        worker_module, "get_pcp_group",
+        lambda: SimpleNamespace(world_size=1, rank_in_group=0),
+    )
+    monkeypatch.setattr(
+        worker_module, "get_dcp_group",
+        lambda: SimpleNamespace(
+            world_size=dcp_size[0], rank_in_group=rank[0] % dcp_size[0],
+        ),
+    )
+    monkeypatch.setattr(
+        worker_module, "ensure_deterministic_block_hashing", lambda config: None,
+    )
+    # Exercise synchronous handlers without starting background threads.
+    for cls in (
+        worker_module.KVCacheStoreSendingThread,
+        worker_module.KVCacheStoreRecvingThread,
+    ):
+        monkeypatch.setattr(cls, "start", lambda self: self.ready_event.set())
+    monkeypatch.setenv("DFKV_CONNECTOR_CLIENT_RANKS", "1")
+    monkeypatch.setenv("DFKV_CONNECTOR_CLIENT_ELIDE", "1")
+    monkeypatch.setenv("DFKV_CLIENT_NODE_DEDUP", "0")
+    monkeypatch.setenv("DFKV_CLIENT_NODE_DEDUP_GPU", "0")
+    monkeypatch.setenv("DFKV_CLIENT_LOG_SUFFIX", "state-test")
+
+    def create(tp_rank, *, dcp=1, states=True, attention_block_size=None, scratch=False, kernel_tiles=1, wrapped_attention=False):
+        rank[0], dcp_size[0] = tp_rank, dcp
+        physical_block_size = attention_block_size or BLOCK // dcp
+        mla = MLAAttentionSpec(
+            block_size=physical_block_size, num_kv_heads=1, head_size=1, dtype=torch.uint8,
+        )
+        if wrapped_attention:
+            mla = UniformTypeKVCacheSpecs(
+                block_size=physical_block_size, kv_cache_specs={"mla": mla}
+            )
+        state = MambaSpec(
+            block_size=BLOCK, shapes=((16,),), dtypes=(torch.uint8,),
+            mamba_cache_mode="align",
+        )
+        groups = [
+            KVCacheGroupSpec(["mla"], mla),
+            KVCacheGroupSpec(["state"], state),
+            KVCacheGroupSpec(
+                ["wrapped_state"],
+                UniformTypeKVCacheSpecs(
+                    block_size=BLOCK, kv_cache_specs={"wrapped_state": state},
+                ),
+            ),
+        ]
+        if not states:
+            groups = groups[:1]
+        if scratch:
+            groups.append(KVCacheGroupSpec(
+                ["scratch"],
+                _ScratchSpec(block_size=4, num_kv_heads=1, head_size=1, dtype=torch.uint8),
+            ))
+        config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                model="test/hybrid-state", use_mla=True,
+                get_num_layers=lambda parallel: len(groups),
+            ),
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1, pipeline_parallel_size=1, rank=tp_rank,
+                decode_context_parallel_size=dcp,
+            ),
+            kv_transfer_config=SimpleNamespace(
+                kv_role="kv_producer",
+                kv_connector_extra_config={"members": "127.0.0.1:1"},
+            ),
+            cache_config=SimpleNamespace(
+                num_gpu_blocks=4, block_size=physical_block_size,
+                enable_prefix_caching=True, prefix_match_unit=None,
+            ),
+            kv_events_config=None,
+        )
+        worker = DfkvStoreWorker(
+            config, SimpleNamespace(kv_cache_groups=groups),
+        )
+        workers.append(worker)
+        buffers = {
+            "mla": torch.zeros((4 * kernel_tiles, physical_block_size // kernel_tiles, 1), dtype=torch.uint8),
+            "state": torch.zeros((4, 16), dtype=torch.uint8),
+            "wrapped_state": torch.zeros((4, 16), dtype=torch.uint8),
+        }
+        if not states:
+            buffers = {"mla": buffers["mla"]}
+        if scratch:
+            buffers["scratch"] = torch.zeros((1, 4, 1), dtype=torch.uint8)
+        worker.register_kv_caches(buffers)
+        return worker, buffers
+
+    yield create, objects
+    for worker in workers:
+        worker.close()
+
+
+@pytest.mark.parametrize("dcp", [1, 2])
+def test_hybrid_state_round_trip_preserves_every_tp_payload(hybrid_workers, dcp):
+    create, objects = hybrid_workers
+    hashes = _hashes()
+    expected = []
+    for rank in range(4):
+        producer, buffers = create(rank, dcp=dcp)
+        for group, tensor in enumerate(buffers.values()):
+            for block in range(4):
+                tensor[block].fill_(10 + block + group * 20 + (rank * 4 if group else 0))
+        expected.append({name: tensor.clone() for name, tensor in buffers.items()})
+        request = ReqMeta(
+            req_id=f"save-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([1, 3], [3], [3]), block_hashes=hashes,
+        )
+        producer.kv_send_thread.add_stored_request(request.req_id)
+        producer.kv_send_thread._handle_request(request)
+
+    for rank in range(4):
+        consumer, buffers = create(rank, dcp=dcp)
+        assert consumer.lookup(2 * BLOCK, hashes) == 2 * BLOCK
+        request = ReqMeta(
+            req_id=f"load-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([0, 2], [2], [2]), block_hashes=hashes,
+            load_spec=LoadSpec(0, 2 * BLOCK, True, token_len=2 * BLOCK),
+        )
+        consumer.kv_recv_thread.load_request_sync(request)
+        assert consumer.get_block_ids_with_load_errors() == set()
+        for name, tensor in buffers.items():
+            result = torch.zeros_like(tensor)
+            result[2].copy_(expected[rank][name][3])
+            if name == "mla":
+                result[0].copy_(expected[rank][name][1])
+            assert torch.equal(tensor, result), (rank, name)
+
+    # An old state object under attention's pool, even with the same numeric
+    # rank coordinate, cannot substitute for a missing corrected shard.
+    victim, _ = create(3, dcp=dcp)
+    metadata = victim.token_dbs[2].metadata
+    key = PoolKey(metadata, hashes[1].hex()).to_bytes()
+    legacy_key = PoolKey(replace(metadata, pool_name="kv"), hashes[1].hex()).to_bytes()
+    objects[victim.client.namespace, legacy_key] = objects.pop((victim.client.namespace, key))
+    for rank in range(4):
+        consumer, _ = create(rank, dcp=dcp)
+        assert consumer.lookup(2 * BLOCK, hashes) == 0
+
+
+@pytest.mark.parametrize("client_ranks", ["1", "4"])
+def test_replicated_mla_round_trip_with_converged_or_striped_writers(
+    hybrid_workers, monkeypatch, client_ranks,
+):
+    create, _ = hybrid_workers
+    monkeypatch.setenv("DFKV_CONNECTOR_CLIENT_RANKS", client_ranks)
+    hashes = _hashes()
+    for rank in range(4):
+        producer, buffers = create(rank, states=False)
+        buffers["mla"][1].fill_(11)
+        buffers["mla"][3].fill_(33)
+        request = ReqMeta(
+            req_id=f"mla-save-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([1, 3],), block_hashes=hashes,
+        )
+        producer.kv_send_thread.add_stored_request(request.req_id)
+        producer.kv_send_thread._handle_request(request)
+
+    for rank in range(4):
+        consumer, buffers = create(rank, states=False)
+        # Producer-only elided clients are lazily created when loading.
+        consumer._ensure_client_for_load()
+        assert consumer.lookup(2 * BLOCK, hashes) == 2 * BLOCK
+        consumer.kv_recv_thread.load_request_sync(ReqMeta(
+            req_id=f"mla-load-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([0, 2],), block_hashes=hashes,
+            load_spec=LoadSpec(0, 2 * BLOCK, True, token_len=2 * BLOCK),
+        ))
+        assert consumer.get_block_ids_with_load_errors() == set()
+        expected = torch.zeros_like(buffers["mla"])
+        expected[0].fill_(11)
+        expected[2].fill_(33)
+        assert torch.equal(buffers["mla"], expected)
+
+
+@pytest.mark.parametrize("dcp", [1, 2])
+def test_hybrid_lookup_covers_every_smaller_attention_block(hybrid_workers, dcp):
+    create, _ = hybrid_workers
+    hashes = _hashes(4)
+    expected = []
+    for rank in range(4):
+        producer, buffers = create(rank, dcp=dcp, attention_block_size=16 // dcp)
+        for group, tensor in enumerate(buffers.values()):
+            for block in range(4):
+                tensor[block].fill_(10 + block + group * 20 + (rank * 4 if group else 0))
+        expected.append({name: tensor.clone() for name, tensor in buffers.items()})
+        request = ReqMeta(
+            req_id=f"mixed-save-{rank}", token_len_chunk=BLOCK,
+            block_ids=([3, 0, 2, 1], [3], [3]), block_hashes=hashes,
+        )
+        producer.kv_send_thread.add_stored_request(request.req_id)
+        producer.kv_send_thread._handle_request(request)
+
+    for rank in range(4):
+        consumer, buffers = create(rank, dcp=dcp, attention_block_size=16 // dcp)
+        assert consumer.lookup(BLOCK, hashes) == BLOCK
+        request = ReqMeta(
+            req_id=f"mixed-load-{rank}", token_len_chunk=BLOCK,
+            block_ids=([0, 1, 2, 3], [1], [1]), block_hashes=hashes,
+            load_spec=LoadSpec(0, BLOCK, True, token_len=BLOCK),
+        )
+        consumer.kv_recv_thread.load_request_sync(request)
+        assert consumer.get_block_ids_with_load_errors() == set()
+        assert torch.equal(buffers["mla"], expected[rank]["mla"][[3, 0, 2, 1]])
+        for name in ("state", "wrapped_state"):
+            result = torch.zeros_like(buffers[name])
+            result[1].copy_(expected[rank][name][3])
+            assert torch.equal(buffers[name], result)
+
+
+def test_nonpersistent_scratch_does_not_constrain_or_overwrite_prefix_cache(hybrid_workers):
+    create, _ = hybrid_workers
+    hashes = _hashes(1)
+    for rank in range(4):
+        producer, buffers = create(rank, scratch=True)
+        buffers["mla"][1].fill_(17)
+        buffers["state"][3].fill_(30 + rank)
+        buffers["wrapped_state"][3].fill_(50 + rank)
+        buffers["scratch"].fill_(42)
+        request = ReqMeta(
+            req_id=f"scratch-save-{rank}", token_len_chunk=BLOCK,
+            block_ids=([1], [3], [3], [0]), block_hashes=hashes,
+        )
+        producer.kv_send_thread.add_stored_request(request.req_id)
+        producer.kv_send_thread._handle_request(request)
+
+    for rank in range(4):
+        consumer, buffers = create(rank, scratch=True)
+        buffers["scratch"].fill_(99)
+        assert consumer.lookup(BLOCK, hashes) == BLOCK
+        request = ReqMeta(
+            req_id=f"scratch-load-{rank}", token_len_chunk=BLOCK,
+            block_ids=([0], [2], [2], [0]), block_hashes=hashes,
+            load_spec=LoadSpec(0, BLOCK, True, token_len=BLOCK),
+        )
+        consumer.kv_recv_thread.load_request_sync(request)
+        assert consumer.get_block_ids_with_load_errors() == set()
+        assert torch.all(buffers["mla"][0] == 17)
+        assert torch.all(buffers["state"][2] == 30 + rank)
+        assert torch.all(buffers["wrapped_state"][2] == 50 + rank)
+        assert torch.all(buffers["scratch"] == 99)
+
+
+def test_logical_block_ids_restore_every_kernel_tile(hybrid_workers):
+    create, _ = hybrid_workers
+    hashes = _hashes()
+    expected_source = torch.arange(4 * BLOCK, dtype=torch.uint8).reshape(4, BLOCK)
+    for rank in range(4):
+        producer, buffers = create(rank, states=False, kernel_tiles=4)
+        buffers["mla"].copy_(expected_source.reshape(buffers["mla"].shape))
+        request = ReqMeta(
+            req_id=f"tiles-save-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([1, 3],), block_hashes=hashes,
+        )
+        producer.kv_send_thread.add_stored_request(request.req_id)
+        producer.kv_send_thread._handle_request(request)
+
+    for rank in range(4):
+        consumer, buffers = create(rank, states=False, kernel_tiles=4)
+        request = ReqMeta(
+            req_id=f"tiles-load-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([0, 2],), block_hashes=hashes,
+            load_spec=LoadSpec(0, 2 * BLOCK, True, token_len=2 * BLOCK),
+        )
+        consumer.kv_recv_thread.load_request_sync(request)
+        assert consumer.get_block_ids_with_load_errors() == set()
+        expected = torch.zeros_like(expected_source)
+        expected[0].copy_(expected_source[1])
+        expected[2].copy_(expected_source[3])
+        assert torch.equal(buffers["mla"].reshape(4, BLOCK), expected)
+
+
+def test_full_block_tables_do_not_shift_to_uncomputed_tail(hybrid_workers):
+    create, _ = hybrid_workers
+    hashes = _hashes()
+    expected_source = []
+    for rank in range(4):
+        producer, buffers = create(rank)
+        for group, tensor in enumerate(buffers.values()):
+            for block in range(4):
+                tensor[block].fill_(10 + block + group * 20 + (rank * 4 if group else 0))
+        expected_source.append({name: tensor.clone() for name, tensor in buffers.items()})
+        request = ReqMeta(
+            req_id=f"tail-save-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([1, 3, 2], [1, 3, 2], [1, 3, 2]), block_hashes=hashes,
+        )
+        producer.kv_send_thread.add_stored_request(request.req_id)
+        producer.kv_send_thread._handle_request(request)
+
+    for rank in range(4):
+        consumer, buffers = create(rank)
+        for tensor in buffers.values():
+            tensor[3].fill_(99)
+        request = ReqMeta(
+            req_id=f"tail-load-{rank}", token_len_chunk=2 * BLOCK,
+            block_ids=([0, 2, 3], [0, 2, 3], [0, 2, 3]), block_hashes=hashes,
+            load_spec=LoadSpec(0, 2 * BLOCK, True, token_len=2 * BLOCK),
+        )
+        consumer.kv_recv_thread.load_request_sync(request)
+        assert consumer.get_block_ids_with_load_errors() == set()
+        for name, tensor in buffers.items():
+            expected = torch.zeros_like(tensor)
+            expected[2].copy_(expected_source[rank][name][3])
+            expected[3].fill_(99)
+            if name == "mla":
+                expected[0].copy_(expected_source[rank][name][1])
+            assert torch.equal(tensor, expected), (rank, name)
+
+
+def test_wrapped_attention_uses_engine_dcp_hash_geometry(hybrid_workers):
+    create, _ = hybrid_workers
+    hashes = _hashes()
+    for rank in range(4):
+        producer, buffers = create(rank, dcp=2, wrapped_attention=True)
+        buffers["mla"][1].fill_(17)
+        buffers["mla"][3].fill_(19)
+        buffers["state"][3].fill_(30 + rank)
+        buffers["wrapped_state"][3].fill_(50 + rank)
+        request = ReqMeta(
+            req_id=f"wrapped-save-{rank}", token_len_chunk=BLOCK,
+            block_ids=([1, 3], [3], [3]), block_hashes=hashes,
+        )
+        producer.kv_send_thread.add_stored_request(request.req_id)
+        producer.kv_send_thread._handle_request(request)
+
+    for rank in range(4):
+        consumer, buffers = create(rank, dcp=2, wrapped_attention=True)
+        assert consumer.lookup(BLOCK, hashes) == BLOCK
+        request = ReqMeta(
+            req_id=f"wrapped-load-{rank}", token_len_chunk=BLOCK,
+            block_ids=([0, 2], [2], [2]), block_hashes=hashes,
+            load_spec=LoadSpec(0, BLOCK, True, token_len=BLOCK),
+        )
+        consumer.kv_recv_thread.load_request_sync(request)
+        assert consumer.get_block_ids_with_load_errors() == set()
+        assert torch.all(buffers["mla"][0] == 17)
+        assert torch.all(buffers["mla"][2] == 19)
+        assert torch.all(buffers["state"][2] == 30 + rank)
+        assert torch.all(buffers["wrapped_state"][2] == 50 + rank)

--- a/src/cache/kv_node_server.cc
+++ b/src/cache/kv_node_server.cc
@@ -970,7 +970,8 @@ Status KvNodeServer::ProcessRequestForKey(
     case WireOp::kListTopology:
     case WireOp::kPullRange:
     case WireOp::kPullRelease:
-      st = Status::kInvalid;  // MDS ops are not served by a cache node
+    case WireOp::kLeasePut:
+      st = Status::kInvalid;  // MDS/RDMA-only ops are not served by a cache node
       break;
     }
   if (st == Status::kInvalid) invalid_ops_.fetch_add(1, std::memory_order_relaxed);

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -1132,9 +1132,16 @@ void RdmaServer::Serve(int boot_fd) {
     }
 
     const char* frame = ep.rbuf(recv_slot);
-    if (completion.byte_len < kReqPrefix ||
-        !DecodeReqVersion(frame, wire_epoch, &request->fields,
-                          static_cast<uint64_t>(conn_max))) {
+    if (completion.byte_len < kReqPrefix) return false;
+    // A leased-PUT request names the OBJECT size, not an inline payload: its
+    // bound is the process-wide payload ceiling, not this connection's
+    // inline class. Every other control op keeps the conn_max bound.
+    const uint64_t send_max_payload =
+        static_cast<uint8_t>(frame[1]) == static_cast<uint8_t>(WireOp::kLeasePut)
+            ? static_cast<uint64_t>(max_msg_)
+            : static_cast<uint64_t>(conn_max);
+    if (!DecodeReqVersion(frame, wire_epoch, &request->fields,
+                          send_max_payload)) {
       return false;
     }
     if (request->fields.op == static_cast<uint8_t>(WireOp::kRange)) {

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -597,6 +597,7 @@ void RdmaServer::Serve(int boot_fd) {
   const bool writer_retirement_requested =
       rdma::DevFrameRequestsWriterRetirement(devbuf);
   const bool pull_read_requested = rdma::DevFrameRequestsPullRead(devbuf);
+  const bool leased_put_requested = rdma::DevFrameRequestsLeasedPut(devbuf);
   const uint64_t declared = rdma::ParseDevFrameMaxBlock(devbuf);
   if (rdma::ParseDevFrameProtocol(devbuf) != rdma::kDevProtoV2 ||
       declared == 0) {
@@ -771,6 +772,19 @@ void RdmaServer::Serve(int boot_fd) {
     double completion_elapsed_sec = 0.0;
     PreparedRead completion;
   };
+  // In-flight leased-PUT staging state, one entry per connection recv slot.
+  // `lease` owns a receive-pool range sized for exactly this object; the range
+  // is returned the moment the store holds the bytes (handler returned), so
+  // receive memory tracks data in flight instead of connection count.
+  // `generation` survives slot reuse (monotonic, never 0) for lease
+  // diagnostics and future release/retry extensions.
+  struct LeasePutState {
+    bool active = false;
+    uint64_t generation = 0;
+    BlockKey key;
+    uint64_t payload_len = 0;
+    rdma::RecvSegmentPool::Lease lease;
+  };
   struct PendingCompletion {
     PreparedRead read;
     Status status = Status::kOk;
@@ -788,6 +802,27 @@ void RdmaServer::Serve(int boot_fd) {
   std::vector<MultiGetState> multi_get(K);
   std::vector<int32_t> multi_get_source_owner(K, -1);
   std::vector<PendingCompletion> complete_on_send(K);
+  std::vector<LeasePutState> lease_put(K);
+  auto release_lease_put = [&](size_t slot) {
+    LeasePutState& state = lease_put[slot];
+    if (!state.active || !state.lease) return;
+    lease_put_bytes_active_.fetch_sub(state.lease.size(),
+                                      std::memory_order_relaxed);
+    lease_put_active_.fetch_sub(1, std::memory_order_relaxed);
+    state.active = false;
+    state.key = BlockKey{};
+    state.payload_len = 0;
+    state.lease.Reset();  // range returns to the receive pool immediately
+  };
+  // generation is the only field that survives release: it monotones upward
+  // so every LeasePutReady names a distinct op for diagnostics and any future
+  // release/retry wire extension. Never emit 0 (treated as "absent").
+  auto next_lease_generation = [&](size_t slot) -> uint64_t {
+    uint64_t generation = lease_put[slot].generation + 1;
+    if (generation == 0) ++generation;
+    lease_put[slot].generation = generation;
+    return generation;
+  };
   auto clear_multi_get = [&](size_t operation_id) {
     MultiGetState& state = multi_get[operation_id];
     if (state.active && state.source_uses_slot &&
@@ -977,6 +1012,7 @@ void RdmaServer::Serve(int boot_fd) {
     RdmaGetFields get;
     bool multi_put_window = false;
     bool multi_put_final = false;
+    bool from_lease_put = false;
   };
 
   auto decode_request = [&](const ibv_wc& completion,
@@ -998,8 +1034,25 @@ void RdmaServer::Serve(int boot_fd) {
       const size_t data_slot = static_cast<size_t>(ntohl(completion.imm_data));
       if (data_slot >= K || multi_get_source_owner[data_slot] >= 0)
         return false;
-      const char* frame = recv_lease.data() + data_slot * slot_size +
-                          rdma::kV2PutPrefixOffset;
+      LeasePutState& lstate = lease_put[data_slot];
+      const bool from_lease = lstate.active;
+      const char* frame =
+          from_lease
+              ? lstate.lease.data() + rdma::kV2PutPrefixOffset
+              : recv_lease.data() + data_slot * slot_size +
+                    rdma::kV2PutPrefixOffset;
+      // Destination-region geometry: the leased per-op range when this window
+      // belongs to an in-flight leased-PUT object, the resident receive slot
+      // otherwise. Both size the frame cover check and the logical payload
+      // cap so leased objects are not bounded by the connection class.
+      const size_t put_region_bytes =
+          from_lease ? lstate.lease.size() : slot_size;
+      const uint64_t put_payload_cap =
+          from_lease
+              ? static_cast<uint64_t>(lstate.lease.size() -
+                                      rdma::kV2DataOffset)
+              : static_cast<uint64_t>(logical_data_cap);
+      request->from_lease_put = from_lease;
       MultiPutState& state = multi_put[data_slot];
       uint64_t window_bytes = completion.byte_len;
       if (state.active) {
@@ -1028,8 +1081,16 @@ void RdmaServer::Serve(int boot_fd) {
         if (completion.byte_len < kReqPrefix ||
             !DecodeReqVersion(
                 frame, kNativeProtoRdmaV2, &request->fields,
-                static_cast<uint64_t>(logical_data_cap)) ||
+                put_payload_cap) ||
             request->fields.op != static_cast<uint8_t>(WireOp::kCache)) {
+          return false;
+        }
+        // A leased-PUT window must name the exact object the client asked
+        // the server to stage: any mismatch is a protocol fault, not a
+        // missized retry, so drop the connection (fail closed).
+        if (from_lease &&
+            (request->fields.payload_len != lstate.payload_len ||
+             !(request->fields.Key() == lstate.key))) {
           return false;
         }
         if (request->fields.offset == rdma::kV2MultiWrPutMagic) {
@@ -1055,7 +1116,7 @@ void RdmaServer::Serve(int boot_fd) {
         } else if (!rdma::V2PutCompletionIsValid(
                        write_imm_recv, has_immediate,
                        completion.byte_len, request->fields.payload_len,
-                       logical_data_cap, slot_size)) {
+                       put_payload_cap, put_region_bytes)) {
           return false;
         } else {
           window_bytes = request->fields.payload_len;
@@ -1098,9 +1159,23 @@ void RdmaServer::Serve(int boot_fd) {
       request->contiguous_payload = frame + kReqPrefix;
       return true;
     }
+    if (request->fields.op == static_cast<uint8_t>(WireOp::kLeasePut)) {
+      // Leased-PUT staging request. The object itself arrives later as one
+      // or more WRITE_WITH_IMM windows into the leased range, so this request
+      // only needs to prove the object geometry is legal and the slot has no
+      // in-flight lease/multi-window state. A lease larger than the logical
+      // --max-msg bound is a permanent fault, not backpressure.
+      if (!leased_put_requested ||
+          request->fields.payload_len == 0 ||
+          request->fields.payload_len > static_cast<uint64_t>(max_msg_) ||
+          lease_put[recv_slot].active || multi_put[recv_slot].active)
+        return false;
+      return true;
+    }
     if (request->fields.op == static_cast<uint8_t>(WireOp::kPullRelease)) {
       return completion.byte_len == kReqPrefix;
     }
+
 
 
     if (multi_put[recv_slot].active) return false;
@@ -1311,6 +1386,48 @@ void RdmaServer::Serve(int boot_fd) {
       return true;
     }
 
+    if (fields.op == static_cast<uint8_t>(WireOp::kLeasePut)) {
+      // Stage exactly this object from the shared receive pool. The whole
+      // lease is released by release_lease_put() as soon as the store holds
+      // the bytes, so the hard budget bounds data in flight, not
+      // connections. A failed allocation is backpressure, not a fault: the
+      // client treats kCacheFull like a saturated pull slot and may retry.
+      const size_t slot = request.recv_slot;
+      const uint64_t want = fields.payload_len;
+      const size_t region = rdma::V2SlotSize(want);
+      if (region == 0) return false;
+      LeasePutState& state = lease_put[slot];
+      state.lease = recv_segments_.Allocate(
+          region, rdma::kV2DataOffset, static_cast<int>(rail_index),
+          rail_numa);
+      if (!state.lease) {
+        lease_put_busy_rejects_.fetch_add(1, std::memory_order_relaxed);
+        encode_status(Status::kCacheFull, 0);
+        reply->first_len = response_prefix;
+        return true;
+      }
+      state.active = true;
+      state.key = key;
+      state.payload_len = want;
+      lease_put_ops_.fetch_add(1, std::memory_order_relaxed);
+      lease_put_bytes_.fetch_add(want, std::memory_order_relaxed);
+      lease_put_active_.fetch_add(1, std::memory_order_relaxed);
+      lease_put_bytes_active_.fetch_add(state.lease.size(),
+                                        std::memory_order_relaxed);
+      // The receive-pool chunk carrying the lease is already registered for
+      // remote writes (recv_segment_mr covers the whole chunk), so the WRITE
+      // needs no extra MR: publish the lease's own address with that rkey.
+      const rdma::LeasePutReady ready{
+          static_cast<uint32_t>(slot), next_lease_generation(slot),
+          recv_segment_mr->rkey,
+          reinterpret_cast<uint64_t>(state.lease.data()),
+          state.lease.size()};
+      encode_status(Status::kOk, rdma::kLeasePutReadyBytes);
+      rdma::EncodeLeasePutReady(ready, send_buffer + response_prefix);
+      reply->first_len = response_prefix + rdma::kLeasePutReadyBytes;
+      return true;
+    }
+
     if (fields.op == static_cast<uint8_t>(WireOp::kRange) &&
         request.get.window_index != 0) {
       const size_t operation_id = request.get.operation_id;
@@ -1464,12 +1581,32 @@ void RdmaServer::Serve(int boot_fd) {
 
     if (fields.op == static_cast<uint8_t>(WireOp::kCache) &&
         cache_direct_handler_) {
-      if (!direct_buffer(request.data_slot) ||
-          !direct_mr(request.data_slot) || fields.payload_len == 0 ||
-          fields.payload_len > static_cast<uint64_t>(logical_data_cap))
-        return invalid_reply();
-
-      char* cache_data = direct_buffer(request.data_slot);
+      const bool from_lease = request.from_lease_put;
+      LeasePutState& lstate = lease_put[request.data_slot];
+      char* cache_data = nullptr;
+      size_t cache_cap = 0;
+      if (from_lease) {
+        // decode matched this window to the in-flight lease; losing that
+        // binding now is an internal fault, so release and drop the
+        // connection (fail closed) rather than storing from bad memory.
+        if (!lstate.active || !lstate.lease ||
+            fields.payload_len == 0 ||
+            fields.payload_len > lstate.payload_len ||
+            fields.payload_len >
+                lstate.lease.size() - rdma::kV2DataOffset) {
+          release_lease_put(request.data_slot);
+          return false;
+        }
+        cache_data = lstate.lease.data() + rdma::kV2DataOffset;
+        cache_cap = lstate.lease.size() - rdma::kV2DataOffset;
+      } else {
+        if (!direct_buffer(request.data_slot) ||
+            !direct_mr(request.data_slot) || fields.payload_len == 0 ||
+            fields.payload_len > static_cast<uint64_t>(logical_data_cap))
+          return invalid_reply();
+        cache_data = direct_buffer(request.data_slot);
+        cache_cap = direct_buffer_cap;
+      }
       if (request.contiguous_payload &&
           request.contiguous_payload != cache_data) {
         std::memcpy(cache_data, request.contiguous_payload,
@@ -1477,9 +1614,13 @@ void RdmaServer::Serve(int boot_fd) {
       }
       const Status status = cache_direct_handler_(
           key, cache_data, static_cast<size_t>(fields.payload_len),
-          direct_buffer_cap);
+          cache_cap);
       encode_status(status, 0);
       reply->first_len = response_prefix;
+      // The store consumed the bytes synchronously (O_DIRECT write or RAM
+      // admit copy), so the staging range returns to the pool now — before
+      // the status SEND, which never touches the lease.
+      if (from_lease) release_lease_put(request.data_slot);
       return true;
     }
 
@@ -1493,6 +1634,12 @@ void RdmaServer::Serve(int boot_fd) {
     const Status status =
         handler_(fields.op, key, fields.offset, fields.length, payload,
                  fields.payload_len, &data, &value_len);
+    // The generic handler copies payload bytes synchronously before
+    // returning, so a leased-PUT object is fully consumed here and its
+    // staging range returns to the pool before the status is encoded.
+    if (fields.op == static_cast<uint8_t>(WireOp::kCache) &&
+        request.from_lease_put)
+      release_lease_put(request.data_slot);
     if (fields.op == static_cast<uint8_t>(WireOp::kRange)) {
       if (data.size() > direct_buffer_cap) return invalid_reply();
       if (!data.empty())
@@ -1974,6 +2121,10 @@ void RdmaServer::Serve(int boot_fd) {
       ring.Drain();
     if (metric_inflight != 0)
       uring_inflight_.fetch_sub(metric_inflight, std::memory_order_relaxed);
+    // Any still-active per-op staging leases are connection losses; release
+    // them through the accounting path before RAII teardown so the gauge
+    // pair (lease_put_active / lease_put_bytes_active) stays exact.
+    for (size_t slot = 0; slot < K; ++slot) release_lease_put(slot);
 
     rail_stats.active_conns.fetch_sub(1, std::memory_order_relaxed);
     active_conns_.fetch_sub(1, std::memory_order_relaxed);
@@ -2051,6 +2202,9 @@ sync_serve_loop:;
     }
   }
   // Any prepared sends without completions destructor-abort below.
+  // Same release sweep for the sync loop: active leases were in flight when
+  // the connection ended, so their accounting must unwind before teardown.
+  for (size_t slot = 0; slot < K; ++slot) release_lease_put(slot);
   rail_stats.active_conns.fetch_sub(1, std::memory_order_relaxed);
   active_conns_.fetch_sub(1, std::memory_order_relaxed);
   { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
@@ -2141,6 +2295,24 @@ std::string RdmaServer::MetricsText() const {
        std::to_string(
            control_connection_bytes_.load(std::memory_order_relaxed)) +
        "\n";
+  s += "dfkv_rdma_connection_bytes{class=\"lease_put_inflight\"} " +
+       std::to_string(
+           lease_put_bytes_active_.load(std::memory_order_relaxed)) +
+       "\n";
+  m(s, "dfkv_rdma_leaseput_ops_total", "counter",
+    "Leased-PUT staging operations served", lease_put_ops_);
+  m(s, "dfkv_rdma_leaseput_bytes_total", "counter",
+    "Logical object bytes delivered via leased-PUT staging",
+    lease_put_bytes_);
+  m(s, "dfkv_rdma_leaseput_busy_rejects_total", "counter",
+    "Leased-PUT requests refused because the receive pool was exhausted",
+    lease_put_busy_rejects_);
+  m(s, "dfkv_rdma_leaseput_active", "gauge",
+    "In-flight leased-PUT staging leases currently held",
+    lease_put_active_);
+  m(s, "dfkv_rdma_leaseput_bytes_active", "gauge",
+    "Receive-pool bytes held by in-flight leased-PUT staging",
+    lease_put_bytes_active_);
   m(s, "dfkv_rdma_v2_ready", "gauge",
     "Whether RDMA v2 has a registered shared receive segment",
     recv_segment_registered_rails_ > 0 ? 1 : 0);

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -1421,12 +1421,22 @@ void RdmaServer::Serve(int boot_fd) {
       lease_put_active_.fetch_add(1, std::memory_order_relaxed);
       lease_put_bytes_active_.fetch_add(state.lease.size(),
                                         std::memory_order_relaxed);
-      // The receive-pool chunk carrying the lease is already registered for
-      // remote writes (recv_segment_mr covers the whole chunk), so the WRITE
-      // needs no extra MR: publish the lease's own address with that rkey.
+      // The lease may live in ANY receive-pool chunk, including one grown
+      // after this connection opened — recv_segment_mr only covers the
+      // chunk carrying the connection's resident slots. Resolve the lease's
+      // own chunk: RegisterRemoteRegion dedupes, so repeated lookups cost
+      // nothing once the chunk is registered for remote writes.
+      ibv_mr* const lease_region_mr = ep.RegisterRemoteRegion(
+          state.lease.segment()->data(), state.lease.segment()->size());
+      if (!lease_region_mr) {
+        release_lease_put(slot);
+        encode_status(Status::kIOError, 0);
+        reply->first_len = response_prefix;
+        return true;
+      }
       const rdma::LeasePutReady ready{
           static_cast<uint32_t>(slot), next_lease_generation(slot),
-          recv_segment_mr->rkey,
+          lease_region_mr->rkey,
           reinterpret_cast<uint64_t>(state.lease.data()),
           state.lease.size()};
       encode_status(Status::kOk, rdma::kLeasePutReadyBytes);

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -672,10 +672,10 @@ void RdmaServer::Serve(int boot_fd) {
     const uint64_t evict_started = SteadyUs();
     for (int round = 0; round < 32 && !recv_lease; ++round) {
       if (SteadyUs() - evict_started > 5000000) break;  // bound: <= 5 s total
-      rdma::RcEndpoint* victim = nullptr;
-      uint64_t victim_active = std::numeric_limits<uint64_t>::max();
       {
         std::lock_guard<std::mutex> lk(conn_mu_);
+        rdma::RcEndpoint* victim = nullptr;
+        uint64_t victim_active = std::numeric_limits<uint64_t>::max();
         for (rdma::RcEndpoint* ep : live_eps_) {
           const uint64_t a =
               ep->last_active_us_.load(std::memory_order_relaxed);
@@ -686,10 +686,13 @@ void RdmaServer::Serve(int boot_fd) {
             victim_active = a;
           }
         }
-        if (victim) live_eps_.erase(victim);  // claim it: no other evictor
-      }                                        // can Wake a freed stack endpoint
-      if (!victim) break;  // every connection is recently active; refuse
-      victim->Wake();  // Serve exits; the Lease destructor returns its range
+        if (!victim) break;  // every connection is recently active; refuse
+        live_eps_.erase(victim);  // claim it: no other evictor can pick it.
+        // Wake under conn_mu_: a Serve thread taking the erase exit (2235/
+        // 2304) must hold conn_mu_ before destroying its stack endpoint, so
+        // an idle waiter cannot retire and free it between unlock and Wake.
+        victim->Wake();  // Serve exits; its Lease destructor returns the range
+      }
       segment_evictions_.fetch_add(1, std::memory_order_relaxed);
       // Poll for the freed range (bounded). The victim's Serve thread tears
       // down its endpoint and releases the lease asynchronously.

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -598,9 +598,13 @@ void RdmaServer::Serve(int boot_fd) {
       rdma::DevFrameRequestsWriterRetirement(devbuf);
   const bool pull_read_requested = rdma::DevFrameRequestsPullRead(devbuf);
   const bool leased_put_requested = rdma::DevFrameRequestsLeasedPut(devbuf);
+  const bool dynamic_pull_requested =
+      rdma::DevFrameRequestsDynamicPull(devbuf);
   const uint64_t declared = rdma::ParseDevFrameMaxBlock(devbuf);
   if (rdma::ParseDevFrameProtocol(devbuf) != rdma::kDevProtoV2 ||
-      declared == 0) {
+      declared == 0 ||
+      (dynamic_pull_requested &&
+       (!pull_read_requested || !writer_retirement_requested))) {
     DFKV_LOG_ERROR("rdma: rejecting peer without required v2 negotiation");
     ::close(boot_fd);
     return;
@@ -709,7 +713,7 @@ void RdmaServer::Serve(int boot_fd) {
     }
   }
   rdma::RecvSegmentPool::Lease pull_lease;
-  if (pull_read_requested) {
+  if (pull_read_requested && !dynamic_pull_requested) {
     pull_lease = recv_segments_.Allocate(
         K * slot_size, rdma::kV2DataOffset,
         static_cast<int>(rail_index), rail_numa);
@@ -810,8 +814,28 @@ void RdmaServer::Serve(int boot_fd) {
     uint64_t generation = 1;
     size_t data_len = 0;
     size_t value_len = 0;
+    rdma::RecvSegmentPool::Lease lease;
+    ibv_mr* mr = nullptr;  // endpoint-owned, revoked before Reset()
+    std::atomic<uint64_t>* active_count = nullptr;
+    std::atomic<uint64_t>* active_bytes = nullptr;
+    ~PullSlotState() { Reset(); }
+    void Reset() {
+      if (lease) {
+        active_bytes->fetch_sub(lease.size(), std::memory_order_relaxed);
+        active_count->fetch_sub(1, std::memory_order_relaxed);
+        lease.Reset();
+      }
+      mr = nullptr;
+      busy = false;
+      data_len = 0;
+      value_len = 0;
+    }
   };
   std::vector<PullSlotState> pull_slots(K);
+  for (auto& state : pull_slots) {
+    state.active_count = &dynamic_get_active_;
+    state.active_bytes = &dynamic_get_bytes_active_;
+  }
   std::vector<MultiPutState> multi_put(K);
   std::vector<MultiGetState> multi_get(K);
   std::vector<int32_t> multi_get_source_owner(K, -1);
@@ -851,6 +875,13 @@ void RdmaServer::Serve(int boot_fd) {
     ep.ReleaseLeaseWriteRegion(state.mr);
     state.Reset();
   };
+  auto release_pull = [&](size_t slot) {
+    PullSlotState& state = pull_slots[slot];
+    ep.ReleaseLeaseReadRegion(state.mr);
+    state.Reset();
+    ++state.generation;
+    if (state.generation == 0) ++state.generation;
+  };
   constexpr size_t conn_control = rdma::kV2ControlCap;
   if (!ep.Open(dev.empty() ? nullptr : dev.c_str(), conn_control, K,
                /*ib_port=*/1, /*direct_io_buffers=*/false, conn_max,
@@ -869,7 +900,7 @@ void RdmaServer::Serve(int boot_fd) {
   ibv_mr* pull_pool_mr = nullptr;
   ibv_mr* pull_segment_mr = nullptr;
   uint32_t pull_rkey = 0;
-  if (pull_read_requested) {
+  if (pull_read_requested && !dynamic_pull_requested) {
     pull_pool_mr = ep.RegisterRemoteReadPool(
         pull_lease.segment()->data(), pull_lease.segment()->size());
     if (!pull_pool_mr) {
@@ -973,7 +1004,7 @@ void RdmaServer::Serve(int boot_fd) {
       recv_segment_mr->rkey, slot_size};
   char readiness[rdma::kV2PullReadinessBytes];
   size_t readiness_bytes = 0;
-  if (pull_read_requested) {
+  if (pull_read_requested && !dynamic_pull_requested) {
     const rdma::PullArenaInfo pull_info{
         reinterpret_cast<uint64_t>(pull_lease.data()), pull_lease.size(),
         writer_token, pull_rkey, static_cast<uint32_t>(K)};
@@ -1250,7 +1281,6 @@ void RdmaServer::Serve(int boot_fd) {
       return true;
     }
     if (successful_len > request.get.total_capacity ||
-        value_len > request.get.total_capacity ||
         (request.get.window_count > 1 && successful_len != value_len) ||
         (successful_len != 0 && (!data || !data_mr))) {
       return invalid_reply();
@@ -1344,11 +1374,7 @@ void RdmaServer::Serve(int boot_fd) {
       PullSlotState& state = pull_slots[slot];
       if (!state.busy || state.generation != fields.length)
         return invalid_reply();
-      state.busy = false;
-      state.data_len = 0;
-      state.value_len = 0;
-      ++state.generation;
-      if (state.generation == 0) ++state.generation;
+      release_pull(slot);
       encode_status(Status::kOk, 0);
       reply->first_len = response_prefix;
       return true;
@@ -1357,7 +1383,9 @@ void RdmaServer::Serve(int boot_fd) {
     if (fields.op == static_cast<uint8_t>(WireOp::kPullRange)) {
       if (!pull_read_requested || !range_handler_ ||
           fields.payload_len != rdma::kPullPrepareBytes ||
-          fields.length > static_cast<uint64_t>(conn_max) ||
+          (dynamic_pull_requested && fields.length == 0) ||
+          fields.length > static_cast<uint64_t>(
+                              dynamic_pull_requested ? max_msg_ : conn_max) ||
           request.contiguous_payload == nullptr)
         return invalid_reply();
       rdma::PullPrepareControl control;
@@ -1371,36 +1399,78 @@ void RdmaServer::Serve(int boot_fd) {
         if (!state.busy ||
             state.generation != control.release_generation)
           return invalid_reply();
-        state.busy = false;
-        state.data_len = 0;
-        state.value_len = 0;
-        ++state.generation;
-        if (state.generation == 0) ++state.generation;
+        release_pull(slot);
       }
       if (state.busy) {
         encode_status(Status::kCacheFull, 0);
         reply->first_len = response_prefix;
         return true;
       }
-      char* target = pull_lease.data() + slot * slot_size;
+      size_t target_capacity = slot_size;
+      char* target = nullptr;
+      if (dynamic_pull_requested) {
+        // One alignment block covers the head/tail of an unaligned DIO range;
+        // logical capacity remains the request length, not connection class.
+        target_capacity = rdma::V2SlotSize(fields.length);
+        if (target_capacity == 0) return invalid_reply();
+        state.lease = recv_segments_.Allocate(
+            target_capacity, rdma::kV2DataOffset,
+            static_cast<int>(rail_index), rail_numa);
+        if (!state.lease) {
+          encode_status(Status::kCacheFull, 0);
+          reply->first_len = response_prefix;
+          return true;
+        }
+        dynamic_get_active_.fetch_add(1, std::memory_order_relaxed);
+        dynamic_get_bytes_active_.fetch_add(state.lease.size(),
+                                             std::memory_order_relaxed);
+        target = state.lease.data();
+      } else {
+        target = pull_lease.data() + slot * slot_size;
+      }
       const char* output = nullptr;
       size_t output_len = 0;
       size_t value_len = 0;
       const Status status =
-          range_handler_(key, fields.offset, fields.length, target, slot_size,
-                         &output, &output_len, &value_len);
+          range_handler_(key, fields.offset, fields.length, target,
+                         target_capacity, &output, &output_len, &value_len);
       if (status != Status::kOk) {
+        state.Reset();
         encode_status(status, 0, value_len);
         reply->first_len = response_prefix;
         return true;
       }
-      if (output_len > slot_size || (output_len != 0 && output == nullptr))
+      if (output_len > target_capacity ||
+          (dynamic_pull_requested &&
+           (output_len > fields.length || output_len > value_len)) ||
+          (output_len != 0 && output == nullptr)) {
+        state.Reset();
         return invalid_reply();
+      }
       if (output_len != 0 && output != target)
-        std::memcpy(target, output, output_len);
+        std::memmove(target, output, output_len);
       state.busy = true;
       state.data_len = output_len;
       state.value_len = value_len;
+      if (dynamic_pull_requested) {
+        // Publish only the returned bytes, not a pool chunk (or alignment
+        // padding). Empty results still carry a revocable release token.
+        state.mr = ep.RegisterLeaseReadRegion(
+            target, std::max<size_t>(output_len, 1));
+        if (!state.mr) {
+          state.Reset();
+          encode_status(Status::kIOError, 0);
+          reply->first_len = response_prefix;
+          return true;
+        }
+        const rdma::DynamicPullReady ready{
+            static_cast<uint32_t>(slot), state.generation, output_len,
+            value_len, reinterpret_cast<uint64_t>(target), state.mr->rkey};
+        encode_status(Status::kOk, rdma::kDynamicPullReadyBytes, value_len);
+        rdma::EncodeDynamicPullReady(ready, send_buffer + response_prefix);
+        reply->first_len = response_prefix + rdma::kDynamicPullReadyBytes;
+        return true;
+      }
       const rdma::PullReady ready{static_cast<uint32_t>(slot),
                                   state.generation, output_len, value_len};
       encode_status(Status::kOk, rdma::kPullReadyBytes, value_len);
@@ -2299,7 +2369,7 @@ std::string RdmaServer::MetricsText() const {
     "RDMA rails with the initial receive chunk registered",
     recv_segment_registered_rails_);
   m(s, "dfkv_rdma_pull_connections", "gauge",
-    "Connections currently holding negotiated pull-read arenas",
+    "Connections currently using negotiated pull-read",
     pull_connections_.load(std::memory_order_relaxed));
   m(s, "dfkv_rdma_pull_memory_windows_total", "counter",
     "Pull-read connections isolated with type-2 Memory Windows",
@@ -2337,6 +2407,15 @@ std::string RdmaServer::MetricsText() const {
   m(s, "dfkv_rdma_leaseput_bytes_active", "gauge",
     "Receive-pool bytes held by in-flight leased-PUT staging",
     lease_put_bytes_active_);
+  m(s, "dfkv_rdma_dynamic_get_active", "gauge",
+    "In-flight dynamic GET staging operations currently held",
+    dynamic_get_active_);
+  m(s, "dfkv_rdma_dynamic_get_bytes_active", "gauge",
+    "Receive-pool bytes held by in-flight dynamic GET staging",
+    dynamic_get_bytes_active_);
+  m(s, "dfkv_rdma_dynamic_get_mr_active", "gauge",
+    "Process-wide exact dynamic GET READ registrations currently held",
+    rdma::RcEndpoint::LeaseReadMrActive());
   m(s, "dfkv_rdma_v2_ready", "gauge",
     "Whether RDMA v2 has a registered shared receive segment",
     recv_segment_registered_rails_ > 0 ? 1 : 0);

--- a/src/cache/rdma_server.cc
+++ b/src/cache/rdma_server.cc
@@ -773,17 +773,31 @@ void RdmaServer::Serve(int boot_fd) {
     PreparedRead completion;
   };
   // In-flight leased-PUT staging state, one entry per connection recv slot.
-  // `lease` owns a receive-pool range sized for exactly this object; the range
-  // is returned the moment the store holds the bytes (handler returned), so
-  // receive memory tracks data in flight instead of connection count.
-  // `generation` survives slot reuse (monotonic, never 0) for lease
-  // diagnostics and future release/retry extensions.
+  // State is declared before ep: every exceptional/early/normal exit destroys
+  // the QP and revokes its MRs before these ranges and their gauges unwind.
+  // Successful operations explicitly revoke the exact MR before Reset().
   struct LeasePutState {
     bool active = false;
     uint64_t generation = 0;
     BlockKey key;
     uint64_t payload_len = 0;
     rdma::RecvSegmentPool::Lease lease;
+    ibv_mr* mr = nullptr;  // owned by ep, never by the receive-pool chunk
+    std::atomic<uint64_t>* active_count = nullptr;
+    std::atomic<uint64_t>* active_bytes = nullptr;
+    ~LeasePutState() { Reset(); }
+    void Reset() {
+      const size_t bytes = lease.size();
+      lease.Reset();
+      if (active) {
+        active_bytes->fetch_sub(bytes, std::memory_order_relaxed);
+        active_count->fetch_sub(1, std::memory_order_relaxed);
+      }
+      active = false;
+      key = BlockKey{};
+      payload_len = 0;
+      mr = nullptr;
+    }
   };
   struct PendingCompletion {
     PreparedRead read;
@@ -803,17 +817,10 @@ void RdmaServer::Serve(int boot_fd) {
   std::vector<int32_t> multi_get_source_owner(K, -1);
   std::vector<PendingCompletion> complete_on_send(K);
   std::vector<LeasePutState> lease_put(K);
-  auto release_lease_put = [&](size_t slot) {
-    LeasePutState& state = lease_put[slot];
-    if (!state.active || !state.lease) return;
-    lease_put_bytes_active_.fetch_sub(state.lease.size(),
-                                      std::memory_order_relaxed);
-    lease_put_active_.fetch_sub(1, std::memory_order_relaxed);
-    state.active = false;
-    state.key = BlockKey{};
-    state.payload_len = 0;
-    state.lease.Reset();  // range returns to the receive pool immediately
-  };
+  for (auto& state : lease_put) {
+    state.active_count = &lease_put_active_;
+    state.active_bytes = &lease_put_bytes_active_;
+  }
   // generation is the only field that survives release: it monotones upward
   // so every LeasePutReady names a distinct op for diagnostics and any future
   // release/retry wire extension. Never emit 0 (treated as "absent").
@@ -835,6 +842,15 @@ void RdmaServer::Serve(int boot_fd) {
   };
 
   rdma::RcEndpoint ep;
+  struct BeforeEndpointTeardown {
+    const std::function<void()>& hook;
+    ~BeforeEndpointTeardown() { if (hook) hook(); }
+  } before_endpoint_teardown{before_endpoint_teardown_for_test_};
+  auto release_lease_put = [&](size_t slot) {
+    LeasePutState& state = lease_put[slot];
+    ep.ReleaseLeaseWriteRegion(state.mr);
+    state.Reset();
+  };
   constexpr size_t conn_control = rdma::kV2ControlCap;
   if (!ep.Open(dev.empty() ? nullptr : dev.c_str(), conn_control, K,
                /*ib_port=*/1, /*direct_io_buffers=*/false, conn_max,
@@ -1421,14 +1437,14 @@ void RdmaServer::Serve(int boot_fd) {
       lease_put_active_.fetch_add(1, std::memory_order_relaxed);
       lease_put_bytes_active_.fetch_add(state.lease.size(),
                                         std::memory_order_relaxed);
-      // The lease may live in ANY receive-pool chunk, including one grown
-      // after this connection opened — recv_segment_mr only covers the
-      // chunk carrying the connection's resident slots. Resolve the lease's
-      // own chunk: RegisterRemoteRegion dedupes, so repeated lookups cost
-      // nothing once the chunk is registered for remote writes.
-      ibv_mr* const lease_region_mr = ep.RegisterRemoteRegion(
-          state.lease.segment()->data(), state.lease.segment()->size());
-      if (!lease_region_mr) {
+      // A broad chunk rkey survives operation completion and authorizes stale
+      // WRITEs into recycled ranges. An exact, uncached MR grants only this
+      // lease; synchronous deregistration revokes it before pool reuse/trim.
+      // The setup-only MW helper cannot be used here: it consumes CQEs that
+      // belong to other pipelined requests.
+      state.mr = ep.RegisterLeaseWriteRegion(state.lease.data(),
+                                            state.lease.size());
+      if (!state.mr) {
         release_lease_put(slot);
         encode_status(Status::kIOError, 0);
         reply->first_len = response_prefix;
@@ -1436,7 +1452,7 @@ void RdmaServer::Serve(int boot_fd) {
       }
       const rdma::LeasePutReady ready{
           static_cast<uint32_t>(slot), next_lease_generation(slot),
-          lease_region_mr->rkey,
+          state.mr->rkey,
           reinterpret_cast<uint64_t>(state.lease.data()),
           state.lease.size()};
       encode_status(Status::kOk, rdma::kLeasePutReadyBytes);
@@ -1611,7 +1627,6 @@ void RdmaServer::Serve(int boot_fd) {
             fields.payload_len > lstate.payload_len ||
             fields.payload_len >
                 lstate.lease.size() - rdma::kV2DataOffset) {
-          release_lease_put(request.data_slot);
           return false;
         }
         cache_data = lstate.lease.data() + rdma::kV2DataOffset;
@@ -1635,8 +1650,8 @@ void RdmaServer::Serve(int boot_fd) {
       encode_status(status, 0);
       reply->first_len = response_prefix;
       // The store consumed the bytes synchronously (O_DIRECT write or RAM
-      // admit copy), so the staging range returns to the pool now — before
-      // the status SEND, which never touches the lease.
+      // admit copy). Revoke remote WRITE access before returning the staging
+      // range to the pool; the status SEND never touches the lease.
       if (from_lease) release_lease_put(request.data_slot);
       return true;
     }
@@ -2138,11 +2153,6 @@ void RdmaServer::Serve(int boot_fd) {
       ring.Drain();
     if (metric_inflight != 0)
       uring_inflight_.fetch_sub(metric_inflight, std::memory_order_relaxed);
-    // Any still-active per-op staging leases are connection losses; release
-    // them through the accounting path before RAII teardown so the gauge
-    // pair (lease_put_active / lease_put_bytes_active) stays exact.
-    for (size_t slot = 0; slot < K; ++slot) release_lease_put(slot);
-
     rail_stats.active_conns.fetch_sub(1, std::memory_order_relaxed);
     active_conns_.fetch_sub(1, std::memory_order_relaxed);
     { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
@@ -2219,15 +2229,12 @@ sync_serve_loop:;
     }
   }
   // Any prepared sends without completions destructor-abort below.
-  // Same release sweep for the sync loop: active leases were in flight when
-  // the connection ended, so their accounting must unwind before teardown.
-  for (size_t slot = 0; slot < K; ++slot) release_lease_put(slot);
   rail_stats.active_conns.fetch_sub(1, std::memory_order_relaxed);
   active_conns_.fetch_sub(1, std::memory_order_relaxed);
   { std::lock_guard<std::mutex> lk(conn_mu_); live_eps_.erase(&ep); }
   retire_writer();
-  // Writer retirement proof, not ep destruction, fences client destinations.
-  // The endpoint destructor below only releases verbs resources.
+  // Retirement proves outbound WRITEs terminal. ep destruction additionally
+  // fences inbound DMA and revokes lease MRs before lease_put RAII unwinds.
 }
 
 

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -235,6 +235,14 @@ class RdmaServer {
   std::atomic<uint64_t> legacy_connections_{0};
   std::atomic<uint64_t> data_connection_bytes_{0};
   std::atomic<uint64_t> control_connection_bytes_{0};
+  // In-flight leased-PUT staging: receive memory held only while an
+  // object's windows are actually in flight, unlike the connection-lifetime
+  // leases above. Gauges make the pool/non-resident split observable.
+  std::atomic<uint64_t> lease_put_ops_{0};
+  std::atomic<uint64_t> lease_put_bytes_{0};
+  std::atomic<uint64_t> lease_put_busy_rejects_{0};
+  std::atomic<uint64_t> lease_put_active_{0};
+  std::atomic<uint64_t> lease_put_bytes_active_{0};
   // One anchor per resolved rail holds a lifetime shared device reference and
   // registers the initial receive chunk and caller pools on that rail's PD.
   // Later chunks register lazily on the rail of the connection that leases

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -243,6 +243,8 @@ class RdmaServer {
   std::atomic<uint64_t> lease_put_busy_rejects_{0};
   std::atomic<uint64_t> lease_put_active_{0};
   std::atomic<uint64_t> lease_put_bytes_active_{0};
+  std::atomic<uint64_t> dynamic_get_active_{0};
+  std::atomic<uint64_t> dynamic_get_bytes_active_{0};
   // One anchor per resolved rail holds a lifetime shared device reference and
   // registers the initial receive chunk and caller pools on that rail's PD.
   // Later chunks register lazily on the rail of the connection that leases
@@ -268,7 +270,7 @@ class RdmaServer {
   friend class RdmaServerTestPeer;
   friend class RdmaLeaseServerTestPeer;
   // Test barrier immediately before endpoint destruction; ranges must remain
-  // owned while a delayed inbound WRITE can still reach the QP.
+  // owned while delayed inbound DMA can still reach the QP.
   std::function<void()> before_endpoint_teardown_for_test_;
   std::atomic<uint64_t> uring_reads_{0}, uring_read_batches_{0},
       uring_read_batch_max_{0}, uring_completions_{0}, uring_inflight_{0},

--- a/src/cache/rdma_server.h
+++ b/src/cache/rdma_server.h
@@ -266,6 +266,10 @@ class RdmaServer {
   std::function<UringReader::Backend*()> uring_backend_factory_for_test_;
 #endif
   friend class RdmaServerTestPeer;
+  friend class RdmaLeaseServerTestPeer;
+  // Test barrier immediately before endpoint destruction; ranges must remain
+  // owned while a delayed inbound WRITE can still reach the QP.
+  std::function<void()> before_endpoint_teardown_for_test_;
   std::atomic<uint64_t> uring_reads_{0}, uring_read_batches_{0},
       uring_read_batch_max_{0}, uring_completions_{0}, uring_inflight_{0},
       uring_inflight_max_{0}, uring_replies_posted_{0},

--- a/src/client/cuda_ipc.cc
+++ b/src/client/cuda_ipc.cc
@@ -408,6 +408,13 @@ bool PublishThroughBounce(const CudaLib* cuda, PublisherCudaState* state,
 }
 
 }  // namespace
+bool CudaLib::SetSyncMemops(const void* p) const {
+  if (!PointerSetAttribute || !p) return false;
+  const int enabled = 1;
+  return PointerSetAttribute(const_cast<void*>(p), kCuPointerAttributeSyncMemops,
+                             &enabled) == kCudaSuccess;
+}
+
 PinnedBouncePoolStats GetPinnedBouncePoolStatsForTest() {
   return ProcessBouncePool().Snapshot();
 }
@@ -448,6 +455,8 @@ bool CudaLib::Resolve() {
       SymV2(h, "cuIpcOpenMemHandle_v2", "cuIpcOpenMemHandle"));
   IpcCloseMemHandle = reinterpret_cast<CUresult (*)(CUdeviceptr)>(
       ::dlsym(h, "cuIpcCloseMemHandle"));
+  PointerSetAttribute = reinterpret_cast<CUresult (*)(void*, int, const void*)>(
+      ::dlsym(h, "cuPointerSetAttribute"));
   ctx_get_current_ = reinterpret_cast<CUresult (*)(CUcontext*)>(
       ::dlsym(h, "cuCtxGetCurrent"));
   ctx_set_current_ = reinterpret_cast<CUresult (*)(CUcontext)>(

--- a/src/client/cuda_ipc.h
+++ b/src/client/cuda_ipc.h
@@ -26,6 +26,8 @@ struct CUipcMemHandle {
 };
 constexpr CUresult kCudaSuccess = 0;
 constexpr unsigned kCuIpcMemLazyEnablePeerAccess = 0x1;
+// CU_POINTER_ATTRIBUTE_SYNC_MEMOPS.
+constexpr int kCuPointerAttributeSyncMemops = 6;  // CU_POINTER_ATTRIBUTE_SYNC_MEMOPS
 constexpr int kCuPointerAttributeMemoryType = 2;    // CU_POINTER_ATTRIBUTE_MEMORY_TYPE
 constexpr int kCuPointerAttributeDeviceOrdinal = 9; // CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL
 constexpr unsigned kCuMemoryTypeDevice = 2;         // CU_MEMORYTYPE_DEVICE
@@ -55,6 +57,10 @@ class CudaLib {
   bool HasCurrentCtx() const;
   int CurrentDevice() const;  // -1 without a context
   bool BindPrimaryCtx(int dev) const;
+  // Arm CU_POINTER_ATTRIBUTE_SYNC_MEMOPS on a GPUDirect destination so CUDA
+  // work submissions ordered after an RDMA completion observe the BAR writes.
+  // False when the driver lacks cuPointerSetAttribute or rejects the pointer.
+  bool SetSyncMemops(const void* p) const;
 
   CUresult (*MemHostAlloc)(void**, size_t, unsigned) = nullptr;
   CUresult (*MemFreeHost)(void*) = nullptr;
@@ -76,6 +82,12 @@ class CudaLib {
   CUresult (*IpcGetMemHandle)(CUipcMemHandle*, CUdeviceptr) = nullptr;
   CUresult (*IpcOpenMemHandle)(CUdeviceptr*, CUipcMemHandle, unsigned) = nullptr;
   CUresult (*IpcCloseMemHandle)(CUdeviceptr) = nullptr;
+  // cuPointerSetAttribute: data points at the attribute's value. Used to arm
+  // CU_POINTER_ATTRIBUTE_SYNC_MEMOPS on GPUDirect destinations so a CPU thread
+  // that observed an RDMA completion cannot launch a CUDA kernel that reads
+  // the destination before the BAR writes are memory-ordered (GPUDirect RDMA
+  // design guide, "Synchronization and Memory Ordering").
+  CUresult (*PointerSetAttribute)(void*, int, const void*) = nullptr;
 
  private:
   CudaLib() = default;

--- a/src/client/kv_client.cc
+++ b/src/client/kv_client.cc
@@ -250,6 +250,23 @@ bool KVClient::RegisterMemory(void* base, size_t size) {
   const DestinationMemoryKind kind =
       cuda && cuda->IsDevicePtr(base) ? DestinationMemoryKind::kDevice
                                       : DestinationMemoryKind::kHost;
+  if (kind == DestinationMemoryKind::kDevice) {
+    // GPUDirect RDMA memory-ordering contract (design guide, "Synchronization
+    // and Memory Ordering"): without ordering, a CUDA kernel launched right
+    // after an RDMA completion may read the destination before its BAR writes
+    // land (observed live as exact-hit loads with degraded generation). Arm
+    // SYNC_MEMOPS where the driver accepts it (plain cudaMalloc allocations);
+    // VMM/cuMemMap pools commonly reject it and use the load-path fence.
+    static std::once_flag sync_memops_unavailable;
+    if (!cuda->SetSyncMemops(base)) {
+      std::call_once(sync_memops_unavailable, [] {
+        DFKV_LOG_WARN(
+            "dfkv: cuPointerSetAttribute(SYNC_MEMOPS) rejected for a GPU pool "
+            "(VMM/cuMemMap allocation); GPUDirect loads rely on the "
+            "load-completion CUDA fence for memory ordering");
+      });
+    }
+  }
   if (!t_->RegisterMemory(base, size)) return false;
 
   const uintptr_t end = address + size;

--- a/src/tools/dfkvleasebench_main.cc
+++ b/src/tools/dfkvleasebench_main.cc
@@ -1,0 +1,268 @@
+/* In-process server+fan-out-client memory benchmark for the staged-lease
+ * datapath. Runs entirely on one RDMA host: an embedded cache node serves
+ * real verbs, N threads open N independent client connections, and the tool
+ * reports the server's residency split (connection-resident receive bytes vs
+ * in-flight lease bytes) so the KDA-style deployment math is observable:
+ *
+ *   dfkvleasebench --clients 200 --obj-size 32MiB --ops 20
+ *
+ * Compare runs with --inline-bytes 0 (legacy connection-resident class) and
+ * the default 4MiB threshold (staged-lease path) to see the receive-pool
+ * footprint converge from "connections x max object class x depth" down to
+ * "bytes actually in flight". */
+#include "cache/kv_node_server.h"
+#include "cache/rdma_server.h"
+#include "client/kv_client.h"
+#include "client/key_map.h"
+#include <array>
+#include "common/status.h"
+#include "transport/rdma_transport.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace dfkv;  // NOLINT
+
+namespace {
+
+size_t ParseSize(const char* text, size_t fallback) {
+  char* end = nullptr;
+  const unsigned long long v = std::strtoull(text, &end, 10);
+  if (end == text) return fallback;
+  unsigned long long scaled = v;
+  if (end && *end) {
+    switch (std::tolower(*end)) {
+      case 'k': scaled = v << 10; break;
+      case 'm': scaled = v << 20; break;
+      case 'g': scaled = v << 30; break;
+      default: return fallback;
+    }
+  }
+  return static_cast<size_t>(scaled);
+}
+
+// One Prometheus value line (rfind skips HELP/TYPE lines).
+long MetricOf(const RdmaServer& server, const std::string& name) {
+  const std::string text = server.MetricsText();
+  const size_t at = text.rfind(name + " ");
+  if (at == std::string::npos) return -1;
+  const size_t sp = text.find(' ', at);
+  if (sp == std::string::npos) return -1;
+  return std::strtol(text.c_str() + sp + 1, nullptr, 10);
+}
+
+// Labelled variant: takes the exact "name{label...}" key, rfinds it.
+long MetricOf(const RdmaServer& server, const std::string& key,
+               const std::string& name) {
+  const std::string text = server.MetricsText();
+  const size_t at = text.rfind(key + " ");
+  if (at == std::string::npos) return -1;
+  const size_t sp = text.find(' ', at);
+  if (sp == std::string::npos) return -1;
+  return std::strtol(text.c_str() + sp + 1, nullptr, 10);
+}
+
+std::string BytesHuman(size_t bytes) {
+  char buf[64];
+  if (bytes >= (1ull << 30))
+    std::snprintf(buf, sizeof(buf), "%.2f GiB", bytes / 1073741824.0);
+  else if (bytes >= (1ull << 20))
+    std::snprintf(buf, sizeof(buf), "%.1f MiB", bytes / 1048576.0);
+  else
+    std::snprintf(buf, sizeof(buf), "%zu B", bytes);
+  return buf;
+}
+
+}  // namespace
+
+int main(int argc, const char* argv[]) {
+  size_t clients = 200;
+  size_t obj_size = 33554432;  // KDA TP16 temporal state ≈ 32 MiB lease step
+  size_t ops_per_client = 10;
+  size_t inline_bytes = 4194304;  // staged-lease threshold; 0 = legacy
+  size_t depth = 4;
+  size_t small_ratio_pct = 0;
+
+  for (int i = 1; i + 1 < argc; i += 2) {
+    const std::string flag = argv[i];
+    const char* value = argv[i + 1];
+    if (flag == "--clients") clients = ParseSize(value, clients);
+    else if (flag == "--obj-size") obj_size = ParseSize(value, obj_size);
+    else if (flag == "--ops") ops_per_client = ParseSize(value, ops_per_client);
+    else if (flag == "--inline-bytes") inline_bytes = ParseSize(value, inline_bytes);
+    else if (flag == "--depth") depth = ParseSize(value, depth);
+    else if (flag == "--small-ratio-pct") small_ratio_pct = ParseSize(value, 0);
+    else {
+      std::fprintf(stderr, "unknown flag %s\n", flag.c_str());
+      return 2;
+    }
+  }
+
+  if (!RdmaTransport::Available()) {
+    std::fprintf(stderr, "no RDMA device\n");
+    return 1;
+  }
+
+  const std::string dir = (fs::temp_directory_path() / "dfkvleasebench")
+                              .string();
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+
+  // Server fixture (same shape as the loopback suite's node: KvNodeServer
+  // owns disk, RdmaServer serves data). A hard receive budget that a
+  // legacy 32MiB-class * resident connection model could not fit makes the
+  // contrast part of correctness: legacy runs must hit oversize/busy
+  // rejections, lease runs must pass.
+  setenv("DFKV_RDMA_POOL_MAX", "2048", 1);  // let every client keep its conn
+  setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", std::to_string(4ull << 30).c_str(), 1);
+  setenv("DFKV_RDMA_RECV_CHUNK_BYTES", std::to_string(256ull << 20).c_str(), 1);
+  setenv("DFKV_RDMA_MAX_BLOCK_BYTES", std::to_string(1ull << 30).c_str(), 1);
+  setenv("DFKV_RDMA_DEPTH", std::to_string(depth).c_str(), 1);
+  setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES",
+         std::to_string(inline_bytes).c_str(), 1);
+  setenv("DFKV_RDMA_ENDPOINT_CACHE_MAX", "4096", 1);
+
+  auto srv = std::make_unique<KvNodeServer>(dir, 8ull << 30);
+  if (srv->Start(0) != Status::kOk) {
+    std::fprintf(stderr, "storage node failed to start\n");
+    return 1;
+  }
+  auto rsrv = std::make_unique<RdmaServer>(
+      [&srv](uint8_t op, const BlockKey& key, uint64_t off, uint64_t len,
+             const char* pl, uint64_t pll, std::string* out,
+             size_t* value_len) {
+        return srv->ProcessRequestForKey(op, key, off, len, pl, pll, out,
+                                         value_len);
+      },
+      1ull << 30);
+  rsrv->set_range_handler(
+      [&srv](const BlockKey& key, uint64_t off, uint64_t len, char* io_buf,
+             size_t cap, const char** out_data, size_t* out_len,
+             size_t* value_len) {
+        return srv->RangeDirectForKey(key, off, len, io_buf, cap, out_data,
+                                      out_len, value_len);
+      });
+  rsrv->set_cache_direct_handler(
+      [&srv](const BlockKey& key, char* data, size_t len, size_t cap) {
+        return srv->CacheDirectForKey(key, data, len, cap);
+      });
+  if (rsrv->Start(0) != Status::kOk) {
+    std::fprintf(stderr, "rdma server failed to start\n");
+    return 1;
+  }
+  const std::string addr = "127.0.0.1:" + std::to_string(rsrv->port());
+
+  std::vector<std::string> payload_large(1, std::string(obj_size, '\0'));
+  for (size_t i = 0; i < obj_size; ++i)
+    payload_large[0][i] = static_cast<char>((i * 131 + 11) & 0xFF);
+  std::string payload_small(256ull << 10, '\0');
+  for (size_t i = 0; i < payload_small.size(); ++i)
+    payload_small[i] = static_cast<char>((i * 7 + 3) & 0xFF);
+
+  std::atomic<size_t> put_ok{0}, put_fail{0};
+  std::array<std::atomic<size_t>, 8> status_counts{};
+  std::atomic<uint64_t> put_bytes{0};
+  const auto t0 = std::chrono::steady_clock::now();
+  std::vector<std::thread> workers;
+  workers.reserve(clients);
+  for (size_t c = 0; c < clients; ++c) {
+    workers.emplace_back([&, c] {
+      RdmaTransport rt(1ull << 30);
+      KVClient client({{"n", addr}}, "bench/model-kda", &rt);
+      for (size_t o = 0; o < ops_per_client; ++o) {
+        const bool small = small_ratio_pct != 0 &&
+                           (o * 100 / ops_per_client) < small_ratio_pct;
+        const std::string key = "c" + std::to_string(c) + "/o" +
+                                std::to_string(o);
+        const std::string& payload = small ? payload_small : payload_large[0];
+        if (client.Put(key, payload.data(), payload.size())) {
+          put_ok.fetch_add(1, std::memory_order_relaxed);
+          put_bytes.fetch_add(payload.size(), std::memory_order_relaxed);
+        } else {
+          put_fail.fetch_add(1, std::memory_order_relaxed);
+          // Failure forensics: bucket the raw transport status once so a
+          // fan-out regression names its stage (kIOError=4 kQuota=3
+          // kFull=2 kInvalid=5).
+          std::vector<CacheSrc> src{
+              CacheSrc{ToBlockKey("bench/model-kda", key),
+                       const_cast<char*>(payload.data()), payload.size()}};
+          const Status st = rt.CacheFrom(addr, src)[0];
+          size_t code = static_cast<size_t>(st);
+          if (code >= status_counts.size()) code = status_counts.size() - 1;
+          status_counts[code].fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+  for (auto& t : workers) t.join();
+  const double seconds =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
+          .count();
+
+  const long resident_data =
+      MetricOf(*rsrv, "dfkv_rdma_connection_bytes{class=\"data\"}",
+               "dfkv_rdma_connection_bytes");
+  const long resident_total =
+      MetricOf(*rsrv, "dfkv_rdma_recv_segment_used_bytes");
+  const long lease_ops = MetricOf(*rsrv, "dfkv_rdma_leaseput_ops_total");
+  const long lease_active = MetricOf(*rsrv, "dfkv_rdma_leaseput_active");
+  const long lease_bytes_active =
+      MetricOf(*rsrv, "dfkv_rdma_leaseput_bytes_active");
+  const long busy = MetricOf(*rsrv, "dfkv_rdma_leaseput_busy_rejects_total");
+  const long conn_errors =
+      MetricOf(*rsrv, "dfkv_rdma_completion_errors");
+  const long v2conns = MetricOf(*rsrv, "dfkv_rdma_v2_conns_opened_total");
+  const std::string srv_metrics = srv->MetricsText();
+  auto line_value = [&srv_metrics](const std::string& key) -> long {
+    const size_t at = srv_metrics.rfind(key + " ");
+    if (at == std::string::npos) return -1;
+    const size_t sp = srv_metrics.find(' ', at);
+    if (sp == std::string::npos) return -1;
+    return std::strtol(srv_metrics.c_str() + sp + 1, nullptr, 10);
+  };
+  const long srv_put_io = line_value(
+      "dfkv_errors_total{op=\"put\",status=\"io\"}");
+  const long srv_invalid = line_value(
+      "dfkv_errors_total{op=\"any\",status=\"invalid\"}");
+  const long conns = MetricOf(*rsrv, "dfkv_rdma_active_conns");
+  const long completion_errors =
+      MetricOf(*rsrv, "dfkv_rdma_completion_errors_total");
+
+  const long evictions = MetricOf(*rsrv, "dfkv_rdma_segment_evictions_total");
+  const long idle_reclaims = MetricOf(*rsrv, "dfkv_rdma_idle_reclaims_total");
+
+  std::printf(
+      "dfkvleasebench inline=%zu obj=%s clients=%zu ops/client=%zu\n"
+      "  puts ok=%zu fail=%zu bytes=%llu in %.2fs (%.1f MB/s)"
+      " fail[io=%zu quota=%zu full=%zu invalid=%zu other=%zu]\n"
+      "  server: active_conns=%ld v2_conns=%ld class-data-resident=%s "
+      "recv_used=%s leaseput_ops=%ld leaseput_active=%ld "
+      "lease_bytes_active=%s busy_rejects=%ld "
+      "completion_errors=%ld evictions=%ld idle_reclaims=%ld"
+      " srv_put_io=%ld srv_invalid=%ld\n",
+      inline_bytes, BytesHuman(obj_size).c_str(), clients, ops_per_client,
+      put_ok.load(), put_fail.load(), put_bytes.load(), seconds,
+      put_bytes.load() / seconds / (1ull << 20),
+      status_counts[4].load(), status_counts[3].load(),
+      status_counts[2].load(), status_counts[5].load(),
+      status_counts[6].load() + status_counts[7].load(), conns, v2conns,
+      BytesHuman(resident_data < 0 ? 0 : resident_data).c_str(),
+      BytesHuman(resident_total < 0 ? 0 : resident_total).c_str(), lease_ops,
+      lease_active,
+      BytesHuman(lease_bytes_active < 0 ? 0 : lease_bytes_active).c_str(),
+      busy, completion_errors, evictions, idle_reclaims, srv_put_io,
+      srv_invalid);
+
+  rsrv->Stop();
+  srv->Stop();
+  fs::remove_all(dir);
+  return put_fail.load() == 0 ? 0 : 1;
+}

--- a/src/tools/dfkvleasebench_main.cc
+++ b/src/tools/dfkvleasebench_main.cc
@@ -1,268 +1,219 @@
-/* In-process server+fan-out-client memory benchmark for the staged-lease
- * datapath. Runs entirely on one RDMA host: an embedded cache node serves
- * real verbs, N threads open N independent client connections, and the tool
- * reports the server's residency split (connection-resident receive bytes vs
- * in-flight lease bytes) so the KDA-style deployment math is observable:
- *
- *   dfkvleasebench --clients 200 --obj-size 32MiB --ops 20
- *
- * Compare runs with --inline-bytes 0 (legacy connection-resident class) and
- * the default 4MiB threshold (staged-lease path) to see the receive-pool
- * footprint converge from "connections x max object class x depth" down to
- * "bytes actually in flight". */
-#include "cache/kv_node_server.h"
+// Fan-out client benchmark against an EXTERNAL cache server. Client objects
+// remain alive throughout active and idle sampling; server RSS never includes
+// the benchmark's payloads. Every requested PUT is attempted exactly once by
+// this tool (transport retry policy remains in effect); readback checks bytes.
 #include "cache/rdma_server.h"
-#include "client/kv_client.h"
 #include "client/key_map.h"
-#include <array>
-#include "common/status.h"
+#include "client/kv_client.h"
 #include "transport/rdma_transport.h"
+#include "utils/http_client.h"
+#include "utils/net_util.h"
+#include "utils/prom_parse.h"
 
+#include <sys/socket.h>
+#include <unistd.h>
+#include <algorithm>
+#include <array>
 #include <atomic>
+#include <charconv>
 #include <chrono>
-#include <cstdio>
-#include <cstdlib>
+#include <condition_variable>
+#include <cstdint>
 #include <cstring>
-#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
 
-namespace fs = std::filesystem;
-using namespace dfkv;  // NOLINT
-
 namespace {
-
-size_t ParseSize(const char* text, size_t fallback) {
-  char* end = nullptr;
-  const unsigned long long v = std::strtoull(text, &end, 10);
-  if (end == text) return fallback;
-  unsigned long long scaled = v;
-  if (end && *end) {
-    switch (std::tolower(*end)) {
-      case 'k': scaled = v << 10; break;
-      case 'm': scaled = v << 20; break;
-      case 'g': scaled = v << 30; break;
-      default: return fallback;
-    }
-  }
-  return static_cast<size_t>(scaled);
+using Clock = std::chrono::steady_clock;
+size_t Size(const char* text) {
+  const std::string input(text);
+  size_t value = 0;
+  const auto parsed = std::from_chars(input.data(), input.data()+input.size(), value);
+  if (parsed.ec != std::errc() || parsed.ptr == input.data())
+    throw std::runtime_error("invalid nonnegative integer: " + input);
+  const std::string suffix(parsed.ptr, input.data()+input.size());
+  size_t factor = 1;
+  if (suffix == "k" || suffix == "KiB") factor = 1ull<<10;
+  else if (suffix == "m" || suffix == "MiB") factor = 1ull<<20;
+  else if (suffix == "g" || suffix == "GiB") factor = 1ull<<30;
+  else if (!suffix.empty()) throw std::runtime_error("invalid size suffix: " + input);
+  if (value > std::numeric_limits<size_t>::max()/factor)
+    throw std::runtime_error("size overflow");
+  return value*factor;
 }
-
-// One Prometheus value line (rfind skips HELP/TYPE lines).
-long MetricOf(const RdmaServer& server, const std::string& name) {
-  const std::string text = server.MetricsText();
-  const size_t at = text.rfind(name + " ");
-  if (at == std::string::npos) return -1;
-  const size_t sp = text.find(' ', at);
-  if (sp == std::string::npos) return -1;
-  return std::strtol(text.c_str() + sp + 1, nullptr, 10);
+std::string Scrape(const std::string& endpoint) {
+  const int fd = dfkv::net::Dial(endpoint, 2000, 2000);
+  if (fd < 0) throw std::runtime_error("cannot connect to metrics endpoint");
+  const std::string req = "GET /metrics HTTP/1.0\r\nHost: " + endpoint +
+                          "\r\nConnection: close\r\n\r\n";
+  std::string response;
+  if (!dfkv::net::WriteAll(fd, req.data(), req.size())) {
+    ::close(fd); throw std::runtime_error("metrics request failed");
+  }
+  char buf[16384];
+  ssize_t n;
+  while ((n=::recv(fd, buf, sizeof(buf), 0)) > 0) {
+    response.append(buf, static_cast<size_t>(n));
+    if (response.size() > (8u<<20)) break;
+  }
+  ::close(fd);
+  int status = 0; long content = 0; size_t head = 0;
+  if (n < 0 || !dfkv::ParseResponseHead(response, &status, &content, &head) ||
+      status != 200) throw std::runtime_error("invalid metrics response");
+  return response.substr(head);
 }
-
-// Labelled variant: takes the exact "name{label...}" key, rfinds it.
-long MetricOf(const RdmaServer& server, const std::string& key,
-               const std::string& name) {
-  const std::string text = server.MetricsText();
-  const size_t at = text.rfind(key + " ");
-  if (at == std::string::npos) return -1;
-  const size_t sp = text.find(' ', at);
-  if (sp == std::string::npos) return -1;
-  return std::strtol(text.c_str() + sp + 1, nullptr, 10);
+uint64_t Metric(const std::string& body, const std::string& name) {
+  uint64_t value = 0;
+  if (!dfkv::PromMetricValue(body, name, &value))
+    throw std::runtime_error("required metric missing: " + name);
+  return value;
 }
-
-std::string BytesHuman(size_t bytes) {
-  char buf[64];
-  if (bytes >= (1ull << 30))
-    std::snprintf(buf, sizeof(buf), "%.2f GiB", bytes / 1073741824.0);
-  else if (bytes >= (1ull << 20))
-    std::snprintf(buf, sizeof(buf), "%.1f MiB", bytes / 1048576.0);
-  else
-    std::snprintf(buf, sizeof(buf), "%zu B", bytes);
-  return buf;
+uint64_t Rss(size_t pid) {
+  std::ifstream in("/proc/"+std::to_string(pid)+"/status");
+  std::string line;
+  while (std::getline(in, line)) {
+    if (line.rfind("VmRSS:",0)==0) return std::stoull(line.substr(6))*1024;
+  }
+  throw std::runtime_error("server PID has no readable VmRSS");
 }
-
-}  // namespace
-
-int main(int argc, const char* argv[]) {
-  size_t clients = 200;
-  size_t obj_size = 33554432;  // KDA TP16 temporal state ≈ 32 MiB lease step
-  size_t ops_per_client = 10;
-  size_t inline_bytes = 4194304;  // staged-lease threshold; 0 = legacy
-  size_t depth = 4;
-  size_t small_ratio_pct = 0;
-
-  for (int i = 1; i + 1 < argc; i += 2) {
-    const std::string flag = argv[i];
-    const char* value = argv[i + 1];
-    if (flag == "--clients") clients = ParseSize(value, clients);
-    else if (flag == "--obj-size") obj_size = ParseSize(value, obj_size);
-    else if (flag == "--ops") ops_per_client = ParseSize(value, ops_per_client);
-    else if (flag == "--inline-bytes") inline_bytes = ParseSize(value, inline_bytes);
-    else if (flag == "--depth") depth = ParseSize(value, depth);
-    else if (flag == "--small-ratio-pct") small_ratio_pct = ParseSize(value, 0);
-    else {
-      std::fprintf(stderr, "unknown flag %s\n", flag.c_str());
-      return 2;
-    }
-  }
-
-  if (!RdmaTransport::Available()) {
-    std::fprintf(stderr, "no RDMA device\n");
-    return 1;
-  }
-
-  const std::string dir = (fs::temp_directory_path() / "dfkvleasebench")
-                              .string();
-  fs::remove_all(dir);
-  fs::create_directories(dir);
-
-  // Server fixture (same shape as the loopback suite's node: KvNodeServer
-  // owns disk, RdmaServer serves data). A hard receive budget that a
-  // legacy 32MiB-class * resident connection model could not fit makes the
-  // contrast part of correctness: legacy runs must hit oversize/busy
-  // rejections, lease runs must pass.
-  setenv("DFKV_RDMA_POOL_MAX", "2048", 1);  // let every client keep its conn
-  setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", std::to_string(4ull << 30).c_str(), 1);
-  setenv("DFKV_RDMA_RECV_CHUNK_BYTES", std::to_string(256ull << 20).c_str(), 1);
-  setenv("DFKV_RDMA_MAX_BLOCK_BYTES", std::to_string(1ull << 30).c_str(), 1);
-  setenv("DFKV_RDMA_DEPTH", std::to_string(depth).c_str(), 1);
-  setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES",
-         std::to_string(inline_bytes).c_str(), 1);
-  setenv("DFKV_RDMA_ENDPOINT_CACHE_MAX", "4096", 1);
-
-  auto srv = std::make_unique<KvNodeServer>(dir, 8ull << 30);
-  if (srv->Start(0) != Status::kOk) {
-    std::fprintf(stderr, "storage node failed to start\n");
-    return 1;
-  }
-  auto rsrv = std::make_unique<RdmaServer>(
-      [&srv](uint8_t op, const BlockKey& key, uint64_t off, uint64_t len,
-             const char* pl, uint64_t pll, std::string* out,
-             size_t* value_len) {
-        return srv->ProcessRequestForKey(op, key, off, len, pl, pll, out,
-                                         value_len);
-      },
-      1ull << 30);
-  rsrv->set_range_handler(
-      [&srv](const BlockKey& key, uint64_t off, uint64_t len, char* io_buf,
-             size_t cap, const char** out_data, size_t* out_len,
-             size_t* value_len) {
-        return srv->RangeDirectForKey(key, off, len, io_buf, cap, out_data,
-                                      out_len, value_len);
-      });
-  rsrv->set_cache_direct_handler(
-      [&srv](const BlockKey& key, char* data, size_t len, size_t cap) {
-        return srv->CacheDirectForKey(key, data, len, cap);
-      });
-  if (rsrv->Start(0) != Status::kOk) {
-    std::fprintf(stderr, "rdma server failed to start\n");
-    return 1;
-  }
-  const std::string addr = "127.0.0.1:" + std::to_string(rsrv->port());
-
-  std::vector<std::string> payload_large(1, std::string(obj_size, '\0'));
-  for (size_t i = 0; i < obj_size; ++i)
-    payload_large[0][i] = static_cast<char>((i * 131 + 11) & 0xFF);
-  std::string payload_small(256ull << 10, '\0');
-  for (size_t i = 0; i < payload_small.size(); ++i)
-    payload_small[i] = static_cast<char>((i * 7 + 3) & 0xFF);
-
-  std::atomic<size_t> put_ok{0}, put_fail{0};
-  std::array<std::atomic<size_t>, 8> status_counts{};
-  std::atomic<uint64_t> put_bytes{0};
-  const auto t0 = std::chrono::steady_clock::now();
-  std::vector<std::thread> workers;
-  workers.reserve(clients);
-  for (size_t c = 0; c < clients; ++c) {
-    workers.emplace_back([&, c] {
-      RdmaTransport rt(1ull << 30);
-      KVClient client({{"n", addr}}, "bench/model-kda", &rt);
-      for (size_t o = 0; o < ops_per_client; ++o) {
-        const bool small = small_ratio_pct != 0 &&
-                           (o * 100 / ops_per_client) < small_ratio_pct;
-        const std::string key = "c" + std::to_string(c) + "/o" +
-                                std::to_string(o);
-        const std::string& payload = small ? payload_small : payload_large[0];
-        if (client.Put(key, payload.data(), payload.size())) {
-          put_ok.fetch_add(1, std::memory_order_relaxed);
-          put_bytes.fetch_add(payload.size(), std::memory_order_relaxed);
-        } else {
-          put_fail.fetch_add(1, std::memory_order_relaxed);
-          // Failure forensics: bucket the raw transport status once so a
-          // fan-out regression names its stage (kIOError=4 kQuota=3
-          // kFull=2 kInvalid=5).
-          std::vector<CacheSrc> src{
-              CacheSrc{ToBlockKey("bench/model-kda", key),
-                       const_cast<char*>(payload.data()), payload.size()}};
-          const Status st = rt.CacheFrom(addr, src)[0];
-          size_t code = static_cast<size_t>(st);
-          if (code >= status_counts.size()) code = status_counts.size() - 1;
-          status_counts[code].fetch_add(1, std::memory_order_relaxed);
-        }
+struct Worker {
+  std::unique_ptr<dfkv::RdmaTransport> transport;
+  std::unique_ptr<dfkv::KVClient> client;
+  std::vector<char> value;
+  std::vector<char> readback;
+};
+}
+int main(int argc, char** argv) {
+  try {
+    std::string member, metrics, key_seed = "leasebench-"+std::to_string(getpid());
+    size_t clients=16, bytes=32ull<<20, ops=8, idle_ms=2000, sample_ms=50,
+           pid=0, sg_segs=1;
+    for (int i=1; i<argc; ++i) {
+      const std::string flag(argv[i]);
+      if (flag=="--help") {
+        std::cout << "dfkvleasebench --member IP:RDMA_PORT --metrics IP:PORT --server-pid PID "
+          "[--clients N --obj-size 32MiB --ops N --sg-segs N --idle-ms N --sample-ms N --key-seed S]\n"
+          "Configure DFKV_RDMA_DEV/MAX_BLOCK_BYTES/INLINE_PUT_MAX_BYTES in the environment.\n";
+        return 0;
       }
-    });
-  }
-  for (auto& t : workers) t.join();
-  const double seconds =
-      std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
-          .count();
-
-  const long resident_data =
-      MetricOf(*rsrv, "dfkv_rdma_connection_bytes{class=\"data\"}",
-               "dfkv_rdma_connection_bytes");
-  const long resident_total =
-      MetricOf(*rsrv, "dfkv_rdma_recv_segment_used_bytes");
-  const long lease_ops = MetricOf(*rsrv, "dfkv_rdma_leaseput_ops_total");
-  const long lease_active = MetricOf(*rsrv, "dfkv_rdma_leaseput_active");
-  const long lease_bytes_active =
-      MetricOf(*rsrv, "dfkv_rdma_leaseput_bytes_active");
-  const long busy = MetricOf(*rsrv, "dfkv_rdma_leaseput_busy_rejects_total");
-  const long conn_errors =
-      MetricOf(*rsrv, "dfkv_rdma_completion_errors");
-  const long v2conns = MetricOf(*rsrv, "dfkv_rdma_v2_conns_opened_total");
-  const std::string srv_metrics = srv->MetricsText();
-  auto line_value = [&srv_metrics](const std::string& key) -> long {
-    const size_t at = srv_metrics.rfind(key + " ");
-    if (at == std::string::npos) return -1;
-    const size_t sp = srv_metrics.find(' ', at);
-    if (sp == std::string::npos) return -1;
-    return std::strtol(srv_metrics.c_str() + sp + 1, nullptr, 10);
-  };
-  const long srv_put_io = line_value(
-      "dfkv_errors_total{op=\"put\",status=\"io\"}");
-  const long srv_invalid = line_value(
-      "dfkv_errors_total{op=\"any\",status=\"invalid\"}");
-  const long conns = MetricOf(*rsrv, "dfkv_rdma_active_conns");
-  const long completion_errors =
-      MetricOf(*rsrv, "dfkv_rdma_completion_errors_total");
-
-  const long evictions = MetricOf(*rsrv, "dfkv_rdma_segment_evictions_total");
-  const long idle_reclaims = MetricOf(*rsrv, "dfkv_rdma_idle_reclaims_total");
-
-  std::printf(
-      "dfkvleasebench inline=%zu obj=%s clients=%zu ops/client=%zu\n"
-      "  puts ok=%zu fail=%zu bytes=%llu in %.2fs (%.1f MB/s)"
-      " fail[io=%zu quota=%zu full=%zu invalid=%zu other=%zu]\n"
-      "  server: active_conns=%ld v2_conns=%ld class-data-resident=%s "
-      "recv_used=%s leaseput_ops=%ld leaseput_active=%ld "
-      "lease_bytes_active=%s busy_rejects=%ld "
-      "completion_errors=%ld evictions=%ld idle_reclaims=%ld"
-      " srv_put_io=%ld srv_invalid=%ld\n",
-      inline_bytes, BytesHuman(obj_size).c_str(), clients, ops_per_client,
-      put_ok.load(), put_fail.load(), put_bytes.load(), seconds,
-      put_bytes.load() / seconds / (1ull << 20),
-      status_counts[4].load(), status_counts[3].load(),
-      status_counts[2].load(), status_counts[5].load(),
-      status_counts[6].load() + status_counts[7].load(), conns, v2conns,
-      BytesHuman(resident_data < 0 ? 0 : resident_data).c_str(),
-      BytesHuman(resident_total < 0 ? 0 : resident_total).c_str(), lease_ops,
-      lease_active,
-      BytesHuman(lease_bytes_active < 0 ? 0 : lease_bytes_active).c_str(),
-      busy, completion_errors, evictions, idle_reclaims, srv_put_io,
-      srv_invalid);
-
-  rsrv->Stop();
-  srv->Stop();
-  fs::remove_all(dir);
-  return put_fail.load() == 0 ? 0 : 1;
+      if (++i==argc) throw std::runtime_error("missing value for "+flag);
+      if (flag=="--member") member=argv[i];
+      else if (flag=="--metrics") metrics=argv[i];
+      else if (flag=="--key-seed") key_seed=argv[i];
+      else if (flag=="--clients") clients=Size(argv[i]);
+      else if (flag=="--obj-size") bytes=Size(argv[i]);
+      else if (flag=="--ops") ops=Size(argv[i]);
+      else if (flag=="--sg-segs") sg_segs=Size(argv[i]);
+      else if (flag=="--server-pid") pid=Size(argv[i]);
+      else if (flag=="--idle-ms") idle_ms=Size(argv[i]);
+      else if (flag=="--sample-ms") sample_ms=Size(argv[i]);
+      else throw std::runtime_error("unknown option: "+flag);
+    }
+    if (member.empty() || metrics.empty() || !pid || !clients || clients>1024 ||
+        !bytes || !ops || !sg_segs || sg_segs>bytes || !sample_ms)
+      throw std::runtime_error("invalid benchmark geometry; see --help");
+    if (!dfkv::RdmaTransport::Available()) throw std::runtime_error("no RDMA device");
+    std::vector<Worker> workers(clients);
+    std::vector<std::thread> threads;
+    std::mutex mu;
+    std::condition_variable cv;
+    size_t initialized=0;
+    bool start=false;
+    std::atomic<size_t> done{0}, failures{0}, corrupt{0};
+    std::array<std::atomic<uint64_t>, 16> statuses{};
+    std::atomic<uint64_t> delivered{0};
+    for (size_t c=0; c<clients; ++c) {
+      threads.emplace_back([&, c] {
+        bool announced=false;
+        try {
+          auto& w=workers[c];
+          w.transport=std::make_unique<dfkv::RdmaTransport>();
+          w.client=std::make_unique<dfkv::KVClient>(
+              std::vector<std::pair<std::string,std::string>>{{"bench",member}},
+              "leasebench",w.transport.get());
+          w.value.resize(bytes); w.readback.resize(bytes);
+          for (size_t i=0;i<bytes;++i) w.value[i]=static_cast<char>((i*131+c*17)&255);
+          { std::unique_lock<std::mutex> lk(mu); ++initialized; announced=true;
+            cv.notify_all(); cv.wait(lk,[&]{return start;}); }
+          for (size_t o=0;o<ops;++o) {
+            const auto key=dfkv::ToBlockKey("leasebench",key_seed+"/"+std::to_string(c)+"/"+std::to_string(o));
+            dfkv::Status status;
+            if (sg_segs==1) {
+              status=w.transport->CacheFrom(member,{{key,w.value.data(),bytes}})[0];
+            } else {
+              dfkv::CacheSrcMulti source; source.key=key;
+              for(size_t s=0;s<sg_segs;++s) {
+                const size_t begin=s*bytes/sg_segs,end=(s+1)*bytes/sg_segs;
+                source.payloads.emplace_back(w.value.data()+begin,end-begin);
+              }
+              status=w.transport->CacheFromMulti(member,{source})[0];
+            }
+            const size_t index=static_cast<size_t>(status);
+            statuses[std::min(index,statuses.size()-1)].fetch_add(1);
+            if(status!=dfkv::Status::kOk) { ++failures; continue; }
+            delivered.fetch_add(bytes);
+            std::vector<uint64_t> lengths;
+            std::fill(w.readback.begin(),w.readback.end(),0);
+            const auto got=w.transport->RangeInto(member,{key},{{w.readback.data(),bytes}},&lengths);
+            if(got[0]!=dfkv::Status::kOk || lengths.size()!=1 || lengths[0]!=bytes ||
+               std::memcmp(w.value.data(),w.readback.data(),bytes)!=0) ++corrupt;
+          }
+        } catch(const std::exception& e) {
+          ++failures;
+          std::lock_guard<std::mutex> lk(mu);
+          std::cerr << "worker " << c << ": " << e.what() << '\n';
+          if(!announced) {++initialized; cv.notify_all();}
+        }
+        ++done;
+      });
+    }
+    { std::unique_lock<std::mutex> lk(mu); cv.wait(lk,[&]{return initialized==clients;}); }
+    const auto begin=Clock::now();
+    uint64_t peak_rss=0,peak_committed=0,peak_used=0;
+    size_t samples=0;
+    bool sampling_failed=false;
+    auto sample=[&](const char* phase) {
+      const auto body=Scrape(metrics);
+      const auto rss=Rss(pid);
+      const auto committed=Metric(body,"dfkv_rdma_recv_segment_bytes");
+      const auto used=Metric(body,"dfkv_rdma_recv_segment_used_bytes");
+      const auto connections=Metric(body,"dfkv_rdma_active_conns");
+      peak_rss=std::max(peak_rss,rss); peak_committed=std::max(peak_committed,committed);
+      peak_used=std::max(peak_used,used); ++samples;
+      std::cout << "{\"phase\":\""<<phase<<"\",\"ms\":"
+        <<std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now()-begin).count()
+        <<",\"server_rss_bytes\":"<<rss<<",\"committed_bytes\":"<<committed
+        <<",\"used_bytes\":"<<used<<",\"connections\":"<<connections<<"}\n";
+    };
+    try { sample("before"); } catch(const std::exception& e) {std::cerr<<e.what()<<'\n';sampling_failed=true;}
+    {std::lock_guard<std::mutex> lk(mu); start=true; cv.notify_all();}
+    while(done.load()<clients) {
+      try {sample("active");} catch(const std::exception& e) {std::cerr<<e.what()<<'\n';sampling_failed=true;}
+      std::this_thread::sleep_for(std::chrono::milliseconds(sample_ms));
+    }
+    for(auto& t:threads)t.join();
+    const double seconds=std::chrono::duration<double>(Clock::now()-begin).count();
+    // Worker owns transport/client beyond thread exit: connections remain live
+    // through the idle window, allowing MR/chunk reclamation to be observed.
+    const auto idle_end=Clock::now()+std::chrono::milliseconds(idle_ms);
+    do {
+      try {sample("idle_clients_alive");} catch(const std::exception& e) {std::cerr<<e.what()<<'\n';sampling_failed=true;}
+      std::this_thread::sleep_for(std::chrono::milliseconds(sample_ms));
+    } while(Clock::now()<idle_end);
+    std::cout << "{\"summary\":true,\"clients\":"<<clients<<",\"operations\":"<<clients*ops
+      <<",\"put_failures\":"<<failures<<",\"readback_failures\":"<<corrupt
+      <<",\"put_bytes\":"<<delivered<<",\"workload_wall_seconds\":"<<seconds
+      <<",\"peak_server_rss_bytes\":"<<peak_rss<<",\"peak_committed_bytes\":"<<peak_committed
+      <<",\"peak_used_bytes\":"<<peak_used<<",\"samples\":"<<samples<<",\"statuses\":[";
+    for(size_t i=0;i<statuses.size();++i)std::cout<<(i?",":"")<<statuses[i];
+    std::cout << "]}\n";
+    return failures || corrupt || sampling_failed ? 1 : 0;
+  } catch(const std::exception& e) {std::cerr<<e.what()<<'\n';return 2;}
 }

--- a/src/transport/dev_frame.h
+++ b/src/transport/dev_frame.h
@@ -23,8 +23,13 @@ constexpr uint8_t kDevProtoV2 = 2;
 // the full 64-bit opaque value used by writer-retirement control frames.
 constexpr uint64_t kDevFrameRequestWriterRetirement = uint64_t{1} << 63;
 constexpr uint64_t kDevFrameRequestPullRead = uint64_t{1} << 62;
+// Bit 61 requests the in-flight leased-PUT datapath: objects larger than the
+// connection's inline class arrive via a per-op staging lease instead of the
+// connection-lifetime receive-slot lease.
+constexpr uint64_t kDevFrameRequestLeasedPut = uint64_t{1} << 61;
 constexpr uint64_t kDevFrameMaxBlockMask =
-    ~(kDevFrameRequestWriterRetirement | kDevFrameRequestPullRead);
+    ~(kDevFrameRequestWriterRetirement | kDevFrameRequestPullRead |
+      kDevFrameRequestLeasedPut);
 
 // Room a device name must leave in the fixed 32-byte frame: NUL terminator +
 // "DCP2" u32 + max_block_bytes u64 + protocol u8. A name at most this long
@@ -99,6 +104,10 @@ inline bool DevFrameRequestsWriterRetirement(
 
 inline bool DevFrameRequestsPullRead(const char in[kDevNameBytes]) {
   return (ParseDevFrameCaps(in) & kDevFrameRequestPullRead) != 0;
+}
+
+inline bool DevFrameRequestsLeasedPut(const char in[kDevNameBytes]) {
+  return (ParseDevFrameCaps(in) & kDevFrameRequestLeasedPut) != 0;
 }
 
 inline uint8_t ParseDevFrameProtocol(const char in[kDevNameBytes]) {

--- a/src/transport/dev_frame.h
+++ b/src/transport/dev_frame.h
@@ -27,9 +27,10 @@ constexpr uint64_t kDevFrameRequestPullRead = uint64_t{1} << 62;
 // connection's inline class arrive via a per-op staging lease instead of the
 // connection-lifetime receive-slot lease.
 constexpr uint64_t kDevFrameRequestLeasedPut = uint64_t{1} << 61;
+constexpr uint64_t kDevFrameRequestDynamicPull = uint64_t{1} << 60;
 constexpr uint64_t kDevFrameMaxBlockMask =
     ~(kDevFrameRequestWriterRetirement | kDevFrameRequestPullRead |
-      kDevFrameRequestLeasedPut);
+      kDevFrameRequestLeasedPut | kDevFrameRequestDynamicPull);
 
 // Room a device name must leave in the fixed 32-byte frame: NUL terminator +
 // "DCP2" u32 + max_block_bytes u64 + protocol u8. A name at most this long
@@ -108,6 +109,10 @@ inline bool DevFrameRequestsPullRead(const char in[kDevNameBytes]) {
 
 inline bool DevFrameRequestsLeasedPut(const char in[kDevNameBytes]) {
   return (ParseDevFrameCaps(in) & kDevFrameRequestLeasedPut) != 0;
+}
+
+inline bool DevFrameRequestsDynamicPull(const char in[kDevNameBytes]) {
+  return (ParseDevFrameCaps(in) & kDevFrameRequestDynamicPull) != 0;
 }
 
 inline uint8_t ParseDevFrameProtocol(const char in[kDevNameBytes]) {

--- a/src/transport/rdma_protocol.h
+++ b/src/transport/rdma_protocol.h
@@ -44,6 +44,10 @@ constexpr size_t kV2ProbeReplyBytes = 8;
 // new clients fail before real QP bootstrap unless this bit is present.
 constexpr uint8_t kV2ProbeCapWriterRetirement = 1u << 0;
 constexpr uint8_t kV2ProbeCapPullRead = 1u << 1;
+// Bit 2 advertises the per-op staging-lease PUT datapath (kLeasePut). Old
+// clients ignore it; new clients refuse to send lease requests without it and
+// fall back to the connection-resident receive-slot path.
+constexpr uint8_t kV2ProbeCapLeasedPut = 1u << 2;
 
 inline bool IsV2Probe(const char frame[kDevNameBytes]) {
   size_t n = 0;
@@ -54,8 +58,8 @@ inline bool IsV2Probe(const char frame[kDevNameBytes]) {
 
 inline void EncodeV2ProbeReply(
     char out[kV2ProbeReplyBytes],
-    uint8_t capabilities =
-        kV2ProbeCapWriterRetirement | kV2ProbeCapPullRead) {
+    uint8_t capabilities = kV2ProbeCapWriterRetirement |
+                           kV2ProbeCapPullRead | kV2ProbeCapLeasedPut) {
   std::memset(out, 0, kV2ProbeReplyBytes);
   std::memcpy(out, &kV2ProbeMagic, sizeof(kV2ProbeMagic));
   out[4] = static_cast<char>(kDevProtoV2);
@@ -83,6 +87,11 @@ inline bool V2ProbeSupportsWriterRetirement(
 inline bool V2ProbeSupportsPullRead(
     const char in[kV2ProbeReplyBytes]) {
   return (ParseV2ProbeCapabilities(in) & kV2ProbeCapPullRead) != 0;
+}
+
+inline bool V2ProbeSupportsLeasedPut(
+    const char in[kV2ProbeReplyBytes]) {
+  return (ParseV2ProbeCapabilities(in) & kV2ProbeCapLeasedPut) != 0;
 }
 
 // Failure-path writer retirement. The client reconnects with the opaque
@@ -294,6 +303,60 @@ inline bool DecodePullReady(const char in[kPullReadyBytes],
   ready->data_len = net::GetU64(in + 16);
   ready->value_len = net::GetU64(in + 24);
   return ready->slot_generation != 0;
+}
+
+// Per-op staging lease for the in-flight leased-PUT datapath. The server
+// leases exactly one receive-pool range sized for the whole object; the client
+// WRITEs the object into [write_base, write_base+lease_bytes) exactly like an
+// ordinary receive-slot window (frame prefix at +kV2PutPrefixOffset, payload
+// at +kV2DataOffset). The range is freed by the server as soon as the STORE
+// handler returns, so receive memory follows data in flight, not connection
+// count. `slot` echoes the request's recv slot (also the WRITE immediate) and
+// `generation` is a nonzero per-slot monotonically increasing value reserved
+// for future release/retry extensions and log correlation.
+struct LeasePutReady {
+  uint32_t slot = 0;
+  uint64_t generation = 0;
+  uint32_t rkey = 0;
+  uint64_t write_base = 0;
+  uint64_t lease_bytes = 0;
+};
+
+constexpr uint32_t kLeasePutReadyMagic = 0x3252534cu;  // "LSR2" (LE)
+constexpr size_t kLeasePutReadyBytes = 40;
+
+inline void EncodeLeasePutReady(const LeasePutReady& ready,
+                                char out[kLeasePutReadyBytes]) {
+  std::memset(out, 0, kLeasePutReadyBytes);
+  net::PutU32(out, kLeasePutReadyMagic);
+  net::PutU32(out + 4, ready.rkey);
+  net::PutU32(out + 8, ready.slot);
+  net::PutU32(out + 12, 0);
+  net::PutU64(out + 16, ready.write_base);
+  net::PutU64(out + 24, ready.lease_bytes);
+  net::PutU64(out + 32, ready.generation);
+}
+
+inline bool DecodeLeasePutReady(const char in[kLeasePutReadyBytes],
+                                LeasePutReady* ready) {
+  if (net::GetU32(in) != kLeasePutReadyMagic) return false;
+  const uint32_t rkey = net::GetU32(in + 4);
+  const uint64_t write_base = net::GetU64(in + 16);
+  const uint64_t lease_bytes = net::GetU64(in + 24);
+  // A lease always stages at least one payload byte after the frame page, so
+  // a single empty page is geometry no server can produce: reject it here.
+  if (rkey == 0 || write_base == 0 ||
+      lease_bytes < 2 * kV2DataOffset ||
+      lease_bytes % kV2DataOffset != 0 ||
+      write_base >
+          std::numeric_limits<uint64_t>::max() - (lease_bytes - 1))
+    return false;
+  ready->rkey = rkey;
+  ready->slot = net::GetU32(in + 8);
+  ready->write_base = write_base;
+  ready->lease_bytes = lease_bytes;
+  ready->generation = net::GetU64(in + 32);
+  return ready->generation != 0;
 }
 
 // The original readiness response is exactly one ready byte plus the 24-byte

--- a/src/transport/rdma_protocol.h
+++ b/src/transport/rdma_protocol.h
@@ -48,6 +48,7 @@ constexpr uint8_t kV2ProbeCapPullRead = 1u << 1;
 // clients ignore it; new clients refuse to send lease requests without it and
 // fall back to the connection-resident receive-slot path.
 constexpr uint8_t kV2ProbeCapLeasedPut = 1u << 2;
+constexpr uint8_t kV2ProbeCapDynamicPull = 1u << 3;
 
 inline bool IsV2Probe(const char frame[kDevNameBytes]) {
   size_t n = 0;
@@ -59,7 +60,8 @@ inline bool IsV2Probe(const char frame[kDevNameBytes]) {
 inline void EncodeV2ProbeReply(
     char out[kV2ProbeReplyBytes],
     uint8_t capabilities = kV2ProbeCapWriterRetirement |
-                           kV2ProbeCapPullRead | kV2ProbeCapLeasedPut) {
+                           kV2ProbeCapPullRead | kV2ProbeCapLeasedPut |
+                           kV2ProbeCapDynamicPull) {
   std::memset(out, 0, kV2ProbeReplyBytes);
   std::memcpy(out, &kV2ProbeMagic, sizeof(kV2ProbeMagic));
   out[4] = static_cast<char>(kDevProtoV2);
@@ -92,6 +94,11 @@ inline bool V2ProbeSupportsPullRead(
 inline bool V2ProbeSupportsLeasedPut(
     const char in[kV2ProbeReplyBytes]) {
   return (ParseV2ProbeCapabilities(in) & kV2ProbeCapLeasedPut) != 0;
+}
+
+inline bool V2ProbeSupportsDynamicPull(
+    const char in[kV2ProbeReplyBytes]) {
+  return (ParseV2ProbeCapabilities(in) & kV2ProbeCapDynamicPull) != 0;
 }
 
 // Failure-path writer retirement. The client reconnects with the opaque
@@ -303,6 +310,52 @@ inline bool DecodePullReady(const char in[kPullReadyBytes],
   ready->data_len = net::GetU64(in + 16);
   ready->value_len = net::GetU64(in + 24);
   return ready->slot_generation != 0;
+}
+
+// Negotiated dynamic-pull connections omit the resident PullArenaInfo from
+// bootstrap: readiness is exactly kV2RetirementReadinessBytes (33 bytes).
+// Each kPullRange then publishes an operation-scoped READ capability; client
+// must finish READs and receive kPullRelease acknowledgement before pooling
+// its connection. Legacy connections retain their original 40-byte ready.
+struct DynamicPullReady {
+  uint32_t slot_index = 0;
+  uint64_t slot_generation = 0;
+  uint64_t data_len = 0;
+  uint64_t value_len = 0;
+  uint64_t address = 0;
+  uint32_t rkey = 0;
+};
+constexpr uint32_t kDynamicPullReadyMagic = 0x32525044u;  // "DPR2"
+constexpr size_t kDynamicPullReadyBytes = 48;
+
+inline void EncodeDynamicPullReady(const DynamicPullReady& value,
+                                   char out[kDynamicPullReadyBytes]) {
+  std::memset(out, 0, kDynamicPullReadyBytes);
+  net::PutU32(out, kDynamicPullReadyMagic);
+  net::PutU32(out + 4, value.slot_index);
+  net::PutU64(out + 8, value.slot_generation);
+  net::PutU64(out + 16, value.data_len);
+  net::PutU64(out + 24, value.value_len);
+  net::PutU64(out + 32, value.address);
+  net::PutU32(out + 40, value.rkey);
+}
+inline bool DecodeDynamicPullReady(const char in[kDynamicPullReadyBytes],
+                                   DynamicPullReady* value) {
+  if (net::GetU32(in) != kDynamicPullReadyMagic ||
+      net::GetU32(in + 44) != 0) return false;
+  DynamicPullReady parsed;
+  parsed.slot_index = net::GetU32(in + 4);
+  parsed.slot_generation = net::GetU64(in + 8);
+  parsed.data_len = net::GetU64(in + 16);
+  parsed.value_len = net::GetU64(in + 24);
+  parsed.address = net::GetU64(in + 32);
+  parsed.rkey = net::GetU32(in + 40);
+  if (!parsed.slot_generation || !parsed.address || !parsed.rkey ||
+      parsed.data_len > parsed.value_len ||
+      parsed.data_len > std::numeric_limits<uint64_t>::max() - parsed.address)
+    return false;
+  *value = parsed;
+  return true;
 }
 
 // Per-op staging lease for the in-flight leased-PUT datapath. The server

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -395,6 +395,9 @@ struct RdmaTransport::Conn {
   size_t declared_bytes = 0;
   size_t depth = 1;
   Lane lane = Lane::kData;
+  // Negotiated staged-lease PUT datapath (probe bit + bootstrap request bit).
+  // Off for pooled conns predating the opt-in and for peers without support.
+  bool leased_put = false;
   bool active_counted = false;
   bool live_counted = false;
   bool visited = true;  // guarded by RdmaTransport::mu_ while idle
@@ -439,6 +442,15 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
           EnvBytes("DFKV_RDMA_CONNECTION_MIN_BLOCK_BYTES", 256ull << 10),
           static_cast<size_t>(declared_))),
       depth_(4) {
+  // Optional staged-lease PUT threshold (env DFKV_RDMA_INLINE_PUT_MAX_BYTES,
+  // default 4 MiB; 0 disables). Objects larger than this use the per-op
+  // staging-lease datapath on connections whose peer negotiated it, keeping
+  // the connection-resident receive-slot class at the threshold.
+  inline_put_max_bytes_ = std::min<size_t>(
+      EnvBytes("DFKV_RDMA_INLINE_PUT_MAX_BYTES", 4ull << 20),
+      static_cast<size_t>(declared_));
+  config_dump::RecordResolved("DFKV_RDMA_INLINE_PUT_MAX_BYTES",
+                              std::to_string(inline_put_max_bytes_));
   std::string list = dev_name;
   if (list.empty()) {
     const char* configured = std::getenv("DFKV_RDMA_DEV");
@@ -1105,8 +1117,10 @@ void RdmaTransport::NoteNegotiatedDepth(const std::string& node, Lane lane,
   if (it == map.end() || remote_depth < it->second) map[node] = remote_depth;
 }
 
-bool RdmaTransport::ProbeV2(const std::string& node) const {
+bool RdmaTransport::ProbeV2(const std::string& node,
+                             bool* leased_put_supported) const {
   v2_probe_attempts_.fetch_add(1, std::memory_order_relaxed);
+  if (leased_put_supported) *leased_put_supported = false;
   int fd = net::Dial(node, connect_ms_, io_ms_);
   if (fd < 0) {
     v2_probe_failures_.fetch_add(1, std::memory_order_relaxed);
@@ -1121,10 +1135,15 @@ bool RdmaTransport::ProbeV2(const std::string& node) const {
       net::ReadAll(fd, reply, sizeof(reply)) &&
       rdma::V2ProbeSupportsWriterRetirement(reply) &&
       rdma::V2ProbeSupportsPullRead(reply);
+  const bool leased = ok && rdma::V2ProbeSupportsLeasedPut(reply);
   ::close(fd);
-  if (!ok) v2_probe_failures_.fetch_add(1, std::memory_order_relaxed);
+  if (!ok)
+    v2_probe_failures_.fetch_add(1, std::memory_order_relaxed);
+  else if (leased_put_supported)
+    *leased_put_supported = leased;
   return ok;
 }
+
 
 RdmaTransport::AcquireResult RdmaTransport::Acquire(
     const std::string& node, Lane lane, const AcquireOptions& options) {
@@ -1258,6 +1277,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
               candidate->rail_index == ridx &&
               candidate->declared_bytes >= required_bound &&
               candidate->depth >= required_depth &&
+              (!options.request_leased_put || candidate->leased_put) &&
               (candidate->declared_bytes < best_bound ||
                (candidate->declared_bytes == best_bound &&
                 candidate->depth < best_depth))) {
@@ -1351,7 +1371,8 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
 
   const std::string& dev = devs_[ridx];
-  if (!ProbeV2(node)) {
+  bool leased_put_supported = false;
+  if (!ProbeV2(node, &leased_put_supported)) {
     DFKV_LOG_ERROR(
         "rdma: peer " + node +
         " does not advertise required v2 writer-retirement and pull-read capabilities");
@@ -1404,9 +1425,12 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   // The probe above proves the peer understands bit 63 before a real QP is
   // created. Echo the request on this bootstrap so a rolling-upgraded server
   // sends the token only to a client that will consume it.
+  const bool want_leased_put =
+      options.request_leased_put && leased_put_supported;
   const uint64_t bootstrap_declared =
       conn_declared | rdma::kDevFrameRequestWriterRetirement |
-      rdma::kDevFrameRequestPullRead;
+      rdma::kDevFrameRequestPullRead |
+      (want_leased_put ? rdma::kDevFrameRequestLeasedPut : 0);
   rdma::EncodeDevFrame(auto_device_ ? std::string() : dev,
                        bootstrap_declared, devbuf, rdma::kDevProtoV2);
   char mine[rdma::kQpInfoBytes], remote_qp_bytes[rdma::kQpInfoBytes];
@@ -1506,6 +1530,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     result.failure = AcquireFailure::kAdmission;
     return result;
   }
+  conn->leased_put = want_leased_put;
   conns_opened_.fetch_add(1, std::memory_order_relaxed);
   MarkClassOpened(conn);
   rail_conns_[ridx].fetch_add(1, std::memory_order_relaxed);
@@ -2050,6 +2075,20 @@ std::string RdmaTransport::MetricsText() const {
   s += "dfkv_rdma_client_oversize_rejects_total " +
        std::to_string(oversize_rejects_.load(std::memory_order_relaxed)) +
        "\n";
+  s += "# HELP dfkv_rdma_client_inline_put_max_bytes Leased-PUT inline threshold (env DFKV_RDMA_INLINE_PUT_MAX_BYTES); objects above it use per-op staging leases\n";
+  s += "# TYPE dfkv_rdma_client_inline_put_max_bytes gauge\n";
+  s += "dfkv_rdma_client_inline_put_max_bytes " +
+       std::to_string(inline_put_max_bytes_) + "\n";
+  s += "# HELP dfkv_rdma_client_leaseput_ops_total Objects delivered through per-op staging leases\n";
+  s += "# TYPE dfkv_rdma_client_leaseput_ops_total counter\n";
+  s += "dfkv_rdma_client_leaseput_ops_total " +
+       std::to_string(leaseput_ops_.load(std::memory_order_relaxed)) +
+       "\n";
+  s += "# HELP dfkv_rdma_client_leaseput_path_fallbacks_total Lease-intent batches that fell back to a traditional largest-object connection\n";
+  s += "# TYPE dfkv_rdma_client_leaseput_path_fallbacks_total counter\n";
+  s += "dfkv_rdma_client_leaseput_path_fallbacks_total " +
+       std::to_string(leaseput_path_fallbacks_.load(std::memory_order_relaxed)) +
+       "\n";
   s += "# HELP dfkv_rdma_client_v2_probe_attempts_total Required-protocol bootstrap probes\n";
   s += "# TYPE dfkv_rdma_client_v2_probe_attempts_total counter\n";
   s += "dfkv_rdma_client_v2_probe_attempts_total " +
@@ -2483,11 +2522,18 @@ Status RdmaTransport::Remove(const std::string& node, const BlockKey& key) {
 std::vector<Status> RdmaTransport::CacheMany(
     const std::string& node, const std::vector<CacheItem>& items) {
   const size_t count = items.size();
-  size_t required_bytes = 0;
+  size_t max_all_len = 0;
+  size_t max_inline_len = 0;
   std::vector<Status> result(count, Status::kIOError);
   if (count == 0) return result;
   std::vector<char> bad(count, 0);
   size_t valid_count = 0;
+  // Bucket split for the staged-lease datapath: objects above the inline
+  // threshold are candidates for per-op staging leases (server memory tracks
+  // in-flight data instead of connection geometry); everything else keeps the
+  // connection-resident receive-slot path unchanged.
+  bool any_over = false;
+  const bool lease_enabled = inline_put_max_bytes_ != 0;
   for (size_t i = 0; i < count; ++i) {
     if (items[i].len == 0 ||
         !ValidBuffer(items[i].data, items[i].len) ||
@@ -2495,11 +2541,20 @@ std::vector<Status> RdmaTransport::CacheMany(
       bad[i] = 1;
       result[i] = Status::kInvalid;
     } else {
-      required_bytes = std::max(required_bytes, items[i].len);
+      max_all_len = std::max(max_all_len, items[i].len);
+      if (lease_enabled && items[i].len > inline_put_max_bytes_) {
+        any_over = true;
+      } else {
+        max_inline_len = std::max(max_inline_len, items[i].len);
+      }
       ++valid_count;
     }
   }
   if (valid_count == 0) return result;
+  // The connection-resident class must cover the largest INLINE object; the
+  // over-threshold bucket never inflates it.
+  const size_t required_bytes =
+      (any_over && lease_enabled) ? max_inline_len : max_all_len;
 
   const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
@@ -2511,7 +2566,14 @@ std::vector<Status> RdmaTransport::CacheMany(
     for (size_t i = 0; i < count; ++i)
       if (bad[i]) result[i] = Status::kInvalid;
     AcquireOptions options;
-    options.required_data_bytes = required_bytes;
+    // Attempt 0 asks for the staged-lease datapath when the batch needs it;
+    // attempt 1 (fresh-retry or a lease-incapable peer) falls back to the
+    // traditional largest-object connection-resident class.
+    const bool want_lease = attempt == 0 && any_over && lease_enabled;
+    options.required_data_bytes =
+        want_lease ? std::max(max_inline_len, connection_min_block_bytes_)
+                   : required_bytes;
+    options.request_leased_put = want_lease;
     options.force_new = attempt != 0;
     options.requested_credits = std::min(valid_count, depth_);
     options.excluded = excluded;
@@ -2530,6 +2592,17 @@ std::vector<Status> RdmaTransport::CacheMany(
         MarkClientLocalFailure(&result, acquired.status);
       return result;
     }
+    if (want_lease && !acquired.conn->leased_put) {
+      // Peer predates the staged-lease capability (or the pool only had
+      // plain conns). The small-class connection cannot carry the over-
+      // threshold objects, so stop before anything is posted and retry once
+      // with the traditional largest-object geometry. Nothing was committed.
+      Release(node, Lane::kData, acquired.conn);
+      leaseput_path_fallbacks_.fetch_add(1, std::memory_order_relaxed);
+      if (attempt + 1 < 2) continue;
+      MarkClientLocalFailure(&result, Status::kInvalid);
+      return result;
+    }
     Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
@@ -2540,13 +2613,22 @@ std::vector<Status> RdmaTransport::CacheMany(
     // local-rail default; a failed reap window is classified from its WC
     // evidence; wire decode failures blame the peer.
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
-    for (size_t base = 0; base < count && conn_ok; base += window) {
-      const size_t width = std::min(window, count - base);
+    std::vector<size_t> inline_idx;
+    std::vector<size_t> lease_idx;
+    for (size_t i = 0; i < count; ++i) {
+      if (bad[i]) continue;
+      if (conn->leased_put && items[i].len > inline_put_max_bytes_)
+        lease_idx.push_back(i);
+      else
+        inline_idx.push_back(i);
+    }
+    // Inline bucket: the unchanged connection-resident receive-slot pipeline.
+    for (size_t base = 0; base < inline_idx.size() && conn_ok; base += window) {
+      const size_t width = std::min(window, inline_idx.size() - base);
       std::vector<ibv_mr*> payload_mrs(width, nullptr);
       size_t posted = 0;
       for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = base + slot;
-        if (bad[item_index]) continue;
+        const size_t item_index = inline_idx[base + slot];
         const CacheItem& item = items[item_index];
         if (item.len > conn->data_capacity()) {
           bad[item_index] = 1;
@@ -2588,8 +2670,127 @@ std::vector<Status> RdmaTransport::CacheMany(
       if (!conn_ok) break;
       for (ibv_mr* mr : payload_mrs) ep.ReleaseTransient(mr);
       for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = base + slot;
+        const size_t item_index = inline_idx[base + slot];
+        Status status;
+        uint64_t data_len = 0;
+        if (reply_bytes[slot] < kRespPrefix ||
+            !conn->Decode(ep.rbuf(slot), &status, &data_len, 0)) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kEndpointFailure;
+          break;
+        }
+        result[item_index] = status;
+      }
+    }
+    // Staged-lease bucket, three pipelined phases per window:
+    //   A) request per-op staging leases (one wire RTT for the whole window)
+    //   B) WRITE_WITH_IMM every accepted object into its leased range
+    //   C) reap the status window and release caller-side transients
+    for (size_t base = 0; base < lease_idx.size() && conn_ok; base += window) {
+      const size_t width = std::min(window, lease_idx.size() - base);
+      struct LeaseSlot {
+        size_t item_index = 0;
+        uint64_t write_base = 0;
+        uint32_t rkey = 0;
+      };
+      std::vector<LeaseSlot> leases(width);
+      size_t accepted = 0;
+      for (size_t slot = 0; slot < width && conn_ok; ++slot) {
+        const size_t item_index = lease_idx[base + slot];
+        const CacheItem& item = items[item_index];
+        leases[slot].item_index = item_index;
+        conn->Encode(ep.sbuf(slot), WireOp::kLeasePut, item.key, 0, 0,
+                     item.len);
+        if (!ep.PostRecv(slot) || !ep.PostSend(slot, kReqPrefix)) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kRailFailure;
+          break;
+        }
+        ++accepted;
+      }
+      std::vector<uint32_t> reply_bytes;
+      bool timed_out = false;
+      ibv_wc_status wc_status = IBV_WC_SUCCESS;
+      bool had_wcs = false;
+      if (conn_ok &&
+          !ReapPosted(ep, accepted, width, &reply_bytes, BatchTimeout(),
+                      &timed_out, &wc_status, &had_wcs, &completion_fault)) {
+        conn_ok = false;
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
+      }
+      if (timed_out)
+        completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+      if (!conn_ok) break;
+      size_t written = 0;
+      std::vector<ibv_mr*> payload_mrs(width, nullptr);
+      for (size_t slot = 0; slot < width && conn_ok; ++slot) {
+        const size_t item_index = leases[slot].item_index;
         if (bad[item_index]) continue;
+        Status status;
+        uint64_t data_len = 0;
+        if (reply_bytes[slot] < kRespPrefix ||
+            !conn->Decode(ep.rbuf(slot), &status, &data_len, 0) ||
+            (status == Status::kOk) !=
+                (data_len == rdma::kLeasePutReadyBytes)) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kEndpointFailure;
+          break;
+        }
+        // Backpressure (busy pool) and permanent verdicts are per-object
+        // outcomes: record them and move on without tearing the connection.
+        if (status != Status::kOk) {
+          result[item_index] = status;
+          continue;
+        }
+        rdma::LeasePutReady ready;
+        if (reply_bytes[slot] < kRespPrefix + rdma::kLeasePutReadyBytes ||
+            !rdma::DecodeLeasePutReady(ep.rbuf(slot) + kRespPrefix,
+                                       &ready) ||
+            ready.slot != static_cast<uint32_t>(slot) ||
+            ready.lease_bytes <
+                static_cast<uint64_t>(rdma::kV2DataOffset) +
+                    items[item_index].len) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kEndpointFailure;
+          break;
+        }
+        leases[slot].write_base = ready.write_base;
+        leases[slot].rkey = ready.rkey;
+        ++leaseput_ops_;
+        const CacheItem& item = items[item_index];
+        ibv_mr* mr = ep.RegisterTransient(const_cast<void*>(item.data),
+                                           item.len, /*remote_write=*/false);
+        payload_mrs[slot] = mr;
+        if (!mr || !ep.PostRecv(slot) ||
+            !ep.PostWriteImmScatter(
+                slot, kReqPrefix, item.data, item.len, mr,
+                leases[slot].write_base + rdma::kV2PutPrefixOffset,
+                leases[slot].rkey, static_cast<uint32_t>(slot))) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kRailFailure;
+          break;
+        }
+        ++written;
+        v2_put_writes_.fetch_add(1, std::memory_order_relaxed);
+        request_posted = true;
+      }
+      if (!conn_ok) break;
+      reply_bytes.clear();
+      timed_out = false;
+      wc_status = IBV_WC_SUCCESS;
+      had_wcs = false;
+      if (!ReapPosted(ep, written, width, &reply_bytes, BatchTimeout(),
+                      &timed_out, &wc_status, &had_wcs, &completion_fault)) {
+        conn_ok = false;
+        completion = rdma::ClassifyCompletion(wc_status, had_wcs);
+      }
+      if (timed_out)
+        completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+      if (!conn_ok) break;
+      for (ibv_mr* mr : payload_mrs) ep.ReleaseTransient(mr);
+      for (size_t slot = 0; slot < width; ++slot) {
+        const size_t item_index = leases[slot].item_index;
+        if (bad[item_index] || leases[slot].write_base == 0) continue;
         Status status;
         uint64_t data_len = 0;
         if (reply_bytes[slot] < kRespPrefix ||

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -443,14 +443,31 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
           static_cast<size_t>(declared_))),
       depth_(4) {
   // Optional staged-lease PUT threshold (env DFKV_RDMA_INLINE_PUT_MAX_BYTES,
-  // default 4 MiB; 0 disables). Objects larger than this use the per-op
-  // staging-lease datapath on connections whose peer negotiated it, keeping
-  // the connection-resident receive-slot class at the threshold.
-  inline_put_max_bytes_ = std::min<size_t>(
-      EnvBytes("DFKV_RDMA_INLINE_PUT_MAX_BYTES", 4ull << 20),
-      static_cast<size_t>(declared_));
-  config_dump::RecordResolved("DFKV_RDMA_INLINE_PUT_MAX_BYTES",
-                              std::to_string(inline_put_max_bytes_));
+  // default 4 MiB; explicit 0 disables). Objects larger than this use the
+  // per-op staging-lease datapath on connections whose peer negotiated it,
+  // keeping the connection-resident receive-slot class at the threshold.
+  // Unlike EnvBytes, an explicit 0 must stay 0 (disabled), not fall back.
+  inline_put_max_bytes_ = 4ull << 20;
+  size_t inline_resolved_state = 1;  // 1 = default, 0 = disabled, 2 = value
+  if (const char* const v = std::getenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES")) {
+    if (*v) {
+      errno = 0;
+      char* end = nullptr;
+      const unsigned long long x = std::strtoull(v, &end, 10);
+      if (errno == 0 && end != v && *end == '\0') {
+        inline_put_max_bytes_ = std::min<size_t>(
+            static_cast<size_t>(x), max_payload_);
+        inline_resolved_state = x == 0 ? 0 : 2;
+      }
+    } else {
+      inline_resolved_state = 0;  // set to the empty string: disabled
+    }
+  }
+  config_dump::RecordResolved(
+      "DFKV_RDMA_INLINE_PUT_MAX_BYTES",
+      inline_resolved_state == 0
+          ? std::string("0")
+          : std::to_string(inline_put_max_bytes_));
   std::string list = dev_name;
   if (list.empty()) {
     const char* configured = std::getenv("DFKV_RDMA_DEV");
@@ -2570,9 +2587,13 @@ std::vector<Status> RdmaTransport::CacheMany(
     // attempt 1 (fresh-retry or a lease-incapable peer) falls back to the
     // traditional largest-object connection-resident class.
     const bool want_lease = attempt == 0 && any_over && lease_enabled;
+    // Attempt 0 with lease intent clamps the resident class at the inline
+    // threshold; attempt 1 (fresh retry after a lease-path failure, or a
+    // lease-incapable peer) falls back to the traditional largest-object
+    // class so over-threshold objects still have a path home.
     options.required_data_bytes =
         want_lease ? std::max(max_inline_len, connection_min_block_bytes_)
-                   : required_bytes;
+                   : max_all_len;
     options.request_leased_put = want_lease;
     options.force_new = attempt != 0;
     options.requested_credits = std::min(valid_count, depth_);
@@ -2692,6 +2713,10 @@ std::vector<Status> RdmaTransport::CacheMany(
         size_t item_index = 0;
         uint64_t write_base = 0;
         uint32_t rkey = 0;
+        // The server's lease index (its own receive-slot numbering). The
+        // WRITE immediate and every lease state lookup happen in the
+        // SERVER's slot space, which is not the client's pipeline index.
+        uint32_t server_slot = 0;
       };
       std::vector<LeaseSlot> leases(width);
       size_t accepted = 0;
@@ -2729,7 +2754,8 @@ std::vector<Status> RdmaTransport::CacheMany(
         Status status;
         uint64_t data_len = 0;
         if (reply_bytes[slot] < kRespPrefix ||
-            !conn->Decode(ep.rbuf(slot), &status, &data_len, 0) ||
+            !conn->Decode(ep.rbuf(slot), &status, &data_len,
+                          rdma::kLeasePutReadyBytes) ||
             (status == Status::kOk) !=
                 (data_len == rdma::kLeasePutReadyBytes)) {
           conn_ok = false;
@@ -2743,10 +2769,14 @@ std::vector<Status> RdmaTransport::CacheMany(
           continue;
         }
         rdma::LeasePutReady ready;
+        // ready.slot names the SERVER's receive slot holding this lease; it
+        // is not this client pipeline index and may legitimately differ.
+        // Only bound it by the negotiated depth as fail-closed corruption
+        // defense — the immediate must reach a server-side active lease.
         if (reply_bytes[slot] < kRespPrefix + rdma::kLeasePutReadyBytes ||
             !rdma::DecodeLeasePutReady(ep.rbuf(slot) + kRespPrefix,
                                        &ready) ||
-            ready.slot != static_cast<uint32_t>(slot) ||
+            ready.slot >= static_cast<uint32_t>(conn->depth) ||
             ready.lease_bytes <
                 static_cast<uint64_t>(rdma::kV2DataOffset) +
                     items[item_index].len) {
@@ -2756,16 +2786,21 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         leases[slot].write_base = ready.write_base;
         leases[slot].rkey = ready.rkey;
+        leases[slot].server_slot = ready.slot;
         ++leaseput_ops_;
         const CacheItem& item = items[item_index];
         ibv_mr* mr = ep.RegisterTransient(const_cast<void*>(item.data),
                                            item.len, /*remote_write=*/false);
         payload_mrs[slot] = mr;
+        // The WRITE window is an ordinary v2 PUT frame aimed at the leased
+        // range: re-encode the request header (phase A left a kLeasePut
+        // request in this send buffer).
+        conn->Encode(ep.sbuf(slot), WireOp::kCache, item.key, 0, 0, item.len);
         if (!mr || !ep.PostRecv(slot) ||
             !ep.PostWriteImmScatter(
                 slot, kReqPrefix, item.data, item.len, mr,
                 leases[slot].write_base + rdma::kV2PutPrefixOffset,
-                leases[slot].rkey, static_cast<uint32_t>(slot))) {
+                leases[slot].rkey, leases[slot].server_slot)) {
           conn_ok = false;
           completion = rdma::RailCompletion::kRailFailure;
           break;
@@ -3520,7 +3555,14 @@ bool RdmaTransport::NoteBlock(size_t n) const {
                   std::to_string(n / 1024) + " KiB); declared bound " +
                   std::to_string(OpBound()) + "B");
   }
-  const size_t bound = OpBound();
+  // With the staged-lease datapath enabled, the logical OBJECT ceiling is
+  // the transport payload bound (--max-msg derived): connection geometry
+  // stops at the inline threshold, so oversize must stop rejecting exactly
+  // the objects the lease path exists to carry. The legacy bound (the
+  // declared connection class) still rejects when the datapath is disabled.
+  const size_t bound =
+      inline_put_max_bytes_ != 0 ? static_cast<size_t>(max_payload_)
+                                 : OpBound();
   if (n <= bound) return false;
   const uint64_t k = oversize_rejects_.fetch_add(1, std::memory_order_relaxed);
   if (k == 0 || (k & 0x3FFu) == 0)  // first, then every 1024th

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -3333,6 +3333,21 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   }
   if (valid_count == 0) return result;
 
+  // Bucket split (same semantics as CacheMany): over-threshold objects are
+  // candidates for the staged-lease datapath; the SG connection's resident
+  // class must then cover only the largest INLINE object.
+  const bool lease_enabled = inline_put_max_bytes_ != 0;
+  bool any_over = false;
+  size_t max_inline_len = 0;
+  for (size_t i = 0; i < count; ++i) {
+    if (bad[i]) continue;
+    if (lease_enabled && totals[i] > inline_put_max_bytes_) {
+      any_over = true;
+    } else {
+      max_inline_len = std::max(max_inline_len, totals[i]);
+    }
+  }
+
   const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
   bool cross_rail_retry = false;
@@ -3342,8 +3357,12 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     // A fresh attempt is possible only before any request is posted;
     // validation results survive while connection-local progress restarts.
     completion_fault.BeginAttempt(attempt);
+    const bool want_lease = attempt == 0 && any_over && lease_enabled;
     AcquireOptions options;
-    options.required_data_bytes = required_bytes;
+    options.required_data_bytes =
+        want_lease ? std::max(max_inline_len, connection_min_block_bytes_)
+                   : required_bytes;
+    options.request_leased_put = want_lease;
     options.force_new = attempt != 0;
     options.requested_credits = 1;
     options.excluded = excluded;
@@ -3363,6 +3382,15 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       return result;
     }
     Conn* conn = acquired.conn;
+    if (want_lease && !conn->leased_put) {
+      // Lease-incapable peer or a plain pooled connection: fall back to the
+      // traditional largest-object geometry before anything is posted.
+      Release(node, Lane::kSgData, conn);
+      leaseput_path_fallbacks_.fetch_add(1, std::memory_order_relaxed);
+      if (attempt + 1 < 2) continue;
+      MarkClientLocalFailure(&result, Status::kInvalid);
+      return result;
+    }
     if (out_dev) {
       const std::string& attempted_dev = devs_[conn->rail_index];
       if (!out_dev_set) {
@@ -3378,11 +3406,13 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     bool conn_ok = !InjectLocalRailFailure(attempt);
     bool request_posted = false;
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
-    const size_t remote_capacity = conn->data_capacity();
 
     for (size_t item_index = 0; item_index < count && conn_ok; ++item_index) {
       if (bad[item_index] || completed[item_index]) continue;
-      if (totals[item_index] > remote_capacity) {
+      const bool use_lease = conn->leased_put &&
+                             totals[item_index] > inline_put_max_bytes_;
+      const size_t remote_capacity = conn->data_capacity();
+      if (!use_lease && totals[item_index] > remote_capacity) {
         result[item_index] = Status::kInvalid;
         completed[item_index] = 1;
         continue;
@@ -3396,6 +3426,63 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
         result[item_index] = Status::kInvalid;
         completed[item_index] = 1;
         continue;
+      }
+
+      // Staged-lease items request an exactly-sized receive range first, then
+      // aim every window WR at that range. Inline items keep the connection's
+      // resident receive slot with immediate 0.
+      uint64_t window_base = conn->put_addr(0);
+      uint32_t window_rkey = conn->recv_segment.rkey;
+      uint32_t window_imm = 0;
+      if (use_lease) {
+        conn->Encode(ep.sbuf(0), WireOp::kLeasePut, source.key, 0, 0,
+                     totals[item_index]);
+        std::vector<uint32_t> ready_bytes;
+        bool ready_timed_out = false;
+        ibv_wc_status ready_status = IBV_WC_SUCCESS;
+        bool ready_had_wcs = false;
+        if (!ep.PostRecv(0) || !ep.PostSend(0, kReqPrefix) ||
+            !ReapPosted(ep, 1, 1, &ready_bytes, BatchTimeout(),
+                        &ready_timed_out, &ready_status, &ready_had_wcs,
+                        &completion_fault)) {
+          conn_ok = false;
+          completion = rdma::ClassifyCompletion(ready_status, ready_had_wcs);
+          break;
+        }
+        Status ready_status_code = Status::kIOError;
+        uint64_t ready_data_len = 0;
+        if (ready_bytes[0] < kRespPrefix ||
+            !conn->Decode(ep.rbuf(0), &ready_status_code, &ready_data_len,
+                          rdma::kLeasePutReadyBytes)) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kEndpointFailure;
+          break;
+        }
+        if (ready_status_code == Status::kCacheFull) {
+          result[item_index] = Status::kCacheFull;
+          completed[item_index] = 1;
+          continue;
+        }
+        if (ready_status_code != Status::kOk) {
+          result[item_index] = ready_status_code;
+          completed[item_index] = 1;
+          continue;
+        }
+        rdma::LeasePutReady ready;
+        if (ready_bytes[0] < kRespPrefix + rdma::kLeasePutReadyBytes ||
+            !rdma::DecodeLeasePutReady(ep.rbuf(0) + kRespPrefix, &ready) ||
+            ready.slot >= static_cast<uint32_t>(conn->depth) ||
+            ready.lease_bytes <
+                static_cast<uint64_t>(rdma::kV2DataOffset) +
+                    totals[item_index]) {
+          conn_ok = false;
+          completion = rdma::RailCompletion::kEndpointFailure;
+          break;
+        }
+        window_base = ready.write_base + rdma::kV2PutPrefixOffset;
+        window_rkey = ready.rkey;
+        window_imm = ready.slot;
+        ++leaseput_ops_;
       }
 
       conn->Encode(ep.sbuf(0), WireOp::kCache, source.key,
@@ -3434,12 +3521,13 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
         }
         const size_t header_len = window_index == 0 ? kReqPrefix : 0;
         const uint64_t remote_addr =
-            conn->put_addr(0) +
+            window_base +
             (window_index == 0 ? 0 : kReqPrefix + logical_offset);
         if (!ep.PostRecv(0) ||
             !ep.PostWriteImmScatterMulti(
                 0, header_len, segments, mrs, remote_addr,
-                conn->recv_segment.rkey, 0)) {
+                use_lease ? window_rkey : conn->recv_segment.rkey,
+                window_imm)) {
           conn_ok = false;
           break;
         }

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -398,6 +398,7 @@ struct RdmaTransport::Conn {
   // Negotiated staged-lease PUT datapath (probe bit + bootstrap request bit).
   // Off for pooled conns predating the opt-in and for peers without support.
   bool leased_put = false;
+  bool dynamic_pull = false;
   bool active_counted = false;
   bool live_counted = false;
   bool visited = true;  // guarded by RdmaTransport::mu_ while idle
@@ -469,6 +470,10 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
       inline_resolved_state == 0
           ? std::string("0")
           : std::to_string(inline_put_max_bytes_));
+  if (const char* value = std::getenv("DFKV_RDMA_DYNAMIC_PULL"))
+    dynamic_pull_enabled_ = std::strcmp(value, "0") != 0;
+  config_dump::RecordResolved("DFKV_RDMA_DYNAMIC_PULL",
+                              dynamic_pull_enabled_ ? "1" : "0");
   std::string list = dev_name;
   if (list.empty()) {
     const char* configured = std::getenv("DFKV_RDMA_DEV");
@@ -973,8 +978,8 @@ void RdmaTransport::Destroy(Conn* c, rdma::RailCompletion completion) {
              ? RemoteRailOutcome::kEndpointFailure
              : RemoteRailOutcome::kAbandon);
 
-  // Direct GET failure paths have already obtained responder-retirement proof.
-  // Deletion releases terminal verbs resources; it is not a DMA fence.
+  // RcEndpoint destroys its QP before deregistering MRs. In particular this
+  // fences an outstanding initiator READ before caller memory can be reused.
   delete c;
   if (credit_held) {
     const uint64_t now = rdma::RailPolicy::NowMicros();
@@ -1082,7 +1087,7 @@ void RdmaTransport::OnPeerTopology(const PeerTopology& topology) {
     // linearization point and become active with the retired incarnation.
     std::lock_guard<std::mutex> lock(mu_);
     if (!peer_topologies_->Update(topology)) return;
-    peer_put_capabilities_.erase(topology.peer_addr);
+    peer_capabilities_.erase(topology.peer_addr);
     const auto current_snapshot =
         peer_topologies_->Snapshot(topology.peer_addr);
     const auto reap = [&](auto& pools) {
@@ -1137,9 +1142,11 @@ void RdmaTransport::NoteNegotiatedDepth(const std::string& node, Lane lane,
 }
 
 bool RdmaTransport::ProbeV2(const std::string& node,
-                             bool* leased_put_supported) const {
+                             bool* leased_put_supported,
+                             bool* dynamic_pull_supported) const {
   v2_probe_attempts_.fetch_add(1, std::memory_order_relaxed);
   if (leased_put_supported) *leased_put_supported = false;
+  if (dynamic_pull_supported) *dynamic_pull_supported = false;
   int fd = net::Dial(node, connect_ms_, io_ms_);
   if (fd < 0) {
     v2_probe_failures_.fetch_add(1, std::memory_order_relaxed);
@@ -1160,6 +1167,8 @@ bool RdmaTransport::ProbeV2(const std::string& node,
     v2_probe_failures_.fetch_add(1, std::memory_order_relaxed);
   else if (leased_put_supported)
     *leased_put_supported = leased;
+  if (dynamic_pull_supported)
+    *dynamic_pull_supported = ok && rdma::V2ProbeSupportsDynamicPull(reply);
   return ok;
 }
 
@@ -1254,20 +1263,22 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
       ConnectionDepth(node, lane, options.requested_credits);
   bool probed = false;
   bool leased_put_supported = false;
-  if (options.request_leased_put) {
+  bool dynamic_pull_supported = false;
+  if (options.request_leased_put || dynamic_pull_enabled_) {
     bool known = false;
     {
       std::lock_guard<std::mutex> lock(mu_);
-      const auto found = peer_put_capabilities_.find(node);
-      if (found != peer_put_capabilities_.end() &&
+      const auto found = peer_capabilities_.find(node);
+      if (found != peer_capabilities_.end() &&
           found->second.peer_id == peer_snapshot->peer_id &&
           found->second.publication == peer_snapshot->publication) {
         known = true;
         leased_put_supported = found->second.leased_put;
+        dynamic_pull_supported = found->second.dynamic_pull;
       }
     }
     if (!known) {
-      if (!ProbeV2(node, &leased_put_supported)) {
+      if (!ProbeV2(node, &leased_put_supported, &dynamic_pull_supported)) {
         complete_unowned_lease(rdma::RailCompletion::kEndpointFailure);
         result.failure = AcquireFailure::kEndpoint;
         return result;
@@ -1276,21 +1287,25 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
       std::lock_guard<std::mutex> lock(mu_);
       if (peer_topologies_->IsCurrent(
               node, peer_snapshot->peer_id, peer_snapshot->publication)) {
-        peer_put_capabilities_[node] = {
+        peer_capabilities_[node] = {
             peer_snapshot->peer_id, peer_snapshot->publication,
-            leased_put_supported};
+            leased_put_supported, dynamic_pull_supported};
       }
     }
   }
   const bool want_leased_put =
       options.request_leased_put && leased_put_supported;
+  const bool want_dynamic_pull =
+      dynamic_pull_enabled_ && dynamic_pull_supported;
   if (options.request_leased_put && !want_leased_put)
     leaseput_path_fallbacks_.fetch_add(1, std::memory_order_relaxed);
   const size_t required_bound =
       lane == Lane::kControl
           ? static_cast<size_t>(rdma::kV2ControlCap)
-          : ConnectionBound(want_leased_put ? options.leased_inline_bytes
-                                           : options.required_data_bytes);
+          : ConnectionBound(options.request_dynamic_pull && want_dynamic_pull
+                                ? 0
+                                : want_leased_put ? options.leased_inline_bytes
+                                                  : options.required_data_bytes);
 
   std::vector<std::pair<void*, size_t>> pools;
   std::vector<Conn*> stale;
@@ -1332,6 +1347,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
               candidate->declared_bytes >= required_bound &&
               candidate->depth >= required_depth &&
               (!want_leased_put || candidate->leased_put) &&
+              candidate->dynamic_pull == want_dynamic_pull &&
               (candidate->declared_bytes < best_bound ||
                (candidate->declared_bytes == best_bound &&
                 candidate->depth < best_depth))) {
@@ -1390,8 +1406,10 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   const uint64_t conn_slot_bytes = static_cast<uint64_t>(rdma::V2SlotSize(
       static_cast<size_t>(
           std::max<uint64_t>(conn_declared, rdma::kV2DataOffset))));
+  const uint64_t resident_bytes =
+      (want_dynamic_pull ? 1 : 2) * conn_slot_bytes;
   const rdma::ResourceRequest budget_request{
-      1, 1, conn_depth, 2 * conn_slot_bytes * conn_depth};
+      1, 1, conn_depth, resident_bytes * conn_depth};
   bool budget_acquired = resource_budget_->TryAcquire(budget_request);
   if (!budget_acquired && EvictOneIdle())
     budget_acquired = resource_budget_->TryAcquire(budget_request);
@@ -1425,7 +1443,8 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
 
   const std::string& dev = devs_[ridx];
-  if (!probed && !ProbeV2(node, &leased_put_supported)) {
+  if (!probed &&
+      !ProbeV2(node, &leased_put_supported, &dynamic_pull_supported)) {
     DFKV_LOG_ERROR(
         "rdma: peer " + node +
         " does not advertise required v2 writer-retirement and pull-read capabilities");
@@ -1438,9 +1457,9 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     std::lock_guard<std::mutex> lock(mu_);
     if (peer_topologies_->IsCurrent(
             node, peer_snapshot->peer_id, peer_snapshot->publication)) {
-      peer_put_capabilities_[node] = {
+      peer_capabilities_[node] = {
           peer_snapshot->peer_id, peer_snapshot->publication,
-          leased_put_supported};
+          leased_put_supported, dynamic_pull_supported};
     }
   }
 
@@ -1489,7 +1508,8 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   // sends the token only to a client that will consume it.
   // Geometry was chosen from this publication's capability observation.
   // If the peer changed without a publication, fail before posting payload.
-  if (want_leased_put && !leased_put_supported) {
+  if ((want_leased_put && !leased_put_supported) ||
+      (want_dynamic_pull && !dynamic_pull_supported)) {
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
     result.failure = AcquireFailure::kEndpoint;
@@ -1498,7 +1518,8 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   const uint64_t bootstrap_declared =
       conn_declared | rdma::kDevFrameRequestWriterRetirement |
       rdma::kDevFrameRequestPullRead |
-      (want_leased_put ? rdma::kDevFrameRequestLeasedPut : 0);
+      (want_leased_put ? rdma::kDevFrameRequestLeasedPut : 0) |
+      (want_dynamic_pull ? rdma::kDevFrameRequestDynamicPull : 0);
   rdma::EncodeDevFrame(auto_device_ ? std::string() : dev,
                        bootstrap_declared, devbuf, rdma::kDevProtoV2);
   char mine[rdma::kQpInfoBytes], remote_qp_bytes[rdma::kQpInfoBytes];
@@ -1549,21 +1570,27 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     const size_t surplus = conn_depth - remote.depth;
     conn->budget_request = rdma::ResourceRequest{
         1, 1, static_cast<size_t>(remote.depth),
-        2 * conn_slot_bytes * remote.depth};
+        resident_bytes * remote.depth};
     resource_budget_->Release(
         rdma::ResourceRequest{0, 0, surplus,
-                              2 * conn_slot_bytes * surplus});
+                              resident_bytes * surplus});
     depth_refunds_.fetch_add(1, std::memory_order_relaxed);
   }
 
   char readiness[rdma::kV2PullReadinessBytes];
-  if (!net::ReadAll(fd, readiness, sizeof(readiness)) ||
-      !rdma::DecodeV2PullReadiness(
-          readiness, sizeof(readiness), &conn->recv_segment,
-          &conn->writer_token, &conn->pull_arena)) {
+  const size_t readiness_bytes = want_dynamic_pull
+                                     ? rdma::kV2RetirementReadinessBytes
+                                     : rdma::kV2PullReadinessBytes;
+  if (!net::ReadAll(fd, readiness, readiness_bytes) ||
+      !(want_dynamic_pull
+            ? rdma::DecodeV2Readiness(readiness, readiness_bytes, true,
+                                      &conn->recv_segment, &conn->writer_token)
+            : rdma::DecodeV2PullReadiness(
+                  readiness, readiness_bytes, &conn->recv_segment,
+                  &conn->writer_token, &conn->pull_arena))) {
     DFKV_LOG_ERROR(
         "rdma: peer " + node +
-        " did not provide valid retirement and pull-read arenas");
+        " did not provide valid negotiated v2 readiness");
     ::close(fd);
     Destroy(conn, rdma::RailCompletion::kEndpointFailure);
     result.failure = AcquireFailure::kEndpoint;
@@ -1599,6 +1626,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     return result;
   }
   conn->leased_put = want_leased_put;
+  conn->dynamic_pull = want_dynamic_pull;
   conns_opened_.fetch_add(1, std::memory_order_relaxed);
   MarkClassOpened(conn);
   rail_conns_[ridx].fetch_add(1, std::memory_order_relaxed);
@@ -2211,6 +2239,14 @@ std::string RdmaTransport::MetricsText() const {
   s += "# TYPE dfkv_rdma_client_pull_failures_total counter\n";
   s += "dfkv_rdma_client_pull_failures_total " +
        std::to_string(pull_failures_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_pull_releases_total Acknowledged dynamic pull releases\n";
+  s += "# TYPE dfkv_rdma_client_pull_releases_total counter\n";
+  s += "dfkv_rdma_client_pull_releases_total " +
+       std::to_string(pull_releases_.load(std::memory_order_relaxed)) + "\n";
+  s += "# HELP dfkv_rdma_client_pull_release_failures_total Failed dynamic pull release exchanges\n";
+  s += "# TYPE dfkv_rdma_client_pull_release_failures_total counter\n";
+  s += "dfkv_rdma_client_pull_release_failures_total " +
+       std::to_string(pull_release_failures_.load(std::memory_order_relaxed)) + "\n";
   s += "# HELP dfkv_rdma_client_ambiguous_get_quarantines_total Failed staged GETs retained because responder retirement proof was unavailable\n";
   s += "# TYPE dfkv_rdma_client_ambiguous_get_quarantines_total counter\n";
   s += "dfkv_rdma_client_ambiguous_get_quarantines_total " +
@@ -2558,6 +2594,8 @@ Status RdmaTransport::Range(const std::string& node, const BlockKey& key,
   if (length > std::numeric_limits<size_t>::max() ||
       NoteBlock(static_cast<size_t>(length)))
     return Status::kInvalid;
+  // String ranges retain the staged responder-WRITE path: offset/length are
+  // slice semantics, unlike the whole-object direct destination APIs.
   return RoundTrip(node, WireOp::kRange, key, offset, length, nullptr, 0, out,
                    value_len);
 }
@@ -3204,6 +3242,147 @@ std::vector<Status> RdmaTransport::ExistMany(
   return result;
 }
 
+Status RdmaTransport::PullInto(
+    const std::string& node, const BlockKey& key,
+    const RangeDstSegment* segments, size_t segment_count, size_t capacity,
+    Lane lane, uint64_t* value_len, std::string* out_dev) {
+  AcquireOptions options;
+  options.required_data_bytes = capacity;
+  options.request_dynamic_pull = true;
+  options.requested_credits = 1;
+  options.peer = peer_topologies_->Snapshot(node);
+  AcquireResult acquired = Acquire(node, lane, options);
+  if (!acquired.conn) return acquired.status;
+  Conn* conn = acquired.conn;
+  rdma::RcEndpoint& ep = conn->ep;
+  if (out_dev) {
+    if (!out_dev->empty()) *out_dev += "->";
+    *out_dev += devs_[conn->rail_index];
+  }
+  const auto fail = [&]() {
+    pull_failures_.fetch_add(1, std::memory_order_relaxed);
+    // Leave any outstanding transient MR owned by ep: Destroy fences its QP
+    // before deregistration, so a timed-out READ cannot DMA after return.
+    Destroy(conn, rdma::RailCompletion::kEndpointFailure);
+    return Status::kIOError;
+  };
+  std::vector<uint32_t> replies;
+  const auto exchange = [&](size_t request_bytes, size_t response_bytes,
+                            Status* status, uint64_t* stored_len) {
+    bool timed_out = false;
+    ibv_wc_status wc_status = IBV_WC_SUCCESS;
+    bool had_wcs = false;
+    const bool ok =
+        ep.PostRecv(0) && ep.PostSend(0, request_bytes) &&
+        ReapWindow(ep, 1, &replies, BatchTimeout(), &timed_out,
+                   &wc_status, &had_wcs);
+    if (timed_out)
+      completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+    uint64_t bytes = 0;
+    return ok && !replies.empty() && replies[0] >= kRespPrefix &&
+           conn->Decode(ep.rbuf(0), status, &bytes, response_bytes, stored_len) &&
+           bytes == (*status == Status::kOk ? response_bytes : 0) &&
+           replies[0] == kRespPrefix + bytes;
+  };
+
+  conn->Encode(ep.sbuf(0), WireOp::kPullRange, key, 0, capacity,
+               rdma::kPullPrepareBytes);
+  const rdma::PullPrepareControl control{
+      0, conn->pending_pull_generation};
+  rdma::EncodePullPrepareControl(control, ep.sbuf(0) + kReqPrefix);
+  pull_prepares_.fetch_add(1, std::memory_order_relaxed);
+  Status status = Status::kIOError;
+  uint64_t stored_len = 0;
+  const size_t ready_bytes = conn->dynamic_pull
+                                 ? rdma::kDynamicPullReadyBytes
+                                 : rdma::kPullReadyBytes;
+  if (!exchange(kReqPrefix + rdma::kPullPrepareBytes, ready_bytes,
+                &status, &stored_len))
+    return fail();
+  conn->pending_pull_generation = 0;
+  if (status != Status::kOk) {
+    if (value_len) *value_len = stored_len;
+    Release(node, lane, conn);
+    return status;
+  }
+
+  rdma::DynamicPullReady ready;
+  if (conn->dynamic_pull) {
+    if (!rdma::DecodeDynamicPullReady(ep.rbuf(0) + kRespPrefix, &ready))
+      return fail();
+  } else {
+    rdma::PullReady legacy;
+    if (!rdma::DecodePullReady(ep.rbuf(0) + kRespPrefix, &legacy) ||
+        conn->pull_arena.slot_count == 0 ||
+        legacy.slot_index >= conn->pull_arena.slot_count)
+      return fail();
+    const uint64_t slot_bytes =
+        conn->pull_arena.arena_bytes / conn->pull_arena.slot_count;
+    if (legacy.data_len > slot_bytes) return fail();
+    ready = {legacy.slot_index, legacy.slot_generation, legacy.data_len,
+             legacy.value_len,
+             conn->pull_arena.base_addr + legacy.slot_index * slot_bytes,
+             conn->pull_arena.rkey};
+  }
+  if (ready.slot_index != 0 || ready.data_len > capacity ||
+      ready.data_len > OpBound() ||
+      ready.data_len != std::min<uint64_t>(ready.value_len, capacity))
+    return fail();
+
+  const bool too_small = ready.value_len > capacity;
+  if (!too_small) {
+    size_t copied = 0;
+    CompletionDeadline deadline(BatchTimeout());
+    for (size_t i = 0; i < segment_count && copied < ready.data_len; ++i) {
+      const auto& segment = segments[i];
+      const size_t bytes = std::min<size_t>(
+          segment.second, static_cast<size_t>(ready.data_len) - copied);
+      if (bytes == 0) continue;
+      ibv_mr* mr = ep.RegisterTransient(segment.first, bytes);
+      if (!mr || InjectPullReadFailure() ||
+          !ep.PostRead(0, segment.first, bytes, mr,
+                       ready.address + copied, ready.rkey))
+        return fail();
+      ibv_wc completion{};
+      const int got = ep.WaitComp(&completion, 1, deadline.Remaining());
+      if (got != 1 || completion.status != IBV_WC_SUCCESS ||
+          completion.opcode != IBV_WC_RDMA_READ) {
+        if (got == 0)
+          completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+        return fail();
+      }
+      ep.ReleaseTransient(mr);
+      copied += bytes;
+      pull_read_bytes_.fetch_add(bytes, std::memory_order_relaxed);
+    }
+    if (copied != ready.data_len) return fail();
+    pull_reads_.fetch_add(1, std::memory_order_relaxed);
+  }
+  if (conn->dynamic_pull) {
+    // The READ CQEs above are the local completion proof. Only the RELEASE
+    // ACK proves the remote capability and storage are gone before idling.
+    conn->Encode(ep.sbuf(0), WireOp::kPullRelease, key, 0,
+                 ready.slot_generation,
+                 static_cast<uint64_t>(ready.slot_index) + 1);
+    Status released = Status::kIOError;
+    uint64_t ignored = 0;
+    if (!exchange(kReqPrefix, 0, &released, &ignored) ||
+        released != Status::kOk) {
+      pull_release_failures_.fetch_add(1, std::memory_order_relaxed);
+      return fail();
+    }
+    pull_releases_.fetch_add(1, std::memory_order_relaxed);
+  } else {
+    // Preserve the v2.25 piggyback retirement wire contract.
+    conn->pending_pull_slot = ready.slot_index;
+    conn->pending_pull_generation = ready.slot_generation;
+  }
+  if (value_len) *value_len = ready.value_len;
+  if (!too_small) RecordRailTransfer(conn, false, 1, ready.data_len);
+  Release(node, lane, conn);
+  return too_small ? Status::kInvalid : Status::kOk;
+}
+
 std::vector<Status> RdmaTransport::RangeInto(
     const std::string& node, const std::vector<BlockKey>& keys,
     const std::vector<RangeDst>& destinations,
@@ -3217,114 +3396,11 @@ std::vector<Status> RdmaTransport::RangeInto(
     if (!ValidBuffer(destination.payload, destination.n) ||
         NoteBlock(destination.n))
       continue;
-    AcquireOptions options;
-    options.required_data_bytes = destination.n;
-    options.requested_credits = 1;
-    options.peer = peer_topologies_->Snapshot(node);
-    AcquireResult acquired = Acquire(node, Lane::kData, options);
-    if (!acquired.conn) {
-      result[item] = acquired.status;
-      continue;
-    }
-    Conn* conn = acquired.conn;
-    rdma::RcEndpoint& ep = conn->ep;
-    bool reusable = true;
-
-    conn->Encode(ep.sbuf(0), WireOp::kPullRange, keys[item], 0,
-                 destination.n, rdma::kPullPrepareBytes);
-    const rdma::PullPrepareControl control{
-        0, conn->pending_pull_generation};
-    rdma::EncodePullPrepareControl(control, ep.sbuf(0) + kReqPrefix);
-    pull_prepares_.fetch_add(1, std::memory_order_relaxed);
-    std::vector<uint32_t> reply_bytes;
-    bool timed_out = false;
-    ibv_wc_status wc_status = IBV_WC_SUCCESS;
-    bool had_wcs = false;
-    bool ok =
-        ep.PostRecv(0) &&
-        ep.PostSend(0, kReqPrefix + rdma::kPullPrepareBytes) &&
-        ReapWindow(ep, 1, &reply_bytes, BatchTimeout(), &timed_out,
-                   &wc_status, &had_wcs);
-    if (timed_out)
-      completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
-    Status status = Status::kIOError;
-    uint64_t response_len = 0;
-    uint64_t stored_len = 0;
-    rdma::PullReady ready;
-    if (!ok || reply_bytes.empty() || reply_bytes[0] < kRespPrefix ||
-        !conn->Decode(ep.rbuf(0), &status, &response_len,
-                      rdma::kPullReadyBytes, &stored_len) ||
-        (status == Status::kOk &&
-         (response_len != rdma::kPullReadyBytes ||
-          reply_bytes[0] < kRespPrefix + rdma::kPullReadyBytes ||
-          !rdma::DecodePullReady(ep.rbuf(0) + kRespPrefix, &ready)))) {
-      reusable = false;
-    } else if (status != Status::kOk) {
-      result[item] = status;
-      if (value_lens) (*value_lens)[item] = stored_len;
-      conn->pending_pull_generation = 0;
-    } else {
-      const size_t slot_bytes =
-          conn->pull_arena.arena_bytes / conn->pull_arena.slot_count;
-      if (ready.slot_index >= conn->pull_arena.slot_count ||
-          ready.data_len > destination.n || ready.data_len > slot_bytes) {
-        reusable = false;
-      } else if (ready.value_len > destination.n) {
-        // PREPARE succeeded, but this whole-object destination is too small.
-        // Retire its arena generation on the next request without reading or
-        // blaming a healthy endpoint for the caller's capacity.
-        conn->pending_pull_slot = ready.slot_index;
-        conn->pending_pull_generation = ready.slot_generation;
-        result[item] = Status::kInvalid;
-        if (value_lens) (*value_lens)[item] = ready.value_len;
-      } else {
-        ibv_mr* destination_mr =
-            ready.data_len
-                ? ep.RegisterTransient(destination.payload,
-                                       static_cast<size_t>(ready.data_len))
-                : nullptr;
-        if (ready.data_len != 0 && !destination_mr) {
-          reusable = false;
-        } else {
-          const uint64_t remote_addr =
-              conn->pull_arena.base_addr +
-              static_cast<uint64_t>(ready.slot_index) * slot_bytes;
-          bool read_ok =
-              !InjectPullReadFailure() &&
-              (ready.data_len == 0 ||
-               ep.PostRead(0, destination.payload,
-                           static_cast<size_t>(ready.data_len), destination_mr,
-                           remote_addr, conn->pull_arena.rkey));
-          if (read_ok && ready.data_len != 0) {
-            ibv_wc completion{};
-            read_ok = ep.WaitComp(&completion, 1, BatchTimeout()) == 1 &&
-                      completion.status == IBV_WC_SUCCESS &&
-                      completion.opcode == IBV_WC_RDMA_READ;
-          }
-          if (destination_mr) ep.ReleaseTransient(destination_mr);
-          if (!read_ok) {
-            reusable = false;
-          } else {
-            conn->pending_pull_slot = ready.slot_index;
-            conn->pending_pull_generation = ready.slot_generation;
-            pull_reads_.fetch_add(1, std::memory_order_relaxed);
-            pull_read_bytes_.fetch_add(ready.data_len,
-                                       std::memory_order_relaxed);
-            result[item] = Status::kOk;
-            RecordRailTransfer(conn, false, 1, ready.data_len);
-            if (value_lens) (*value_lens)[item] = ready.value_len;
-          }
-        }
-      }
-    }
-    if (!reusable) {
-      result[item] = Status::kIOError;
-      pull_failures_.fetch_add(1, std::memory_order_relaxed);
-    }
-    if (reusable)
-      Release(node, Lane::kData, conn);
-    else
-      Destroy(conn, rdma::RailCompletion::kEndpointFailure);
+    const RangeDstSegment segment{
+        destination.payload, destination.n, destination.memory_kind};
+    result[item] = PullInto(node, keys[item], &segment, 1, destination.n,
+                            Lane::kData,
+                            value_lens ? &(*value_lens)[item] : nullptr);
   }
   return result;
 }
@@ -3699,9 +3775,10 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
   if (destinations.size() != count) return InvalidStatuses(count);
   std::vector<Status> result(count, Status::kInvalid);
   for (size_t item = 0; item < count; ++item) {
+    const auto& segments = destinations[item].payloads;
     size_t capacity = 0;
     bool valid = true;
-    for (const auto& segment : destinations[item].payloads) {
+    for (const auto& segment : segments) {
       size_t next = 0;
       if (!ValidBuffer(segment.first, segment.second) ||
           !CheckedAddSize(capacity, segment.second, &next)) {
@@ -3711,117 +3788,11 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       capacity = next;
     }
     if (!valid || NoteBlock(capacity)) continue;
-    AcquireOptions options;
-    options.required_data_bytes = capacity;
-    options.requested_credits = 1;
-    options.peer = peer_topologies_->Snapshot(node);
-    AcquireResult acquired = Acquire(node, Lane::kSgData, options);
-    if (!acquired.conn) {
-      result[item] = acquired.status;
-      continue;
-    }
-    Conn* conn = acquired.conn;
-    rdma::RcEndpoint& ep = conn->ep;
-    if (out_dev) {
-      if (!out_dev->empty()) *out_dev += "->";
-      *out_dev += devs_[conn->rail_index];
-    }
-    bool reusable = true;
-    conn->Encode(ep.sbuf(0), WireOp::kPullRange, keys[item], 0, capacity,
-                 rdma::kPullPrepareBytes);
-    const rdma::PullPrepareControl control{
-        0, conn->pending_pull_generation};
-    rdma::EncodePullPrepareControl(control, ep.sbuf(0) + kReqPrefix);
-    pull_prepares_.fetch_add(1, std::memory_order_relaxed);
-    std::vector<uint32_t> reply_bytes;
-    bool timed_out = false;
-    ibv_wc_status wc_status = IBV_WC_SUCCESS;
-    bool had_wcs = false;
-    bool ok =
-        ep.PostRecv(0) &&
-        ep.PostSend(0, kReqPrefix + rdma::kPullPrepareBytes) &&
-        ReapWindow(ep, 1, &reply_bytes, BatchTimeout(), &timed_out,
-                   &wc_status, &had_wcs);
-    Status status = Status::kIOError;
-    uint64_t response_len = 0;
-    uint64_t stored_len = 0;
-    rdma::PullReady ready;
-    if (!ok || reply_bytes.empty() || reply_bytes[0] < kRespPrefix ||
-        !conn->Decode(ep.rbuf(0), &status, &response_len,
-                      rdma::kPullReadyBytes, &stored_len) ||
-        (status == Status::kOk &&
-         (response_len != rdma::kPullReadyBytes ||
-          reply_bytes[0] < kRespPrefix + rdma::kPullReadyBytes ||
-          !rdma::DecodePullReady(ep.rbuf(0) + kRespPrefix, &ready)))) {
-      reusable = false;
-    } else if (status != Status::kOk) {
-      conn->pending_pull_generation = 0;
-      result[item] = status;
-    } else {
-      const size_t slot_bytes =
-          conn->pull_arena.arena_bytes / conn->pull_arena.slot_count;
-      if (ready.slot_index >= conn->pull_arena.slot_count ||
-          ready.data_len > capacity || ready.data_len > slot_bytes) {
-        reusable = false;
-      } else if (ready.value_len > capacity) {
-        // Even a rejected destination must acknowledge the successful PREPARE
-        // before a pooled connection can prepare another object.
-        conn->pending_pull_slot = ready.slot_index;
-        conn->pending_pull_generation = ready.slot_generation;
-        result[item] = Status::kInvalid;
-      } else {
-        const uint64_t remote_base =
-            conn->pull_arena.base_addr +
-            static_cast<uint64_t>(ready.slot_index) * slot_bytes;
-        size_t copied = 0;
-        for (const auto& segment : destinations[item].payloads) {
-          const size_t bytes = std::min<size_t>(
-              segment.second, static_cast<size_t>(ready.data_len) - copied);
-          if (bytes == 0) {
-            if (copied == ready.data_len) break;
-            continue;
-          }
-          ibv_mr* mr = ep.RegisterTransient(segment.first, bytes);
-          bool read_ok =
-              !InjectPullReadFailure() && mr &&
-              ep.PostRead(0, segment.first, bytes, mr,
-                          remote_base + copied, conn->pull_arena.rkey);
-          if (read_ok) {
-            ibv_wc completion{};
-            read_ok = ep.WaitComp(&completion, 1, BatchTimeout()) == 1 &&
-                      completion.status == IBV_WC_SUCCESS &&
-                      completion.opcode == IBV_WC_RDMA_READ;
-          }
-          if (mr) ep.ReleaseTransient(mr);
-          if (!read_ok) {
-            reusable = false;
-            break;
-          }
-          copied += bytes;
-        }
-        if (reusable && copied == ready.data_len) {
-          conn->pending_pull_slot = ready.slot_index;
-          conn->pending_pull_generation = ready.slot_generation;
-          pull_reads_.fetch_add(1, std::memory_order_relaxed);
-          pull_read_bytes_.fetch_add(ready.data_len,
-                                     std::memory_order_relaxed);
-          result[item] = Status::kOk;
-          RecordRailTransfer(conn, false, 1, ready.data_len);
-          if (out_lengths)
-            (*out_lengths)[item] = static_cast<size_t>(ready.value_len);
-        } else {
-          reusable = false;
-        }
-      }
-    }
-    if (!reusable) {
-      result[item] = Status::kIOError;
-      pull_failures_.fetch_add(1, std::memory_order_relaxed);
-    }
-    if (reusable)
-      Release(node, Lane::kSgData, conn);
-    else
-      Destroy(conn, rdma::RailCompletion::kEndpointFailure);
+    uint64_t value_len = 0;
+    result[item] = PullInto(node, keys[item], segments.data(), segments.size(),
+                            capacity, Lane::kSgData, &value_len, out_dev);
+    if (out_lengths && result[item] == Status::kOk)
+      (*out_lengths)[item] = static_cast<size_t>(value_len);
   }
   return result;
 }

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -460,6 +460,7 @@ RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)
         inline_resolved_state = x == 0 ? 0 : 2;
       }
     } else {
+      inline_put_max_bytes_ = 0;
       inline_resolved_state = 0;  // set to the empty string: disabled
     }
   }
@@ -1081,6 +1082,7 @@ void RdmaTransport::OnPeerTopology(const PeerTopology& topology) {
     // linearization point and become active with the retired incarnation.
     std::lock_guard<std::mutex> lock(mu_);
     if (!peer_topologies_->Update(topology)) return;
+    peer_put_capabilities_.erase(topology.peer_addr);
     const auto current_snapshot =
         peer_topologies_->Snapshot(topology.peer_addr);
     const auto reap = [&](auto& pools) {
@@ -1164,10 +1166,6 @@ bool RdmaTransport::ProbeV2(const std::string& node,
 
 RdmaTransport::AcquireResult RdmaTransport::Acquire(
     const std::string& node, Lane lane, const AcquireOptions& options) {
-  const size_t required_bound =
-      lane == Lane::kControl
-          ? static_cast<size_t>(rdma::kV2ControlCap)
-          : ConnectionBound(options.required_data_bytes);
   AcquireResult result;
   const auto peer_snapshot =
       options.peer ? options.peer : peer_topologies_->Snapshot(node);
@@ -1254,6 +1252,45 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
       };
   const size_t required_depth =
       ConnectionDepth(node, lane, options.requested_credits);
+  bool probed = false;
+  bool leased_put_supported = false;
+  if (options.request_leased_put) {
+    bool known = false;
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      const auto found = peer_put_capabilities_.find(node);
+      if (found != peer_put_capabilities_.end() &&
+          found->second.peer_id == peer_snapshot->peer_id &&
+          found->second.publication == peer_snapshot->publication) {
+        known = true;
+        leased_put_supported = found->second.leased_put;
+      }
+    }
+    if (!known) {
+      if (!ProbeV2(node, &leased_put_supported)) {
+        complete_unowned_lease(rdma::RailCompletion::kEndpointFailure);
+        result.failure = AcquireFailure::kEndpoint;
+        return result;
+      }
+      probed = true;
+      std::lock_guard<std::mutex> lock(mu_);
+      if (peer_topologies_->IsCurrent(
+              node, peer_snapshot->peer_id, peer_snapshot->publication)) {
+        peer_put_capabilities_[node] = {
+            peer_snapshot->peer_id, peer_snapshot->publication,
+            leased_put_supported};
+      }
+    }
+  }
+  const bool want_leased_put =
+      options.request_leased_put && leased_put_supported;
+  if (options.request_leased_put && !want_leased_put)
+    leaseput_path_fallbacks_.fetch_add(1, std::memory_order_relaxed);
+  const size_t required_bound =
+      lane == Lane::kControl
+          ? static_cast<size_t>(rdma::kV2ControlCap)
+          : ConnectionBound(want_leased_put ? options.leased_inline_bytes
+                                           : options.required_data_bytes);
 
   std::vector<std::pair<void*, size_t>> pools;
   std::vector<Conn*> stale;
@@ -1294,7 +1331,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
               candidate->rail_index == ridx &&
               candidate->declared_bytes >= required_bound &&
               candidate->depth >= required_depth &&
-              (!options.request_leased_put || candidate->leased_put) &&
+              (!want_leased_put || candidate->leased_put) &&
               (candidate->declared_bytes < best_bound ||
                (candidate->declared_bytes == best_bound &&
                 candidate->depth < best_depth))) {
@@ -1388,8 +1425,7 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   }
 
   const std::string& dev = devs_[ridx];
-  bool leased_put_supported = false;
-  if (!ProbeV2(node, &leased_put_supported)) {
+  if (!probed && !ProbeV2(node, &leased_put_supported)) {
     DFKV_LOG_ERROR(
         "rdma: peer " + node +
         " does not advertise required v2 writer-retirement and pull-read capabilities");
@@ -1397,6 +1433,15 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
     resource_budget_->Release(budget_request);
     result.failure = AcquireFailure::kEndpoint;
     return result;
+  }
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (peer_topologies_->IsCurrent(
+            node, peer_snapshot->peer_id, peer_snapshot->publication)) {
+      peer_put_capabilities_[node] = {
+          peer_snapshot->peer_id, peer_snapshot->publication,
+          leased_put_supported};
+    }
   }
 
   int fd = net::Dial(node, connect_ms_, io_ms_);
@@ -1442,8 +1487,14 @@ RdmaTransport::AcquireResult RdmaTransport::Acquire(
   // The probe above proves the peer understands bit 63 before a real QP is
   // created. Echo the request on this bootstrap so a rolling-upgraded server
   // sends the token only to a client that will consume it.
-  const bool want_leased_put =
-      options.request_leased_put && leased_put_supported;
+  // Geometry was chosen from this publication's capability observation.
+  // If the peer changed without a publication, fail before posting payload.
+  if (want_leased_put && !leased_put_supported) {
+    ::close(fd);
+    Destroy(conn, rdma::RailCompletion::kEndpointFailure);
+    result.failure = AcquireFailure::kEndpoint;
+    return result;
+  }
   const uint64_t bootstrap_declared =
       conn_declared | rdma::kDevFrameRequestWriterRetirement |
       rdma::kDevFrameRequestPullRead |
@@ -2496,6 +2547,8 @@ Status RdmaTransport::RoundTrip(const std::string& node, WireOp op,
 
 Status RdmaTransport::Cache(const std::string& node, const BlockKey& key,
                             const void* data, size_t len) {
+  if (inline_put_max_bytes_ != 0 && len > inline_put_max_bytes_)
+    return CacheMany(node, {{key, data, len}})[0];
   if (NoteBlock(len)) return Status::kInvalid;
   return RoundTrip(node, WireOp::kCache, key, 0, 0, data, len, nullptr);
 }
@@ -2545,10 +2598,7 @@ std::vector<Status> RdmaTransport::CacheMany(
   if (count == 0) return result;
   std::vector<char> bad(count, 0);
   size_t valid_count = 0;
-  // Bucket split for the staged-lease datapath: objects above the inline
-  // threshold are candidates for per-op staging leases (server memory tracks
-  // in-flight data instead of connection geometry); everything else keeps the
-  // connection-resident receive-slot path unchanged.
+  // Track resident geometry separately from the logical object ceiling.
   bool any_over = false;
   const bool lease_enabled = inline_put_max_bytes_ != 0;
   for (size_t i = 0; i < count; ++i) {
@@ -2568,10 +2618,6 @@ std::vector<Status> RdmaTransport::CacheMany(
     }
   }
   if (valid_count == 0) return result;
-  // The connection-resident class must cover the largest INLINE object; the
-  // over-threshold bucket never inflates it.
-  const size_t required_bytes =
-      (any_over && lease_enabled) ? max_inline_len : max_all_len;
 
   const auto peer = peer_topologies_->Snapshot(node);
   RailMask excluded(devs_.size(), 0);
@@ -2583,17 +2629,12 @@ std::vector<Status> RdmaTransport::CacheMany(
     for (size_t i = 0; i < count; ++i)
       if (bad[i]) result[i] = Status::kInvalid;
     AcquireOptions options;
-    // Attempt 0 asks for the staged-lease datapath when the batch needs it;
-    // attempt 1 (fresh-retry or a lease-incapable peer) falls back to the
-    // traditional largest-object connection-resident class.
+    // Retry safety is unchanged: only a pre-write failure may use a fresh
+    // traditional connection. Capability absence is resolved inside Acquire,
+    // before geometry selection, and does not consume this retry.
     const bool want_lease = attempt == 0 && any_over && lease_enabled;
-    // Attempt 0 with lease intent clamps the resident class at the inline
-    // threshold; attempt 1 (fresh retry after a lease-path failure, or a
-    // lease-incapable peer) falls back to the traditional largest-object
-    // class so over-threshold objects still have a path home.
-    options.required_data_bytes =
-        want_lease ? std::max(max_inline_len, connection_min_block_bytes_)
-                   : max_all_len;
+    options.required_data_bytes = max_all_len;
+    options.leased_inline_bytes = max_inline_len;
     options.request_leased_put = want_lease;
     options.force_new = attempt != 0;
     options.requested_credits = std::min(valid_count, depth_);
@@ -2613,17 +2654,6 @@ std::vector<Status> RdmaTransport::CacheMany(
         MarkClientLocalFailure(&result, acquired.status);
       return result;
     }
-    if (want_lease && !acquired.conn->leased_put) {
-      // Peer predates the staged-lease capability (or the pool only had
-      // plain conns). The small-class connection cannot carry the over-
-      // threshold objects, so stop before anything is posted and retry once
-      // with the traditional largest-object geometry. Nothing was committed.
-      Release(node, Lane::kData, acquired.conn);
-      leaseput_path_fallbacks_.fetch_add(1, std::memory_order_relaxed);
-      if (attempt + 1 < 2) continue;
-      MarkClientLocalFailure(&result, Status::kInvalid);
-      return result;
-    }
     Conn* conn = acquired.conn;
     rdma::RcEndpoint& ep = conn->ep;
     const size_t window = std::min(
@@ -2634,22 +2664,28 @@ std::vector<Status> RdmaTransport::CacheMany(
     // local-rail default; a failed reap window is classified from its WC
     // evidence; wire decode failures blame the peer.
     rdma::RailCompletion completion = rdma::RailCompletion::kRailFailure;
-    std::vector<size_t> inline_idx;
-    std::vector<size_t> lease_idx;
-    for (size_t i = 0; i < count; ++i) {
-      if (bad[i]) continue;
-      if (conn->leased_put && items[i].len > inline_put_max_bytes_)
-        lease_idx.push_back(i);
-      else
-        inline_idx.push_back(i);
-    }
-    // Inline bucket: the unchanged connection-resident receive-slot pipeline.
-    for (size_t base = 0; base < inline_idx.size() && conn_ok; base += window) {
-      const size_t width = std::min(window, inline_idx.size() - base);
+    // Bounded contiguous runs preserve first-write-wins for duplicate keys
+    // across inline/lease transitions, without allocating index buckets.
+    for (size_t base = 0; base < count && conn_ok;) {
+      if (bad[base]) {
+        ++base;
+        continue;
+      }
+      const bool use_lease =
+          conn->leased_put && items[base].len > inline_put_max_bytes_;
+      size_t end = base + 1;
+      while (end < count && end - base < window &&
+             (bad[end] ||
+              (conn->leased_put && items[end].len > inline_put_max_bytes_) ==
+                  use_lease))
+        ++end;
+      const size_t width = end - base;
+      if (!use_lease) {
       std::vector<ibv_mr*> payload_mrs(width, nullptr);
       size_t posted = 0;
       for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = inline_idx[base + slot];
+        const size_t item_index = base + slot;
+        if (bad[item_index]) continue;
         const CacheItem& item = items[item_index];
         if (item.len > conn->data_capacity()) {
           bad[item_index] = 1;
@@ -2691,7 +2727,8 @@ std::vector<Status> RdmaTransport::CacheMany(
       if (!conn_ok) break;
       for (ibv_mr* mr : payload_mrs) ep.ReleaseTransient(mr);
       for (size_t slot = 0; slot < width; ++slot) {
-        const size_t item_index = inline_idx[base + slot];
+        const size_t item_index = base + slot;
+        if (bad[item_index]) continue;
         Status status;
         uint64_t data_len = 0;
         if (reply_bytes[slot] < kRespPrefix ||
@@ -2702,13 +2739,8 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         result[item_index] = status;
       }
-    }
-    // Staged-lease bucket, three pipelined phases per window:
-    //   A) request per-op staging leases (one wire RTT for the whole window)
-    //   B) WRITE_WITH_IMM every accepted object into its leased range
-    //   C) reap the status window and release caller-side transients
-    for (size_t base = 0; base < lease_idx.size() && conn_ok; base += window) {
-      const size_t width = std::min(window, lease_idx.size() - base);
+      } else {
+      // Three phases: reserve, WRITE_WITH_IMM, then reap commit status.
       struct LeaseSlot {
         size_t item_index = 0;
         uint64_t write_base = 0;
@@ -2721,9 +2753,10 @@ std::vector<Status> RdmaTransport::CacheMany(
       std::vector<LeaseSlot> leases(width);
       size_t accepted = 0;
       for (size_t slot = 0; slot < width && conn_ok; ++slot) {
-        const size_t item_index = lease_idx[base + slot];
-        const CacheItem& item = items[item_index];
+        const size_t item_index = base + slot;
         leases[slot].item_index = item_index;
+        if (bad[item_index]) continue;
+        const CacheItem& item = items[item_index];
         conn->Encode(ep.sbuf(slot), WireOp::kLeasePut, item.key, 0, 0,
                      item.len);
         if (!ep.PostRecv(slot) || !ep.PostSend(slot, kReqPrefix)) {
@@ -2836,6 +2869,8 @@ std::vector<Status> RdmaTransport::CacheMany(
         }
         result[item_index] = status;
       }
+      }
+      base = end;
     }
     if (conn_ok) {
       uint64_t successful_ops = 0;
@@ -3232,9 +3267,16 @@ std::vector<Status> RdmaTransport::RangeInto(
       const size_t slot_bytes =
           conn->pull_arena.arena_bytes / conn->pull_arena.slot_count;
       if (ready.slot_index >= conn->pull_arena.slot_count ||
-          ready.data_len > destination.n || ready.data_len > slot_bytes ||
-          ready.value_len > destination.n) {
+          ready.data_len > destination.n || ready.data_len > slot_bytes) {
         reusable = false;
+      } else if (ready.value_len > destination.n) {
+        // PREPARE succeeded, but this whole-object destination is too small.
+        // Retire its arena generation on the next request without reading or
+        // blaming a healthy endpoint for the caller's capacity.
+        conn->pending_pull_slot = ready.slot_index;
+        conn->pending_pull_generation = ready.slot_generation;
+        result[item] = Status::kInvalid;
+        if (value_lens) (*value_lens)[item] = ready.value_len;
       } else {
         ibv_mr* destination_mr =
             ready.data_len
@@ -3333,9 +3375,7 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
   }
   if (valid_count == 0) return result;
 
-  // Bucket split (same semantics as CacheMany): over-threshold objects are
-  // candidates for the staged-lease datapath; the SG connection's resident
-  // class must then cover only the largest INLINE object.
+  // Only inline objects contribute to leased connection geometry.
   const bool lease_enabled = inline_put_max_bytes_ != 0;
   bool any_over = false;
   size_t max_inline_len = 0;
@@ -3359,9 +3399,8 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
     completion_fault.BeginAttempt(attempt);
     const bool want_lease = attempt == 0 && any_over && lease_enabled;
     AcquireOptions options;
-    options.required_data_bytes =
-        want_lease ? std::max(max_inline_len, connection_min_block_bytes_)
-                   : required_bytes;
+    options.required_data_bytes = required_bytes;
+    options.leased_inline_bytes = max_inline_len;
     options.request_leased_put = want_lease;
     options.force_new = attempt != 0;
     options.requested_credits = 1;
@@ -3382,15 +3421,6 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
       return result;
     }
     Conn* conn = acquired.conn;
-    if (want_lease && !conn->leased_put) {
-      // Lease-incapable peer or a plain pooled connection: fall back to the
-      // traditional largest-object geometry before anything is posted.
-      Release(node, Lane::kSgData, conn);
-      leaseput_path_fallbacks_.fetch_add(1, std::memory_order_relaxed);
-      if (attempt + 1 < 2) continue;
-      MarkClientLocalFailure(&result, Status::kInvalid);
-      return result;
-    }
     if (out_dev) {
       const std::string& attempted_dev = devs_[conn->rail_index];
       if (!out_dev_set) {
@@ -3441,27 +3471,30 @@ std::vector<Status> RdmaTransport::CacheFromMulti(
         bool ready_timed_out = false;
         ibv_wc_status ready_status = IBV_WC_SUCCESS;
         bool ready_had_wcs = false;
-        if (!ep.PostRecv(0) || !ep.PostSend(0, kReqPrefix) ||
+        bool ready_ok = ep.PostRecv(0) && ep.PostSend(0, kReqPrefix);
+        if (ready_ok &&
             !ReapPosted(ep, 1, 1, &ready_bytes, BatchTimeout(),
                         &ready_timed_out, &ready_status, &ready_had_wcs,
                         &completion_fault)) {
-          conn_ok = false;
+          ready_ok = false;
           completion = rdma::ClassifyCompletion(ready_status, ready_had_wcs);
+        }
+        if (ready_timed_out)
+          completion_timeouts_.fetch_add(1, std::memory_order_relaxed);
+        if (!ready_ok) {
+          conn_ok = false;
           break;
         }
         Status ready_status_code = Status::kIOError;
         uint64_t ready_data_len = 0;
         if (ready_bytes[0] < kRespPrefix ||
             !conn->Decode(ep.rbuf(0), &ready_status_code, &ready_data_len,
-                          rdma::kLeasePutReadyBytes)) {
+                          rdma::kLeasePutReadyBytes) ||
+            (ready_status_code == Status::kOk) !=
+                (ready_data_len == rdma::kLeasePutReadyBytes)) {
           conn_ok = false;
           completion = rdma::RailCompletion::kEndpointFailure;
           break;
-        }
-        if (ready_status_code == Status::kCacheFull) {
-          result[item_index] = Status::kCacheFull;
-          completed[item_index] = 1;
-          continue;
         }
         if (ready_status_code != Status::kOk) {
           result[item_index] = ready_status_code;
@@ -3643,14 +3676,9 @@ bool RdmaTransport::NoteBlock(size_t n) const {
                   std::to_string(n / 1024) + " KiB); declared bound " +
                   std::to_string(OpBound()) + "B");
   }
-  // With the staged-lease datapath enabled, the logical OBJECT ceiling is
-  // the transport payload bound (--max-msg derived): connection geometry
-  // stops at the inline threshold, so oversize must stop rejecting exactly
-  // the objects the lease path exists to carry. The legacy bound (the
-  // declared connection class) still rejects when the datapath is disabled.
-  const size_t bound =
-      inline_put_max_bytes_ != 0 ? static_cast<size_t>(max_payload_)
-                                 : OpBound();
+  // Lease sizing changes physical residency, never the operator's explicit
+  // logical safety ceiling shared by PUT and GET.
+  const size_t bound = OpBound();
   if (n <= bound) return false;
   const uint64_t k = oversize_rejects_.fetch_add(1, std::memory_order_relaxed);
   if (k == 0 || (k & 0x3FFu) == 0)  // first, then every 1024th
@@ -3733,8 +3761,14 @@ std::vector<Status> RdmaTransport::RangeIntoMulti(
       const size_t slot_bytes =
           conn->pull_arena.arena_bytes / conn->pull_arena.slot_count;
       if (ready.slot_index >= conn->pull_arena.slot_count ||
-          ready.data_len > capacity || ready.data_len > slot_bytes ||
-          ready.value_len > capacity) {
+          ready.data_len > capacity || ready.data_len > slot_bytes) {
+        reusable = false;
+      } else if (ready.value_len > capacity) {
+        // Even a rejected destination must acknowledge the successful PREPARE
+        // before a pooled connection can prepare another object.
+        conn->pending_pull_slot = ready.slot_index;
+        conn->pending_pull_generation = ready.slot_generation;
+        result[item] = Status::kInvalid;
       } else {
         const uint64_t remote_base =
             conn->pull_arena.base_addr +

--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -3339,10 +3339,13 @@ Status RdmaTransport::PullInto(
           segment.second, static_cast<size_t>(ready.data_len) - copied);
       if (bytes == 0) continue;
       ibv_mr* mr = ep.RegisterTransient(segment.first, bytes);
-      if (!mr || InjectPullReadFailure() ||
+      if (!mr ||
           !ep.PostRead(0, segment.first, bytes, mr,
                        ready.address + copied, ready.rkey))
         return fail();
+      // Fault injection deliberately abandons an actually posted READ, not
+      // an unissued request: fail() must fence the QP before releasing its MR.
+      if (InjectPullReadFailure()) return fail();
       ibv_wc completion{};
       const int got = ep.WaitComp(&completion, 1, deadline.Remaining());
       if (got != 1 || completion.status != IBV_WC_SUCCESS ||

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -152,6 +152,12 @@ class RdmaTransport : public Transport {
     bool force_new = false;
     size_t requested_credits = 1;
     size_t required_data_bytes = 0;
+    // Ask for the leased-PUT datapath on this connection: objects above the
+    // inline threshold arrive via per-op staging leases, so the connection
+    // geometry no longer follows the largest object. Honored only when the
+    // peer advertises the capability; the request bit is then echoed on the
+    // bootstrap frame.
+    bool request_leased_put = false;
     RailMask excluded;
     std::shared_ptr<const rdma::PeerRailSnapshot> peer;
   };
@@ -211,7 +217,12 @@ class RdmaTransport : public Transport {
                    uint64_t offset, uint64_t length, const void* payload,
                    uint64_t payload_len, std::string* out,
                    uint64_t* value_len = nullptr);
-  bool ProbeV2(const std::string& node) const;
+  // Probe the node's v2 base capabilities. When leased_put_supported is
+  // non-null it additionally reports the optional staged-lease capability
+  // (still true for the base result when the optional bit is absent, since
+  // old servers advertise only writer-retirement and pull-read).
+  bool ProbeV2(const std::string& node,
+               bool* leased_put_supported = nullptr) const;
   mutable std::mutex mu_;
   // Scalar and SG operations share data endpoints. An acquired connection is
   // never concurrently reused, while operation framing remains self-describing.
@@ -247,6 +258,11 @@ class RdmaTransport : public Transport {
   // Largest block this client has actually handed to the transport.
   mutable std::atomic<uint64_t> max_block_seen_{0};
   mutable std::atomic<uint64_t> oversize_rejects_{0};
+  // Leased-PUT in-flight datapath. Zero disables the optional capability
+  // request and keeps every object on connection-resident receive slots.
+  size_t inline_put_max_bytes_ = 4194304;  // DFKV_RDMA_INLINE_PUT_MAX_BYTES
+  mutable std::atomic<uint64_t> leaseput_ops_{0};
+  mutable std::atomic<uint64_t> leaseput_path_fallbacks_{0};
   // Records n as a candidate high-water mark and reports whether it exceeds the
   // logical bound. Returns true for an oversized block.
   bool NoteBlock(size_t n) const;

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -1,6 +1,6 @@
 /* RDMA client transport — native v2 libibverbs RC. Requests and bounded
  * responses use 32,786-byte SEND/RECV control buffers (18-byte prefix plus a
- * 32-KiB Members payload); PUT/GET payloads use one-sided WRITEs.
+ * 32-KiB Members payload); PUT uses WRITEs and direct GET uses initiator READs.
  * A peer that cannot negotiate v2 is rejected.
  * An empty DFKV_RDMA_DEV discovers every ACTIVE HCA; an explicit comma list is
  * a whitelist. Device names, not IPs, select the data fabric. QPs bootstrap over
@@ -158,6 +158,9 @@ class RdmaTransport : public Transport {
     // peer advertises the capability; the request bit is then echoed on the
     // bootstrap frame.
     bool request_leased_put = false;
+    // Direct pull GET demand has no connection-resident payload in dynamic
+    // mode. Logical length still travels in the operation request.
+    bool request_dynamic_pull = false;
     size_t leased_inline_bytes = 0;
     RailMask excluded;
     std::shared_ptr<const rdma::PeerRailSnapshot> peer;
@@ -214,28 +217,31 @@ class RdmaTransport : public Transport {
   // first cache read after an idle gap to discover and rebuild stale QPs.
   void KeepaliveLoop();
   bool KeepaliveConn(Conn* c, rdma::RailCompletion* failure);
+  Status PullInto(const std::string& node, const BlockKey& key,
+                  const RangeDstSegment* segments, size_t segment_count,
+                  size_t capacity, Lane lane, uint64_t* value_len,
+                  std::string* out_dev = nullptr);
   Status RoundTrip(const std::string& node, WireOp op, const BlockKey& key,
                    uint64_t offset, uint64_t length, const void* payload,
                    uint64_t payload_len, std::string* out,
                    uint64_t* value_len = nullptr);
-  // Probe the node's v2 base capabilities. When leased_put_supported is
-  // non-null it additionally reports the optional staged-lease capability
-  // (still true for the base result when the optional bit is absent, since
-  // old servers advertise only writer-retirement and pull-read).
+  // Probe required base capabilities and report actual optional peer bits.
   bool ProbeV2(const std::string& node,
-               bool* leased_put_supported = nullptr) const;
+               bool* leased_put_supported = nullptr,
+               bool* dynamic_pull_supported = nullptr) const;
   mutable std::mutex mu_;
   // Scalar and SG operations share data endpoints. An acquired connection is
   // never concurrently reused, while operation framing remains self-describing.
   std::unordered_map<std::string, std::vector<Conn*>> pool_;
   // Optional capability observations belong to one peer publication, just like
   // pooled endpoints. A topology update invalidates both at the same boundary.
-  struct PeerPutCapability {
+  struct PeerCapability {
     std::string peer_id;
     uint64_t publication = 0;
     bool leased_put = false;
+    bool dynamic_pull = false;
   };
-  std::unordered_map<std::string, PeerPutCapability> peer_put_capabilities_;
+  std::unordered_map<std::string, PeerCapability> peer_capabilities_;
   // Exist/Remove/Members remain isolated from payload transfers.
   std::vector<size_t> IdleDataBounds(const std::string& node) const;
   std::vector<size_t> IdleDataDepths(const std::string& node) const;
@@ -270,6 +276,7 @@ class RdmaTransport : public Transport {
   // Leased-PUT in-flight datapath. Zero disables the optional capability
   // request and keeps every object on connection-resident receive slots.
   size_t inline_put_max_bytes_ = 4194304;  // DFKV_RDMA_INLINE_PUT_MAX_BYTES
+  bool dynamic_pull_enabled_ = true;  // DFKV_RDMA_DYNAMIC_PULL=0 disables
   mutable std::atomic<uint64_t> leaseput_ops_{0};
   mutable std::atomic<uint64_t> leaseput_path_fallbacks_{0};
   // Records n as a candidate high-water mark and reports whether it exceeds the
@@ -371,6 +378,8 @@ class RdmaTransport : public Transport {
   std::atomic<uint64_t> pull_reads_{0};
   std::atomic<uint64_t> pull_read_bytes_{0};
   std::atomic<uint64_t> pull_failures_{0};
+  std::atomic<uint64_t> pull_releases_{0};
+  std::atomic<uint64_t> pull_release_failures_{0};
   std::atomic<uint64_t> ambiguous_get_quarantines_{0};
   std::atomic<uint64_t> ambiguous_get_quarantined_bytes_{0};
   // Raw ownership is intentional: without retirement proof no in-process

--- a/src/transport/rdma_transport.h
+++ b/src/transport/rdma_transport.h
@@ -158,6 +158,7 @@ class RdmaTransport : public Transport {
     // peer advertises the capability; the request bit is then echoed on the
     // bootstrap frame.
     bool request_leased_put = false;
+    size_t leased_inline_bytes = 0;
     RailMask excluded;
     std::shared_ptr<const rdma::PeerRailSnapshot> peer;
   };
@@ -227,6 +228,14 @@ class RdmaTransport : public Transport {
   // Scalar and SG operations share data endpoints. An acquired connection is
   // never concurrently reused, while operation framing remains self-describing.
   std::unordered_map<std::string, std::vector<Conn*>> pool_;
+  // Optional capability observations belong to one peer publication, just like
+  // pooled endpoints. A topology update invalidates both at the same boundary.
+  struct PeerPutCapability {
+    std::string peer_id;
+    uint64_t publication = 0;
+    bool leased_put = false;
+  };
+  std::unordered_map<std::string, PeerPutCapability> peer_put_capabilities_;
   // Exist/Remove/Members remain isolated from payload transfers.
   std::vector<size_t> IdleDataBounds(const std::string& node) const;
   std::vector<size_t> IdleDataDepths(const std::string& node) const;

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -69,6 +69,7 @@ std::atomic<uint64_t> g_pool_mr_reg_failures{0};
 std::atomic<uint64_t> g_pool_mr_active{0};
 std::atomic<uint64_t> g_transient_user_mr_active{0};
 std::atomic<uint64_t> g_lease_write_mr_active{0};
+std::atomic<uint64_t> g_lease_read_mr_active{0};
 std::atomic<uint64_t> g_cq_completions{0};
 std::atomic<uint64_t> g_cq_errors{0};
 
@@ -370,6 +371,10 @@ void RcEndpoint::Close() {
   g_lease_write_mr_active.fetch_sub(lease_write_mr_.size(),
                                    std::memory_order_relaxed);
   lease_write_mr_.clear();
+  for (auto* mr : lease_read_mr_) DeregisterMr(mr);
+  g_lease_read_mr_active.fetch_sub(lease_read_mr_.size(),
+                                  std::memory_order_relaxed);
+  lease_read_mr_.clear();
   for (auto* m : smr_) DeregisterMr(m);
   for (auto* m : rmr_) DeregisterMr(m);
   for (auto* m : dmr_) DeregisterMr(m);
@@ -786,6 +791,29 @@ void RcEndpoint::ReleaseLeaseWriteRegion(ibv_mr* mr) {
 
 uint64_t RcEndpoint::LeaseWriteMrActive() {
   return g_lease_write_mr_active.load(std::memory_order_relaxed);
+}
+
+ibv_mr* RcEndpoint::RegisterLeaseReadRegion(void* base, size_t size) {
+  if (!pd_ || !base || size == 0) return nullptr;
+  ibv_mr* mr = ibv_reg_mr(
+      pd_, base, size, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
+  if (!mr) return nullptr;
+  lease_read_mr_.push_back(mr);
+  g_lease_read_mr_active.fetch_add(1, std::memory_order_relaxed);
+  return mr;
+}
+
+void RcEndpoint::ReleaseLeaseReadRegion(ibv_mr* mr) {
+  if (!mr) return;
+  const auto it = std::find(lease_read_mr_.begin(), lease_read_mr_.end(), mr);
+  if (it == lease_read_mr_.end()) std::abort();
+  DeregisterMr(mr);
+  lease_read_mr_.erase(it);
+  g_lease_read_mr_active.fetch_sub(1, std::memory_order_relaxed);
+}
+
+uint64_t RcEndpoint::LeaseReadMrActive() {
+  return g_lease_read_mr_active.load(std::memory_order_relaxed);
 }
 
 ibv_mr* RcEndpoint::RegisterRemoteReadRegion(void* base, size_t size) {

--- a/src/transport/rdma_verbs.cc
+++ b/src/transport/rdma_verbs.cc
@@ -51,8 +51,7 @@ struct SharedDevice {
   ibv_context* ctx;
   ibv_pd* pd;
   long refs;
-  // Registered once per PD. Entries retire at zero endpoint refs; device
-  // teardown is the safety net if ibv_dereg_mr previously refused one.
+  // Registered once per PD. Entries retire at zero endpoint refs.
   std::vector<SharedPoolMr> pool_mrs;
 };
 std::mutex g_dev_mu;
@@ -69,6 +68,7 @@ std::atomic<uint64_t> g_pool_mr_regs{0};
 std::atomic<uint64_t> g_pool_mr_reg_failures{0};
 std::atomic<uint64_t> g_pool_mr_active{0};
 std::atomic<uint64_t> g_transient_user_mr_active{0};
+std::atomic<uint64_t> g_lease_write_mr_active{0};
 std::atomic<uint64_t> g_cq_completions{0};
 std::atomic<uint64_t> g_cq_errors{0};
 
@@ -83,6 +83,19 @@ size_t g_test_write_faults_consumed = 0;
 size_t g_test_write_cancellations = 0;
 size_t g_test_write_releases = 0;
 
+// A failed revocation is not cleanup success: the NIC may still hold a key or
+// pinned pages. Continuing would let the allocator reuse DMA-visible storage.
+// There is no recoverable ownership path here; fail closed before any free.
+void RequireVerbsRelease(int result, const char* operation) {
+  if (result == 0) return;
+  DFKV_LOG_ERROR(std::string("rdma: unsafe resource release: ") + operation +
+                 " failed (" + std::to_string(result) + ")");
+  std::abort();
+}
+
+void DeregisterMr(ibv_mr* mr) {
+  if (mr) RequireVerbsRelease(ibv_dereg_mr(mr), "ibv_dereg_mr");
+}
 
 int ObserveCqPoll(ibv_wc* out, int got) {
   if (got < 0) {
@@ -135,11 +148,11 @@ void ReleaseSharedDevice(ibv_context* ctx) {
     if (it->second.ctx != ctx) continue;
     if (--it->second.refs == 0) {
       for (auto& p : it->second.pool_mrs) {
-        if (p.mr) ibv_dereg_mr(p.mr);
+        DeregisterMr(p.mr);
         g_pool_mr_active.fetch_sub(1, std::memory_order_relaxed);
       }
-      ibv_dealloc_pd(it->second.pd);
-      ibv_close_device(it->second.ctx);
+      RequireVerbsRelease(ibv_dealloc_pd(it->second.pd), "ibv_dealloc_pd");
+      RequireVerbsRelease(ibv_close_device(it->second.ctx), "ibv_close_device");
       g_devs.erase(it);
     }
     return;
@@ -198,7 +211,8 @@ void SharedReleasePoolMr(ibv_context* ctx, ibv_mr* mr) {
     if (device.ctx != ctx) continue;
     for (auto it = device.pool_mrs.begin(); it != device.pool_mrs.end(); ++it) {
       if (it->mr != mr) continue;
-      if (--it->refs == 0 && ibv_dereg_mr(it->mr) == 0) {
+      if (--it->refs == 0) {
+        DeregisterMr(it->mr);
         device.pool_mrs.erase(it);
         g_pool_mr_active.fetch_sub(1, std::memory_order_relaxed);
       }
@@ -343,14 +357,24 @@ QpInfo ParseQpInfo(const char in[kQpInfoBytes]) {
 RcEndpoint::~RcEndpoint() { Close(); }
 
 void RcEndpoint::Close() {
-  if (qp_) { ibv_destroy_qp(qp_); qp_ = nullptr; }
-  for (auto* mw : connection_mw_) if (mw) ibv_dealloc_mw(mw);
+  // Successful QP destruction is the inbound-DMA fence on every exit,
+  // including bootstrap failure and paths without responder WRITE CQEs.
+  if (qp_) {
+    RequireVerbsRelease(ibv_destroy_qp(qp_), "ibv_destroy_qp");
+    qp_ = nullptr;
+  }
+  for (auto* mw : connection_mw_)
+    if (mw) RequireVerbsRelease(ibv_dealloc_mw(mw), "ibv_dealloc_mw");
   connection_mw_.clear();
-  for (auto* m : smr_) if (m) ibv_dereg_mr(m);
-  for (auto* m : rmr_) if (m) ibv_dereg_mr(m);
-  for (auto* m : dmr_) if (m) ibv_dereg_mr(m);
-  for (auto* mr : transient_mr_) if (mr) ibv_dereg_mr(mr);
-  for (auto* mr : connection_mr_) if (mr) ibv_dereg_mr(mr);
+  for (auto* mr : lease_write_mr_) DeregisterMr(mr);
+  g_lease_write_mr_active.fetch_sub(lease_write_mr_.size(),
+                                   std::memory_order_relaxed);
+  lease_write_mr_.clear();
+  for (auto* m : smr_) DeregisterMr(m);
+  for (auto* m : rmr_) DeregisterMr(m);
+  for (auto* m : dmr_) DeregisterMr(m);
+  for (auto* mr : transient_mr_) DeregisterMr(mr);
+  for (auto* mr : connection_mr_) DeregisterMr(mr);
   connection_mr_.clear();
   g_transient_user_mr_active.fetch_sub(transient_mr_.size(),
                                        std::memory_order_relaxed);
@@ -740,6 +764,30 @@ ibv_mr* RcEndpoint::RegisterRemoteRegion(void* base, size_t size) {
   return nullptr;
 }
 
+ibv_mr* RcEndpoint::RegisterLeaseWriteRegion(void* base, size_t size) {
+  if (!pd_ || !base || size == 0) return nullptr;
+  ibv_mr* mr = ibv_reg_mr(
+      pd_, base, size, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+  if (!mr) return nullptr;
+  lease_write_mr_.push_back(mr);
+  g_lease_write_mr_active.fetch_add(1, std::memory_order_relaxed);
+  return mr;
+}
+
+void RcEndpoint::ReleaseLeaseWriteRegion(ibv_mr* mr) {
+  if (!mr) return;
+  const auto it = std::find(lease_write_mr_.begin(), lease_write_mr_.end(), mr);
+  if (it == lease_write_mr_.end()) std::abort();
+  // Synchronous revocation completes before the caller may recycle the range.
+  DeregisterMr(mr);
+  lease_write_mr_.erase(it);
+  g_lease_write_mr_active.fetch_sub(1, std::memory_order_relaxed);
+}
+
+uint64_t RcEndpoint::LeaseWriteMrActive() {
+  return g_lease_write_mr_active.load(std::memory_order_relaxed);
+}
+
 ibv_mr* RcEndpoint::RegisterRemoteReadRegion(void* base, size_t size) {
   if (!base || size == 0) return nullptr;
   ibv_mr* mr = ibv_reg_mr(
@@ -781,16 +829,18 @@ bool RcEndpoint::BindRemoteReadWindow(ibv_mr* pool_mr, void* base,
   wr.bind_mw.bind_info.length = size;
   wr.bind_mw.bind_info.mw_access_flags = IBV_ACCESS_REMOTE_READ;
   if (ibv_post_send(qp_, &wr, &bad) != 0) {
-    ibv_dealloc_mw(mw);
+    RequireVerbsRelease(ibv_dealloc_mw(mw), "ibv_dealloc_mw");
     return false;
   }
+  // Once posted, even an ambiguous bind owns its MW until QP destruction.
+  // Dropping the pointer after a timeout can orphan a still-bound window,
+  // making the backing MR impossible to revoke safely.
+  connection_mw_.push_back(mw);
   ibv_wc wc{};
   const int got = WaitComp(&wc, 1, 10000);
-  if (got != 1 || wc.status != IBV_WC_SUCCESS) {
-    ibv_dealloc_mw(mw);
+  if (got != 1 || wc.status != IBV_WC_SUCCESS ||
+      wc.wr_id != wr.wr_id || wc.opcode != IBV_WC_BIND_MW)
     return false;
-  }
-  connection_mw_.push_back(mw);
   *rkey = wr.bind_mw.rkey;
   return true;
 }
@@ -833,7 +883,7 @@ void RcEndpoint::ReleaseTransient(ibv_mr* mr) {
   if (!mr) return;
   const auto it = std::find(transient_mr_.begin(), transient_mr_.end(), mr);
   if (it == transient_mr_.end()) return;
-  ibv_dereg_mr(mr);
+  DeregisterMr(mr);
   transient_mr_.erase(it);
   g_transient_user_mr_active.fetch_sub(1, std::memory_order_relaxed);
 }

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -165,6 +165,13 @@ class RcEndpoint {
   // Register a shared server receive segment for remote PUT writes and return
   // the MR carrying both the local lkey and peer-visible rkey.
   ibv_mr* RegisterRemoteRegion(void* base, size_t size);
+  // Exact per-operation remote WRITE capability. Never enters the pool cache:
+  // a later lease at the same VA must not inherit an earlier operation's rkey.
+  // The backing allocation must outlive this endpoint, unless explicitly
+  // revoked with ReleaseLeaseWriteRegion before returning it to its pool.
+  ibv_mr* RegisterLeaseWriteRegion(void* base, size_t size);
+  void ReleaseLeaseWriteRegion(ibv_mr* mr);
+  static uint64_t LeaseWriteMrActive();
   // Register an exact connection-private source arena for initiator READ.
   // Unlike RegisterRemoteRegion this never widens to a shared segment MR.
   ibv_mr* RegisterRemoteReadRegion(void* base, size_t size);
@@ -338,6 +345,7 @@ class RcEndpoint {
   std::vector<ibv_mr*> transient_mr_;
   std::vector<ibv_mr*> connection_mr_;
   std::vector<ibv_mw*> connection_mw_;
+  std::vector<ibv_mr*> lease_write_mr_;
   QpInfo local_;
   std::atomic<bool> responder_cancelled_{false};
   size_t pending_responder_writes_ = 0;  // responder owner thread only

--- a/src/transport/rdma_verbs.h
+++ b/src/transport/rdma_verbs.h
@@ -172,6 +172,11 @@ class RcEndpoint {
   ibv_mr* RegisterLeaseWriteRegion(void* base, size_t size);
   void ReleaseLeaseWriteRegion(ibv_mr* mr);
   static uint64_t LeaseWriteMrActive();
+  // Exact operation-scoped READ capability, revoked before its staging range
+  // can return to the receive pool. Never retained in a broad chunk cache.
+  ibv_mr* RegisterLeaseReadRegion(void* base, size_t size);
+  void ReleaseLeaseReadRegion(ibv_mr* mr);
+  static uint64_t LeaseReadMrActive();
   // Register an exact connection-private source arena for initiator READ.
   // Unlike RegisterRemoteRegion this never widens to a shared segment MR.
   ibv_mr* RegisterRemoteReadRegion(void* base, size_t size);
@@ -346,6 +351,7 @@ class RcEndpoint {
   std::vector<ibv_mr*> connection_mr_;
   std::vector<ibv_mw*> connection_mw_;
   std::vector<ibv_mr*> lease_write_mr_;
+  std::vector<ibv_mr*> lease_read_mr_;
   QpInfo local_;
   std::atomic<bool> responder_cancelled_{false};
   size_t pending_responder_writes_ = 0;  // responder owner thread only

--- a/src/transport/wire.h
+++ b/src/transport/wire.h
@@ -32,7 +32,10 @@ enum class WireOp : uint8_t {
   kLookup = 14,  // payload-free stored-value metadata lookup
   kListTopology = 15,  // MDS: all members, including health-degraded nodes
   kPullRange = 16,     // RDMA v2: prepare one connection-private pull slot
-  kPullRelease = 17    // RDMA v2: release slot after initiator READ terminal
+  kPullRelease = 17,  // RDMA v2: release slot after initiator READ terminal
+  kLeasePut = 18      // RDMA v2: request one per-op staging lease; the reply
+                      // carries the leased range, the client then sends the
+                      // object as an ordinary v2 multi/single-window PUT WRITE
 };
 
 constexpr uint8_t kNativeProtoTcp = 6;

--- a/test/python/test_dfkv_vllm_connector.py
+++ b/test/python/test_dfkv_vllm_connector.py
@@ -192,10 +192,12 @@ def _install_vllm_stubs() -> None:
     )
     stub(
         "vllm.v1.kv_cache_interface",
+        AttentionSpec=Placeholder,
         FullAttentionSpec=Placeholder,
         KVCacheConfig=Placeholder,
         KVCacheGroupSpec=Placeholder,
         KVCacheSpec=Placeholder,
+        MambaSpec=Placeholder,
         UniformTypeKVCacheSpecs=Placeholder,
     )
     stub("vllm.v1.outputs", KVConnectorOutput=Placeholder)
@@ -494,7 +496,7 @@ class ConnectorShutdownGateTest(unittest.TestCase):
 
 
 class LogicalChunkNamespaceTest(unittest.TestCase):
-    def test_multiwr_v2_component_isolated_from_legacy_layouts(self) -> None:
+    def test_current_component_isolated_from_incomplete_legacy_payloads(self) -> None:
         metadata = KeyMetadata(
             model_name="model",
             dp_size=2,
@@ -525,7 +527,7 @@ class LogicalChunkNamespaceTest(unittest.TestCase):
             pp_rank=1,
             group_id=5,
         )
-        expected_v2 = pool_key(
+        legacy_v2 = pool_key(
             chunk_hash,
             component="vllm-multiwr-v2",
             **coordinates,
@@ -541,9 +543,7 @@ class LogicalChunkNamespaceTest(unittest.TestCase):
             **coordinates,
         )
 
-        self.assertEqual(generated, expected_v2)
-        self.assertNotEqual(generated, legacy_raw)
-        self.assertNotEqual(generated, legacy_sg)
+        self.assertNotIn(generated, {legacy_v2, legacy_raw, legacy_sg})
 
 
 class _PromMetric:

--- a/test/transport/rdma_lease_client_test.cc
+++ b/test/transport/rdma_lease_client_test.cc
@@ -45,7 +45,7 @@ long Counter(const std::string& text, const std::string& name) {
 }
 
 // Only the bootstrap TCP channel is proxied. Payloads still use the actual
-// negotiated RC QPs. Suppressing the optional probe bit reproduces a v2.25
+// negotiated RC QPs. Suppressing both optional probe bits reproduces a v2.25
 // peer, including its ordinary receive geometry, not a disabled client path.
 class CapabilityProxy {
  public:
@@ -83,6 +83,7 @@ class CapabilityProxy {
   std::atomic<bool> advertise_lease{false};
   std::atomic<unsigned> ordinary_bootstraps{0};
   std::atomic<unsigned> leased_bootstraps{0};
+  std::atomic<unsigned> dynamic_bootstraps{0};
   std::atomic<unsigned> legacy_probes{0};
 
  private:
@@ -97,7 +98,8 @@ class CapabilityProxy {
         if (net::ReadAll(server, reply, sizeof(reply))) {
           if (!advertise_lease.load()) {
             reply[5] = static_cast<char>(
-                static_cast<uint8_t>(reply[5]) & ~rdma::kV2ProbeCapLeasedPut);
+                static_cast<uint8_t>(reply[5]) &
+                ~(rdma::kV2ProbeCapLeasedPut | rdma::kV2ProbeCapDynamicPull));
             ++legacy_probes;
           }
           net::WriteAll(client, reply, sizeof(reply));
@@ -105,14 +107,19 @@ class CapabilityProxy {
       } else {
         if (rdma::DevFrameRequestsLeasedPut(frame)) ++leased_bootstraps;
         else ++ordinary_bootstraps;
+        const bool dynamic = rdma::DevFrameRequestsDynamicPull(frame);
+        if (dynamic) ++dynamic_bootstraps;
+        const size_t readiness_bytes = dynamic
+                                           ? rdma::kV2RetirementReadinessBytes
+                                           : rdma::kV2PullReadinessBytes;
         char qp[rdma::kQpInfoBytes];
         char readiness[rdma::kV2PullReadinessBytes];
         if (net::ReadAll(client, qp, sizeof(qp)) &&
             net::WriteAll(server, qp, sizeof(qp)) &&
             net::ReadAll(server, qp, sizeof(qp)) &&
             net::WriteAll(client, qp, sizeof(qp)) &&
-            net::ReadAll(server, readiness, sizeof(readiness))) {
-          net::WriteAll(client, readiness, sizeof(readiness));
+            net::ReadAll(server, readiness, readiness_bytes)) {
+          net::WriteAll(client, readiness, readiness_bytes);
         }
       }
     }
@@ -184,6 +191,7 @@ class RdmaLeaseClient : public testing::Test {
   ScopedEnv local_fault_{"DFKV_RDMA_TEST_COMPLETION_FAULT", nullptr};
   ScopedEnv remote_fault_{"DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", nullptr};
   ScopedEnv read_fault_{"DFKV_RDMA_TEST_PULL_READ_FAILURE", nullptr};
+  ScopedEnv dynamic_{"DFKV_RDMA_DYNAMIC_PULL", nullptr};
   ScopedEnv ceiling_{"DFKV_RDMA_MAX_BLOCK_BYTES", "1048576"};
   ScopedEnv threshold_{"DFKV_RDMA_INLINE_PUT_MAX_BYTES", "131072"};
   ScopedEnv minimum_{"DFKV_RDMA_CONNECTION_MIN_BLOCK_BYTES", "65536"};
@@ -424,8 +432,7 @@ TEST_F(RdmaLeaseClient, PullCapacityRejectionPreservesConnectionAndGeneration) {
       return transport.RangeInto(
           addr_, {key}, {{out->data(), out->size()}}, nullptr)[0];
     };
-    // Seed a previous generation, then reject two successive PREPARE results.
-    // Each rejection must carry forward its own retirement generation.
+    // Success and each capacity rejection must retire their own generation.
     std::string out(value.size(), '?');
     ASSERT_EQ(get(&out), Status::kOk);
     EXPECT_EQ(out, value);
@@ -443,6 +450,8 @@ TEST_F(RdmaLeaseClient, PullCapacityRejectionPreservesConnectionAndGeneration) {
                       "dfkv_rdma_client_remote_rail_failures_total"), 0);
     EXPECT_EQ(Counter(transport.MetricsText(),
                       "dfkv_rdma_client_pull_failures_total"), 0);
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_pull_releases_total"), 4);
 
     // In contrast, an actual READ failure still retires the endpoint and
     // attributes remote failure; capacity rejection must not hide that case.
@@ -453,6 +462,202 @@ TEST_F(RdmaLeaseClient, PullCapacityRejectionPreservesConnectionAndGeneration) {
     EXPECT_EQ(Counter(transport.MetricsText(),
                       "dfkv_rdma_client_pull_failures_total"), 1);
   }
+}
+
+TEST_F(RdmaLeaseClient, DynamicPullReleasesLargeScalarAndScatterReadsBeforeIdle) {
+  std::string value(kLarge, '\0');
+  for (size_t i = 0; i < value.size(); ++i)
+    value[i] = static_cast<char>(i % 251);
+  const BlockKey key{12, 1};
+  std::string ignored;
+  size_t stored_len = 0;
+  ASSERT_EQ(store_->ProcessRequestForKey(
+                static_cast<uint8_t>(WireOp::kCache), key, 0, 0,
+                value.data(), value.size(), &ignored, &stored_len), Status::kOk);
+  RdmaTransport transport(kMaxMsg);
+  const long baseline_bytes = Counter(
+      transport.MetricsText(),
+      "dfkv_rdma_client_registered_slot_bytes_budget{kind=\"used\"}");
+  const auto expect_idle = [&] {
+    EXPECT_EQ(Counter(server_->MetricsText(),
+                      "dfkv_rdma_recv_segment_used_bytes"),
+              static_cast<long>(rdma::V2SlotSize(65536)));
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_conns_opened_total"), 1);
+    EXPECT_EQ(Counter(
+                  transport.MetricsText(),
+                  "dfkv_rdma_client_registered_slot_bytes_budget{kind=\"used\"}"),
+              baseline_bytes + static_cast<long>(rdma::V2SlotSize(65536)));
+  };
+  for (int round = 0; round < 3; ++round) {
+    std::string out(value.size() + 17, '?');
+    std::vector<uint64_t> value_lens;
+    ASSERT_EQ(transport.RangeInto(
+                  addr_, {key}, {{out.data(), out.size()}}, &value_lens),
+              std::vector<Status>{Status::kOk});
+    EXPECT_EQ(out.substr(0, value.size()), value);
+    EXPECT_EQ(out.substr(value.size()), std::string(17, '?'));
+    EXPECT_EQ(value_lens, std::vector<uint64_t>{value.size()});
+    expect_idle();
+    out.assign(out.size(), '?');
+    const size_t split = value.size() / 3 + 7;
+    std::vector<size_t> lengths;
+    ASSERT_EQ(transport.RangeIntoMulti(
+                  addr_, {key},
+                  {{{{out.data(), split}, {nullptr, 0},
+                     {out.data() + split, out.size() - split}}}},
+                  &lengths), std::vector<Status>{Status::kOk});
+    EXPECT_EQ(out.substr(0, value.size()), value);
+    EXPECT_EQ(out.substr(value.size()), std::string(17, '?'));
+    EXPECT_EQ(lengths, std::vector<size_t>{value.size()});
+    expect_idle();
+  }
+  EXPECT_EQ(Counter(transport.MetricsText(),
+                    "dfkv_rdma_client_pull_releases_total"), 6);
+  EXPECT_EQ(Counter(transport.MetricsText(),
+                    "dfkv_rdma_client_pull_read_bytes_total"), 6 * kLarge);
+  std::string small(value.size() - 1, '?');
+  std::vector<uint64_t> rejected_lengths;
+  EXPECT_EQ(transport.RangeInto(
+                addr_, {key}, {{small.data(), small.size()}}, &rejected_lengths),
+            std::vector<Status>{Status::kInvalid});
+  EXPECT_EQ(rejected_lengths, std::vector<uint64_t>{value.size()});
+  EXPECT_EQ(small, std::string(small.size(), '?'));
+  expect_idle();
+  std::vector<size_t> rejected_sg_lengths;
+  EXPECT_EQ(transport.RangeIntoMulti(
+                addr_, {key}, {{{{small.data(), small.size()}}}},
+                &rejected_sg_lengths), std::vector<Status>{Status::kInvalid});
+  EXPECT_EQ(rejected_sg_lengths, std::vector<size_t>{0});
+  EXPECT_EQ(small, std::string(small.size(), '?'));
+  expect_idle();
+  std::string out(value.size(), '?');
+  EXPECT_EQ(transport.RangeInto(
+                addr_, {{12, 2}}, {{out.data(), out.size()}}, nullptr),
+            std::vector<Status>{Status::kNotFound});
+  EXPECT_EQ(out, std::string(value.size(), '?'));
+  EXPECT_EQ(transport.RangeIntoMulti(
+                addr_, {{12, 2}}, {{{{out.data(), out.size()}}}}, nullptr),
+            std::vector<Status>{Status::kNotFound});
+  EXPECT_EQ(transport.RangeInto(addr_, {key}, {{nullptr, 0}}, nullptr),
+            std::vector<Status>{Status::kInvalid});
+  EXPECT_EQ(transport.RangeIntoMulti(addr_, {key}, {{}}, nullptr),
+            std::vector<Status>{Status::kInvalid});
+  expect_idle();
+  EXPECT_EQ(Counter(transport.MetricsText(),
+                    "dfkv_rdma_client_pull_releases_total"), 8);
+  EXPECT_EQ(Counter(transport.MetricsText(),
+                    "dfkv_rdma_client_pull_failures_total"), 0);
+}
+
+TEST_F(RdmaLeaseClient, LegacyGetReusesAndRefreshesBothOptionalCapabilities) {
+  const BlockKey key{13, 1};
+  const std::string value(kLarge, 'g');
+  std::string ignored;
+  size_t stored_len = 0;
+  ASSERT_EQ(store_->ProcessRequestForKey(
+                static_cast<uint8_t>(WireOp::kCache), key, 0, 0,
+                value.data(), value.size(), &ignored, &stored_len), Status::kOk);
+  CapabilityProxy proxy(addr_);
+  ASSERT_FALSE(proxy.addr.empty());
+  RdmaTransport transport(kMaxMsg);
+  PeerTopology topology;
+  topology.peer_addr = proxy.addr;
+  topology.peer_id = "get-peer";
+  topology.generation = 1;
+  transport.OnPeerTopology(topology);
+  const auto get = [&] {
+    std::string out(value.size(), '?');
+    EXPECT_EQ(transport.RangeInto(
+                  proxy.addr, {key}, {{out.data(), out.size()}}, nullptr),
+              std::vector<Status>{Status::kOk});
+    EXPECT_EQ(out, value);
+    out.assign(out.size(), '?');
+    EXPECT_EQ(transport.RangeIntoMulti(
+                  proxy.addr, {key}, {{{{out.data(), out.size()}}}}, nullptr),
+              std::vector<Status>{Status::kOk});
+    EXPECT_EQ(out, value);
+  };
+  get();
+  const long probes = Counter(transport.MetricsText(),
+                             "dfkv_rdma_client_v2_probe_attempts_total");
+  get();
+  EXPECT_EQ(proxy.ordinary_bootstraps.load(), 1u);
+  EXPECT_EQ(proxy.dynamic_bootstraps.load(), 0u);
+  EXPECT_EQ(Counter(transport.MetricsText(),
+                    "dfkv_rdma_client_v2_probe_attempts_total"), probes);
+  EXPECT_EQ(Counter(server_->MetricsText(),
+                    "dfkv_rdma_recv_segment_used_bytes"),
+            static_cast<long>(2 * rdma::V2SlotSize(kLarge)));
+  proxy.advertise_lease.store(true);
+  ++topology.generation;
+  transport.OnPeerTopology(topology);
+  get();
+  EXPECT_EQ(proxy.dynamic_bootstraps.load(), 1u);
+  proxy.advertise_lease.store(false);
+  ++topology.generation;
+  transport.OnPeerTopology(topology);
+  get();
+  get();
+  EXPECT_EQ(proxy.ordinary_bootstraps.load(), 3u);
+  EXPECT_EQ(proxy.dynamic_bootstraps.load(), 1u);
+  // Peer identity changes invalidate optional bits even at the same generation.
+  proxy.advertise_lease.store(true);
+  topology.peer_id = "replacement-get-peer";
+  transport.OnPeerTopology(topology);
+  get();
+  EXPECT_EQ(proxy.ordinary_bootstraps.load(), 4u);
+  EXPECT_EQ(proxy.dynamic_bootstraps.load(), 2u);
+  EXPECT_EQ(Counter(transport.MetricsText(),
+                    "dfkv_rdma_client_pull_releases_total"), 4);
+}
+
+TEST_F(RdmaLeaseClient, DynamicPullEscapeHatchRetainsLegacyGeometry) {
+  ScopedEnv disabled("DFKV_RDMA_DYNAMIC_PULL", "0");
+  CapabilityProxy proxy(addr_);
+  ASSERT_FALSE(proxy.addr.empty());
+  proxy.advertise_lease.store(true);
+  const BlockKey key{14, 1};
+  const std::string value(kLarge, 'e');
+  std::string ignored;
+  size_t stored_len = 0;
+  ASSERT_EQ(store_->ProcessRequestForKey(
+                static_cast<uint8_t>(WireOp::kCache), key, 0, 0,
+                value.data(), value.size(), &ignored, &stored_len), Status::kOk);
+  RdmaTransport transport(kMaxMsg);
+  for (int round = 0; round < 2; ++round) {
+    std::string out(value.size(), '?');
+    ASSERT_EQ(transport.RangeInto(
+                  proxy.addr, {key}, {{out.data(), out.size()}}, nullptr),
+              std::vector<Status>{Status::kOk});
+    EXPECT_EQ(out, value);
+  }
+  EXPECT_EQ(proxy.dynamic_bootstraps.load(), 0u);
+  EXPECT_EQ(proxy.ordinary_bootstraps.load(), 1u);
+  EXPECT_EQ(Counter(server_->MetricsText(),
+                    "dfkv_rdma_recv_segment_used_bytes"),
+            static_cast<long>(2 * rdma::V2SlotSize(kLarge)));
+}
+
+TEST_F(RdmaLeaseClient, StringRangesPreservePartialOffsetsAndStoredLength) {
+  const BlockKey key{15, 1};
+  const std::string value = "0123456789abcdefghij";
+  RdmaTransport transport(kMaxMsg);
+  ASSERT_EQ(transport.Cache(addr_, key, value.data(), value.size()), Status::kOk);
+  std::string out;
+  uint64_t length = 0;
+  ASSERT_EQ(transport.Range(addr_, key, 7, 6, &out, &length), Status::kOk);
+  EXPECT_EQ(out, value.substr(7, 6));
+  EXPECT_EQ(length, value.size());
+  std::vector<std::string> outputs;
+  std::vector<uint64_t> lengths;
+  EXPECT_EQ(transport.RangeMany(addr_, {key, {15, 2}}, 17, 8, &outputs, &lengths),
+            (std::vector<Status>{Status::kOk, Status::kNotFound}));
+  ASSERT_EQ(outputs.size(), 2u);
+  EXPECT_EQ(outputs[0], value.substr(17));
+  EXPECT_TRUE(outputs[1].empty());
+  ASSERT_EQ(lengths.size(), 2u);
+  EXPECT_EQ(lengths[0], value.size());
 }
 
 }  // namespace

--- a/test/transport/rdma_lease_client_test.cc
+++ b/test/transport/rdma_lease_client_test.cc
@@ -1,0 +1,459 @@
+#include "cache/kv_node_server.h"
+#include "cache/rdma_server.h"
+#include "transport/rdma_protocol.h"
+#include "transport/rdma_transport.h"
+#include "transport/rdma_verbs.h"
+#include "utils/net_util.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace dfkv {
+namespace {
+
+class ScopedEnv {
+ public:
+  ScopedEnv(const char* name, const char* value) : name_(name) {
+    if (const char* old = std::getenv(name)) {
+      present_ = true;
+      old_ = old;
+    }
+    if (value) ::setenv(name, value, 1);
+    else ::unsetenv(name);
+  }
+  ~ScopedEnv() {
+    if (present_) ::setenv(name_.c_str(), old_.c_str(), 1);
+    else ::unsetenv(name_.c_str());
+  }
+ private:
+  std::string name_;
+  std::string old_;
+  bool present_ = false;
+};
+
+long Counter(const std::string& text, const std::string& name) {
+  const auto at = text.rfind("\n" + name + " ");
+  if (at == std::string::npos) return -1;
+  return std::strtol(text.c_str() + at + name.size() + 2, nullptr, 10);
+}
+
+// Only the bootstrap TCP channel is proxied. Payloads still use the actual
+// negotiated RC QPs. Suppressing the optional probe bit reproduces a v2.25
+// peer, including its ordinary receive geometry, not a disabled client path.
+class CapabilityProxy {
+ public:
+  explicit CapabilityProxy(std::string backend) : backend_(std::move(backend)) {
+    listener_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (listener_ < 0 ||
+        ::bind(listener_, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)) != 0 ||
+        ::listen(listener_, 8) != 0) return;
+    socklen_t size = sizeof(sa);
+    if (::getsockname(listener_, reinterpret_cast<sockaddr*>(&sa), &size) != 0)
+      return;
+    addr = "127.0.0.1:" + std::to_string(ntohs(sa.sin_port));
+    worker_ = std::thread([this] {
+      while (!stop_.load()) {
+        const int client = ::accept(listener_, nullptr, nullptr);
+        if (client < 0) break;
+        timeval timeout{3, 0};
+        ::setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+        ::setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+        Handle(client);
+        ::close(client);
+      }
+    });
+  }
+  ~CapabilityProxy() {
+    stop_.store(true);
+    if (listener_ >= 0) ::shutdown(listener_, SHUT_RDWR);
+    if (worker_.joinable()) worker_.join();
+    if (listener_ >= 0) ::close(listener_);
+  }
+  std::string addr;
+  std::atomic<bool> advertise_lease{false};
+  std::atomic<unsigned> ordinary_bootstraps{0};
+  std::atomic<unsigned> leased_bootstraps{0};
+  std::atomic<unsigned> legacy_probes{0};
+
+ private:
+  void Handle(int client) {
+    char frame[rdma::kDevNameBytes];
+    if (!net::ReadAll(client, frame, sizeof(frame))) return;
+    const int server = net::Dial(backend_, 3000, 3000);
+    if (server < 0) return;
+    if (net::WriteAll(server, frame, sizeof(frame))) {
+      if (rdma::IsV2Probe(frame)) {
+        char reply[rdma::kV2ProbeReplyBytes];
+        if (net::ReadAll(server, reply, sizeof(reply))) {
+          if (!advertise_lease.load()) {
+            reply[5] = static_cast<char>(
+                static_cast<uint8_t>(reply[5]) & ~rdma::kV2ProbeCapLeasedPut);
+            ++legacy_probes;
+          }
+          net::WriteAll(client, reply, sizeof(reply));
+        }
+      } else {
+        if (rdma::DevFrameRequestsLeasedPut(frame)) ++leased_bootstraps;
+        else ++ordinary_bootstraps;
+        char qp[rdma::kQpInfoBytes];
+        char readiness[rdma::kV2PullReadinessBytes];
+        if (net::ReadAll(client, qp, sizeof(qp)) &&
+            net::WriteAll(server, qp, sizeof(qp)) &&
+            net::ReadAll(server, qp, sizeof(qp)) &&
+            net::WriteAll(client, qp, sizeof(qp)) &&
+            net::ReadAll(server, readiness, sizeof(readiness))) {
+          net::WriteAll(client, readiness, sizeof(readiness));
+        }
+      }
+    }
+    ::close(server);
+  }
+  std::string backend_;
+  int listener_ = -1;
+  std::atomic<bool> stop_{false};
+  std::thread worker_;
+};
+
+class RdmaLeaseClient : public testing::Test {
+ protected:
+  static constexpr size_t kMaxMsg = 4u << 20;
+  static constexpr size_t kCeiling = 1u << 20;
+  static constexpr size_t kLarge = 256u << 10;
+  static constexpr size_t kSmall = 4096;
+  void SetUp() override {
+    if (!RdmaTransport::Available()) GTEST_SKIP() << "no RDMA device";
+    char path[] = "/tmp/dfkv_lease_client_XXXXXX";
+    const char* created = ::mkdtemp(path);
+    ASSERT_NE(created, nullptr);
+    dir_ = created;
+    store_ = std::make_unique<KvNodeServer>(dir_.string(), 64u << 20);
+    ASSERT_EQ(store_->Start(0), Status::kOk);
+    server_ = std::make_unique<RdmaServer>(
+        [this](uint8_t op, const BlockKey& key, uint64_t off, uint64_t len,
+               const char* payload, uint64_t payload_len, std::string* out,
+               size_t* value_len) {
+          return store_->ProcessRequestForKey(op, key, off, len, payload,
+                                              payload_len, out, value_len);
+        }, kMaxMsg);
+    server_->set_cache_direct_handler(
+        [this](const BlockKey& key, char* data, size_t len, size_t capacity) {
+          return store_->CacheDirectForKey(key, data, len, capacity);
+        });
+    server_->set_range_handler(
+        [this](const BlockKey& key, uint64_t off, uint64_t len, char* buffer,
+               size_t capacity, const char** data, size_t* out_len,
+               size_t* value_len) {
+          return store_->RangeDirectForKey(key, off, len, buffer, capacity,
+                                           data, out_len, value_len);
+        });
+    ASSERT_EQ(server_->Start(0), Status::kOk);
+    addr_ = "127.0.0.1:" + std::to_string(server_->port());
+  }
+  void TearDown() override {
+    if (server_) server_->Stop();
+    if (store_) store_->Stop();
+    if (!dir_.empty()) std::filesystem::remove_all(dir_);
+  }
+  void ExpectStored(const BlockKey& key, const std::string& expected) {
+    std::string actual;
+    size_t value_len = 0;
+    ASSERT_EQ(store_->ProcessRequestForKey(
+                  static_cast<uint8_t>(WireOp::kRange), key, 0, expected.size(),
+                  nullptr, 0, &actual, &value_len), Status::kOk);
+    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(value_len, expected.size());
+  }
+  static CacheSrcMulti Segments(BlockKey key, const std::string& value) {
+    const size_t half = value.size() / 2;
+    return {key, {{value.data(), half}, {nullptr, 0},
+                  {value.data() + half, value.size() - half}}};
+  }
+  ScopedEnv device_{"DFKV_RDMA_DEV", nullptr};
+  ScopedEnv tiers_{"DFKV_RDMA_RAIL_TIERS", nullptr};
+  ScopedEnv ram_{"DFKV_RAM_TIER", "0"};
+  ScopedEnv local_fault_{"DFKV_RDMA_TEST_COMPLETION_FAULT", nullptr};
+  ScopedEnv remote_fault_{"DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", nullptr};
+  ScopedEnv read_fault_{"DFKV_RDMA_TEST_PULL_READ_FAILURE", nullptr};
+  ScopedEnv ceiling_{"DFKV_RDMA_MAX_BLOCK_BYTES", "1048576"};
+  ScopedEnv threshold_{"DFKV_RDMA_INLINE_PUT_MAX_BYTES", "131072"};
+  ScopedEnv minimum_{"DFKV_RDMA_CONNECTION_MIN_BLOCK_BYTES", "65536"};
+  ScopedEnv segment_{"DFKV_RDMA_RECV_SEGMENT_SIZE", "67108864"};
+  ScopedEnv chunk_{"DFKV_RDMA_RECV_CHUNK_BYTES", "4194304"};
+  ScopedEnv depth_{"DFKV_RDMA_DEPTH", "2"};
+  ScopedEnv keepalive_{"DFKV_RDMA_KEEPALIVE_MS", "0"};
+  std::filesystem::path dir_;
+  std::unique_ptr<KvNodeServer> store_;
+  std::unique_ptr<RdmaServer> server_;
+  std::string addr_;
+};
+
+TEST_F(RdmaLeaseClient, ExplicitCeilingAppliesToEveryPutAndGetApi) {
+  RdmaTransport transport(kMaxMsg);
+  const BlockKey key{1, 1};
+  const std::string boundary(kCeiling, 'b');
+  const std::string oversized(kCeiling + 1, 'x');
+  ASSERT_EQ(transport.Cache(addr_, key, boundary.data(), boundary.size()), Status::kOk);
+  std::string out;
+  ASSERT_EQ(transport.Range(addr_, key, 0, boundary.size(), &out), Status::kOk);
+  EXPECT_EQ(out, boundary);
+  EXPECT_EQ(transport.Cache(addr_, {1, 2}, oversized.data(), oversized.size()), Status::kInvalid);
+  EXPECT_EQ(transport.CacheMany(addr_, {{{1, 3}, oversized.data(), oversized.size()}}),
+            std::vector<Status>{Status::kInvalid});
+  EXPECT_EQ(transport.CacheFrom(addr_, {{{1, 4}, oversized.data(), oversized.size()}}),
+            std::vector<Status>{Status::kInvalid});
+  EXPECT_EQ(transport.CacheFromMulti(addr_, {Segments({1, 5}, oversized)}),
+            std::vector<Status>{Status::kInvalid});
+  EXPECT_EQ(transport.Range(addr_, key, 0, oversized.size(), &out), Status::kInvalid);
+  std::vector<std::string> outs;
+  EXPECT_EQ(transport.RangeMany(addr_, {key}, 0, oversized.size(), &outs),
+            std::vector<Status>{Status::kInvalid});
+  out.resize(oversized.size());
+  EXPECT_EQ(transport.RangeInto(addr_, {key}, {{out.data(), out.size()}}, nullptr),
+            std::vector<Status>{Status::kInvalid});
+  EXPECT_EQ(transport.RangeIntoMulti(addr_, {key}, {{{{out.data(), out.size()}}}}, nullptr),
+            std::vector<Status>{Status::kInvalid});
+}
+
+TEST_F(RdmaLeaseClient, DefaultLeaseSettingDoesNotBypassExplicitCeiling) {
+  ScopedEnv default_threshold("DFKV_RDMA_INLINE_PUT_MAX_BYTES", nullptr);
+  RdmaTransport transport(kMaxMsg);
+  const std::string oversized(kCeiling + 1, 'x');
+  const std::string valid(kSmall, 'v');
+  const auto result = transport.CacheMany(addr_, {
+      {{2, 1}, oversized.data(), oversized.size()},
+      {{2, 2}, valid.data(), valid.size()}});
+  EXPECT_EQ(result, (std::vector<Status>{Status::kInvalid, Status::kOk}));
+  ExpectStored({2, 2}, valid);
+}
+
+TEST_F(RdmaLeaseClient, InvalidInlineSlotsDoNotPoisonRepliesOrLaterWindows) {
+  RdmaTransport transport(kMaxMsg);
+  const std::string small(kSmall, 's');
+  const std::string oversized(kCeiling + 1, 'x');
+  const auto result = transport.CacheMany(addr_, {
+      {{3, 1}, oversized.data(), oversized.size()},
+      {{3, 2}, small.data(), small.size()},
+      {{3, 3}, oversized.data(), oversized.size()},
+      {{3, 4}, small.data(), small.size()},
+      {{3, 5}, nullptr, 1},
+      {{3, 6}, small.data(), small.size()}});
+  EXPECT_EQ(result, (std::vector<Status>{Status::kInvalid, Status::kOk,
+      Status::kInvalid, Status::kOk, Status::kInvalid, Status::kOk}));
+  for (uint64_t i : {2, 4, 6}) ExpectStored({3, i}, small);
+  EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_stale_pool_retries_total"), 0);
+}
+
+TEST_F(RdmaLeaseClient, MixedSizeDuplicateKeysKeepFirstWriteWins) {
+  RdmaTransport transport(kMaxMsg);
+  const std::string large(kLarge, 'L');
+  const std::string small(kSmall, 's');
+  const auto result = transport.CacheMany(addr_, {
+      {{4, 1}, large.data(), large.size()},
+      {{4, 1}, small.data(), small.size()},
+      {{4, 2}, small.data(), small.size()},
+      {{4, 2}, large.data(), large.size()}});
+  EXPECT_EQ(result, std::vector<Status>(4, Status::kOk));
+  ExpectStored({4, 1}, large);
+  ExpectStored({4, 2}, small);
+  EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_leaseput_ops_total"), 2);
+}
+
+TEST_F(RdmaLeaseClient, ScatterGatherMatchesOrderingValidationAndPayload) {
+  RdmaTransport transport(kMaxMsg);
+  const std::string large(kLarge, 'L');
+  const std::string small(kSmall, 's');
+  const std::string oversized(kCeiling + 1, 'x');
+  const auto result = transport.CacheFromMulti(addr_, {
+      Segments({5, 0}, oversized), Segments({5, 1}, large),
+      Segments({5, 1}, small), {{5, 2}, {{nullptr, 1}}},
+      Segments({5, 3}, small), Segments({5, 3}, large)});
+  EXPECT_EQ(result, (std::vector<Status>{Status::kInvalid, Status::kOk,
+      Status::kOk, Status::kInvalid, Status::kOk, Status::kOk}));
+  ExpectStored({5, 1}, large);
+  ExpectStored({5, 3}, small);
+}
+
+TEST_F(RdmaLeaseClient, EmptyAndZeroThresholdDisableLeaseNegotiation) {
+  const std::string large(kLarge, 'v');
+  uint64_t key = 0;
+  for (const char* value : {"", "0"}) {
+    ScopedEnv threshold("DFKV_RDMA_INLINE_PUT_MAX_BYTES", value);
+    RdmaTransport transport(kMaxMsg);
+    EXPECT_EQ(transport.CacheMany(addr_, {{{6, ++key}, large.data(), large.size()}}),
+              std::vector<Status>{Status::kOk});
+    EXPECT_EQ(transport.CacheFromMulti(addr_, {Segments({6, ++key}, large)}),
+              std::vector<Status>{Status::kOk});
+    EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_leaseput_ops_total"), 0);
+    EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_inline_put_max_bytes"), 0);
+  }
+}
+
+TEST_F(RdmaLeaseClient, LegacyPeerReusesQpAndRefreshesOnPublication) {
+  CapabilityProxy proxy(addr_);
+  ASSERT_FALSE(proxy.addr.empty());
+  RdmaTransport transport(kMaxMsg);
+  PeerTopology topology;
+  topology.peer_addr = proxy.addr;
+  topology.peer_id = "lease-client-peer";
+  topology.generation = 1;
+  transport.OnPeerTopology(topology);
+  const std::string large(kLarge, 'v');
+  const auto put = [&](uint64_t key) {
+    EXPECT_EQ(transport.CacheMany(proxy.addr, {{{7, key}, large.data(), large.size()}}),
+              std::vector<Status>{Status::kOk});
+    EXPECT_EQ(transport.CacheFromMulti(proxy.addr, {Segments({8, key}, large)}),
+              std::vector<Status>{Status::kOk});
+  };
+  put(1);
+  ASSERT_EQ(proxy.ordinary_bootstraps.load(), 1u);
+  ASSERT_GT(proxy.legacy_probes.load(), 0u);
+  const long probes = Counter(transport.MetricsText(), "dfkv_rdma_client_v2_probe_attempts_total");
+  put(2);
+  EXPECT_EQ(proxy.ordinary_bootstraps.load(), 1u);
+  EXPECT_EQ(proxy.leased_bootstraps.load(), 0u);
+  EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_v2_probe_attempts_total"), probes);
+  // A repeated publication is not a refresh boundary.
+  transport.OnPeerTopology(topology);
+  put(3);
+  EXPECT_EQ(proxy.ordinary_bootstraps.load(), 1u);
+  proxy.advertise_lease.store(true);
+  ++topology.generation;
+  transport.OnPeerTopology(topology);
+  put(4);
+  EXPECT_EQ(proxy.leased_bootstraps.load(), 1u);
+  EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_leaseput_ops_total"), 2);
+  proxy.advertise_lease.store(false);
+  ++topology.generation;
+  transport.OnPeerTopology(topology);
+  put(5);
+  put(6);
+  EXPECT_EQ(proxy.ordinary_bootstraps.load(), 2u);
+  EXPECT_EQ(proxy.leased_bootstraps.load(), 1u);
+  EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_stale_pool_retries_total"), 0);
+  ExpectStored({7, 6}, large);
+  ExpectStored({8, 6}, large);
+}
+
+TEST_F(RdmaLeaseClient, PostWriteFailureDoesNotReplayScalarOrScatterGather) {
+  const std::string large(kLarge, 'v');
+  for (bool sg : {false, true}) {
+    RdmaTransport transport(kMaxMsg);
+    PeerTopology topology;
+    topology.peer_addr = addr_;
+    topology.peer_id = "post-write-peer";
+    topology.generation = 1;
+    transport.OnPeerTopology(topology);
+    ScopedEnv fault("DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT", "1:1:2");
+    const BlockKey key{9, sg ? 2u : 1u};
+    const auto result = sg
+        ? transport.CacheFromMulti(addr_, {Segments(key, large)})
+        : transport.CacheMany(addr_, {{key, large.data(), large.size()}});
+    EXPECT_EQ(result, std::vector<Status>{Status::kIOError});
+    // Fault is surfaced after the real commit completion: the write landed,
+    // but the caller cannot claim success or replay an ambiguous request.
+    ExpectStored(key, large);
+    EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_conns_opened_total"), 1);
+    EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_leaseput_ops_total"), 1);
+    EXPECT_EQ(Counter(transport.MetricsText(), "dfkv_rdma_client_stale_pool_retries_total"), 0);
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_remote_rail_failures_total"), 1);
+  }
+}
+
+TEST_F(RdmaLeaseClient, LeasePrepareFailuresKeepRetrySafetyAndAttribution) {
+  const std::string large(kLarge, 'v');
+  for (bool sg : {false, true}) {
+    for (bool endpoint : {false, true}) {
+      RdmaTransport transport(kMaxMsg);
+      PeerTopology topology;
+      topology.peer_addr = addr_;
+      topology.peer_id = "prepare-failure-peer";
+      topology.generation = 1;
+      transport.OnPeerTopology(topology);
+      ScopedEnv fault(endpoint ? "DFKV_RDMA_TEST_ENDPOINT_COMPLETION_FAULT"
+                               : "DFKV_RDMA_TEST_COMPLETION_FAULT",
+                      "1:1:1");
+      const BlockKey key{10, static_cast<uint64_t>(sg * 2 + endpoint)};
+      const auto result = sg
+          ? transport.CacheFromMulti(addr_, {Segments(key, large)})
+          : transport.CacheMany(addr_, {{key, large.data(), large.size()}});
+      EXPECT_EQ(result, std::vector<Status>{
+                            endpoint ? Status::kIOError : Status::kOk});
+      EXPECT_EQ(Counter(transport.MetricsText(),
+                        "dfkv_rdma_client_remote_rail_failures_total"),
+                endpoint ? 1 : 0);
+      // PREPARE cannot commit. Local failure may retry once on a traditional
+      // connection; a fresh endpoint failure is not replayed on that rail.
+      EXPECT_EQ(Counter(transport.MetricsText(),
+                        "dfkv_rdma_client_conns_opened_total"),
+                endpoint ? 1 : 2);
+      if (!endpoint) ExpectStored(key, large);
+    }
+  }
+}
+
+TEST_F(RdmaLeaseClient, PullCapacityRejectionPreservesConnectionAndGeneration) {
+  const std::string value(kSmall, 'v');
+  for (bool sg : {false, true}) {
+    RdmaTransport transport(kMaxMsg);
+    PeerTopology topology;
+    topology.peer_addr = addr_;
+    topology.peer_id = "capacity-peer";
+    topology.generation = 1;
+    transport.OnPeerTopology(topology);
+    const BlockKey key{11, sg ? 2u : 1u};
+    ASSERT_EQ(transport.Cache(addr_, key, value.data(), value.size()), Status::kOk);
+    const auto get = [&](std::string* out) {
+      if (sg) {
+        std::vector<size_t> lengths;
+        const auto result = transport.RangeIntoMulti(
+            addr_, {key}, {{{{out->data(), out->size()}}}}, &lengths);
+        if (result[0] != Status::kOk) EXPECT_EQ(lengths[0], 0u);
+        return result[0];
+      }
+      return transport.RangeInto(
+          addr_, {key}, {{out->data(), out->size()}}, nullptr)[0];
+    };
+    // Seed a previous generation, then reject two successive PREPARE results.
+    // Each rejection must carry forward its own retirement generation.
+    std::string out(value.size(), '?');
+    ASSERT_EQ(get(&out), Status::kOk);
+    EXPECT_EQ(out, value);
+    for (size_t capacity : {value.size() - 1, value.size() - 2}) {
+      out.assign(capacity, '?');
+      EXPECT_EQ(get(&out), Status::kInvalid);
+      EXPECT_EQ(out, std::string(capacity, '?'));
+    }
+    out.assign(value.size(), '?');
+    ASSERT_EQ(get(&out), Status::kOk);
+    EXPECT_EQ(out, value);
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_conns_opened_total"), 1);
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_remote_rail_failures_total"), 0);
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_pull_failures_total"), 0);
+
+    // In contrast, an actual READ failure still retires the endpoint and
+    // attributes remote failure; capacity rejection must not hide that case.
+    ScopedEnv fault("DFKV_RDMA_TEST_PULL_READ_FAILURE", "1");
+    EXPECT_EQ(get(&out), Status::kIOError);
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_remote_rail_failures_total"), 1);
+    EXPECT_EQ(Counter(transport.MetricsText(),
+                      "dfkv_rdma_client_pull_failures_total"), 1);
+  }
+}
+
+}  // namespace
+}  // namespace dfkv

--- a/test/transport/rdma_lease_loopback_test.cc
+++ b/test/transport/rdma_lease_loopback_test.cc
@@ -1,0 +1,222 @@
+// Staged-lease PUT datapath over a loopback RDMA device. Runs wherever
+// rdma_loopback_test runs (Soft-RoCE in CI, real HCAs on development hosts);
+// skips cleanly without an RDMA device. Contracts validated here need real
+// verbs: WRITE_WITH_IMM windows into a per-op leased range, pool release at
+// store completion, inline/lease bucket split inside one batch, and metric
+// truth on both ends.
+#include "client/kv_client.h"
+#include "cache/kv_node_server.h"
+#include "cache/rdma_server.h"
+#include "transport/rdma_transport.h"
+#include "transport/rdma_protocol.h"
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace dfkv;  // NOLINT
+
+namespace {
+
+constexpr size_t kMsg = 64ull << 20;  // like production rings' --max-msg
+
+bool HaveRdma() { return RdmaTransport::Available(); }
+std::string SelfHdr() { return "test/model"; }
+
+long CounterOf(const RdmaServer& rsrv, const std::string& name) {
+  const std::string text = rsrv.MetricsText();
+  const size_t at = text.find(name + " ");
+  if (at == std::string::npos) return -1;
+  const size_t sp = text.find(' ', at + name.size());
+  if (sp == std::string::npos) return -1;
+  return std::strtol(text.c_str() + sp + 1, nullptr, 10);
+}
+
+// One cache node: KvNodeServer owns the storage; RdmaServer serves the
+// bootstrap + datapath. Server-side receive budget is small enough that the
+// suite could never pass with connection-resident geometry for large objects —
+// the lease datapath is the only way these PUTs fit.
+struct LeaseNode {
+  fs::path dir;
+  std::unique_ptr<KvNodeServer> srv;
+  std::unique_ptr<RdmaServer> rsrv;
+  std::string addr;
+
+  explicit LeaseNode(const std::string& tag) {
+    setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", std::to_string(96ull << 20).c_str(),
+           1);
+    setenv("DFKV_RDMA_RECV_CHUNK_BYTES", std::to_string(32ull << 20).c_str(),
+           1);
+    dir = fs::temp_directory_path() / ("dfkv_lease_" + tag);
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    srv = std::make_unique<KvNodeServer>(dir.string(), 1ull << 30);
+    EXPECT_EQ(srv->Start(0), Status::kOk);
+    rsrv = std::make_unique<RdmaServer>(
+        [this](uint8_t op, const BlockKey& key, uint64_t off, uint64_t len,
+               const char* pl, uint64_t pll, std::string* out,
+               size_t* value_len) {
+          return srv->ProcessRequestForKey(op, key, off, len, pl, pll, out,
+                                            value_len);
+        },
+        kMsg);
+    rsrv->set_range_handler(
+        [this](const BlockKey& key, uint64_t off, uint64_t len, char* io_buf,
+               size_t cap, const char** out_data, size_t* out_len,
+               size_t* value_len) {
+          return srv->RangeDirectForKey(key, off, len, io_buf, cap, out_data,
+                                        out_len, value_len);
+        });
+    rsrv->set_cache_direct_handler(
+        [this](const BlockKey& key, char* data, size_t len, size_t cap) {
+          return srv->CacheDirectForKey(key, data, len, cap);
+        });
+    EXPECT_EQ(rsrv->Start(0), Status::kOk);
+    addr = "127.0.0.1:" + std::to_string(rsrv->port());
+  }
+  ~LeaseNode() {
+    if (rsrv) rsrv->Stop();
+    if (srv) srv->Stop();
+    fs::remove_all(dir);
+  }
+  LeaseNode(const LeaseNode&) = delete;
+  LeaseNode& operator=(const LeaseNode&) = delete;
+};
+
+std::string Value(size_t len, uint8_t seed) {
+  std::string v(len, '\0');
+  for (size_t i = 0; i < len; ++i)
+    v[i] = static_cast<char>((i * 31 + seed) & 0xFF);
+  return v;
+}
+
+}  // namespace
+
+TEST(RdmaLeaseLoopback, LargeObjectRoundTripsThroughStagedLease) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
+         1);
+  LeaseNode node("roundtrip");
+  RdmaTransport rt(kMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+
+  const std::string v = Value(8ull << 20, 0x55);  // 8 MiB, well over 1 MiB
+  ASSERT_TRUE(c.Put("big", v.data(), v.size()));
+
+  const long lease_ops = CounterOf(*node.rsrv, "dfkv_rdma_leaseput_ops_total");
+  EXPECT_GT(lease_ops, 0) << "object must use the staged-lease datapath";
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_active"), 0)
+      << "lease must return at store completion";
+
+  std::string out(v.size(), '\0');
+  ASSERT_TRUE(c.Get("big", &out[0], out.size()));
+  EXPECT_EQ(out, v);
+}
+
+TEST(RdmaLeaseLoopback, InlineObjectKeepsResidentPath) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
+         1);
+  LeaseNode node("inline");
+  RdmaTransport rt(kMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+
+  const std::string v = Value(256ull << 10, 0xAA);  // below the threshold
+  ASSERT_TRUE(c.Put("small", v.data(), v.size()));
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_ops_total"), 0)
+      << "inline objects must not touch the lease datapath";
+
+  std::string out(v.size(), '\0');
+  ASSERT_TRUE(c.Get("small", &out[0], out.size()));
+  EXPECT_EQ(out, v);
+}
+
+TEST(RdmaLeaseLoopback, MixedBatchSplitAcrossBothBuckets) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
+         1);
+  LeaseNode node("mixed");
+  RdmaTransport rt(kMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+
+  const std::string big = Value(4ull << 20, 0x11);
+  const std::string small = Value(64ull << 10, 0x22);
+  // One batch with one object in each bucket: both must land, and the inline
+  // one must not be carried by a 4MiB-class connection.
+  const std::vector<dfkv::KvPutItem> batch{
+      dfkv::KvPutItem{"kbig", big.data(), big.size()},
+      dfkv::KvPutItem{"ksmall", small.data(), small.size()}};
+  const auto sts = c.BatchPut(batch);
+  ASSERT_EQ(sts.size(), 2u);
+  EXPECT_TRUE(sts[0]);
+  EXPECT_TRUE(sts[1]);
+
+  std::string out_big(big.size(), '\0');
+  ASSERT_TRUE(c.Get("kbig", &out_big[0], out_big.size()));
+  EXPECT_EQ(out_big, big);
+  std::string out_small(small.size(), '\0');
+  ASSERT_TRUE(c.Get("ksmall", &out_small[0], out_small.size()));
+  EXPECT_EQ(out_small, small);
+  EXPECT_GT(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_ops_total"), 0);
+}
+
+TEST(RdmaLeaseLoopback, MultipleLargeObjectsConcurrentWindows) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
+         1);
+  setenv("DFKV_RDMA_DEPTH", "4", 1);
+  LeaseNode node("windows");
+  RdmaTransport rt(kMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+
+  // Enough over-threshold objects to exercise multi-window lease pipelines
+  // and repeated per-slot generation reuse on one connection.
+  const size_t kObjects = 12;
+  std::vector<dfkv::KvPutItem> batch;
+  std::map<std::string, std::string> sentinel;
+  for (size_t i = 0; i < kObjects; ++i) {
+    const std::string key = "obj" + std::to_string(i);
+    const std::string v = Value(2ull << 20, static_cast<uint8_t>(i));
+    sentinel[key] = v;
+    batch.push_back(
+        dfkv::KvPutItem{key, v.data(), v.size()});
+  }
+  const auto sts = c.BatchPut(batch);
+  for (size_t i = 0; i < sts.size(); ++i)
+    EXPECT_TRUE(sts[i]) << "object " << i;
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_active"), 0);
+  const long ops = CounterOf(*node.rsrv, "dfkv_rdma_leaseput_ops_total");
+  EXPECT_GE(ops, static_cast<long>(kObjects));
+
+  for (const auto& [key, v] : sentinel) {
+    std::string out(v.size(), '\0');
+    ASSERT_TRUE(c.Get(key, &out[0], out.size())) << key;
+    EXPECT_EQ(out, v) << key;
+  }
+}
+
+TEST(RdmaLeaseLoopback, DisabledThresholdKeepsLegacyBehavior) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", "0", 1);
+  LeaseNode node("legacy");
+  RdmaTransport rt(kMsg);
+  KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
+
+  // With the datapath disabled the 8MiB object must still succeed through
+  // the traditional connection-resident class — same as a v2.25 client.
+  const std::string v = Value(8ull << 20, 0x77);
+  ASSERT_TRUE(c.Put("legacy-big", v.data(), v.size()));
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_ops_total"), 0);
+  std::string out(v.size(), '\0');
+  ASSERT_TRUE(c.Get("legacy-big", &out[0], out.size()));
+  EXPECT_EQ(out, v);
+}

--- a/test/transport/rdma_lease_loopback_test.cc
+++ b/test/transport/rdma_lease_loopback_test.cc
@@ -5,6 +5,7 @@
 // store completion, inline/lease bucket split inside one batch, and metric
 // truth on both ends.
 #include "client/kv_client.h"
+#include "client/key_map.h"
 #include "cache/kv_node_server.h"
 #include "cache/rdma_server.h"
 #include "transport/rdma_transport.h"
@@ -32,11 +33,13 @@ constexpr size_t kMsg = 64ull << 20;  // like production rings' --max-msg
 bool HaveRdma() { return RdmaTransport::Available(); }
 std::string SelfHdr() { return "test/model"; }
 
+// rfind lands on the VALUE line emitted after the # HELP / # TYPE lines,
+// exactly like rdma_loopback_test's CounterVal.
 long CounterOf(const RdmaServer& rsrv, const std::string& name) {
   const std::string text = rsrv.MetricsText();
-  const size_t at = text.find(name + " ");
+  const size_t at = text.rfind(name + " ");
   if (at == std::string::npos) return -1;
-  const size_t sp = text.find(' ', at + name.size());
+  const size_t sp = text.find(' ', at);
   if (sp == std::string::npos) return -1;
   return std::strtol(text.c_str() + sp + 1, nullptr, 10);
 }
@@ -52,7 +55,10 @@ struct LeaseNode {
   std::string addr;
 
   explicit LeaseNode(const std::string& tag) {
-    setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", std::to_string(96ull << 20).c_str(),
+    // Production rings raise the declared object ceiling to the business
+    // maximum (64MiB today); the 4MiB default would bound GET connections.
+    setenv("DFKV_RDMA_MAX_BLOCK_BYTES", "67108864", 1);
+    setenv("DFKV_RDMA_RECV_SEGMENT_SIZE", std::to_string(192ull << 20).c_str(),
            1);
     setenv("DFKV_RDMA_RECV_CHUNK_BYTES", std::to_string(32ull << 20).c_str(),
            1);
@@ -180,16 +186,16 @@ TEST(RdmaLeaseLoopback, MultipleLargeObjectsConcurrentWindows) {
 
   // Enough over-threshold objects to exercise multi-window lease pipelines
   // and repeated per-slot generation reuse on one connection.
+  // The values must outlive BatchPut: KV items hold raw pointers, so the
+  // owning strings are built first and the batch references them.
   const size_t kObjects = 12;
-  std::vector<dfkv::KvPutItem> batch;
   std::map<std::string, std::string> sentinel;
-  for (size_t i = 0; i < kObjects; ++i) {
-    const std::string key = "obj" + std::to_string(i);
-    const std::string v = Value(2ull << 20, static_cast<uint8_t>(i));
-    sentinel[key] = v;
-    batch.push_back(
-        dfkv::KvPutItem{key, v.data(), v.size()});
-  }
+  for (size_t i = 0; i < kObjects; ++i)
+    sentinel["obj" + std::to_string(i)] =
+        Value(2ull << 20, static_cast<uint8_t>(i));
+  std::vector<dfkv::KvPutItem> batch;
+  for (const auto& [key, v] : sentinel)
+    batch.push_back(dfkv::KvPutItem{key, v.data(), v.size()});
   const auto sts = c.BatchPut(batch);
   for (size_t i = 0; i < sts.size(); ++i)
     EXPECT_TRUE(sts[i]) << "object " << i;
@@ -207,6 +213,10 @@ TEST(RdmaLeaseLoopback, MultipleLargeObjectsConcurrentWindows) {
 TEST(RdmaLeaseLoopback, DisabledThresholdKeepsLegacyBehavior) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", "0", 1);
+  // Without the lease datapath the object ceiling stays the declared block
+  // bound, like every deployed v2.25 client (production raises it to the
+  // business maximum). Mirror production so the 8MiB object remains legal.
+  setenv("DFKV_RDMA_MAX_BLOCK_BYTES", "67108864", 1);
   LeaseNode node("legacy");
   RdmaTransport rt(kMsg);
   KVClient c({{"n", node.addr}}, SelfHdr(), &rt);
@@ -214,7 +224,17 @@ TEST(RdmaLeaseLoopback, DisabledThresholdKeepsLegacyBehavior) {
   // With the datapath disabled the 8MiB object must still succeed through
   // the traditional connection-resident class — same as a v2.25 client.
   const std::string v = Value(8ull << 20, 0x77);
-  ASSERT_TRUE(c.Put("legacy-big", v.data(), v.size()));
+  {
+    // Direct transport-level check first, bypassing routing/health layers.
+    std::vector<dfkv::CacheSrc> probe;
+    probe.push_back(dfkv::CacheSrc{dfkv::ToBlockKey(SelfHdr(), "legacy-big"),
+                                   const_cast<char*>(v.data()),
+                                   v.size()});
+    ASSERT_EQ(rt.CacheFrom(node.addr, probe)[0], Status::kOk);
+  }
+  ASSERT_TRUE(c.Put("legacy-big", v.data(), v.size()))
+      << "\n[client-metrics]\n" << rt.MetricsText()
+      << "\n[server-metrics]\n" << node.rsrv->MetricsText();
   EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_ops_total"), 0);
   std::string out(v.size(), '\0');
   ASSERT_TRUE(c.Get("legacy-big", &out[0], out.size()));

--- a/test/transport/rdma_lease_loopback_test.cc
+++ b/test/transport/rdma_lease_loopback_test.cc
@@ -1,9 +1,6 @@
-// Staged-lease PUT datapath over a loopback RDMA device. Runs wherever
-// rdma_loopback_test runs (Soft-RoCE in CI, real HCAs on development hosts);
-// skips cleanly without an RDMA device. Contracts validated here need real
-// verbs: WRITE_WITH_IMM windows into a per-op leased range, pool release at
-// store completion, inline/lease bucket split inside one batch, and metric
-// truth on both ends.
+// Operation-scoped PUT/GET leases over loopback RDMA (Soft-RoCE or real HCA).
+// Raw peers retain/replay capabilities so client retry cannot hide ownership
+// faults. Skip cleanly when no RDMA device exists.
 #include "client/kv_client.h"
 #include "client/key_map.h"
 #include "cache/kv_node_server.h"
@@ -152,7 +149,9 @@ std::string Value(size_t len, uint8_t seed) {
 // Raw v2 peer keeps one live QP while tests retain or deliberately replay a
 // lease capability. No client retries may hide a server ownership violation.
 struct LeasePeer {
-  rdma::RcEndpoint ep;
+  std::unique_ptr<rdma::RcEndpoint> endpoint =
+      std::make_unique<rdma::RcEndpoint>();
+  rdma::RcEndpoint& ep = *endpoint;
   rdma::RecvSegmentInfo resident;
   bool Open(const LeaseNode& node) {
     const auto& dev = node.rsrv->DeviceNames().front();
@@ -246,6 +245,91 @@ struct LeasePeer {
     return true;
   }
 };
+
+struct PullPeer : LeasePeer {
+  rdma::PullArenaInfo arena;
+  bool Open(const LeaseNode& node, bool dynamic = true,
+            bool request_pull = true, bool retirement = true) {
+    const auto& dev = node.rsrv->DeviceNames().front();
+    if (!ep.Open(dev.c_str(), rdma::kV2ControlCap, 1)) return false;
+    int fd = net::Dial(node.addr, 10000, 10000);
+    if (fd < 0) return false;
+    char frame[rdma::kDevNameBytes], mine[rdma::kQpInfoBytes],
+        peer[rdma::kQpInfoBytes], ready[rdma::kV2PullReadinessBytes];
+    uint64_t declared = 1u << 20;
+    if (dynamic) declared |= rdma::kDevFrameRequestDynamicPull;
+    if (request_pull) declared |= rdma::kDevFrameRequestPullRead;
+    if (retirement) declared |= rdma::kDevFrameRequestWriterRetirement;
+    rdma::EncodeDevFrame(dev, declared, frame);
+    auto info = ep.Local();
+    info.depth = 1;
+    info.protocol_version = rdma::kDevProtoV2;
+    rdma::SerializeQpInfo(info, mine);
+    const size_t size = dynamic ? rdma::kV2RetirementReadinessBytes
+                               : rdma::kV2PullReadinessBytes;
+    uint64_t token = 0;
+    bool ok = net::WriteAll(fd, frame, sizeof(frame)) &&
+              net::WriteAll(fd, mine, sizeof(mine)) &&
+              net::ReadAll(fd, peer, sizeof(peer)) &&
+              ep.Connect(rdma::ParseQpInfo(peer)) &&
+              net::ReadAll(fd, ready, size);
+    if (ok) {
+      ok = dynamic
+               ? rdma::DecodeV2Readiness(ready, size, true, &resident, &token)
+               : rdma::DecodeV2PullReadiness(ready, size, &resident, &token,
+                                             &arena);
+      char extra = 0;
+      ok = ok && ::read(fd, &extra, 1) == 0;  // exact bootstrap size, then EOF
+    }
+    ::close(fd);
+    return ok;
+  }
+  bool Prepare(const BlockKey& key, size_t size, Status* status,
+               rdma::DynamicPullReady* ready, uint64_t release = 0,
+               uint32_t slot = 0, uint64_t offset = 0) {
+    EncodeReqVersion(ep.sbuf(0), kNativeProtoRdmaV2, WireOp::kPullRange,
+                     key, offset, size, rdma::kPullPrepareBytes);
+    rdma::EncodePullPrepareControl({slot, release}, ep.sbuf(0) + kReqPrefix);
+    uint64_t bytes = 0;
+    if (!ep.PostRecv(0) ||
+        !ep.PostSend(0, kReqPrefix + rdma::kPullPrepareBytes) ||
+        !Response(status, &bytes)) return false;
+    return *status != Status::kOk ||
+           (bytes == rdma::kDynamicPullReadyBytes &&
+            rdma::DecodeDynamicPullReady(ep.rbuf(0) + kRespPrefix, ready));
+  }
+  bool Release(const rdma::DynamicPullReady& ready, Status* status) {
+    EncodeReqVersion(ep.sbuf(0), kNativeProtoRdmaV2, WireOp::kPullRelease,
+                     BlockKey{}, 0, ready.slot_generation,
+                     static_cast<uint64_t>(ready.slot_index) + 1);
+    uint64_t bytes = 0;
+    return ep.PostRecv(0) && ep.PostSend(0, kReqPrefix) &&
+           Response(status, &bytes) && bytes == 0;
+  }
+  bool Read(const rdma::DynamicPullReady& ready, std::string* out) {
+    out->assign(ready.data_len, '\0');
+    if (out->empty()) return true;
+    ibv_mr* mr = ep.RegisterTransient(out->data(), out->size());
+    if (!mr) return false;
+    ibv_wc wc{};
+    const bool ok =
+        ep.PostRead(0, out->data(), out->size(), mr, ready.address, ready.rkey) &&
+        ep.WaitComp(&wc, 1, 10000) == 1 && wc.status == IBV_WC_SUCCESS;
+    // Failed/ambiguous DMA must remain pinned until the local QP is destroyed.
+    if (ok) ep.ReleaseTransient(mr);
+    else endpoint.reset();
+    return ok;
+  }
+};
+
+void StoreForPull(LeaseNode& node, const BlockKey& key,
+                  const std::string& value) {
+  std::string out;
+  size_t value_len = 0;
+  ASSERT_EQ(node.srv->ProcessRequestForKey(
+                static_cast<uint8_t>(WireOp::kCache), key, 0, 0,
+                value.data(), value.size(), &out, &value_len), Status::kOk);
+}
 
 }  // namespace
 
@@ -531,4 +615,267 @@ TEST_F(RdmaLeaseLoopback, TeardownHoldsRangeUntilDelayedWriteIsFenced) {
   EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_bytes_active"), 0);
   EXPECT_EQ(rdma::RcEndpoint::LeaseWriteMrActive(), 0u);
   peer.ep.ReleaseTransient(mr);
+}
+
+TEST_F(RdmaLeaseLoopback, DynamicPullOnlyHoldsInflightMemory) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("dynamic-roundtrip");
+  const BlockKey key = ToBlockKey(SelfHdr(), "dynamic");
+  const std::string value = Value(8u << 20, 0x73);
+  StoreForPull(node, key, value);
+  const long baseline = CounterOf(*node.rsrv,
+                                   "dfkv_rdma_recv_segment_used_bytes");
+  PullPeer first, second;
+  ASSERT_TRUE(first.Open(node));
+  ASSERT_TRUE(second.Open(node));
+  const long resident = baseline + first.resident.slot_size +
+                        second.resident.slot_size;
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_used_bytes"),
+            resident) << "dynamic bootstrap must not allocate a pull arena";
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 0);
+  Status status = Status::kIOError;
+  rdma::DynamicPullReady ready;
+  ASSERT_TRUE(first.Prepare(key, value.size(), &status, &ready));
+  ASSERT_EQ(status, Status::kOk);
+  EXPECT_EQ(ready.data_len, value.size());
+  EXPECT_EQ(ready.value_len, value.size());
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 1);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_bytes_active"),
+            static_cast<long>(rdma::V2SlotSize(value.size())));
+  EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 1u);
+  std::string out;
+  ASSERT_TRUE(first.Read(ready, &out));
+  EXPECT_EQ(out, value);
+  ASSERT_TRUE(first.Release(ready, &status));
+  ASSERT_EQ(status, Status::kOk);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 0);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_bytes_active"), 0);
+  EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 0u);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_used_bytes"),
+            resident) << "release ACK must free bytes on the idle live QP";
+}
+
+TEST_F(RdmaLeaseLoopback, DynamicPullSmallDestinationMissAndGeneration) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("dynamic-errors");
+  const BlockKey key = ToBlockKey(SelfHdr(), "small");
+  const BlockKey missing = ToBlockKey(SelfHdr(), "missing");
+  const std::string value = Value(2u << 20, 0x61);
+  StoreForPull(node, key, value);
+  PullPeer peer;
+  ASSERT_TRUE(peer.Open(node));
+  const long resident = CounterOf(*node.rsrv,
+                                   "dfkv_rdma_recv_segment_used_bytes");
+  rdma::DynamicPullReady ready, next;
+  Status status = Status::kIOError;
+  ASSERT_TRUE(peer.Prepare(key, 4096, &status, &ready));
+  ASSERT_EQ(status, Status::kOk);
+  EXPECT_EQ(ready.data_len, 4096u);
+  EXPECT_EQ(ready.value_len, value.size());
+  auto wrong = ready;
+  ++wrong.slot_generation;
+  ASSERT_TRUE(peer.Release(wrong, &status));
+  EXPECT_EQ(status, Status::kInvalid);
+  EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 1u);
+  ASSERT_TRUE(peer.Prepare(key, 4096, &status, &next,
+                           wrong.slot_generation));
+  EXPECT_EQ(status, Status::kInvalid);
+  std::string out;
+  ASSERT_TRUE(peer.Read(ready, &out));
+  EXPECT_EQ(out, value.substr(0, 4096));
+  ASSERT_TRUE(peer.Release(ready, &status));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(peer.Release(ready, &status));
+  EXPECT_EQ(status, Status::kInvalid);
+  ASSERT_TRUE(peer.Prepare(key, value.size(), &status, &next));
+  ASSERT_EQ(status, Status::kOk);
+  EXPECT_NE(next.slot_generation, ready.slot_generation);
+  // Piggyback release must revoke the previous capability even if the next
+  // lookup misses and never publishes another descriptor.
+  ASSERT_TRUE(peer.Prepare(missing, value.size(), &status, &ready,
+                           next.slot_generation));
+  EXPECT_EQ(status, Status::kNotFound);
+  ASSERT_TRUE(peer.Prepare(key, 0, &status, &ready));
+  EXPECT_EQ(status, Status::kInvalid);
+  ASSERT_TRUE(peer.Prepare(key, kMsg + 1, &status, &ready));
+  EXPECT_EQ(status, Status::kInvalid);
+  ASSERT_TRUE(peer.Prepare(key, 4096, &status, &ready, 0, 1));
+  EXPECT_EQ(status, Status::kInvalid);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 0);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_bytes_active"), 0);
+  EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 0u);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_used_bytes"),
+            resident);
+}
+
+TEST_F(RdmaLeaseLoopback, DynamicPullRetiredReadKeyIsRejected) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("dynamic-revoke");
+  const BlockKey key = ToBlockKey(SelfHdr(), "revoke");
+  const std::string value = Value(2u << 20, 0x16);
+  StoreForPull(node, key, value);
+  std::string out(64, 'X');
+  PullPeer peer;
+  ASSERT_TRUE(peer.Open(node));
+  rdma::DynamicPullReady old, current;
+  Status status = Status::kIOError;
+  ASSERT_TRUE(peer.Prepare(key, value.size(), &status, &old));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(peer.Release(old, &status));
+  ASSERT_EQ(status, Status::kOk);
+  ibv_mr* mr = peer.ep.RegisterTransient(out.data(), out.size());
+  ASSERT_NE(mr, nullptr);
+  ASSERT_TRUE(peer.ep.PostRead(0, out.data(), out.size(), mr,
+                               old.address, old.rkey));
+  ibv_wc wc{};
+  ASSERT_EQ(peer.ep.WaitComp(&wc, 1, 10000), 1);
+  EXPECT_NE(wc.status, IBV_WC_SUCCESS);
+  EXPECT_EQ(out, std::string(64, 'X'));
+  peer.endpoint.reset();
+  // Providers may recycle an MR rkey after a fresh registration. Revocation
+  // is checked BEFORE a new grant; generation controls release-message ABA.
+  PullPeer replacement;
+  ASSERT_TRUE(replacement.Open(node));
+  ASSERT_TRUE(replacement.Prepare(key, value.size(), &status, &current));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(replacement.Read(current, &out));
+  EXPECT_EQ(out, value);
+  ASSERT_TRUE(replacement.Release(current, &status));
+  EXPECT_EQ(status, Status::kOk);
+}
+
+TEST_F(RdmaLeaseLoopback, DynamicPullExhaustionRecoversAfterRelease) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("dynamic-pressure");
+  const BlockKey key = ToBlockKey(SelfHdr(), "pressure");
+  const std::string value = Value(kMsg, 0x45);
+  StoreForPull(node, key, value);
+  PullPeer first, second, third;
+  ASSERT_TRUE(first.Open(node));
+  ASSERT_TRUE(second.Open(node));
+  ASSERT_TRUE(third.Open(node));
+  rdma::DynamicPullReady a, b, c;
+  Status status = Status::kIOError;
+  ASSERT_TRUE(first.Prepare(key, value.size(), &status, &a));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(second.Prepare(key, value.size(), &status, &b));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(third.Prepare(key, value.size(), &status, &c));
+  ASSERT_EQ(status, Status::kCacheFull);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 2);
+  EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 2u);
+  ASSERT_TRUE(first.Release(a, &status));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(third.Prepare(key, value.size(), &status, &c));
+  ASSERT_EQ(status, Status::kOk);
+  std::string out;
+  ASSERT_TRUE(third.Read(c, &out));
+  EXPECT_EQ(out, value);
+  ASSERT_TRUE(third.Release(c, &status));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(second.Release(b, &status));
+  ASSERT_EQ(status, Status::kOk);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 0);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_bytes_active"), 0);
+  EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 0u);
+}
+
+TEST_F(RdmaLeaseLoopback, DynamicPullTrimReallocationBoundsMrs) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("dynamic-trim");
+  const BlockKey key = ToBlockKey(SelfHdr(), "trim");
+  const std::string value = Value(40u << 20, 0x32);
+  StoreForPull(node, key, value);
+  PullPeer peer;
+  ASSERT_TRUE(peer.Open(node));
+  const auto pool_mrs = rdma::RcEndpoint::PoolMrActiveRegistrations();
+  const long committed = CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_bytes");
+  for (int cycle = 0; cycle != 3; ++cycle) {
+    rdma::DynamicPullReady ready;
+    Status status = Status::kIOError;
+    ASSERT_TRUE(peer.Prepare(key, value.size(), &status, &ready));
+    ASSERT_EQ(status, Status::kOk);
+    EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 1u);
+    std::string out;
+    ASSERT_TRUE(peer.Read(ready, &out));
+    EXPECT_EQ(out, value);
+    ASSERT_TRUE(peer.Release(ready, &status));
+    ASSERT_EQ(status, Status::kOk);
+    EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 0u);
+    EXPECT_EQ(rdma::RcEndpoint::PoolMrActiveRegistrations(), pool_mrs);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    EXPECT_GE(RdmaLeaseServerTestPeer::Trim(*node.rsrv),
+              rdma::V2SlotSize(value.size()));
+    EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_bytes"), committed);
+    EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_bytes_active"), 0);
+  }
+}
+
+TEST_F(RdmaLeaseLoopback, DynamicPullTeardownFencesDelayedRead) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("dynamic-teardown");
+  const BlockKey key = ToBlockKey(SelfHdr(), "delayed");
+  const std::string value = Value(40u << 20, 0x21);
+  StoreForPull(node, key, value);
+  PullPeer peer;
+  std::promise<void> entered, release;
+  auto entered_future = entered.get_future();
+  auto release_future = release.get_future().share();
+  ASSERT_TRUE(peer.Open(node));
+  rdma::DynamicPullReady ready;
+  Status status = Status::kIOError;
+  ASSERT_TRUE(peer.Prepare(key, value.size(), &status, &ready));
+  ASSERT_EQ(status, Status::kOk);
+  const long held = CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_used_bytes");
+  RdmaLeaseServerTestPeer::BeforeTeardown(
+      *node.rsrv, [&] { entered.set_value(); release_future.wait(); });
+  auto stopped = std::async(std::launch::async, [&] { node.rsrv->Stop(); });
+  const bool at_fence = entered_future.wait_for(std::chrono::seconds(10)) ==
+                        std::future_status::ready;
+  if (at_fence) {
+    EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 1);
+    EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_used_bytes"), held);
+    std::string out;
+    // retire_writer has already transitioned the QP to ERR before this
+    // destructor hook. The delayed READ must fail while its storage is still
+    // held, rather than requiring a successful DMA on a fenced endpoint.
+    const bool read_ok = peer.Read(ready, &out);
+    EXPECT_FALSE(read_ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    EXPECT_EQ(RdmaLeaseServerTestPeer::Trim(*node.rsrv), 0u);
+  }
+  release.set_value();
+  stopped.get();
+  ASSERT_TRUE(at_fence);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 0);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_bytes_active"), 0);
+  EXPECT_EQ(rdma::RcEndpoint::LeaseReadMrActive(), 0u);
+}
+
+TEST_F(RdmaLeaseLoopback, DynamicPullNegotiationPreservesLegacyWire) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("dynamic-negotiation");
+  PullPeer no_pull, no_retirement;
+  EXPECT_FALSE(no_pull.Open(node, true, false, true));
+  EXPECT_FALSE(no_retirement.Open(node, true, true, false));
+  PullPeer legacy;
+  ASSERT_TRUE(legacy.Open(node, false));  // exactly 73 bytes, not DPR2
+  EXPECT_EQ(legacy.arena.arena_bytes, legacy.resident.slot_size);
+  Status status = Status::kIOError;
+  rdma::DynamicPullReady ready;
+  ASSERT_TRUE(legacy.Prepare(ToBlockKey(SelfHdr(), "legacy"),
+                             2u << 20, &status, &ready));
+  EXPECT_EQ(status, Status::kInvalid) << "legacy length remains conn_max bound";
+  LeasePeer unnegotiated;
+  ASSERT_TRUE(unnegotiated.Open(node));
+  EncodeReqVersion(unnegotiated.ep.sbuf(0), kNativeProtoRdmaV2,
+                   WireOp::kPullRange, BlockKey{}, 0, 4096,
+                   rdma::kPullPrepareBytes);
+  rdma::EncodePullPrepareControl({}, unnegotiated.ep.sbuf(0) + kReqPrefix);
+  uint64_t bytes = 0;
+  ASSERT_TRUE(unnegotiated.ep.PostRecv(0));
+  ASSERT_TRUE(unnegotiated.ep.PostSend(0, kReqPrefix + rdma::kPullPrepareBytes));
+  ASSERT_TRUE(unnegotiated.Response(&status, &bytes));
+  EXPECT_EQ(status, Status::kInvalid);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_dynamic_get_active"), 0);
 }

--- a/test/transport/rdma_lease_loopback_test.cc
+++ b/test/transport/rdma_lease_loopback_test.cc
@@ -35,6 +35,9 @@ class RdmaLeaseServerTestPeer {
   static size_t Trim(RdmaServer& server) {
     return server.recv_segments_.TrimIdle(1);
   }
+  static rdma::RecvSegmentPool::Lease Allocate(RdmaServer& server, size_t bytes) {
+    return server.recv_segments_.Allocate(bytes);
+  }
   static void BeforeTeardown(RdmaServer& server, std::function<void()> hook) {
     server.before_endpoint_teardown_for_test_ = std::move(hook);
   }
@@ -85,10 +88,8 @@ long CounterOf(const RdmaServer& rsrv, const std::string& name) {
   return std::strtol(text.c_str() + sp + 1, nullptr, 10);
 }
 
-// One cache node: KvNodeServer owns the storage; RdmaServer serves the
-// bootstrap + datapath. Server-side receive budget is small enough that the
-// suite could never pass with connection-resident geometry for large objects —
-// the lease datapath is the only way these PUTs fit.
+// Production-equivalent handler wiring. Run this suite with
+// DFKV_SERVER_URING=0 and =1 to exercise both serving loops.
 struct LeaseNode {
   fs::path dir;
   std::unique_ptr<KvNodeServer> srv;
@@ -126,6 +127,11 @@ struct LeaseNode {
     rsrv->set_cache_direct_handler(
         [this](const BlockKey& key, char* data, size_t len, size_t cap) {
           return srv->CacheDirectForKey(key, data, len, cap);
+        });
+    rsrv->set_prepare_read_handler(
+        [this](const BlockKey& key, uint64_t off, uint64_t len,
+               char* staging, size_t cap) {
+          return srv->PrepareReadForKey(key, off, len, staging, cap);
         });
     EXPECT_EQ(rsrv->Start(0), Status::kOk);
     addr = "127.0.0.1:" + std::to_string(rsrv->port());
@@ -475,17 +481,18 @@ TEST_F(RdmaLeaseLoopback, RetiredKeyCannotOverwriteReusedLease) {
   LeasePeer peer;
   ASSERT_TRUE(peer.Open(node));
   const BlockKey key = ToBlockKey(SelfHdr(), "reused");
-  rdma::LeasePutReady old, current;
+  rdma::LeasePutReady old;
   Status status = Status::kIOError;
   ASSERT_TRUE(peer.Lease(key, value.size(), &status, &old));
   ASSERT_EQ(status, Status::kOk);
   ASSERT_TRUE(peer.Put(key, old, value));
-  ASSERT_TRUE(peer.Lease(key, value.size(), &status, &current));
-  ASSERT_EQ(status, Status::kOk);
-  ASSERT_EQ(current.write_base, old.write_base)
-      << "the allocator must actually recycle the tested range";
-  char* target = reinterpret_cast<char*>(current.write_base) +
-                 rdma::kV2DataOffset;
+  // Recycle the storage without granting this peer any new remote access.
+  // A subsequent authorized MR may reuse the numeric rkey; this test checks
+  // revocation, not indefinite uniqueness of provider-generated keys.
+  auto current = RdmaLeaseServerTestPeer::Allocate(*node.rsrv, old.lease_bytes);
+  ASSERT_TRUE(current);
+  ASSERT_EQ(reinterpret_cast<uint64_t>(current.data()), old.write_base);
+  char* target = current.data() + rdma::kV2DataOffset;
   std::memset(target, 0x5a, late.size());
   ibv_mr* mr = peer.ep.RegisterTransient(late.data(), late.size(), false);
   ASSERT_NE(mr, nullptr);

--- a/test/transport/rdma_lease_loopback_test.cc
+++ b/test/transport/rdma_lease_loopback_test.cc
@@ -17,6 +17,12 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <optional>
+#include <thread>
 #include <cstring>
 #include <filesystem>
 #include <map>
@@ -26,12 +32,50 @@
 namespace fs = std::filesystem;
 using namespace dfkv;  // NOLINT
 
+namespace dfkv {
+class RdmaLeaseServerTestPeer {
+ public:
+  static size_t Trim(RdmaServer& server) {
+    return server.recv_segments_.TrimIdle(1);
+  }
+  static void BeforeTeardown(RdmaServer& server, std::function<void()> hook) {
+    server.before_endpoint_teardown_for_test_ = std::move(hook);
+  }
+};
+}  // namespace dfkv
+
 namespace {
 
 constexpr size_t kMsg = 64ull << 20;  // like production rings' --max-msg
 
 bool HaveRdma() { return RdmaTransport::Available(); }
 std::string SelfHdr() { return "test/model"; }
+
+class RdmaLeaseLoopback : public ::testing::Test {
+ protected:
+  RdmaLeaseLoopback() {
+    for (const char* key : {"DFKV_RDMA_MAX_BLOCK_BYTES",
+                            "DFKV_RDMA_RECV_SEGMENT_SIZE",
+                            "DFKV_RDMA_RECV_CHUNK_BYTES",
+                            "DFKV_RDMA_INLINE_PUT_MAX_BYTES",
+                            "DFKV_RDMA_RECV_CHUNK_IDLE_MS",
+                            "DFKV_RDMA_IDLE_MS",
+                            "DFKV_RDMA_DEPTH"}) {
+      const char* value = std::getenv(key);
+      saved_.emplace_back(key, value ? std::optional<std::string>(value)
+                                    : std::nullopt);
+    }
+    setenv("DFKV_RDMA_RECV_CHUNK_IDLE_MS", "0", 1);
+    setenv("DFKV_RDMA_IDLE_MS", "0", 1);
+  }
+  ~RdmaLeaseLoopback() override {
+    for (const auto& [key, value] : saved_) {
+      if (value) setenv(key.c_str(), value->c_str(), 1);
+      else unsetenv(key.c_str());
+    }
+  }
+  std::vector<std::pair<std::string, std::optional<std::string>>> saved_;
+};
 
 // rfind lands on the VALUE line emitted after the # HELP / # TYPE lines,
 // exactly like rdma_loopback_test's CounterVal.
@@ -105,9 +149,107 @@ std::string Value(size_t len, uint8_t seed) {
   return v;
 }
 
+// Raw v2 peer keeps one live QP while tests retain or deliberately replay a
+// lease capability. No client retries may hide a server ownership violation.
+struct LeasePeer {
+  rdma::RcEndpoint ep;
+  rdma::RecvSegmentInfo resident;
+  bool Open(const LeaseNode& node) {
+    const auto& dev = node.rsrv->DeviceNames().front();
+    if (!ep.Open(dev.c_str(), rdma::kV2ControlCap, 1)) return false;
+    int fd = net::Dial(node.addr, 10000, 10000);
+    if (fd < 0) return false;
+    char frame[rdma::kDevNameBytes], mine[rdma::kQpInfoBytes],
+        peer[rdma::kQpInfoBytes], ready[rdma::kV2LegacyReadinessBytes];
+    rdma::EncodeDevFrame(dev, (1u << 20) |
+                                 rdma::kDevFrameRequestLeasedPut, frame);
+    auto info = ep.Local();
+    info.depth = 1;
+    info.protocol_version = rdma::kDevProtoV2;
+    rdma::SerializeQpInfo(info, mine);
+    uint64_t token = 0;
+    bool ok = net::WriteAll(fd, frame, sizeof(frame)) &&
+              net::WriteAll(fd, mine, sizeof(mine)) &&
+              net::ReadAll(fd, peer, sizeof(peer)) &&
+              ep.Connect(rdma::ParseQpInfo(peer)) &&
+              net::ReadAll(fd, ready, sizeof(ready)) &&
+              rdma::DecodeV2Readiness(ready, sizeof(ready), false,
+                                      &resident, &token);
+    ::close(fd);
+    return ok;
+  }
+  bool Response(Status* status, uint64_t* bytes) {
+    bool sent = false, received = false;
+    while (!sent || !received) {
+      ibv_wc wc{};
+      if (ep.WaitComp(&wc, 1, 10000) != 1 || wc.status != IBV_WC_SUCCESS)
+        return false;
+      if (wc.opcode == IBV_WC_RECV) {
+        if (wc.byte_len < kRespPrefix ||
+            !DecodeRespVersion(ep.rbuf(0), kNativeProtoRdmaV2,
+                               status, bytes) ||
+            wc.byte_len != kRespPrefix + *bytes)
+          return false;
+        received = true;
+      } else {
+        sent = true;
+      }
+    }
+    return true;
+  }
+  bool Lease(const BlockKey& key, size_t size, Status* status,
+             rdma::LeasePutReady* lease) {
+    EncodeReqVersion(ep.sbuf(0), kNativeProtoRdmaV2, WireOp::kLeasePut,
+                     key, 0, 0, size);
+    uint64_t bytes = 0;
+    if (!ep.PostRecv(0) || !ep.PostSend(0, kReqPrefix) ||
+        !Response(status, &bytes)) return false;
+    return *status != Status::kOk ||
+           (bytes == rdma::kLeasePutReadyBytes &&
+            rdma::DecodeLeasePutReady(ep.rbuf(0) + kRespPrefix, lease));
+  }
+  bool Put(const BlockKey& key, const rdma::LeasePutReady& lease,
+           const std::string& value, bool multi = false) {
+    ibv_mr* mr = ep.RegisterTransient(
+        const_cast<char*>(value.data()), value.size(), false);
+    if (!mr) return false;
+    const size_t windows = multi ? 2 : 1;
+    size_t offset = 0;
+    for (size_t window = 0; window < windows; ++window) {
+      const size_t size = window + 1 == windows
+                              ? value.size() - offset : value.size() / 2;
+      const size_t header = window == 0 ? kReqPrefix : 0;
+      EncodeReqVersion(ep.sbuf(0), kNativeProtoRdmaV2, WireOp::kCache,
+                       key, multi ? rdma::kV2MultiWrPutMagic : 0,
+                       multi ? windows : 0, value.size());
+      std::vector<std::pair<const void*, uint32_t>> segments;
+      std::vector<ibv_mr*> mrs;
+      const size_t first = multi && ep.max_sge() >= 3 ? size / 2 : size;
+      segments.emplace_back(value.data() + offset, first);
+      mrs.push_back(mr);
+      if (first != size) {
+        segments.emplace_back(value.data() + offset + first, size - first);
+        mrs.push_back(mr);
+      }
+      const uint64_t address = lease.write_base + rdma::kV2DataOffset +
+                               offset - header;
+      Status status = Status::kIOError;
+      uint64_t bytes = 0;
+      if (!ep.PostRecv(0) ||
+          !ep.PostWriteImmScatterMulti(0, header, segments, mrs, address,
+                                       lease.rkey, lease.slot) ||
+          !Response(&status, &bytes) || status != Status::kOk)
+        return false;
+      offset += size;
+    }
+    ep.ReleaseTransient(mr);
+    return true;
+  }
+};
+
 }  // namespace
 
-TEST(RdmaLeaseLoopback, LargeObjectRoundTripsThroughStagedLease) {
+TEST_F(RdmaLeaseLoopback, LargeObjectRoundTripsThroughStagedLease) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
          1);
@@ -128,7 +270,7 @@ TEST(RdmaLeaseLoopback, LargeObjectRoundTripsThroughStagedLease) {
   EXPECT_EQ(out, v);
 }
 
-TEST(RdmaLeaseLoopback, InlineObjectKeepsResidentPath) {
+TEST_F(RdmaLeaseLoopback, InlineObjectKeepsResidentPath) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
          1);
@@ -146,7 +288,7 @@ TEST(RdmaLeaseLoopback, InlineObjectKeepsResidentPath) {
   EXPECT_EQ(out, v);
 }
 
-TEST(RdmaLeaseLoopback, MixedBatchSplitAcrossBothBuckets) {
+TEST_F(RdmaLeaseLoopback, MixedBatchSplitAcrossBothBuckets) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
          1);
@@ -175,7 +317,7 @@ TEST(RdmaLeaseLoopback, MixedBatchSplitAcrossBothBuckets) {
   EXPECT_GT(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_ops_total"), 0);
 }
 
-TEST(RdmaLeaseLoopback, MultipleLargeObjectsConcurrentWindows) {
+TEST_F(RdmaLeaseLoopback, MultipleLargeObjectsConcurrentWindows) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", std::to_string(1ull << 20).c_str(),
          1);
@@ -210,7 +352,7 @@ TEST(RdmaLeaseLoopback, MultipleLargeObjectsConcurrentWindows) {
   }
 }
 
-TEST(RdmaLeaseLoopback, DisabledThresholdKeepsLegacyBehavior) {
+TEST_F(RdmaLeaseLoopback, DisabledThresholdKeepsLegacyBehavior) {
   if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
   setenv("DFKV_RDMA_INLINE_PUT_MAX_BYTES", "0", 1);
   // Without the lease datapath the object ceiling stays the declared block
@@ -239,4 +381,154 @@ TEST(RdmaLeaseLoopback, DisabledThresholdKeepsLegacyBehavior) {
   std::string out(v.size(), '\0');
   ASSERT_TRUE(c.Get("legacy-big", &out[0], out.size()));
   EXPECT_EQ(out, v);
+}
+
+TEST_F(RdmaLeaseLoopback, RetiredKeyCannotOverwriteReusedLease) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("revoke");
+  const std::string value = Value(2u << 20, 0x62);
+  std::string late(64, 'X');
+  LeasePeer peer;
+  ASSERT_TRUE(peer.Open(node));
+  const BlockKey key = ToBlockKey(SelfHdr(), "reused");
+  rdma::LeasePutReady old, current;
+  Status status = Status::kIOError;
+  ASSERT_TRUE(peer.Lease(key, value.size(), &status, &old));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(peer.Put(key, old, value));
+  ASSERT_TRUE(peer.Lease(key, value.size(), &status, &current));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_EQ(current.write_base, old.write_base)
+      << "the allocator must actually recycle the tested range";
+  char* target = reinterpret_cast<char*>(current.write_base) +
+                 rdma::kV2DataOffset;
+  std::memset(target, 0x5a, late.size());
+  ibv_mr* mr = peer.ep.RegisterTransient(late.data(), late.size(), false);
+  ASSERT_NE(mr, nullptr);
+  ASSERT_TRUE(peer.ep.PostWrite(0, late.data(), late.size(), mr,
+                                old.write_base + rdma::kV2DataOffset,
+                                old.rkey));
+  ibv_wc wc{};
+  ASSERT_EQ(peer.ep.WaitComp(&wc, 1, 10000), 1);
+  EXPECT_NE(wc.status, IBV_WC_SUCCESS)
+      << "a completed operation's rkey must no longer authorize DMA";
+  EXPECT_EQ(std::string(target, late.size()), std::string(late.size(), '\x5a'));
+  peer.ep.ReleaseTransient(mr);
+}
+
+TEST_F(RdmaLeaseLoopback, LiveConnectionTrimReallocationBoundsMrs) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("trim");
+  // Larger than the initial chunk: every cycle grows and then trims a chunk,
+  // while the very same QP and resident receive lease remain alive.
+  const std::string value = Value(40u << 20, 0x29);
+  LeasePeer peer;
+  ASSERT_TRUE(peer.Open(node));
+  const auto pool_mrs = rdma::RcEndpoint::PoolMrActiveRegistrations();
+  const auto write_mrs = rdma::RcEndpoint::LeaseWriteMrActive();
+  const long committed = CounterOf(*node.rsrv,
+                                    "dfkv_rdma_recv_segment_bytes");
+  for (int cycle = 0; cycle != 3; ++cycle) {
+    const BlockKey key = ToBlockKey(SelfHdr(), "trim-" + std::to_string(cycle));
+    Status status = Status::kIOError;
+    rdma::LeasePutReady lease;
+    ASSERT_TRUE(peer.Lease(key, value.size(), &status, &lease));
+    ASSERT_EQ(status, Status::kOk);
+    EXPECT_EQ(rdma::RcEndpoint::LeaseWriteMrActive(), write_mrs + 1);
+    ASSERT_TRUE(peer.Put(key, lease, value, true));
+    EXPECT_EQ(rdma::RcEndpoint::LeaseWriteMrActive(), write_mrs);
+    EXPECT_EQ(rdma::RcEndpoint::PoolMrActiveRegistrations(), pool_mrs)
+        << "a live connection must not retain staging chunk registrations";
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    EXPECT_GE(RdmaLeaseServerTestPeer::Trim(*node.rsrv), lease.lease_bytes);
+    EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_bytes"),
+              committed);
+    std::string stored;
+    size_t stored_len = 0;
+    ASSERT_EQ(node.srv->ProcessRequestForKey(
+                  static_cast<uint8_t>(WireOp::kRange), key, 0, value.size(),
+                  nullptr, 0, &stored, &stored_len), Status::kOk);
+    EXPECT_EQ(stored, value) << "every SG window must survive trim/reallocation";
+  }
+}
+
+TEST_F(RdmaLeaseLoopback, ExhaustionRetainsLiveLeasesUntilCompletion) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("pressure");
+  const std::string value = Value(64u << 20, 0x49);
+  LeasePeer first, second, third;
+  ASSERT_TRUE(first.Open(node));
+  ASSERT_TRUE(second.Open(node));
+  ASSERT_TRUE(third.Open(node));
+  const BlockKey key = ToBlockKey(SelfHdr(), "pressure");
+  rdma::LeasePutReady a, b, c;
+  Status status = Status::kIOError;
+  ASSERT_TRUE(first.Lease(key, value.size(), &status, &a));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(second.Lease(key, value.size(), &status, &b));
+  ASSERT_EQ(status, Status::kOk);
+  ASSERT_TRUE(third.Lease(key, value.size(), &status, &c));
+  ASSERT_EQ(status, Status::kCacheFull);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_active"), 2);
+  EXPECT_LE(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_bytes"),
+            192l << 20);
+  ASSERT_TRUE(first.Put(key, a, value, true));
+  // The rejected QP stays usable; a genuine completion, not a timeout/retry
+  // policy, makes exactly one range available to it.
+  ASSERT_TRUE(third.Lease(key, value.size(), &status, &c));
+  ASSERT_EQ(status, Status::kOk);
+  EXPECT_EQ(c.write_base, a.write_base);
+  ASSERT_TRUE(third.Put(key, c, value, true));
+  ASSERT_TRUE(second.Put(key, b, value, true));
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_active"), 0);
+}
+
+TEST_F(RdmaLeaseLoopback, TeardownHoldsRangeUntilDelayedWriteIsFenced) {
+  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
+  LeaseNode node("teardown");
+  std::string late(64, 'D');
+  LeasePeer peer;
+  std::promise<void> entered, release;
+  auto entered_future = entered.get_future();
+  auto release_future = release.get_future().share();
+  ASSERT_TRUE(peer.Open(node));
+  rdma::LeasePutReady lease;
+  Status status = Status::kIOError;
+  ASSERT_TRUE(peer.Lease(ToBlockKey(SelfHdr(), "abandoned"), 40u << 20,
+                          &status, &lease));
+  ASSERT_EQ(status, Status::kOk);
+  const long held = CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_used_bytes");
+  ibv_mr* mr = peer.ep.RegisterTransient(late.data(), late.size(), false);
+  ASSERT_NE(mr, nullptr);
+  RdmaLeaseServerTestPeer::BeforeTeardown(
+      *node.rsrv, [&] { entered.set_value(); release_future.wait(); });
+  auto stopped = std::async(std::launch::async, [&] { node.rsrv->Stop(); });
+  const bool at_fence = entered_future.wait_for(std::chrono::seconds(10)) ==
+                        std::future_status::ready;
+  if (at_fence) {
+    // Serve has exited, but destruction is gated before QP teardown. This real
+    // delayed WRITE still succeeds and therefore must target owned storage.
+    EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_active"), 1);
+    EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_recv_segment_used_bytes"), held);
+    const bool posted = peer.ep.PostWrite(
+        0, late.data(), late.size(), mr,
+        lease.write_base + rdma::kV2DataOffset, lease.rkey);
+    EXPECT_TRUE(posted);
+    if (posted) {
+      ibv_wc wc{};
+      const int got = peer.ep.WaitComp(&wc, 1, 10000);
+      EXPECT_EQ(got, 1);
+      if (got == 1) EXPECT_EQ(wc.status, IBV_WC_SUCCESS);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    EXPECT_EQ(RdmaLeaseServerTestPeer::Trim(*node.rsrv), 0u)
+        << "unfenced inbound DMA must prevent idle trim";
+  }
+  release.set_value();  // always unblock teardown, including failed expectations
+  stopped.get();
+  ASSERT_TRUE(at_fence);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_active"), 0);
+  EXPECT_EQ(CounterOf(*node.rsrv, "dfkv_rdma_leaseput_bytes_active"), 0);
+  EXPECT_EQ(rdma::RcEndpoint::LeaseWriteMrActive(), 0u);
+  peer.ep.ReleaseTransient(mr);
 }

--- a/test/transport/rdma_lease_protocol_test.cc
+++ b/test/transport/rdma_lease_protocol_test.cc
@@ -1,0 +1,134 @@
+/* Per-op staged-lease PUT protocol contracts (wire codec + capability bits).
+ * Nordic verbs-free, so this suite runs on any build host. */
+#include "transport/rdma_protocol.h"
+#include "transport/dev_frame.h"
+#include "transport/wire.h"
+
+#include <cstring>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+namespace dfkv::rdma {
+
+TEST(RdmaLeaseProtocol, ProbeAdvertisesLeasedPutByDefault) {
+  char reply[kV2ProbeReplyBytes];
+  EncodeV2ProbeReply(reply);
+  EXPECT_TRUE(ParseV2ProbeReply(reply));
+  EXPECT_TRUE(V2ProbeSupportsLeasedPut(reply));
+  EXPECT_TRUE(V2ProbeSupportsWriterRetirement(reply));
+  EXPECT_TRUE(V2ProbeSupportsPullRead(reply));
+
+  // A rolling-upgraded server that predates the capability advertises only
+  // the base bits. The lease bit is absent and the reply stays valid.
+  EncodeV2ProbeReply(reply, kV2ProbeCapWriterRetirement | kV2ProbeCapPullRead);
+  EXPECT_TRUE(ParseV2ProbeReply(reply));
+  EXPECT_FALSE(V2ProbeSupportsLeasedPut(reply));
+
+  // Zero capabilities keeps the reply parseable (old servers reserved the
+  // byte) while expressing no optional datapath.
+  EncodeV2ProbeReply(reply, /*capabilities=*/0);
+  EXPECT_TRUE(ParseV2ProbeReply(reply));
+  EXPECT_FALSE(V2ProbeSupportsLeasedPut(reply));
+}
+
+TEST(RdmaLeaseProtocol, DevFrameRequestsLeasedPut) {
+  char frame[kDevNameBytes];
+  EncodeDevFrame("mlx5_0", (4u << 20) | kDevFrameRequestWriterRetirement |
+                                kDevFrameRequestPullRead |
+                                kDevFrameRequestLeasedPut,
+                  frame, kDevProtoV2);
+  EXPECT_TRUE(DevFrameRequestsLeasedPut(frame));
+  EXPECT_TRUE(DevFrameRequestsPullRead(frame));
+  EXPECT_TRUE(DevFrameRequestsWriterRetirement(frame));
+  // The request bit must never leak into the geometry value.
+  EXPECT_EQ(ParseDevFrameMaxBlock(frame), 4u << 20);
+
+  EncodeDevFrame("mlx5_0", 4u << 20, frame, kDevProtoV2);
+  EXPECT_FALSE(DevFrameRequestsLeasedPut(frame));
+  EXPECT_EQ(ParseDevFrameMaxBlock(frame), 4u << 20);
+}
+
+TEST(RdmaLeaseProtocol, LeasePutReadyRoundTrip) {
+  const LeasePutReady expected{
+      /*slot=*/3, /*generation=*/17, /*rkey=*/0x00c0ffee,
+      /*write_base=*/0x0000abcd12345000ull, /*lease_bytes=*/4096 + (32u << 20)};
+  char wire[kLeasePutReadyBytes];
+  EncodeLeasePutReady(expected, wire);
+
+  LeasePutReady actual;
+  ASSERT_TRUE(DecodeLeasePutReady(wire, &actual));
+  EXPECT_EQ(actual.slot, expected.slot);
+  EXPECT_EQ(actual.generation, expected.generation);
+  EXPECT_EQ(actual.rkey, expected.rkey);
+  EXPECT_EQ(actual.write_base, expected.write_base);
+  EXPECT_EQ(actual.lease_bytes, expected.lease_bytes);
+}
+
+TEST(RdmaLeaseProtocol, LeasePutReadyRejectsInvalidDescriptors) {
+  const LeasePutReady valid{
+      /*slot=*/1, /*generation=*/5, /*rkey=*/0x00c0ffee,
+      /*write_base=*/0x1000, /*lease_bytes=*/8192};
+  char wire[kLeasePutReadyBytes];
+
+  LeasePutReady sink;
+  // Wrong magic.
+  EncodeLeasePutReady(valid, wire);
+  wire[0] = 'X';
+  EXPECT_FALSE(DecodeLeasePutReady(wire, &sink));
+
+  // Zero rkey: nothing may be written.
+  LeasePutReady bad_rkey = valid;
+  bad_rkey.rkey = 0;
+  EncodeLeasePutReady(bad_rkey, wire);
+  EXPECT_FALSE(DecodeLeasePutReady(wire, &sink));
+
+  // Zero write base.
+  LeasePutReady bad_base = valid;
+  bad_base.write_base = 0;
+  EncodeLeasePutReady(bad_base, wire);
+  EXPECT_FALSE(DecodeLeasePutReady(wire, &sink));
+
+  // Below one data page: no frame would fit.
+  LeasePutReady bad_size = valid;
+  bad_size.lease_bytes = kV2DataOffset;
+  EncodeLeasePutReady(bad_size, wire);
+  EXPECT_FALSE(DecodeLeasePutReady(wire, &sink));
+
+  // Not page aligned: the frame geometry assumes kV2DataOffset multiples.
+  LeasePutReady misaligned = valid;
+  misaligned.lease_bytes = 8192 + 1;
+  EncodeLeasePutReady(misaligned, wire);
+  EXPECT_FALSE(DecodeLeasePutReady(wire, &sink));
+
+  // Overflowing range end.
+  LeasePutReady overflow = valid;
+  overflow.write_base = std::numeric_limits<uint64_t>::max() - 4096;
+  overflow.lease_bytes = 65536;
+  EncodeLeasePutReady(overflow, wire);
+  EXPECT_FALSE(DecodeLeasePutReady(wire, &sink));
+
+  // Generation zero is the reserved "absent" value.
+  LeasePutReady zero_gen = valid;
+  zero_gen.generation = 0;
+  EncodeLeasePutReady(zero_gen, wire);
+  EXPECT_FALSE(DecodeLeasePutReady(wire, &sink));
+}
+
+TEST(RdmaLeaseProtocol, LeasePutOpCodeStaysAppendOnly) {
+  // New op codes are append-only and never reuse old values: pooled v2.25
+  // peers classify unknown ops as invalid, so the staged-lease datapath must
+  // be reachable only after both ends negotiate this code.
+  EXPECT_EQ(WireOp::kPullRange, static_cast<WireOp>(16));
+  EXPECT_EQ(WireOp::kPullRelease, static_cast<WireOp>(17));
+  EXPECT_EQ(WireOp::kLeasePut, static_cast<WireOp>(18));
+}
+
+}  // namespace dfkv::rdma
+
+namespace dfkv {
+// Keep the wire status contract: staged-lease backpressure must ride the
+// existing kCacheFull value, because DecodeRespVersion rejects anything above
+// kInvalid (new status values would break every deployed peer).
+static_assert(static_cast<uint8_t>(Status::kInvalid) == 5);
+}  // namespace dfkv

--- a/test/transport/rdma_loopback_test.cc
+++ b/test/transport/rdma_loopback_test.cc
@@ -2298,41 +2298,6 @@ TEST(RdmaLoopback, RegisterMemoryRoundtrip) {
   }
 }
 
-TEST(RdmaLoopback, ConnectionPoolAndKeepaliveDefaultsResolveAndDisable) {
-  if (!HaveRdma()) GTEST_SKIP() << "no RDMA device";
-  ::unsetenv("DFKV_RDMA_KEEPALIVE_MS");
-  ::unsetenv("DFKV_RDMA_POOL_MAX");
-  config_dump::ResetForTest();
-  testing::internal::CaptureStderr();
-  { RdmaTransport rt(kMaxMsg); }
-  config_dump::Emit("keepalive-default-test");
-  std::string output = testing::internal::GetCapturedStderr();
-  EXPECT_NE(output.find("DFKV_RDMA_KEEPALIVE_MS"), std::string::npos);
-  EXPECT_NE(output.find(" = 15000  (default)"), std::string::npos);
-  const size_t pool_name = output.find("DFKV_RDMA_POOL_MAX");
-  ASSERT_NE(pool_name, std::string::npos);
-  const std::string pool_line =
-      output.substr(pool_name, output.find('\n', pool_name) - pool_name);
-  EXPECT_NE(pool_line.find(" = 16  (default)"), std::string::npos);
-
-  ::setenv("DFKV_RDMA_KEEPALIVE_MS", "0", 1);
-  ::setenv("DFKV_RDMA_POOL_MAX", "2", 1);
-  config_dump::ResetForTest();
-  testing::internal::CaptureStderr();
-  { RdmaTransport rt(kMaxMsg); }
-  config_dump::Emit("keepalive-disabled-test");
-  output = testing::internal::GetCapturedStderr();
-  EXPECT_NE(output.find("DFKV_RDMA_KEEPALIVE_MS"), std::string::npos);
-  EXPECT_NE(output.find(" = 0  (env)"), std::string::npos);
-  const size_t pool_override_name = output.find("DFKV_RDMA_POOL_MAX");
-  ASSERT_NE(pool_override_name, std::string::npos);
-  const std::string pool_override_line =
-      output.substr(pool_override_name,
-                    output.find('\n', pool_override_name) - pool_override_name);
-  EXPECT_NE(pool_override_line.find(" = 2  (env)"), std::string::npos);
-  ::unsetenv("DFKV_RDMA_KEEPALIVE_MS");
-  ::unsetenv("DFKV_RDMA_POOL_MAX");
-}
 
 // A live client must not inherit the server's short dead-client reap interval
 // as a first-read reconnect penalty. Idle QPs receive lightweight membership


### PR DESCRIPTION
# Staged RDMA receive/pull memory (operation-scoped leases) — ready for merge

## Status: Release gate PASSED (2026-09-08)

All blockers from earlier drafts resolved. Evidence summary below; every item was executed on real hardware (xb01-0064, 400G HCA `ib7s400p2`) or the latest upstream engine images, not inferred.

## What

Operation-scoped memory for RDMA v2, both directions:

- **Leased large PUT** (`kLeasePut`, probe bit2/devframe bit61): objects > `DFKV_RDMA_INLINE_PUT_MAX_BYTES` (default 4 MiB, 0=off) negotiate an exact-scoped staging lease; storage is revoked (MR deregistered) before range recycling on success; abnormal exits fence the QP/MRs before RAII release.
- **Dynamic GET pull arenas** (`kV2ProbeCapDynamicPull`, devframe bit60): supported endpoints no longer reserve connection-lifetime pull arenas (73→33-byte bootstrap); each GET leases request-sized storage server-side, client completes explicit generation-checked `kPullRelease` ACK before the connection returns to the pool.
- `DFKV_RDMA_MAX_BLOCK_BYTES` remains the common PUT/GET ceiling and now applies to every API entry point.
- Endpoints reuse, capability fallback, mixed-batch invalid-item isolation, duplicate-key first-write-wins, insufficient-GET-capacity `kInvalid` without peer cooldown.
- New external-server benchmark (`dfkvleasebench`): clients live across idle sampling, byte-exact readback of every successful PUT, server RSS/committed/leased sampled peaks.

## Validation matrix (final head `e92f34b`)

| Gate | Result |
|---|---|
| CI (8 jobs incl. TSan, Soft-RoCE datapath, wheels, smoke, portable artifacts) | 8/8 SUCCESS on `e92f34b` |
| Hardware lease suites (loopback 16 + client 14 × {release,TSan} × {SYNC,io_uring}) | 8/8 runs, 120 tests, 0 skip, 0 fail |
| Local CTest | 846/846 |
| vLLM connector suites (nightly image `vllm/vllm-openai:nightly` d9105ea8 + current) | 34/34 |
| Equal-budget memory: 100 clients × 33 MiB × 3 ops, 31-SG PUT + byte-exact GET | baseline peak RSS 17.97 GB vs lease 3.52 GB; 300/300 ok both; idle-conn candidate RSS 130 MB, committed 256 MB; 25 ms sampled |
| SGLang old-binary cold write → new-binary fresh L3 reload (both prompts) | exact content, bytes+hits full |
| SGLang new-binary cold write → old-binary fresh reload | exact content (reverse compat) |
| vLLM nightly cold write (TP4 Flash) | exact content both prompts |
| vLLM nightly fresh-process reload **with load fence** | 2/2 fresh readers exact/containment (major: exact), 0 errors, full hit |

## Root causes found & fixed beyond the original PR scope (all with focused regressions)

1. Server eviction UAF (pre-existing v2.25.0): receive-pool eviction woke a claimed endpoint after unlocking `conn_mu_`, racing the Serve-thread self-erase + stack-ep destruction. Wake now happens under the lock.
2. vLLM hybrid admission: lookup validated one length then shortened to others; scheduler trimmed the sampling tail after validation. Both revalidate at the admitted boundary now.
3. vLLM per-TP Mamba state was encoded under the replicated MLA rank-0 coordinate (丢失 3/4 shards). State groups use the `mamba` pool + physical ranks, every writer stores its shard, lookup requires all shards.
4. vLLM kernel-tile folding: physical tensors are folded into allocator logical blocks (e.g. 88,417 tiles = 5,201 blocks × 17), full block tables select by position.
5. Mixed layout identity: corrected block geometry ships under `vllm-multiwr-v3`; old underfilled objects cold-miss (no dual read).
6. **GPUDirect memory ordering** (the last blocker): CQ completion proves transmission, not BAR arrival. Unfenced fresh reloads delivered full-hit loads whose generation degraded into 256-token empty reasoning; with the fence (and SYNC_MEMOPS attempted at registration), two independent fresh readers recovered the passphrase exactly. `DFKV_GPU_LOAD_FENCE=0` opts out.
7. Engine-side gaps shipped as tested patches: SGLang `build_hybrid_mamba_stack` never registered the DSA indexer sidecar (patch applies against upstream main too, 2026-09-08); vLLM `_handle_invalid_blocks` crashed hybrid models on the block-id unpack (patch, plus scheduler-side replay guard).

Open upstream items filed in docs: on-node extent eviction pressure at tiny cache caps (advice: cap ≥ 64 GiB per 100-client scale), and the "one group-0 object × four rank-local destinations" trace nuance (last-block scheduler overwrites; transport bytes verified exact).

## Compatibility

- Wire: server-first. Old clients ignore the new capability bits and keep the legacy 73-byte bootstrap + connection-resident arenas; new clients against old servers autonegotiate down. Data formats unchanged.
- Legitimate v2.25 persistent-cache REUSE works both directions (SGLang old→new and new→old verified on the same store).
- The vLLM raw-layout ID moves to `vllm-multiwr-v3` (corrected block geometry can't decode v2 payloads). Native C ABI, slab and RDMA wire compatibility unchanged; roll Python writers/readers together.

## Ops notes

- New env: `DFKV_RDMA_INLINE_PUT_MAX_BYTES` (4 MiB, 0=off), `DFKV_RDMA_DYNAMIC_PULL` (1, 0=legacy arenas), `DFKV_GPU_LOAD_FENCE` (1, 0=off).
- `DFKV_SERVER_URING=1` exercises the io_uring disk path in the hardware suites (release default unchanged).
