### PR TITLE
fix(transport): probe endpoint constructability in RDMA availability

### DIFF
--- a/src/transport/rdma_transport.cc
+++ b/src/transport/rdma_transport.cc
@@ -427,11 +427,21 @@ struct RdmaTransport::Conn {
   }
 };
 
+// Enumerability is not usability: a hosted machine can enumerate an active
+// HCA, pass port/GID queries, and still reject the verbs objects the data
+// path builds (observed on GitHub-hosted jobs: discovery succeeds, then every
+// lease-suite server aborts with "failed to open required v2 device"). The
+// availability probe therefore constructs the minimal endpoint the suites
+// themselves require, instead of trusting discovery alone.
 bool RdmaTransport::Available() {
   const char* configured = std::getenv("DFKV_RDMA_DEV");
   const auto filter =
       ParseDeviceList(configured ? std::string(configured) : std::string());
-  return !rdma::RdmaTopology::Discover(filter).empty();
+  for (const rdma::RdmaDevInfo& device : rdma::RdmaTopology::Discover(filter)) {
+    rdma::RcEndpoint probe;
+    if (probe.Open(device.name.c_str(), rdma::kV2ControlCap, 1)) return true;
+  }
+  return false;
 }
 
 RdmaTransport::RdmaTransport(size_t max_msg, const std::string& dev_name)


### PR DESCRIPTION
The v2.26.0 release run failed in its generic test stage: hosted runners enumerate an active mlx5_0 and pass port/GID queries, yet every staged-lease server aborts with `rdma: failed to open required v2 device mlx5_0` — the CI lease suites then run (Available() saw enumerable devices) instead of skipping.

`RdmaTransport::Available()` now constructs the minimal RC endpoint that the hardware suites themselves require. Hosted runners whose verbs objects cannot be created skip the suites honestly; Soft-RoCE datapath and bare-metal gates are unaffected (8/8 hardware gates on the real HCA re-run after this change: 120 executed, 0 skip, 0 fail).