### PR TITLE
fix(vllm): fence preemptions before forward

### DIFF
--- a/integration/vllm/src/dfkv_vllm/connector.py
+++ b/integration/vllm/src/dfkv_vllm/connector.py
@@ -303,13 +303,24 @@ class DfkvStoreConnector(KVConnectorBase_V1, SupportsHMA):
         finally:
             self._finish_call()
 
+    def handle_preemptions(
+        self, kv_connector_metadata: KVConnectorMetadata
+    ) -> None:
+        self._begin_call()
+        try:
+            assert self.connector_worker is not None
+            assert isinstance(
+                kv_connector_metadata, DfkvStoreConnectorMetadata
+            )
+            self.connector_worker.handle_preemptions(kv_connector_metadata)
+        finally:
+            self._finish_call()
+
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         self._begin_call()
         try:
-            # Loads are issued in get_finished() for compute overlap; this hook
-            # only runs the preemption fence, which must happen BEFORE this step's
-            # forward pass can overwrite a preempted request's freed (and possibly
-            # re-allocated) blocks while an in-flight save still reads them.
+            # Loads are issued in get_finished() for compute overlap. Synchronous
+            # loads required by this step are submitted here before forward.
             assert self.connector_worker is not None
             metadata = self._get_connector_metadata()
             assert isinstance(metadata, DfkvStoreConnectorMetadata)

--- a/integration/vllm/src/dfkv_vllm/scheduler.py
+++ b/integration/vllm/src/dfkv_vllm/scheduler.py
@@ -251,90 +251,91 @@ class DfkvStoreScheduler:
             if req_meta is not None:
                 meta.add_request(req_meta)
 
-        # Handle cached (running, or MRV1 resumed-from-preemption) requests
+        # Handle cached (running, or MRV1 resumed-from-preemption) requests.
+        # Consumer-only mode still needs LOAD metadata; skip_save only suppresses
+        # the independent SAVE side of each request.
         cached_reqs = scheduler_output.scheduled_cached_reqs
-        if not force_skip_save:
-            for i, req_id in enumerate(cached_reqs.req_ids):
-                new_block_ids = cached_reqs.new_block_ids[i]
-                if not new_block_ids and req_id not in self._preempted_req_ids:
-                    continue
+        for i, req_id in enumerate(cached_reqs.req_ids):
+            new_block_ids = cached_reqs.new_block_ids[i]
+            if not new_block_ids and req_id not in self._preempted_req_ids:
+                continue
 
-                req_meta = None
-                if req_id in self._preempted_req_ids:
-                    # Resumed after preemption
-                    self._preempted_req_ids.discard(req_id)
-                    load_spec = self.load_specs.pop(req_id, None)
-                    request_real, allocated_block_ids = self._unfinished_requests[req_id]
-                    num_tokens_to_compute = (
-                        request_real.num_computed_tokens
-                        + scheduler_output.num_scheduled_tokens[req_id]
-                    )
-                    # On resume, the request re-prefills prompt + previously
-                    # generated tokens (all_token_ids).
-                    prefill_tokens = list(request_real.all_token_ids)
-                    request_tracker = RequestTracker(
-                        req_id=req_id,
-                        token_len=num_tokens_to_compute,
-                        allocated_block_ids=tuple(b.copy() for b in allocated_block_ids),
-                        num_saved_tokens=0,
-                        token_ids=prefill_tokens[:num_tokens_to_compute].copy(),
-                        prefill_end_tokens=len(prefill_tokens),
-                    )
-                    self._request_trackers[req_id] = request_tracker
+            req_meta = None
+            if req_id in self._preempted_req_ids:
+                # Resumed after preemption
+                self._preempted_req_ids.discard(req_id)
+                load_spec = self.load_specs.pop(req_id, None)
+                request_real, allocated_block_ids = self._unfinished_requests[req_id]
+                num_tokens_to_compute = (
+                    request_real.num_computed_tokens
+                    + scheduler_output.num_scheduled_tokens[req_id]
+                )
+                # On resume, the request re-prefills prompt + previously
+                # generated tokens (all_token_ids).
+                prefill_tokens = list(request_real.all_token_ids)
+                request_tracker = RequestTracker(
+                    req_id=req_id,
+                    token_len=num_tokens_to_compute,
+                    allocated_block_ids=tuple(b.copy() for b in allocated_block_ids),
+                    num_saved_tokens=0,
+                    token_ids=prefill_tokens[:num_tokens_to_compute].copy(),
+                    prefill_end_tokens=len(prefill_tokens),
+                )
+                self._request_trackers[req_id] = request_tracker
 
-                    last_chunk_tokens_num = (
-                        len(prefill_tokens) // self._block_size * self._block_size
-                    )
-                    req_meta = ReqMeta.from_request_tracker(
-                        request_tracker,
-                        self._block_size,
-                        load_spec=load_spec,
-                        skip_save=force_skip_save,
-                        block_hashes=request_real.block_hashes,
-                        is_last_chunk=(
-                            request_tracker.token_len >= last_chunk_tokens_num
-                        ),
-                    )
+                last_chunk_tokens_num = (
+                    len(prefill_tokens) // self._block_size * self._block_size
+                )
+                req_meta = ReqMeta.from_request_tracker(
+                    request_tracker,
+                    self._block_size,
+                    load_spec=load_spec,
+                    skip_save=force_skip_save,
+                    block_hashes=request_real.block_hashes,
+                    is_last_chunk=(
+                        request_tracker.token_len >= last_chunk_tokens_num
+                    ),
+                )
+            else:
+                # Decode/chunked request
+                request_tracker = self._request_trackers[req_id]
+                num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
+                req_tuple = self._unfinished_requests.get(req_id)
+                if req_tuple:
+                    unfinished_req = req_tuple[0]
+                    num_current_tokens = request_tracker.token_len
+                    new_token_ids = unfinished_req.all_token_ids[
+                        num_current_tokens : num_current_tokens + num_new_tokens
+                    ]
+                    request_tracker.token_len += len(new_token_ids)
                 else:
-                    # Decode/chunked request
-                    request_tracker = self._request_trackers[req_id]
-                    num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
-                    req_tuple = self._unfinished_requests.get(req_id)
-                    if req_tuple:
-                        unfinished_req = req_tuple[0]
-                        num_current_tokens = request_tracker.token_len
-                        new_token_ids = unfinished_req.all_token_ids[
-                            num_current_tokens : num_current_tokens + num_new_tokens
-                        ]
-                        request_tracker.token_len += len(new_token_ids)
-                    else:
-                        raise ValueError(
-                            f"Request {req_id} is not in _unfinished_requests"
-                        )
-                    num_computed_token = cached_reqs.num_computed_tokens[i]
-                    # Use the tracker's snapshot of the prefill range so resumed
-                    # requests keep saving past the original prompt boundary.
-                    prefill_end = request_tracker.prefill_end_tokens
-                    if num_computed_token >= prefill_end:
-                        continue
-                    request_tracker.update(new_block_ids)
-
-                    last_chunk_tokens_num = (
-                        prefill_end // self._block_size * self._block_size
+                    raise ValueError(
+                        f"Request {req_id} is not in _unfinished_requests"
                     )
-                    req_meta = ReqMeta.from_request_tracker(
-                        request_tracker,
-                        self._block_size,
-                        load_spec=None,
-                        skip_save=force_skip_save,
-                        block_hashes=unfinished_req.block_hashes,
-                        is_last_chunk=(
-                            request_tracker.token_len >= last_chunk_tokens_num
-                        ),
-                    )
+                num_computed_token = cached_reqs.num_computed_tokens[i]
+                # Use the tracker's snapshot of the prefill range so resumed
+                # requests keep saving past the original prompt boundary.
+                prefill_end = request_tracker.prefill_end_tokens
+                if num_computed_token >= prefill_end:
+                    continue
+                request_tracker.update(new_block_ids)
 
-                if req_meta is not None:
-                    meta.add_request(req_meta)
+                last_chunk_tokens_num = (
+                    prefill_end // self._block_size * self._block_size
+                )
+                req_meta = ReqMeta.from_request_tracker(
+                    request_tracker,
+                    self._block_size,
+                    load_spec=None,
+                    skip_save=force_skip_save,
+                    block_hashes=unfinished_req.block_hashes,
+                    is_last_chunk=(
+                        request_tracker.token_len >= last_chunk_tokens_num
+                    ),
+                )
+
+            if req_meta is not None:
+                meta.add_request(req_meta)
 
         # Handle requests with pending load specs not yet scheduled
         request_ids = [req.req_id for req in scheduler_output.scheduled_new_reqs]

--- a/integration/vllm/src/dfkv_vllm/worker.py
+++ b/integration/vllm/src/dfkv_vllm/worker.py
@@ -2078,34 +2078,41 @@ class DfkvStoreWorker:
         self.kv_recv_thread.start()
         ready_event_recving.wait()
 
+    def handle_preemptions(
+        self,
+        metadata: DfkvStoreConnectorMetadata,
+    ) -> None:
+        """Fence preempted block sources before the next forward pass."""
+        if not metadata.preempted_req_ids:
+            return
+        if self.kv_recv_thread is not None:
+            self.kv_recv_thread.cancel_requests(
+                metadata.preempted_req_ids,
+                wait=True,
+                fail_closed=False,
+            )
+        send_thread = self.kv_send_thread
+        if send_thread is None:
+            return
+        # Drop queued entries first, then join whichever entry is active.
+        for req_id in metadata.preempted_req_ids:
+            send_thread.delete_finished_stored_request(req_id)
+        for req_id in metadata.preempted_req_ids:
+            wait_start = time.perf_counter()
+            while not send_thread.wait_for_inflight_put(req_id):
+                logger.error(
+                    "preemption fence still waiting for in-flight save "
+                    "of request %s after %.1fs; GPU block reuse remains "
+                    "fenced until the native save exits",
+                    req_id,
+                    time.perf_counter() - wait_start,
+                )
+
     def start_load_kv(
         self,
         metadata: DfkvStoreConnectorMetadata,
     ):
-        """Fence preemptions and perform synchronous loads before forward."""
-        if metadata.preempted_req_ids:
-            if self.kv_recv_thread is not None:
-                self.kv_recv_thread.cancel_requests(
-                    metadata.preempted_req_ids,
-                    wait=True,
-                    fail_closed=False,
-                )
-            send_thread = self.kv_send_thread
-            if send_thread is not None:
-                # Drop queued entries first, then join whichever entry is active.
-                for req_id in metadata.preempted_req_ids:
-                    send_thread.delete_finished_stored_request(req_id)
-                for req_id in metadata.preempted_req_ids:
-                    wait_start = time.perf_counter()
-                    while not send_thread.wait_for_inflight_put(req_id):
-                        logger.error(
-                            "preemption fence still waiting for in-flight save "
-                            "of request %s after %.1fs; GPU block reuse remains "
-                            "fenced until the native save exits",
-                            req_id,
-                            time.perf_counter() - wait_start,
-                        )
-
+        """Perform synchronous loads before forward."""
         if self.load_async:
             return
         assert self.kv_recv_thread is not None

--- a/integration/vllm/tests/test_preempt_fence.py
+++ b/integration/vllm/tests/test_preempt_fence.py
@@ -13,6 +13,8 @@ import types
 import unittest
 
 try:
+    from dfkv_vllm.connector import DfkvStoreConnector
+    from dfkv_vllm.data import DfkvStoreConnectorMetadata
     from dfkv_vllm.worker import KVCacheStoreSendingThread
 
     HAVE_VLLM = True
@@ -59,6 +61,29 @@ class PreemptFenceTest(unittest.TestCase):
         self.assertTrue(ready.wait(5))
         self._threads.append(t)
         return t
+
+    def test_connector_fences_preemption_before_starting_loads(self):
+        calls: list[str] = []
+
+        class Worker:
+            def handle_preemptions(self, metadata):
+                calls.append("preemption")
+
+            def start_load_kv(self, metadata):
+                calls.append("load")
+
+        connector = object.__new__(DfkvStoreConnector)
+        connector.connector_worker = Worker()
+        connector._begin_call = lambda: None
+        connector._finish_call = lambda: None
+        metadata = DfkvStoreConnectorMetadata(set(), {"resumed"})
+        connector._get_connector_metadata = lambda: metadata
+
+        connector.handle_preemptions(metadata)
+        self.assertEqual(calls, ["preemption"])
+        connector.start_load_kv(None)
+        self.assertEqual(calls, ["preemption", "load"])
+
 
     def test_wait_blocks_while_put_executes_and_returns_after(self):
         # A store that is already executing cannot be cancelled: the fence

--- a/integration/vllm/tests/test_scheduler_full_block_ids.py
+++ b/integration/vllm/tests/test_scheduler_full_block_ids.py
@@ -91,6 +91,43 @@ def test_cache_bypass_discards_stale_external_admission():
     assert scheduler.load_specs == {"unrelated": other_spec}
 
 
+def test_consumer_cached_resume_emits_load_without_save():
+    scheduler = object.__new__(DfkvStoreScheduler)
+    scheduler.kv_role = "kv_consumer"
+    scheduler.client = MagicMock()
+    scheduler.load_specs = {"resumed": LoadSpec(0, 4, True)}
+    scheduler._request_trackers = {}
+    scheduler._preempted_req_ids = {"resumed"}
+    scheduler._unfinished_request_ids = {"resumed"}
+    scheduler._allocated_req_ids = set()
+    scheduler._block_size = 4
+    request = SimpleNamespace(
+        request_id="resumed", block_hashes=[], all_token_ids=list(range(8)),
+        num_computed_tokens=4,
+    )
+    blocks = ([10, 11],)
+    scheduler._unfinished_requests = {"resumed": (request, blocks)}
+    step = SimpleNamespace(
+        finished_req_ids=set(), preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=["resumed"], new_block_ids=[([11],)],
+            num_computed_tokens=[4],
+        ),
+        num_scheduled_tokens={"resumed": 4},
+    )
+
+    metadata = scheduler.build_connector_meta(step)
+
+    assert len(metadata.requests) == 1
+    restored = metadata.requests[0]
+    assert restored.load_spec is not None and restored.load_spec.can_load
+    assert restored.can_save is False
+    assert restored.block_ids == blocks
+    assert "resumed" not in scheduler.load_specs
+    assert "resumed" not in scheduler._preempted_req_ids
+
+
 @pytest.mark.parametrize("cached_resume", [False, True])
 @pytest.mark.parametrize("async_pending", [False, True])
 def test_same_step_preemption_keeps_new_allocation_and_load(async_pending, cached_resume):

--- a/integration/vllm/tests/test_stateful_lookup_admission.py
+++ b/integration/vllm/tests/test_stateful_lookup_admission.py
@@ -618,7 +618,7 @@ def test_same_step_resume_save_releases_finished_blocks(hybrid_workers, monkeypa
         block_ids=([1], [3], [3]), block_hashes=hashes,
     )
     metadata = SimpleNamespace(requests=[request], preempted_req_ids={request.req_id})
-    producer.start_load_kv(metadata)
+    producer.handle_preemptions(metadata)
     producer.get_finished(set(), metadata)
     key = PoolKey(producer.token_dbs[1].metadata, hashes[0].hex()).to_bytes()
     assert objects[producer.client.namespace, key] == bytes([30]) * 16
@@ -667,7 +667,7 @@ def test_cancelled_save_generation_cannot_revive(hybrid_workers, monkeypatch):
         assert entered.wait(5)
         sender.add_stored_request(stale)
         sender.add_request(stale)
-        producer.start_load_kv(
+        producer.handle_preemptions(
             SimpleNamespace(requests=[], preempted_req_ids={stale.req_id}),
         )
         buffers["mla"][1].fill_(99)

--- a/test/python/test_dfkv_vllm_worker.py
+++ b/test/python/test_dfkv_vllm_worker.py
@@ -675,7 +675,7 @@ class LogicalChunkTransferTest(unittest.TestCase):
 
         def preempt() -> None:
             try:
-                worker.start_load_kv(
+                worker.handle_preemptions(
                     SimpleNamespace(preempted_req_ids={request.req_id})
                 )
             except BaseException as exc:
@@ -1579,7 +1579,9 @@ class ReceiveConcurrencyTest(unittest.TestCase):
         returned = threading.Event()
 
         def preempt() -> None:
-            worker.start_load_kv(SimpleNamespace(preempted_req_ids={"preempted"}))
+            worker.handle_preemptions(
+                SimpleNamespace(preempted_req_ids={"preempted"})
+            )
             returned.set()
 
         thread = threading.Thread(target=preempt)


### PR DESCRIPTION
## Problem

Async SAVE sources were fenced from `start_load_kv`, which vLLM may defer until after forward when no synchronous LOAD is scheduled. A preempted block could therefore be reused before its in-flight SAVE completed. Consumer-only MRV1 cached resumes also skipped LOAD metadata because the cached-request branch was gated by SAVE role.

## Fix

- implement the vLLM `handle_preemptions` hook and fence send/receive work there before forward
- keep synchronous LOAD submission in `start_load_kv`
- process cached resumes for consumer-only roles while continuing to suppress SAVE
- add regressions for hook ordering and consumer cached-resume LOAD metadata

## Verification

- Python syntax and Ruff checks pass
- executable AST harness against the edited methods observes `fence -> forward -> load`
- consumer resume harness emits one LOAD request with SAVE disabled
- full connector tests run in CI because the local workstation has no torch/vLLM runtime